### PR TITLE
ci: make pedantic clippy the default

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -93,7 +93,15 @@ jobs:
         with:
           version: "1.17.0"
           github_token: ${{ secrets.GITHUB_TOKEN }}
-      - name: run clippy
-        run: cargo clippy --workspace --all-targets --exclude astria-sequencer -- -D warnings
       - name: run pedantic clippy
-        run: cargo clippy --all-targets -p astria-sequencer -- -W clippy::pedantic -D warnings
+        run: |
+          cargo clippy --workspace --all-targets \
+          --exclude astria-conductor \
+          --exclude astria-conductor-test \
+          --exclude astria-sequencer-relayer \
+          --exclude astria-sequencer-relayer-test \
+          --exclude astria-gossipnet \
+          --exclude astria-rs-cnc \
+          -- -W clippy::pedantic -D warnings
+      - name: run default clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,6 @@ jobs:
   test:
     runs-on: ubuntu-22.04
     steps:
-      - run: echo $RUSTFLAGS
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@1.69.0
       - uses: Swatinem/rust-cache@v2

--- a/crates/astria-proto/proto/astria/sequencer/v1/block.proto
+++ b/crates/astria-proto/proto/astria/sequencer/v1/block.proto
@@ -5,13 +5,14 @@ package astria.sequencer.v1;
 import "tendermint/types/types.proto";
 import "astria/sequencer/v1/data.proto";
 
-// helper type - these should get parsed into a map from namespace to a vector of IndexedTransactions
+// helper type - these should get parsed into a map from namespace to
+// a vector of `IndexedTransactions`
 message NamespacedIndexedTransactions {
     bytes namespace = 1;
     repeated IndexedTransaction txs = 2;
 }
 
