### PR TITLE
container: link against system rocksdb

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+target/
+
+
+# jetbrains
+.idea
+# direnv
+.envrc

--- a/crates/astria-conductor/Dockerfile
+++ b/crates/astria-conductor/Dockerfile
@@ -1,12 +1,12 @@
-ARG DISTROLESS_TAG=latest
 # build stage
-FROM --platform=$BUILDPLATFORM lukemathwalker/cargo-chef:latest-rust-bullseye AS chef
+FROM --platform=$BUILDPLATFORM lukemathwalker/cargo-chef:latest-rust-bookworm AS chef
 WORKDIR /build/
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
     libprotobuf-dev \
     protobuf-compiler \
+    librocksdb-dev \
     clang \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
@@ -35,6 +35,7 @@ FROM chef as builder
 COPY --from=planner /build/recipe.json recipe.json
 
 ARG TARGETPLATFORM
+ENV ROCKSDB_LIB_DIR=/usr/lib
 RUN case "$TARGETPLATFORM" in \
     "linux/arm64") target="aarch64-unknown-linux-gnu" ;; \
     "linux/amd64") target="x86_64-unknown-linux-gnu" ;; \
@@ -53,8 +54,7 @@ RUN cargo zigbuild --release \
 RUN mkdir -p target/release \
     && cp target/$(cat ./target_triple)/release/astria-conductor target/release/
 
-ARG DISTROLESS_TAG
-FROM gcr.io/distroless/cc-debian11:$DISTROLESS_TAG
+FROM debian:bookworm-slim
 WORKDIR /app/
 EXPOSE 2450
 COPY --from=builder /build/target/release/astria-conductor /usr/local/bin/astria-conductor

--- a/crates/astria-sequencer-relayer/Dockerfile
+++ b/crates/astria-sequencer-relayer/Dockerfile
@@ -1,12 +1,12 @@
-ARG DISTROLESS_TAG=latest
 # build stage
-FROM --platform=$BUILDPLATFORM lukemathwalker/cargo-chef:latest-rust-bullseye AS chef
+FROM --platform=$BUILDPLATFORM lukemathwalker/cargo-chef:latest-rust-bookworm AS chef
 WORKDIR /build/
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
     libprotobuf-dev \
     protobuf-compiler \
+    librocksdb-dev \
     clang \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
@@ -35,6 +35,7 @@ FROM chef as builder
 COPY --from=planner /build/recipe.json recipe.json
 
 ARG TARGETPLATFORM
+ENV ROCKSDB_LIB_DIR=/usr/lib
 RUN case "$TARGETPLATFORM" in \
     "linux/arm64") target="aarch64-unknown-linux-gnu" ;; \
     "linux/amd64") target="x86_64-unknown-linux-gnu" ;; \
@@ -53,8 +54,7 @@ RUN cargo zigbuild --release \
 RUN mkdir -p target/release \
     && cp target/$(cat ./target_triple)/release/astria-sequencer-relayer target/release/
 
-ARG DISTROLESS_TAG
-FROM gcr.io/distroless/cc-debian11:$DISTROLESS_TAG
+FROM debian:bookworm-slim
 WORKDIR /app/
 EXPOSE 2450
 COPY --from=builder /build/target/release/astria-sequencer-relayer /usr/local/bin/astria-sequencer-relayer


### PR DESCRIPTION
This commit installs librocksdb-dev inside the
build image layer and sets the ROCKSDB_LIB_DIR
environment variable so that librocksdb-sys is
build against the pre-compiled artifacts rather
than vendoring rocksdb.

This should significantly speed up build times.

Note that we transitively depend on
`librocksdb-sys:0.8.3+7.4.4` which requires
librocksdb 7.4.4, while debian bookworm provides
librocksdb 7.8.3. This commit assumes that
rocksdb is backward compatible (i.e. 7.8.3 can be used in
place of 7.4.4).

Note that this commit does not yet account for cross compilation on an x86 host targeting aarch64.

Fixes #80 