### PR TITLE
feat(sequencer-relayer): single entry point

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,8 +70,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: nightly-2023-07-01
           components: rustfmt
       - name: run rustfmt
         run: cargo +nightly fmt --all -- --check

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -75,7 +75,7 @@ jobs:
           toolchain: nightly-2023-07-01
           components: rustfmt
       - name: run rustfmt
-        run: cargo +nightly fmt --all -- --check
+        run: cargo fmt --all -- --check
 
   clippy:
     runs-on: ubuntu-latest

--- a/crates/astria-sequencer-relayer/src/lib.rs
+++ b/crates/astria-sequencer-relayer/src/lib.rs
@@ -6,8 +6,11 @@ pub mod network;
 pub mod relayer;
 pub mod sequencer;
 pub mod sequencer_block;
+pub mod sequencer_relayer;
 #[cfg(test)]
 pub mod tests;
 pub mod transaction;
 pub mod types;
 pub mod validator;
+
+pub use sequencer_relayer::SequencerRelayer;

--- a/crates/astria-sequencer-relayer/src/main.rs
+++ b/crates/astria-sequencer-relayer/src/main.rs
@@ -1,23 +1,15 @@
-use std::{
-    net::SocketAddr,
-    time,
-};
-
 use astria_sequencer_relayer::{
-    api,
     config,
-    data_availability::CelestiaClientBuilder,
-    network::GossipNetwork,
-    relayer::Relayer,
-    sequencer::SequencerClient,
+    SequencerRelayer,
 };
+use eyre::WrapErr as _;
 use tracing::{
     info,
     warn,
 };
 
 #[tokio::main]