-// SequencerBlock
+// `SequencerBlock`
 message SequencerBlock {
     bytes block_hash = 1;
     tendermint.types.Header header = 2;

--- a/crates/astria-proto/proto/astria/sequencer/v1/data.proto
+++ b/crates/astria-proto/proto/astria/sequencer/v1/data.proto
@@ -4,7 +4,7 @@ package astria.sequencer.v1;
 
 import "tendermint/types/types.proto";
 
-// IndexedTransaction represents a sequencer transaction along with the index
+// `IndexedTransaction` represents a sequencer transaction along with the index
 // it was originally in the sequencer block.
 message IndexedTransaction {
     uint64 block_index = 1; // TODO: this is usize - how to define for variable size?
@@ -16,13 +16,13 @@ message RollupNamespace {
     bytes namespace = 2;
 }
 
-// RollupNamespaceData
+// `RollupNamespaceData`
 message RollupNamespaceData {
     bytes block_hash = 1;
     repeated IndexedTransaction rollup_txs = 2;
 }
 
-// SequencerNamespaceData
+// `SequencerNamespaceData`
 message SequencerNamespaceData {
     bytes block_hash = 1;
     tendermint.types.Header header = 2;
@@ -30,7 +30,7 @@ message SequencerNamespaceData {
     repeated RollupNamespace rollup_namespaces = 4;
 }
 
-// SignedNamespaceData?
+// `SignedNamespaceData?`
 message SignedNamespaceData {
     bytes data = 1;
     bytes public_key = 2;

--- a/crates/astria-proto/proto/astria/sequencer/v1/tx.proto
+++ b/crates/astria-proto/proto/astria/sequencer/v1/tx.proto
@@ -6,8 +6,8 @@ package astria.sequencer.v1;
 
 import "google/protobuf/any.proto";
 
-// TxRaw is a variant of Tx that pins the signer's exact binary representation
-// of body and auth_info. This is used for signing, broadcasting and
+// `TxRaw` is a variant of `Tx` that pins the signer's exact binary representation
+// of `body` and `auth_info`. This is used for signing, broadcasting and
 // verification. The binary `serialize(tx: TxRaw)` is stored in Tendermint and
 // the hash `sha256(serialize(tx: TxRaw))` becomes the "txhash", commonly used
 // as the transaction ID.
@@ -26,7 +26,7 @@ message TxRaw {
   repeated bytes signatures = 3;
 }
 
-// TxBody is the body of a transaction that all signers sign over.
+// `TxBody` is the body of a transaction that all signers sign over.
 message TxBody {
     // messages is a list of messages to be executed. The required signers of
     // those messages define the number and order of elements in AuthInfo's

--- a/crates/astria-proto/src/lib.rs
+++ b/crates/astria-proto/src/lib.rs
@@ -93,8 +93,8 @@ mod primitive_impls {
         fn u128_roundtrips_work() {
             u128_roundtrip_check(0u128);
             u128_roundtrip_check(1u128);
-            u128_roundtrip_check(u64::MAX as u128);
-            u128_roundtrip_check(u64::MAX as u128 + 1u128);
+            u128_roundtrip_check(u128::from(u64::MAX));
+            u128_roundtrip_check(u128::from(u64::MAX) + 1u128);
             u128_roundtrip_check(1u128 << 127);
             u128_roundtrip_check((1u128 << 127) + (1u128 << 63));
             u128_roundtrip_check(u128::MAX);

--- a/crates/astria-proto/src/lib.rs
+++ b/crates/astria-proto/src/lib.rs
@@ -1,17 +1,36 @@
 pub mod execution {
-    #![allow(unreachable_pub)]
+    // `unreachable_pub` must be permitted due to tonic code generation.
+    #[allow(unreachable_pub)]
+    #[allow(clippy::pedantic)]
+    #[warn(
+        clippy::doc_markdown,
+        clippy::doc_link_with_quotes,
+        clippy::tabs_in_doc_comments
+    )]
     pub mod v1 {
         include!(concat!(env!("OUT_DIR"), "/astria.execution.v1.rs"));
     }
 }
 
 pub mod primitive {
+    #[allow(clippy::pedantic)]
+    #[warn(
+        clippy::doc_markdown,
+        clippy::doc_link_with_quotes,
+        clippy::tabs_in_doc_comments
+    )]
     pub mod v1 {
         include!(concat!(env!("OUT_DIR"), "/astria.primitive.v1.rs"));
     }
 }
 
 pub mod sequencer {
+    #[allow(clippy::pedantic)]
+    #[warn(
+        clippy::doc_markdown,
+        clippy::doc_link_with_quotes,
+        clippy::tabs_in_doc_comments
+    )]
     pub mod v1 {
         include!(concat!(env!("OUT_DIR"), "/astria.sequencer.v1.rs"));
     }
@@ -24,8 +43,26 @@ mod primitive_impls {
     use crate::primitive::v1::Uint128;
     impl From<u128> for Uint128 {
         fn from(primitive: u128) -> Self {
-            let lo = primitive as u64;
-            let hi = (primitive >> 64) as u64;
+            let [
+                h0,
+                h1,
+                h2,
+                h3,
+                h4,
+                h5,
+                h6,
+                h7,
+                l0,
+                l1,
+                l2,
+                l3,
+                l4,
+                l5,
+                l6,
+                l7,
+            ] = primitive.to_be_bytes();
+            let lo = u64::from_be_bytes([l0, l1, l2, l3, l4, l5, l6, l7]);
+            let hi = u64::from_be_bytes([h0, h1, h2, h3, h4, h5, h6, h7]);
             Self {
                 lo,
                 hi,
@@ -35,9 +72,11 @@ mod primitive_impls {
 
     impl From<Uint128> for u128 {
         fn from(pb: Uint128) -> u128 {
-            let lo = pb.lo as u128;
-            let hi = (pb.hi as u128) << 64;
-            hi + lo
+            let [l0, l1, l2, l3, l4, l5, l6, l7] = pb.lo.to_be_bytes();
+            let [h0, h1, h2, h3, h4, h5, h6, h7] = pb.hi.to_be_bytes();
+            u128::from_be_bytes([
+                h0, h1, h2, h3, h4, h5, h6, h7, l0, l1, l2, l3, l4, l5, l6, l7,
+            ])
         }
     }
 


### PR DESCRIPTION
This commit makes `clippy::pedantic` the default
lint group for the repository. Only a few crates
are currently exempt from it. All new crates are
expected to adhere to `clippy::pedantic`.

This commit also ensures that `astria-proto`
does not trigger `clippy::pedantic` warnings:

+ generated code is generally exempt
+ a few doc comment related lints are enabled to make for nicer rust docs from the generated code
+ the conversion methods for `Uint128` are updated to no longer need explicit casts; they expicitly move bytes into the right positions instead.