### PR TITLE
feat(conductor): add more checks to `validate_sequencer_namespace_data`

### DIFF
--- a/crates/astria-sequencer-relayer/src/da.rs
+++ b/crates/astria-sequencer-relayer/src/da.rs
@@ -325,11 +325,12 @@ impl CelestiaClient {
             .iter()
             .filter_map(|d| {
                 let data = SignedNamespaceData::<SequencerNamespaceData>::from_bytes(&d.0).ok()?;
-                let hash = data.data.hash().ok()?;
-                let signature = Signature::from_bytes(&data.signature.0).ok()?;
                 let Some(public_key) = public_key else {
                     return Some(data);
                 };
+                
+                let hash = data.data.hash().ok()?;
+                let signature = Signature::from_bytes(&data.signature.0).ok()?;
                 public_key.verify(&hash, &signature).ok()?;
                 Some(data)
             })

--- a/crates/astria-sequencer-relayer/src/da.rs
+++ b/crates/astria-sequencer-relayer/src/da.rs
@@ -328,7 +328,7 @@ impl CelestiaClient {
                 let Some(public_key) = public_key else {
                     return Some(data);
                 };
-                
+
                 let hash = data.data.hash().ok()?;
                 let signature = Signature::from_bytes(&data.signature.0).ok()?;
                 public_key.verify(&hash, &signature).ok()?;


### PR DESCRIPTION
- check that block hash matches the sequencer block header
- check that the block data hash matches all the txs in the sequencer block

closes #17 