-async fn main() {
+async fn main() -> eyre::Result<()> {
     let cfg = config::get().expect("failed to read configuration");
     tracing_subscriber::fmt().with_env_filter(&cfg.log).init();
     let cfg_json = serde_json::to_string(&cfg).unwrap_or_else(|e| {
@@ -27,37 +19,12 @@ async fn main() {
         );
         format!("{cfg:?}")
     });
-    info!(config = cfg_json, "running astria-sequencer-relayer");
+    info!(config = cfg_json, "starting astria-sequencer-relayer");
 
-    let sequencer_client = SequencerClient::new(cfg.sequencer_endpoint.clone())
-        .expect("failed to create sequencer client");
-    let da_client = CelestiaClientBuilder::new(cfg.celestia_endpoint.clone())
-        .gas_limit(cfg.gas_limit)
-        .build()
-        .expect("failed to create data availability client");
+    SequencerRelayer::new(&cfg)
+        .wrap_err("failed to initialize sequencer relayer")?
+        .run()
+        .await;
 
-    let sleep_duration = time::Duration::from_millis(cfg.block_time);
-    let interval = tokio::time::interval(sleep_duration);
-
-    let (block_tx, block_rx) = tokio::sync::mpsc::unbounded_channel();
-
-    let network = GossipNetwork::new(cfg.p2p_port, block_rx).expect("failed to create network");
-    let network_handle = network.run();
-
-    let mut relayer = Relayer::new(cfg.clone(), sequencer_client, da_client, interval, block_tx)
-        .expect("failed to create relayer");
-
-    if cfg.disable_writing {
-        relayer.disable_writing();
-    }
-
-    let relayer_state = relayer.subscribe_to_state();
-    let relayer_handle = relayer.run();
-
-    let _api_server_task = tokio::task::spawn(async move {
-        let api_addr = SocketAddr::from(([127, 0, 0, 1], cfg.rpc_port));
-        api::start(api_addr, relayer_state).await;
-    });
-
-    tokio::try_join!(relayer_handle, network_handle).expect("failed to join tasks");
+    Ok(())
 }

--- a/crates/astria-sequencer-relayer/src/relayer.rs
+++ b/crates/astria-sequencer-relayer/src/relayer.rs
@@ -67,8 +67,8 @@ impl Relayer {
     /// Returns one of the following errors:
     /// + failed to read the validator keys from the path in cfg;
     /// + failed to construct a client to the sequencer;
-    /// + failed to construct a client to the data availability layer (if cfg.disable_writing is
-    /// set)
+    /// + failed to construct a client to the data availability layer (unless `cfg.disable_writing`
+    ///   is set).
     pub fn new(
         cfg: &crate::config::Config,
         block_tx: UnboundedSender<SequencerBlock>,

--- a/crates/astria-sequencer-relayer/src/relayer.rs
+++ b/crates/astria-sequencer-relayer/src/relayer.rs
@@ -1,4 +1,7 @@
-use std::str::FromStr;
+use std::{
+    str::FromStr,
+    time::Duration,
+};
 
 use bech32::{
     self,
@@ -12,18 +15,24 @@ use eyre::{
 use tokio::{
     sync::{
         mpsc::UnboundedSender,
-        watch,
+        watch::{
+            self,
+            Receiver,
+        },
     },
-    task::JoinHandle,
-    time::Interval,
+    time,
 };
 use tracing::{
+    debug,
     info,
     warn,
 };
 
 use crate::{
-    data_availability::CelestiaClient,
+    data_availability::{
+        CelestiaClient,
+        CelestiaClientBuilder,
+    },
     sequencer::SequencerClient,
     sequencer_block::SequencerBlock,
     validator::Validator,
@@ -31,13 +40,11 @@ use crate::{
 
 pub struct Relayer {
     sequencer_client: SequencerClient,
-    da_client: CelestiaClient,
-    disable_writing: bool,
+    data_availability_client: Option<CelestiaClient>,
     validator: Validator,
-    interval: Interval,
+    sequencer_poll_period: Duration,
     block_tx: UnboundedSender<SequencerBlock>,
-
-    state: watch::Sender<State>,
+    state_tx: watch::Sender<State>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -53,39 +60,54 @@ impl State {
 }
 
 impl Relayer {
+    /// Instantiates a `Relayer`.
+    ///
+    /// # Errors
+    ///
+    /// Returns one of the following errors:
+    /// + failed to read the validator keys from the path in cfg;
+    /// + failed to construct a client to the sequencer;
+    /// + failed to construct a client to the data availability layer (if cfg.disable_writing is
+    /// set)
     pub fn new(
-        cfg: crate::config::Config,
-        sequencer_client: SequencerClient,
-        da_client: CelestiaClient,
-        interval: Interval,
+        cfg: &crate::config::Config,
         block_tx: UnboundedSender<SequencerBlock>,
     ) -> Result<Self> {
-        let validator = Validator::from_path(cfg.validator_key_file)
+        let validator = Validator::from_path(&cfg.validator_key_file)
             .wrap_err("failed to get validator info from file")?;
 
-        let (state, _) = watch::channel(State::default());
+        let sequencer_client = SequencerClient::new(cfg.sequencer_endpoint.clone())
+            .wrap_err("failed to create sequencer client")?;
+
+        let data_availability_client = if cfg.disable_writing {
+            debug!("disabling writing to data availability layer requested; disabling");
+            None
+        } else {
+            let client = CelestiaClientBuilder::new(cfg.celestia_endpoint.clone())
+                .gas_limit(cfg.gas_limit)
+                .build()
+                .wrap_err("failed to create data availability client")?;
+            Some(client)
+        };
+
+        let (state_tx, _) = watch::channel(State::default());
 
         Ok(Self {
             sequencer_client,
-            da_client,
-            disable_writing: false,
+            data_availability_client,
+            sequencer_poll_period: Duration::from_millis(cfg.block_time),
             validator,
-            interval,
             block_tx,
-            state,
+            state_tx,
         })
     }
 
-    pub fn disable_writing(&mut self) {
-        self.disable_writing = true;
-    }
-
-    pub fn subscribe_to_state(&self) -> watch::Receiver<State> {
-        self.state.subscribe()
+    pub(crate) fn subscribe_to_state(&self) -> Receiver<State> {
+        self.state_tx.subscribe()
     }
 
     async fn get_and_submit_latest_block(&self) -> eyre::Result<State> {
-        let mut new_state = (*self.state.borrow()).clone();
+        let mut new_state = (*self.state_tx.borrow()).clone();
         let resp = self.sequencer_client.get_latest_block().await?;
 
         let maybe_height: Result<u64, <u64 as FromStr>::Err> = resp.block.header.height.parse();
@@ -130,48 +152,54 @@ impl Relayer {
         };
 
         self.block_tx.send(sequencer_block.clone())?;
-        if self.disable_writing {
-            return Ok(new_state);
-        }
-
         let tx_count = sequencer_block.rollup_txs.len() + sequencer_block.sequencer_txs.len();
-        match self
-            .da_client
-            .submit_block(
-                sequencer_block,
-                &self.validator.signing_key,
-                self.validator.verification_key,
-            )
-            .await
-        {
-            Ok(resp) => {
-                new_state
-                    .current_data_availability_height
-                    .replace(resp.height);
-                info!(
-                    sequencer_block = height,
-                    da_layer_block = resp.height,
-                    tx_count,
-                    "submitted sequencer block to DA layer",
-                );
+        if let Some(client) = &self.data_availability_client {
+            match client
+                .submit_block(
+                    sequencer_block,
+                    &self.validator.signing_key,
+                    self.validator.verification_key,
+                )
+                .await
+            {
+                Ok(resp) => {
+                    new_state
+                        .current_data_availability_height
+                        .replace(resp.height);
+                    info!(
+                        sequencer_block = height,
+                        da_layer_block = resp.height,
+                        tx_count,
+                        "submitted sequencer block to DA layer",
+                    );
+                }
+                Err(e) => warn!(error = ?e, "failed to submit block to DA layer"),
             }
-            Err(e) => warn!(error = ?e, "failed to submit block to DA layer"),
         }
         Ok(new_state)
     }
 
-    pub fn run(mut self) -> JoinHandle<()> {
-        tokio::task::spawn(async move {
-            loop {
-                self.interval.tick().await;
-                match self.get_and_submit_latest_block().await {
-                    Err(e) => warn!(error = ?e, "failed to get latest block from sequencer"),
-                    Ok(new_state) if new_state != *self.state.borrow() => {
-                        _ = self.state.send_replace(new_state);
-                    }
-                    Ok(_) => {}
+    /// Runs the relayer worker.
+    ///
+    /// # Errors
+    ///
+    /// `Relayer::run` never returns an error. The return type is
+    /// only set to `eyre::Result` for convenient use in `SequencerRelayer`.
+    pub(crate) async fn run(self) -> eyre::Result<()> {
+        let mut interval = time::interval(self.sequencer_poll_period);
+        loop {
+            interval.tick().await;
+            match self.get_and_submit_latest_block().await {
+                Err(e) => warn!(error = ?e, "failed to get latest block from sequencer"),
+                Ok(new_state) if new_state != *self.state_tx.borrow() => {
+                    _ = self.state_tx.send_replace(new_state);
                 }
+                Ok(_) => {}
             }
-        })
+        }
+        // Return Ok to make the types align (see the method's doc comment why this is necessary).
+        // Allow unreachable code to quiet warnings
+        #[allow(unreachable_code)]
+        Ok(())
     }
 }

--- a/crates/astria-sequencer-relayer/src/sequencer_relayer.rs
+++ b/crates/astria-sequencer-relayer/src/sequencer_relayer.rs
@@ -1,0 +1,77 @@
+use eyre::WrapErr as _;
+use futures::Future;
+use tokio::task::JoinError;
+
+use crate::{
+    api,
+    config::Config,
+    network::GossipNetwork,
+    relayer::Relayer,
+};
+
+pub struct SequencerRelayer {
+    api_server: Box<dyn Future<Output = eyre::Result<()>> + Send + Unpin>,
+    gossip_net: GossipNetwork,
+    relayer: Relayer,
+}
+
+impl SequencerRelayer {
+    /// Instantiates a new `SequencerRelayer`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if constructing the gossip network or the relayer
+    /// worked failed.
+    pub fn new(cfg: &Config) -> eyre::Result<Self> {
+        let (block_tx, block_rx) = tokio::sync::mpsc::unbounded_channel();
+        let gossip_net = GossipNetwork::new(cfg.p2p_port, block_rx)
+            .wrap_err("failed to create gossip network")?;
+        let relayer = Relayer::new(cfg, block_tx).wrap_err("failed to create relayer")?;
+        let state_rx = relayer.subscribe_to_state();
+        let api_server = Box::new(api::start(cfg.rpc_port, state_rx));
+        Ok(Self {
+            api_server,
+            gossip_net,
+            relayer,
+        })
+    }
+
+    pub async fn run(self) {
+        let Self {
+            api_server,
+            gossip_net,
+            relayer,
+        } = self;
+        let gossip_task = tokio::spawn(gossip_net.run());
+        let api_task = tokio::spawn(api_server);
+        let relayer_task = tokio::spawn(relayer.run());
+
+        tokio::select!(
+            o = gossip_task => report_exit("gossip network", o),
+            o = api_task => report_exit("api server", o),
+            o = relayer_task => report_exit("relayer worker", o),
+        );
+    }
+}
+
+fn report_exit(task_name: &str, outcome: Result<eyre::Result<()>, JoinError>) {
+    match outcome {
+        Ok(Ok(())) => tracing::info!(task = task_name, "task has exited"),
+        Ok(Err(e)) => {
+            tracing::error!(
+                task = task_name,
+                error.msg = %e,
+                error.cause = ?e,
+                "task exited with error"
+            );
+        }
+        Err(e) => {
+            tracing::error!(
+                task = task_name,
+                error.msg = %e,
+                error.cause = ?e,
+                "task failed to complete"
+            );
+        }
+    }
+}


### PR DESCRIPTION
This commit adds a `SequencerRelayer` type to
`astria-sequencer-relayer`, which serves as the
single entrypoint to the service. It creates all
constituent tasks from the service config, and
runs them until stopped.

This also lays the groundwork for writing
integration tests against `SequencerRelayer`
using the same codepaths as are used by the
binary.

In future commits all items that are currently
exposed will be made crate-private, except for
the `SequencerRelayer` type itself, config
generation, and telemetry initialization.

Because other workspace crates depend on items
defined within `astria-sequencer-relayer` they
are currently left unchanged.

Closes #85 