### PR TITLE
[wip] fix gossipnet in ci

### DIFF
--- a/crates/astria-gossipnet/src/network.rs
+++ b/crates/astria-gossipnet/src/network.rs
@@ -330,7 +330,7 @@ mod test {
         let alice_handle = tokio::task::spawn(async move {
             let topic = Sha256Topic::new(TEST_TOPIC);
 
-            let mut alice = Network::new(None, 9000).unwrap();
+            let mut alice = Network::new(None, 0).unwrap();
             alice.subscribe(&topic);
 
             let Some(event) = alice.next().await else {
@@ -373,7 +373,7 @@ mod test {
             let topic = Sha256Topic::new(TEST_TOPIC);
 
             let bootnode = bootnode_rx.await.unwrap();
-            let mut bob = Network::new(Some(vec![bootnode.to_string()]), 9001).unwrap();
+            let mut bob = Network::new(Some(vec![bootnode.to_string()]), 0).unwrap();
             bob.subscribe(&topic);
 
             loop {


### PR DESCRIPTION
- use os allocated port in test
- the test runs in under 1s locally, so I suspect there's something else going on