### PR TITLE
fix(relayer): fix calculation of data_hash

### DIFF
--- a/crates/astria-conductor/src/driver.rs
+++ b/crates/astria-conductor/src/driver.rs
@@ -128,6 +128,7 @@ impl Driver {
             NetworkEvent::Message(msg) => {
                 debug!("received gossip message: {:?}", msg);
                 let block = SequencerBlock::from_bytes(&msg.data)?;
+                // TODO: validate this block!!!!!
                 self.executor_tx
                     .send(ExecutorCommand::BlockReceivedFromGossipNetwork {
                         block: Box::new(block),

--- a/crates/astria-sequencer-relayer/src/relayer.rs
+++ b/crates/astria-sequencer-relayer/src/relayer.rs
@@ -163,12 +163,14 @@ impl Relayer {
         };
 
         self.block_tx.send(sequencer_block.clone())?;
-
-        let tx_count = sequencer_block.rollup_txs.len() + sequencer_block.sequencer_txs.len();
         if self.disable_writing {
             return Ok(new_state);
         }
 
+        tracing::info!("{:?}", sequencer_block.rollup_txs);
+        tracing::info!("{:?}", sequencer_block.header.data_hash);
+
+        let tx_count = sequencer_block.rollup_txs.len() + sequencer_block.sequencer_txs.len();
         match self
             .da_client
             .submit_block(sequencer_block, &self.keypair)

--- a/crates/astria-sequencer-relayer/src/relayer.rs
+++ b/crates/astria-sequencer-relayer/src/relayer.rs
@@ -167,9 +167,6 @@ impl Relayer {
             return Ok(new_state);
         }
 
-        tracing::info!("{:?}", sequencer_block.rollup_txs);
-        tracing::info!("{:?}", sequencer_block.header.data_hash);
-
         let tx_count = sequencer_block.rollup_txs.len() + sequencer_block.sequencer_txs.len();
         match self
             .da_client

--- a/crates/astria-sequencer-relayer/src/sequencer_block.rs
+++ b/crates/astria-sequencer-relayer/src/sequencer_block.rs
@@ -233,20 +233,11 @@ impl SequencerBlock {
             bail!("block has no data hash");
         };
 
-        tracing::info!(
-            "block transactions: {} {}",
-            self.sequencer_txs.len(),
-            self.rollup_txs.len(),
-        );
-
         let mut ordered_txs = vec![];
         ordered_txs.append(&mut self.sequencer_txs.clone());
-        self.rollup_txs.iter().for_each(|(_, tx)| {
-            tracing::info!("rollup txs: {:?}", tx);
-            ordered_txs.append(&mut tx.clone())
-        });
-
-        use sha2::Digest as _;
+        self.rollup_txs
+            .iter()
+            .for_each(|(_, tx)| ordered_txs.append(&mut tx.clone()));
 
         // TODO: if there are duplicate or missing indices, the hash will obviously be wrong,
         // but we should probably verify that earier to return a better error.
@@ -260,12 +251,6 @@ impl SequencerBlock {
             })
             .collect::<Vec<_>>();
         let data_hash = txs_to_data_hash(&txs);
-
-        tracing::info!(
-            "data hash from transactions: {}",
-            Base64String(data_hash.as_bytes().to_vec())
-        );
-        tracing::info!("data hash from block: {}", this_data_hash,);
 
         ensure!(
             data_hash.as_bytes() == this_data_hash.0,

--- a/crates/astria-sequencer-relayer/src/sequencer_block.rs
+++ b/crates/astria-sequencer-relayer/src/sequencer_block.rs
@@ -244,11 +244,7 @@ impl SequencerBlock {
         ordered_txs.sort_by(|a, b| a.block_index.cmp(&b.block_index));
         let txs = ordered_txs
             .into_iter()
-            .map(|tx| {
-                let mut hasher = sha2::Sha256::new();
-                hasher.update(tx.transaction.0);
-                Base64String(hasher.finalize().to_vec())
-            })
+            .map(|tx| Base64String(sha256_hash(&tx.transaction.0)))
             .collect::<Vec<_>>();
         let data_hash = txs_to_data_hash(&txs);
 
@@ -289,6 +285,12 @@ pub fn cosmos_tx_body_to_sequencer_msgs(tx_body: TxBody) -> eyre::Result<Vec<Seq
         .map(|msg| SequencerMsg::decode(msg.value.as_slice()))
         .collect::<Result<Vec<SequencerMsg>, DecodeError>>()
         .wrap_err("failed decoding sequencer msg from value stored in cosmos tx body")
+}
+
+pub(crate) fn sha256_hash(data: &[u8]) -> Vec<u8> {
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(data);
+    hasher.finalize().to_vec()
 }
 
 #[cfg(test)]

--- a/crates/astria-sequencer-relayer/src/transaction.rs
+++ b/crates/astria-sequencer-relayer/src/transaction.rs
@@ -15,18 +15,15 @@ pub fn txs_to_data_hash(txs: &[Base64String]) -> TmHash {
 
 #[cfg(test)]
 mod test {
-    use sha2::Digest;
-
     use super::*;
+    use crate::sequencer_block::sha256_hash;
 
     #[test]
     fn txs_to_data_hash_test() {
         // data_hash is calculated from the txs in a block, where the leaves of the merkle tree are
         // the sha256 hashes of the txs
         let tx = Base64String::from_string("CscBCsQBCg0vU2VxdWVuY2VyTXNnErIBCghldGhlcmV1bRJ4Avh1ggU5gIRZaC8AhQUD1cTyglIIlBtwp0/22gQLMRmQwVX9/9u8AvfuiA3gtrOnZAAAgMABoLnRqksJblEaolE6wbsAHYTAiSlA14+B5nvWuFrIfevnoBg+UGcWLC4eg1lZylqLnrL8okBc3vTS4qOO/J5sRtVDGixtZXRybzFsbDJobHAzM3J4eTdwN2s2YXhoeDRjdnFtdGcwY3hkZjZnemY5ahJ0Ck4KRgofL2Nvc21vcy5jcnlwdG8uc2VjcDI1NmsxLlB1YktleRIjCiEDJ/LvaMZTBcGX66geJOEmTm/fyyPTZKMUJoDtMDUmSPkSBAoCCAESGAoQCgV1dGljaxIHMTAwMDAwMBCAlOvcAyIIZXRoZXJldW0aQMhoTCUr84xgTkYxsFWDfHH2k+oHCPsKvbTpz8m5YrHfYMv6gdou6V8oj1v0B9ySD5VjMXQi1kJ9DZN6wD2buo8=".to_string()).unwrap();
-        let mut hasher = sha2::Sha256::new();
-        hasher.update(tx.0);
-        let hash = hasher.finalize();
+        let hash = sha256_hash(&tx.0);
 
         let expected_hash =
             Base64String::from_string("rRDu3aQf1V37yGSTdf2fv9GSPeZ6/p0wJ9pjBl8IqFc=".to_string())

--- a/crates/astria-sequencer-relayer/src/transaction.rs
+++ b/crates/astria-sequencer-relayer/src/transaction.rs
@@ -1,4 +1,3 @@
-use prost;
 use tendermint::{
     hash::Hash as TmHash,
     merkle,
@@ -6,19 +5,33 @@ use tendermint::{
 
 use crate::base64_string::Base64String;
 
-fn tx_to_prost_bytes(tx: Vec<u8>) -> prost::alloc::vec::Vec<u8> {
-    let mut buf = prost::alloc::vec::Vec::new();
-    prost::encoding::bytes::encode(1, &tx, &mut buf);
-    buf
-}
-
 pub fn txs_to_data_hash(txs: &[Base64String]) -> TmHash {
-    let txs = txs
-        .iter()
-        .map(|tx| tx_to_prost_bytes(tx.0.clone()))
-        .collect::<Vec<Vec<u8>>>();
+    let txs = txs.iter().map(|tx| tx.0.clone()).collect::<Vec<Vec<u8>>>();
 
     TmHash::Sha256(merkle::simple_hash_from_byte_vectors::<
         tendermint::crypto::default::Sha256,
     >(&txs))
+}
+
+#[cfg(test)]
+mod test {
+    use sha2::Digest;
+
+    use super::*;
+
+    #[test]
+    fn txs_to_data_hash_test() {
+        // data_hash is calculated from the txs in a block, where the leaves of the merkle tree are
+        // the sha256 hashes of the txs
+        let tx = Base64String::from_string("CscBCsQBCg0vU2VxdWVuY2VyTXNnErIBCghldGhlcmV1bRJ4Avh1ggU5gIRZaC8AhQUD1cTyglIIlBtwp0/22gQLMRmQwVX9/9u8AvfuiA3gtrOnZAAAgMABoLnRqksJblEaolE6wbsAHYTAiSlA14+B5nvWuFrIfevnoBg+UGcWLC4eg1lZylqLnrL8okBc3vTS4qOO/J5sRtVDGixtZXRybzFsbDJobHAzM3J4eTdwN2s2YXhoeDRjdnFtdGcwY3hkZjZnemY5ahJ0Ck4KRgofL2Nvc21vcy5jcnlwdG8uc2VjcDI1NmsxLlB1YktleRIjCiEDJ/LvaMZTBcGX66geJOEmTm/fyyPTZKMUJoDtMDUmSPkSBAoCCAESGAoQCgV1dGljaxIHMTAwMDAwMBCAlOvcAyIIZXRoZXJldW0aQMhoTCUr84xgTkYxsFWDfHH2k+oHCPsKvbTpz8m5YrHfYMv6gdou6V8oj1v0B9ySD5VjMXQi1kJ9DZN6wD2buo8=".to_string()).unwrap();
+        let mut hasher = sha2::Sha256::new();
+        hasher.update(tx.0);
+        let hash = hasher.finalize();
+
+        let expected_hash =
+            Base64String::from_string("rRDu3aQf1V37yGSTdf2fv9GSPeZ6/p0wJ9pjBl8IqFc=".to_string())
+                .unwrap();
+        let res = txs_to_data_hash(&[Base64String(hash.to_vec())]);
+        assert_eq!(res.as_bytes(), expected_hash.0);
+    }
 }


### PR DESCRIPTION
fixes data hash mismatch:
```
  2023-06-16T21:50:03.515068Z  WARN astria_conductor::reader: sequencer block failed validation: data hash stored in block header does not match hash calculated from transactions
    at crates/astria-conductor/src/reader.rs:211
```

transactions needed to be hashed first before being merkleized.

closes #105 