### PR TITLE
feat(conductor): implement BlockValidator type and validate blocks received from gossip

### DIFF
--- a/crates/astria-conductor/src/driver.rs
+++ b/crates/astria-conductor/src/driver.rs
@@ -128,6 +128,7 @@ impl Driver {
             NetworkEvent::Message(msg) => {
                 debug!("received gossip message: {:?}", msg);
                 let block = SequencerBlock::from_bytes(&msg.data)?;
+                // TODO: validate this block!!!!!
                 self.executor_tx
                     .send(ExecutorCommand::BlockReceivedFromGossipNetwork {
                         block: Box::new(block),

--- a/crates/astria-conductor/src/lib.rs
+++ b/crates/astria-conductor/src/lib.rs
@@ -18,6 +18,7 @@ pub mod network;
 pub mod reader;
 pub mod telemetry;
 pub mod tendermint;
+pub mod validation;
 
 mod private {
     #[allow(unreachable_pub)]

--- a/crates/astria-conductor/src/reader.rs
+++ b/crates/astria-conductor/src/reader.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::HashMap,
-    str::FromStr,
-};
+use std::sync::Arc;
 
 use astria_sequencer_relayer::{
     data_availability::{
@@ -10,48 +7,13 @@ use astria_sequencer_relayer::{
         SequencerNamespaceData,
         SignedNamespaceData,
     },
-    keys::public_key_to_address,
     sequencer_block::SequencerBlock,
-    types::{
-        Commit,
-        CommitSig,
-    },
-};
-use bech32::{
-    self,
-    ToBase32,
-    Variant,
 };
 use color_eyre::eyre::{
-    bail,
-    ensure,
     eyre,
     Result,
     WrapErr,
 };
-use ed25519_dalek::Verifier;
-use prost::Message;
-use tendermint::{
-    account::Id as AccountId,
-    block::{
-        parts,
-        CommitSig as TendermintCommitSig,
-        Height,
-        Id as BlockId,
-        Round,
-    },
-    chain::Id as ChainId,
-    crypto,
-    merkle,
-    vote::{
-        self,
-        CanonicalVote,
-    },
-    Hash,
-    Signature,
-    Time,
-};
-use tendermint_proto::types::CommitSig as RawCommitSig;
 use tokio::{
     sync::mpsc::{
         self,
@@ -64,17 +26,13 @@ use tracing::{
     debug,
     error,
     info,
-    instrument,
     warn,
 };
 
 use crate::{
     config::Config,
     executor,
-    tendermint::{
-        TendermintClient,
-        ValidatorSet,
-    },
+    validation::BlockValidator,
 };
 
 pub(crate) type JoinHandle = task::JoinHandle<Result<()>>;
@@ -89,10 +47,11 @@ type Receiver = UnboundedReceiver<ReaderCommand>;
 pub(crate) async fn spawn(
     conf: &Config,
     executor_tx: executor::Sender,
+    block_validator: Arc<BlockValidator>,
 ) -> Result<(JoinHandle, Sender)> {
     info!("Spawning reader task.");
     let (mut reader, reader_tx) =
-        Reader::new(&conf.celestia_node_url, &conf.tendermint_url, executor_tx).await?;
+        Reader::new(&conf.celestia_node_url, executor_tx, block_validator).await?;
     let join_handle = task::spawn(async move { reader.run().await });
     info!("Spawned reader task.");
     Ok((join_handle, reader_tx))
@@ -119,15 +78,15 @@ pub struct Reader {
     /// the last block height fetched from Celestia
     curr_block_height: u64,
 
-    tendermint_client: TendermintClient,
+    block_validator: Arc<BlockValidator>,
 }
 
 impl Reader {
     /// Creates a new Reader instance and returns a command sender and an alert receiver.
     pub async fn new(
         celestia_node_url: &str,
-        tendermint_url: &str,
         executor_tx: executor::Sender,
+        block_validator: Arc<BlockValidator>,
     ) -> Result<(Self, Sender)> {
         let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
         let celestia_client = CelestiaClientBuilder::new(celestia_node_url.to_owned())
@@ -143,7 +102,7 @@ impl Reader {
                 executor_tx,
                 celestia_client,
                 curr_block_height,
-                tendermint_client: TendermintClient::new(tendermint_url.to_owned())?,
+                block_validator,
             },
             cmd_tx,
         ))
@@ -203,15 +162,29 @@ impl Reader {
                     };
 
                     for data in datas {
-                        let block = match self.validate_sequencer_namespace_data(data).await {
+                        // validate data
+                        self.block_validator
+                            .validate_signed_namespace_data(&data)
+                            .await?;
+
+                        let block = match self.get_sequencer_block_from_namespace_data(&data).await
+                        {
                             Ok(block) => block,
                             Err(e) => {
                                 // this means someone submitted an invalid block to celestia;
                                 // we can ignore it
-                                warn!("sequencer block failed validation: {}", e);
+                                warn!("failed to get sequencer block from namespace data: {}", e);
                                 continue;
                             }
                         };
+
+                        if let Err(e) = self.block_validator.validate_sequencer_block(&block).await
+                        {
+                            // this means someone submitted an invalid block to celestia;
+                            // we can ignore it
+                            warn!("sequencer block failed validation: {}", e);
+                            continue;
+                        }
 
                         blocks.push(block);
                     }
@@ -231,103 +204,11 @@ impl Reader {
         Ok(blocks)
     }
 
-    /// performs various validation checks on the SignedNamespaceData that was read from Celestia
-    /// and returns the full SequencerBlock corresponding to the given SignedNamespaceData if all
-    /// checks pass.
-    ///
-    /// checks performed:
-    /// - the proposer of the sequencer block matches the expected proposer for the block height
-    ///   from tendermint
-    /// - the signer of the SignedNamespaceData the proposer
-    /// - the signature is valid
-    /// - the root of the markle tree of all the header fields matches the block's block_hash
-    /// - the root of the merkle tree of all transactions in the block matches the block's data_hash
-    /// - validate the block was actually finalized; ie >2/3 stake signed off on it
-    async fn validate_sequencer_namespace_data(
+    async fn get_sequencer_block_from_namespace_data(
         &self,
-        data: SignedNamespaceData<SequencerNamespaceData>,
+        data: &SignedNamespaceData<SequencerNamespaceData>,
     ) -> Result<SequencerBlock> {
-        // sequencer block's height
-        let height = data.data.header.height.parse::<u64>()?;
-
-        // get validator set for this height
-        let validator_set = self.tendermint_client.get_validator_set(height - 1).await?;
-
-        // find proposer address for this height
-        let expected_proposer_address = validator_set
-            .get_proposer()
-            .wrap_err("failed to get proposer from validator set")?
-            .address;
-
-        // check if the proposer address matches the sequencer block's proposer
-        let received_proposer_address = bech32::encode(
-            "metrovalcons",
-            data.data.header.proposer_address.0.to_base32(),
-            Variant::Bech32,
-        )
-        .wrap_err("failed converting bytes to bech32 address")?;
-
-        if received_proposer_address != expected_proposer_address {
-            bail!(
-                "proposer address mismatch: expected {}, got {}",
-                expected_proposer_address,
-                received_proposer_address
-            );
-        }
-
-        // verify the namespace data signing public key matches the proposer address
-        let res_address = public_key_to_address(&data.public_key.0)?;
-        if res_address != expected_proposer_address {
-            bail!(
-                "public key mismatch: expected {}, got {}",
-                expected_proposer_address,
-                res_address
-            );
-        }
-
-        // validate that commit signatures hash to header.last_commit_hash
-        let data = match calculate_last_commit_hash(&data.data.last_commit) {
-            Hash::Sha256(calculated_last_commit_hash) => {
-                let Some(last_commit_hash) = data.data.header.last_commit_hash.as_ref() else {
-                    bail!("last commit hash should not be empty");
-                };
-
-                if calculated_last_commit_hash.as_slice() != last_commit_hash.0 {
-                    bail!("last commit hash in header does not match calculated last commit hash");
-                }
-
-                // verify that the validator votes on the previous block have >2/3 voting power
-                tokio::task::spawn_blocking(
-                    move || -> Result<SignedNamespaceData<SequencerNamespaceData>> {
-                        ensure_commit_has_quorum(
-                            &data.data.last_commit,
-                            &validator_set,
-                            &data.data.header.chain_id,
-                        )?;
-                        Ok(data)
-                    },
-                )
-                .await?
-                .wrap_err("failed to ensure commit has quorum")?
-
-                // TODO: commit is for previous block; how do we handle this?
-            }
-            Hash::None => {
-                // this case only happens if the last commit is empty, which should only happen on
-                // block 1.
-                ensure!(data.data.header.height == "1", "last commit hash not found");
-                ensure!(
-                    data.data.header.last_commit_hash.is_none(),
-                    "last commit hash should be empty"
-                );
-                data
-            }
-        };
-
-        // verify the block signature
-        data.verify()?;
-
-        // finally, get the full SequencerBlock
+        // get the full SequencerBlock
         // the reason the public key type needs to be converted is due to serialization
         // constraints, probably fix this later
         let public_key = ed25519_dalek::PublicKey::from_bytes(&data.public_key.0)?;
@@ -338,12 +219,6 @@ impl Reader {
             .get_sequencer_block(&data.data, Some(&public_key))
             .await
             .map_err(|e| eyre!("failed to get rollup data: {}", e))?;
-
-        // validate the block header matches the block hash
-        block.verify_block_hash()?;
-
-        // finally, validate that the transactions in the block result in the correct data_hash
-        block.verify_data_hash()?;
 
         Ok(block)
     }
@@ -357,357 +232,5 @@ impl Reader {
         )?;
 
         Ok(())
-    }
-}
-
-/// This function ensures that the given Commit has quorum, ie that the Commit contains >2/3 voting
-/// power. It performs the following checks:
-/// - the height of the commit matches the block height of the validator set
-/// - each validator in the commit is in the validator set
-/// - for each signature in the commit, the validator public key matches the validator address in
-///   the commit
-/// - for each signature in the commit, the validator signature in the commit is valid
-/// - the total voting power of the commit is >2/3 of the total voting power of the validator set
-///
-/// # Errors
-///
-/// If any of the above conditions are not satisfied, an error is returned.
-#[instrument]
-fn ensure_commit_has_quorum(
-    commit: &Commit,
-    validator_set: &ValidatorSet,
-    chain_id: &str,
-) -> Result<()> {
-    if commit.height != validator_set.block_height {
-        bail!(
-            "commit height mismatch: expected {}, got {}",
-            validator_set.block_height,
-            commit.height
-        );
-    }
-
-    let Some(total_voting_power) = validator_set
-    .validators
-    .iter()
-    .try_fold(0u64, |acc, validator| acc.checked_add(validator.voting_power)) else {
-        bail!("total voting power exceeded u64:MAX");
-    };
-
-    let validator_map = validator_set
-        .validators
-        .iter()
-        .map(|v| (&v.address, v)) // address is in bech32
-        .collect::<HashMap<_, _>>();
-
-    let mut commit_voting_power = 0u64;
-    for vote in &commit.signatures {
-        // we only care about votes that are for the Commit.BlockId (ignore absent validators and
-        // votes for nil)
-        if vote.block_id_flag != "BLOCK_ID_FLAG_COMMIT" {
-            continue;
-        }
-
-        // verify validator exists in validator set
-        let validator_address = bech32::encode(
-            "metrovalcons",
-            vote.validator_address.0.to_base32(),
-            Variant::Bech32,
-        )?;
-        let Some(validator) = validator_map.get(&validator_address) else {
-            bail!("validator {} not found in validator set", validator_address);
-        };
-
-        // verify address in signature matches validator pubkey
-        let address_from_pubkey = public_key_to_address(&validator.pub_key.key.0)?;
-        ensure!(
-            address_from_pubkey == validator_address,
-            format!(
-                "validator address mismatch: expected {}, got {}",
-                validator_address, address_from_pubkey
-            )
-        );
-
-        // verify vote signature
-        verify_vote_signature(
-            vote,
-            commit,
-            chain_id,
-            &validator.pub_key.key.0,
-            &vote.signature.0,
-        )?;
-
-        commit_voting_power += validator.voting_power;
-    }
-
-    ensure!(
-        commit_voting_power <= total_voting_power,
-        format!(
-            "commit voting power is greater than total voting power: {} > {}",
-            commit_voting_power, total_voting_power
-        )
-    );
-
-    ensure!(
-        does_commit_voting_power_have_quorum(commit_voting_power, total_voting_power),
-        format!(
-            "commit voting power is less than 2/3 of total voting power: {} <= {}",
-            commit_voting_power,
-            total_voting_power * 2 / 3,
-        )
-    );
-
-    Ok(())
-}
-
-fn does_commit_voting_power_have_quorum(commited: u64, total: u64) -> bool {
-    if total < 3 {
-        return commited * 3 > total * 2;
-    }
-
-    commited > total / 3 * 2
-}
-
-// see https://github.com/tendermint/tendermint/blob/35581cf54ec436b8c37fabb43fdaa3f48339a170/types/vote.go#L147
-// TODO: we can change these types (CommitSig and Commit) to be the tendermint types
-// after the other relayer types are updated.
-fn verify_vote_signature(
-    vote: &CommitSig,
-    commit: &Commit,
-    chain_id: &str,
-    public_key_bytes: &[u8],
-    signature_bytes: &[u8],
-) -> Result<()> {
-    let public_key = ed25519_dalek::PublicKey::from_bytes(public_key_bytes)?;
-    let signature = ed25519_dalek::Signature::from_bytes(signature_bytes)?;
-    let canonical_vote = CanonicalVote {
-        vote_type: vote::Type::Precommit,
-        height: Height::from_str(&commit.height)?,
-        round: Round::from(commit.round as u16),
-        block_id: Some(BlockId {
-            hash: Hash::try_from(commit.block_id.hash.0.to_vec())?,
-            part_set_header: parts::Header::new(
-                commit.block_id.part_set_header.total,
-                Hash::try_from(commit.block_id.part_set_header.hash.0.to_vec())?,
-            )?,
-        }),
-        timestamp: Some(Time::parse_from_rfc3339(&vote.timestamp)?),
-        chain_id: ChainId::try_from(chain_id)?,
-    };
-    public_key.verify(
-        &tendermint_proto::types::CanonicalVote::try_from(canonical_vote)?
-            .encode_length_delimited_to_vec(),
-        &signature,
-    )?;
-    Ok(())
-}
-
-// see https://github.com/cometbft/cometbft/blob/539985efc7d461668ffb46dff88b3f7bb9275e5a/types/block.go#L922
-// block_id_flag types are: https://github.com/cometbft/cometbft/blob/4e130bde8e85ec78ae81d06aa54df056a8fae43a/spec/core/data_structures.md?plain=1#L251
-fn calculate_last_commit_hash(commit: &Commit) -> Hash {
-    let signatures = commit
-        .signatures
-        .iter()
-        .filter_map(|v| {
-            match v.block_id_flag.as_str() {
-                "BLOCK_ID_FLAG_COMMIT" => {
-                    let commit_sig = TendermintCommitSig::BlockIdFlagCommit {
-                        signature: Some(Signature::try_from(v.signature.clone().0).ok()?),
-                        validator_address: AccountId::try_from(v.validator_address.clone().0)
-                            .ok()?,
-                        timestamp: Time::parse_from_rfc3339(&v.timestamp).ok()?,
-                    };
-                    Some(RawCommitSig::try_from(commit_sig).ok()?.encode_to_vec())
-                }
-                "BLOCK_ID_FLAG_NIL" => {
-                    let commit_sig = TendermintCommitSig::BlockIdFlagNil {
-                        signature: Some(Signature::try_from(v.signature.clone().0).ok()?),
-                        validator_address: AccountId::try_from(v.validator_address.clone().0)
-                            .ok()?,
-                        timestamp: Time::parse_from_rfc3339(&v.timestamp).ok()?,
-                    };
-                    Some(RawCommitSig::try_from(commit_sig).ok()?.encode_to_vec())
-                }
-                "BLOCK_ID_FLAG_ABSENT" => Some(
-                    RawCommitSig::try_from(TendermintCommitSig::BlockIdFlagAbsent)
-                        .ok()?
-                        .encode_to_vec(),
-                ),
-                _ => None, // TODO: could this ever happen?
-            }
-        })
-        .collect::<Vec<_>>();
-    Hash::Sha256(merkle::simple_hash_from_byte_vectors::<
-        crypto::default::Sha256,
-    >(&signatures))
-}
-
-#[cfg(test)]
-mod test {
-    use astria_sequencer_relayer::{
-        base64_string::Base64String,
-        types::{
-            BlockId,
-            Commit,
-            Parts,
-        },
-    };
-
-    use super::*;
-    use crate::tendermint::{
-        KeyWithType,
-        Validator,
-        ValidatorSet,
-    };
-
-    #[test]
-    fn test_does_commit_voting_power_have_quorum() {
-        assert!(does_commit_voting_power_have_quorum(3, 4));
-        assert!(does_commit_voting_power_have_quorum(101, 150));
-        assert!(does_commit_voting_power_have_quorum(
-            u64::MAX / 3,
-            u64::MAX / 3
-        ));
-        assert!(does_commit_voting_power_have_quorum(
-            u64::MAX / 3,
-            u64::MAX / 2 - 1
-        ));
-        assert!(does_commit_voting_power_have_quorum(u64::MAX, u64::MAX));
-
-        assert!(!does_commit_voting_power_have_quorum(0, 1));
-        assert!(!does_commit_voting_power_have_quorum(1, 2));
-        assert!(!does_commit_voting_power_have_quorum(2, 3));
-        assert!(!does_commit_voting_power_have_quorum(100, 150));
-        assert!(!does_commit_voting_power_have_quorum(
-            u64::MAX / 3 - 1,
-            u64::MAX / 2
-        ));
-        assert!(does_commit_voting_power_have_quorum(
-            u64::MAX / 3,
-            u64::MAX / 2
-        ));
-        assert!(!does_commit_voting_power_have_quorum(0, 0));
-    }
-
-    #[test]
-    fn test_ensure_commit_has_quorum_ok() {
-        let validator_set_str = r#"{
-            "block_height": "2082",
-            "validators": [
-              {
-                "address": "metrovalcons1hdu2nzhcyfnhaj9tfrdlekfnfwx895mk83d322",
-                "pub_key": {
-                  "@type": "/cosmos.crypto.ed25519.PubKey",
-                  "key": "MdfFS4MH09Og5y+9SVxpJRqUnZkDGfnPjdyx4qM2Vng="
-                },
-                "voting_power": "5000",
-                "proposer_priority": "0"
-              }
-            ],
-            "pagination": {
-              "next_key": null,
-              "total": "1"
-            }
-          }"#;
-        let commit_str = r#"{
-            "height": "2082",
-            "round": 0,
-            "block_id": {
-                "hash": "5QrZ8fznJw/X1lviA5cyQ2BwLbma8iuvXHqh6BiMJdU=",
-                "part_set_header": {
-                    "total": 1,
-                    "hash": "DUMkxxMa2M0/aMmNyVGkvLn+3w1HTsGZ/YKyAVu+gdc="
-                }
-            },
-            "signatures": [
-                {
-                    "block_id_flag": "BLOCK_ID_FLAG_COMMIT",
-                    "validator_address": "u3ipivgiZ37Iq0jb/NkzS4xy03Y=",
-                    "timestamp": "2023-05-29T13:57:32.797060160Z",
-                    "signature": "SQdU03IyfHOiTeGrPcbgBnRSpjN7cimaX0XO3jWLIkKL5w8ePx7Lg7V1CaDDTQJ0G5WHtcHVQky2dzq4vmkHBA=="
-                }
-            ]
-        }"#;
-
-        let validator_set = serde_json::from_str::<ValidatorSet>(validator_set_str).unwrap();
-        let commit = serde_json::from_str::<Commit>(commit_str).unwrap();
-        ensure_commit_has_quorum(&commit, &validator_set, "private").unwrap();
-    }
-
-    #[test]
-    fn test_ensure_commit_has_quorum_not_ok() {
-        let validator_set = ValidatorSet {
-            block_height: "2082".to_string(),
-            validators: vec![Validator {
-                address: "metrovalcons1hdu2nzhcyfnhaj9tfrdlekfnfwx895mk83d322".to_string(),
-                pub_key: KeyWithType {
-                    key: Base64String::from_string(
-                        "MdfFS4MH09Og5y+9SVxpJRqUnZkDGfnPjdyx4qM2Vng=".to_string(),
-                    )
-                    .unwrap(),
-                    key_type: "/cosmos.crypto.ed25519.PubKey".to_string(),
-                },
-                voting_power: 5000,
-                proposer_priority: 0,
-            }],
-        };
-
-        let commit = Commit {
-            height: "2082".to_string(),
-            round: 0,
-            block_id: BlockId {
-                hash: Base64String::from_string(
-                    "5QrZ8fznJw/X1lviA5cyQ2BwLbma8iuvXHqh6BiMJdU=".to_string(),
-                )
-                .unwrap(),
-                part_set_header: Parts {
-                    total: 1,
-                    hash: Base64String::from_string(
-                        "DUMkxxMa2M0/aMmNyVGkvLn+3w1HTsGZ/YKyAVu+gdc=".to_string(),
-                    )
-                    .unwrap(),
-                },
-            },
-            signatures: vec![],
-        };
-
-        let result = ensure_commit_has_quorum(&commit, &validator_set, "private");
-        assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("commit voting power is less than 2/3 of total voting power")
-        );
-    }
-
-    #[test]
-    fn test_calculate_last_commit_hash() {
-        let commit_str = r#"{
-            "height": "2082",
-            "round": 0,
-            "block_id": {
-                "hash": "5QrZ8fznJw/X1lviA5cyQ2BwLbma8iuvXHqh6BiMJdU=",
-                "part_set_header": {
-                    "total": 1,
-                    "hash": "DUMkxxMa2M0/aMmNyVGkvLn+3w1HTsGZ/YKyAVu+gdc="
-                }
-            },
-            "signatures": [
-                {
-                    "block_id_flag": "BLOCK_ID_FLAG_COMMIT",
-                    "validator_address": "u3ipivgiZ37Iq0jb/NkzS4xy03Y=",
-                    "timestamp": "2023-05-29T13:57:32.797060160Z",
-                    "signature": "SQdU03IyfHOiTeGrPcbgBnRSpjN7cimaX0XO3jWLIkKL5w8ePx7Lg7V1CaDDTQJ0G5WHtcHVQky2dzq4vmkHBA=="
-                }
-            ]
-        }"#;
-        let expected_last_commit_hash =
-            Base64String::from_string("rpjY+9Y2ZL9y8RsfcgiKSNw4emL6YyBneMbuztCS9HQ=".to_string())
-                .unwrap();
-
-        let commit = serde_json::from_str::<Commit>(commit_str).unwrap();
-        let last_commit_hash = calculate_last_commit_hash(&commit);
-        assert!(matches!(last_commit_hash, Hash::Sha256(_)));
-        assert!(expected_last_commit_hash.0 == last_commit_hash.as_bytes());
     }
 }

--- a/crates/astria-conductor/src/validation.rs
+++ b/crates/astria-conductor/src/validation.rs
@@ -1,0 +1,537 @@
+use std::{
+    collections::HashMap,
+    str::FromStr,
+};
+
+use astria_sequencer_relayer::{
+    data_availability::{
+        SequencerNamespaceData,
+        SignedNamespaceData,
+    },
+    keys::public_key_to_address,
+    sequencer_block::SequencerBlock,
+    types::{
+        Commit,
+        CommitSig,
+    },
+};
+use bech32::{
+    self,
+    ToBase32,
+    Variant,
+};
+use color_eyre::eyre::{
+    bail,
+    ensure,
+    Result,
+    WrapErr,
+};
+use ed25519_dalek::Verifier;
+use prost::Message;
+use tendermint::{
+    account::Id as AccountId,
+    block::{
+        parts,
+        CommitSig as TendermintCommitSig,
+        Height,
+        Id as BlockId,
+        Round,
+    },
+    chain::Id as ChainId,
+    crypto,
+    merkle,
+    vote::{
+        self,
+        CanonicalVote,
+    },
+    Hash,
+    Signature,
+    Time,
+};
+use tendermint_proto::types::CommitSig as RawCommitSig;
+use tracing::{
+    instrument,
+    warn,
+};
+
+use crate::tendermint::{
+    TendermintClient,
+    ValidatorSet,
+};
+
+pub struct BlockValidator {
+    tendermint_client: TendermintClient,
+}
+
+impl BlockValidator {
+    pub fn new(tendermint_url: &str) -> Result<Self> {
+        Ok(Self {
+            tendermint_client: TendermintClient::new(tendermint_url.to_owned())?,
+        })
+    }
+
+    pub(crate) async fn validate_signed_namespace_data(
+        &self,
+        data: &SignedNamespaceData<SequencerNamespaceData>,
+    ) -> Result<()> {
+        // verify the block signature
+        data.verify()?;
+
+        // get validator set for this height
+        let height = data.data.header.height.parse::<u64>()?;
+        let validator_set = self.tendermint_client.get_validator_set(height - 1).await?;
+
+        // find proposer address for this height
+        let expected_proposer_address = validator_set
+            .get_proposer()
+            .wrap_err("failed to get proposer from validator set")?
+            .address;
+
+        // verify the namespace data signing public key matches the proposer address
+        let res_address = public_key_to_address(&data.public_key.0)?;
+        if res_address != expected_proposer_address {
+            bail!(
+                "public key mismatch: expected {}, got {}",
+                expected_proposer_address,
+                res_address
+            );
+        }
+
+        Ok(())
+    }
+
+    /// performs various validation checks on the SignedNamespaceData that was read from Celestia
+    /// and returns the full SequencerBlock corresponding to the given SignedNamespaceData if all
+    /// checks pass.
+    ///
+    /// checks performed:
+    /// - the proposer of the sequencer block matches the expected proposer for the block height
+    ///   from tendermint
+    /// - the signer of the SignedNamespaceData the proposer
+    /// - the signature is valid
+    /// - the root of the markle tree of all the header fields matches the block's block_hash
+    /// - the root of the merkle tree of all transactions in the block matches the block's data_hash
+    /// - validate the block was actually finalized; ie >2/3 stake signed off on it
+    pub(crate) async fn validate_sequencer_block(&self, block: &SequencerBlock) -> Result<()> {
+        // sequencer block's height
+        let height = block.header.height.parse::<u64>()?;
+
+        // get validator set for this height
+        let validator_set = self.tendermint_client.get_validator_set(height - 1).await?;
+
+        // find proposer address for this height
+        let expected_proposer_address = validator_set
+            .get_proposer()
+            .wrap_err("failed to get proposer from validator set")?
+            .address;
+
+        // check if the proposer address matches the sequencer block's proposer
+        let received_proposer_address = bech32::encode(
+            "metrovalcons",
+            block.header.proposer_address.0.to_base32(),
+            Variant::Bech32,
+        )
+        .wrap_err("failed converting bytes to bech32 address")?;
+
+        if received_proposer_address != expected_proposer_address {
+            bail!(
+                "proposer address mismatch: expected {}, got {}",
+                expected_proposer_address,
+                received_proposer_address
+            );
+        }
+
+        // validate that commit signatures hash to header.last_commit_hash
+        match calculate_last_commit_hash(&block.last_commit) {
+            Hash::Sha256(calculated_last_commit_hash) => {
+                let Some(last_commit_hash) = block.header.last_commit_hash.as_ref() else {
+                    bail!("last commit hash should not be empty");
+                };
+
+                if calculated_last_commit_hash.as_slice() != last_commit_hash.0 {
+                    bail!("last commit hash in header does not match calculated last commit hash");
+                }
+
+                // verify that the validator votes on the previous block have >2/3 voting power
+                let last_commit = block.last_commit.clone();
+                let chain_id = block.header.chain_id.clone();
+                tokio::task::spawn_blocking(move || -> Result<()> {
+                    ensure_commit_has_quorum(&last_commit, &validator_set, &chain_id)
+                })
+                .await?
+                .wrap_err("failed to ensure commit has quorum")?
+
+                // TODO: commit is for previous block; how do we handle this?
+            }
+            Hash::None => {
+                // this case only happens if the last commit is empty, which should only happen on
+                // block 1.
+                ensure!(block.header.height == "1", "last commit hash not found");
+                ensure!(
+                    block.header.last_commit_hash.is_none(),
+                    "last commit hash should be empty"
+                );
+            }
+        };
+
+        // validate the block header matches the block hash
+        block.verify_block_hash()?;
+
+        // finally, validate that the transactions in the block result in the correct data_hash
+        block.verify_data_hash()?;
+
+        Ok(())
+    }
+}
+
+/// This function ensures that the given Commit has quorum, ie that the Commit contains >2/3 voting
+/// power. It performs the following checks:
+/// - the height of the commit matches the block height of the validator set
+/// - each validator in the commit is in the validator set
+/// - for each signature in the commit, the validator public key matches the validator address in
+///   the commit
+/// - for each signature in the commit, the validator signature in the commit is valid
+/// - the total voting power of the commit is >2/3 of the total voting power of the validator set
+///
+/// # Errors
+///
+/// If any of the above conditions are not satisfied, an error is returned.
+#[instrument]
+fn ensure_commit_has_quorum(
+    commit: &Commit,
+    validator_set: &ValidatorSet,
+    chain_id: &str,
+) -> Result<()> {
+    if commit.height != validator_set.block_height {
+        bail!(
+            "commit height mismatch: expected {}, got {}",
+            validator_set.block_height,
+            commit.height
+        );
+    }
+
+    let Some(total_voting_power) = validator_set
+    .validators
+    .iter()
+    .try_fold(0u64, |acc, validator| acc.checked_add(validator.voting_power)) else {
+        bail!("total voting power exceeded u64:MAX");
+    };
+
+    let validator_map = validator_set
+        .validators
+        .iter()
+        .map(|v| (&v.address, v)) // address is in bech32
+        .collect::<HashMap<_, _>>();
+
+    let mut commit_voting_power = 0u64;
+    for vote in &commit.signatures {
+        // we only care about votes that are for the Commit.BlockId (ignore absent validators and
+        // votes for nil)
+        if vote.block_id_flag != "BLOCK_ID_FLAG_COMMIT" {
+            continue;
+        }
+
+        // verify validator exists in validator set
+        let validator_address = bech32::encode(
+            "metrovalcons",
+            vote.validator_address.0.to_base32(),
+            Variant::Bech32,
+        )?;
+        let Some(validator) = validator_map.get(&validator_address) else {
+            bail!("validator {} not found in validator set", validator_address);
+        };
+
+        // verify address in signature matches validator pubkey
+        let address_from_pubkey = public_key_to_address(&validator.pub_key.key.0)?;
+        ensure!(
+            address_from_pubkey == validator_address,
+            format!(
+                "validator address mismatch: expected {}, got {}",
+                validator_address, address_from_pubkey
+            )
+        );
+
+        // verify vote signature
+        verify_vote_signature(
+            vote,
+            commit,
+            chain_id,
+            &validator.pub_key.key.0,
+            &vote.signature.0,
+        )?;
+
+        commit_voting_power += validator.voting_power;
+    }
+
+    ensure!(
+        commit_voting_power <= total_voting_power,
+        format!(
+            "commit voting power is greater than total voting power: {} > {}",
+            commit_voting_power, total_voting_power
+        )
+    );
+
+    ensure!(
+        does_commit_voting_power_have_quorum(commit_voting_power, total_voting_power),
+        format!(
+            "commit voting power is less than 2/3 of total voting power: {} <= {}",
+            commit_voting_power,
+            total_voting_power * 2 / 3,
+        )
+    );
+
+    Ok(())
+}
+
+fn does_commit_voting_power_have_quorum(commited: u64, total: u64) -> bool {
+    if total < 3 {
+        return commited * 3 > total * 2;
+    }
+
+    commited > total / 3 * 2
+}
+
+// see https://github.com/tendermint/tendermint/blob/35581cf54ec436b8c37fabb43fdaa3f48339a170/types/vote.go#L147
+// TODO: we can change these types (CommitSig and Commit) to be the tendermint types
+// after the other relayer types are updated.
+fn verify_vote_signature(
+    vote: &CommitSig,
+    commit: &Commit,
+    chain_id: &str,
+    public_key_bytes: &[u8],
+    signature_bytes: &[u8],
+) -> Result<()> {
+    let public_key = ed25519_dalek::PublicKey::from_bytes(public_key_bytes)?;
+    let signature = ed25519_dalek::Signature::from_bytes(signature_bytes)?;
+    let canonical_vote = CanonicalVote {
+        vote_type: vote::Type::Precommit,
+        height: Height::from_str(&commit.height)?,
+        round: Round::from(commit.round as u16),
+        block_id: Some(BlockId {
+            hash: Hash::try_from(commit.block_id.hash.0.to_vec())?,
+            part_set_header: parts::Header::new(
+                commit.block_id.part_set_header.total,
+                Hash::try_from(commit.block_id.part_set_header.hash.0.to_vec())?,
+            )?,
+        }),
+        timestamp: Some(Time::parse_from_rfc3339(&vote.timestamp)?),
+        chain_id: ChainId::try_from(chain_id)?,
+    };
+    public_key.verify(
+        &tendermint_proto::types::CanonicalVote::try_from(canonical_vote)?
+            .encode_length_delimited_to_vec(),
+        &signature,
+    )?;
+    Ok(())
+}
+
+// see https://github.com/cometbft/cometbft/blob/539985efc7d461668ffb46dff88b3f7bb9275e5a/types/block.go#L922
+// block_id_flag types are: https://github.com/cometbft/cometbft/blob/4e130bde8e85ec78ae81d06aa54df056a8fae43a/spec/core/data_structures.md?plain=1#L251
+fn calculate_last_commit_hash(commit: &Commit) -> Hash {
+    let signatures = commit
+        .signatures
+        .iter()
+        .filter_map(|v| {
+            match v.block_id_flag.as_str() {
+                "BLOCK_ID_FLAG_COMMIT" => {
+                    let commit_sig = TendermintCommitSig::BlockIdFlagCommit {
+                        signature: Some(Signature::try_from(v.signature.clone().0).ok()?),
+                        validator_address: AccountId::try_from(v.validator_address.clone().0)
+                            .ok()?,
+                        timestamp: Time::parse_from_rfc3339(&v.timestamp).ok()?,
+                    };
+                    Some(RawCommitSig::try_from(commit_sig).ok()?.encode_to_vec())
+                }
+                "BLOCK_ID_FLAG_NIL" => {
+                    let commit_sig = TendermintCommitSig::BlockIdFlagNil {
+                        signature: Some(Signature::try_from(v.signature.clone().0).ok()?),
+                        validator_address: AccountId::try_from(v.validator_address.clone().0)
+                            .ok()?,
+                        timestamp: Time::parse_from_rfc3339(&v.timestamp).ok()?,
+                    };
+                    Some(RawCommitSig::try_from(commit_sig).ok()?.encode_to_vec())
+                }
+                "BLOCK_ID_FLAG_ABSENT" => Some(
+                    RawCommitSig::try_from(TendermintCommitSig::BlockIdFlagAbsent)
+                        .ok()?
+                        .encode_to_vec(),
+                ),
+                _ => None, // TODO: could this ever happen?
+            }
+        })
+        .collect::<Vec<_>>();
+    Hash::Sha256(merkle::simple_hash_from_byte_vectors::<
+        crypto::default::Sha256,
+    >(&signatures))
+}
+
+#[cfg(test)]
+mod test {
+    use astria_sequencer_relayer::{
+        base64_string::Base64String,
+        types::{
+            BlockId,
+            Commit,
+            Parts,
+        },
+    };
+
+    use super::*;
+    use crate::tendermint::{
+        KeyWithType,
+        Validator,
+        ValidatorSet,
+    };
+
+    #[test]
+    fn test_does_commit_voting_power_have_quorum() {
+        assert!(does_commit_voting_power_have_quorum(3, 4));
+        assert!(does_commit_voting_power_have_quorum(101, 150));
+        assert!(does_commit_voting_power_have_quorum(
+            u64::MAX / 3,
+            u64::MAX / 3
+        ));
+        assert!(does_commit_voting_power_have_quorum(
+            u64::MAX / 3,
+            u64::MAX / 2 - 1
+        ));
+        assert!(does_commit_voting_power_have_quorum(u64::MAX, u64::MAX));
+
+        assert!(!does_commit_voting_power_have_quorum(0, 1));
+        assert!(!does_commit_voting_power_have_quorum(1, 2));
+        assert!(!does_commit_voting_power_have_quorum(2, 3));
+        assert!(!does_commit_voting_power_have_quorum(100, 150));
+        assert!(!does_commit_voting_power_have_quorum(
+            u64::MAX / 3 - 1,
+            u64::MAX / 2
+        ));
+        assert!(does_commit_voting_power_have_quorum(
+            u64::MAX / 3,
+            u64::MAX / 2
+        ));
+        assert!(!does_commit_voting_power_have_quorum(0, 0));
+    }
+
+    #[test]
+    fn test_ensure_commit_has_quorum_ok() {
+        let validator_set_str = r#"{
+            "block_height": "2082",
+            "validators": [
+              {
+                "address": "metrovalcons1hdu2nzhcyfnhaj9tfrdlekfnfwx895mk83d322",
+                "pub_key": {
+                  "@type": "/cosmos.crypto.ed25519.PubKey",
+                  "key": "MdfFS4MH09Og5y+9SVxpJRqUnZkDGfnPjdyx4qM2Vng="
+                },
+                "voting_power": "5000",
+                "proposer_priority": "0"
+              }
+            ],
+            "pagination": {
+              "next_key": null,
+              "total": "1"
+            }
+          }"#;
+        let commit_str = r#"{
+            "height": "2082",
+            "round": 0,
+            "block_id": {
+                "hash": "5QrZ8fznJw/X1lviA5cyQ2BwLbma8iuvXHqh6BiMJdU=",
+                "part_set_header": {
+                    "total": 1,
+                    "hash": "DUMkxxMa2M0/aMmNyVGkvLn+3w1HTsGZ/YKyAVu+gdc="
+                }
+            },
+            "signatures": [
+                {
+                    "block_id_flag": "BLOCK_ID_FLAG_COMMIT",
+                    "validator_address": "u3ipivgiZ37Iq0jb/NkzS4xy03Y=",
+                    "timestamp": "2023-05-29T13:57:32.797060160Z",
+                    "signature": "SQdU03IyfHOiTeGrPcbgBnRSpjN7cimaX0XO3jWLIkKL5w8ePx7Lg7V1CaDDTQJ0G5WHtcHVQky2dzq4vmkHBA=="
+                }
+            ]
+        }"#;
+
+        let validator_set = serde_json::from_str::<ValidatorSet>(validator_set_str).unwrap();
+        let commit = serde_json::from_str::<Commit>(commit_str).unwrap();
+        ensure_commit_has_quorum(&commit, &validator_set, "private").unwrap();
+    }
+
+    #[test]
+    fn test_ensure_commit_has_quorum_not_ok() {
+        let validator_set = ValidatorSet {
+            block_height: "2082".to_string(),
+            validators: vec![Validator {
+                address: "metrovalcons1hdu2nzhcyfnhaj9tfrdlekfnfwx895mk83d322".to_string(),
+                pub_key: KeyWithType {
+                    key: Base64String::from_string(
+                        "MdfFS4MH09Og5y+9SVxpJRqUnZkDGfnPjdyx4qM2Vng=".to_string(),
+                    )
+                    .unwrap(),
+                    key_type: "/cosmos.crypto.ed25519.PubKey".to_string(),
+                },
+                voting_power: 5000,
+                proposer_priority: 0,
+            }],
+        };
+
+        let commit = Commit {
+            height: "2082".to_string(),
+            round: 0,
+            block_id: BlockId {
+                hash: Base64String::from_string(
+                    "5QrZ8fznJw/X1lviA5cyQ2BwLbma8iuvXHqh6BiMJdU=".to_string(),
+                )
+                .unwrap(),
+                part_set_header: Parts {
+                    total: 1,
+                    hash: Base64String::from_string(
+                        "DUMkxxMa2M0/aMmNyVGkvLn+3w1HTsGZ/YKyAVu+gdc=".to_string(),
+                    )
+                    .unwrap(),
+                },
+            },
+            signatures: vec![],
+        };
+
+        let result = ensure_commit_has_quorum(&commit, &validator_set, "private");
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("commit voting power is less than 2/3 of total voting power")
+        );
+    }
+
+    #[test]
+    fn test_calculate_last_commit_hash() {
+        let commit_str = r#"{
+            "height": "2082",
+            "round": 0,
+            "block_id": {
+                "hash": "5QrZ8fznJw/X1lviA5cyQ2BwLbma8iuvXHqh6BiMJdU=",
+                "part_set_header": {
+                    "total": 1,
+                    "hash": "DUMkxxMa2M0/aMmNyVGkvLn+3w1HTsGZ/YKyAVu+gdc="
+                }
+            },
+            "signatures": [
+                {
+                    "block_id_flag": "BLOCK_ID_FLAG_COMMIT",
+                    "validator_address": "u3ipivgiZ37Iq0jb/NkzS4xy03Y=",
+                    "timestamp": "2023-05-29T13:57:32.797060160Z",
+                    "signature": "SQdU03IyfHOiTeGrPcbgBnRSpjN7cimaX0XO3jWLIkKL5w8ePx7Lg7V1CaDDTQJ0G5WHtcHVQky2dzq4vmkHBA=="
+                }
+            ]
+        }"#;
+        let expected_last_commit_hash =
+            Base64String::from_string("rpjY+9Y2ZL9y8RsfcgiKSNw4emL6YyBneMbuztCS9HQ=".to_string())
+                .unwrap();
+
+        let commit = serde_json::from_str::<Commit>(commit_str).unwrap();
+        let last_commit_hash = calculate_last_commit_hash(&commit);
+        assert!(matches!(last_commit_hash, Hash::Sha256(_)));
+        assert!(expected_last_commit_hash.0 == last_commit_hash.as_bytes());
+    }
+}

--- a/crates/astria-conductor/tests/it/reader.rs
+++ b/crates/astria-conductor/tests/it/reader.rs
@@ -1,6 +1,12 @@
-use std::time::Duration;
+use std::{
+    sync::Arc,
+    time::Duration,
+};
 
-use astria_conductor::reader::Reader;
+use astria_conductor::{
+    reader::Reader,
+    validation::BlockValidator,
+};
 use tokio::sync::mpsc;
 
 use crate::helper::init_test;
@@ -13,11 +19,12 @@ async fn should_get_new_block() {
     let metro_endpoint = test_env.sequencer_endpoint();
     let bridge_endpoint = test_env.bridge_endpoint();
 
+    let block_validator = BlockValidator::new(metro_endpoint.as_str()).unwrap();
     let (executor_tx, _) = mpsc::unbounded_channel();
     let (mut reader, _reader_tx) = Reader::new(
         bridge_endpoint.as_str(),
-        metro_endpoint.as_str(),
         executor_tx,
+        Arc::new(block_validator),
     )
     .await
     .unwrap();

--- a/crates/astria-sequencer-relayer/Cargo.toml
+++ b/crates/astria-sequencer-relayer/Cargo.toml
@@ -28,7 +28,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 tokio = { workspace = true, features = [ "macros", "rt-multi-thread" ] }
 
-astria-gossipnet = { path = "../astria-gossipnet", features = [ "mdns" ] }
+astria-gossipnet = { path = "../astria-gossipnet" }
 astria-proto = { path = "../astria-proto" }
 astria-rs-cnc = { path = "../astria-rs-cnc" }
 

--- a/crates/astria-sequencer-relayer/src/relayer.rs
+++ b/crates/astria-sequencer-relayer/src/relayer.rs
@@ -163,12 +163,14 @@ impl Relayer {
         };
 
         self.block_tx.send(sequencer_block.clone())?;
-
-        let tx_count = sequencer_block.rollup_txs.len() + sequencer_block.sequencer_txs.len();
         if self.disable_writing {
             return Ok(new_state);
         }
 
+        tracing::info!("{:?}", sequencer_block.rollup_txs);
+        tracing::info!("{:?}", sequencer_block.header.data_hash);
+
+        let tx_count = sequencer_block.rollup_txs.len() + sequencer_block.sequencer_txs.len();
         match self
             .da_client
             .submit_block(sequencer_block, &self.keypair)

--- a/crates/astria-sequencer-relayer/src/relayer.rs
+++ b/crates/astria-sequencer-relayer/src/relayer.rs
@@ -167,9 +167,6 @@ impl Relayer {
             return Ok(new_state);
         }
 
-        tracing::info!("{:?}", sequencer_block.rollup_txs);
-        tracing::info!("{:?}", sequencer_block.header.data_hash);
-
         let tx_count = sequencer_block.rollup_txs.len() + sequencer_block.sequencer_txs.len();
         match self
             .da_client

--- a/crates/astria-sequencer-relayer/src/sequencer_block.rs
+++ b/crates/astria-sequencer-relayer/src/sequencer_block.rs
@@ -233,20 +233,11 @@ impl SequencerBlock {
             bail!("block has no data hash");
         };
 
-        tracing::info!(
-            "block transactions: {} {}",
-            self.sequencer_txs.len(),
-            self.rollup_txs.len(),
-        );
-
         let mut ordered_txs = vec![];
         ordered_txs.append(&mut self.sequencer_txs.clone());
-        self.rollup_txs.iter().for_each(|(_, tx)| {
-            tracing::info!("rollup txs: {:?}", tx);
-            ordered_txs.append(&mut tx.clone())
-        });
-
-        use sha2::Digest as _;
+        self.rollup_txs
+            .iter()
+            .for_each(|(_, tx)| ordered_txs.append(&mut tx.clone()));
 
         // TODO: if there are duplicate or missing indices, the hash will obviously be wrong,
         // but we should probably verify that earier to return a better error.
@@ -260,12 +251,6 @@ impl SequencerBlock {
             })
             .collect::<Vec<_>>();
         let data_hash = txs_to_data_hash(&txs);
-
-        tracing::info!(
-            "data hash from transactions: {}",
-            Base64String(data_hash.as_bytes().to_vec())
-        );
-        tracing::info!("data hash from block: {}", this_data_hash,);
 
         ensure!(
             data_hash.as_bytes() == this_data_hash.0,

--- a/crates/astria-sequencer-relayer/src/transaction.rs
+++ b/crates/astria-sequencer-relayer/src/transaction.rs
@@ -1,4 +1,3 @@
-use prost;
 use tendermint::{
     hash::Hash as TmHash,
     merkle,
@@ -6,19 +5,33 @@ use tendermint::{
 
 use crate::base64_string::Base64String;
 
-fn tx_to_prost_bytes(tx: Vec<u8>) -> prost::alloc::vec::Vec<u8> {
-    let mut buf = prost::alloc::vec::Vec::new();
-    prost::encoding::bytes::encode(1, &tx, &mut buf);
-    buf
-}
-
 pub fn txs_to_data_hash(txs: &[Base64String]) -> TmHash {
-    let txs = txs
-        .iter()
-        .map(|tx| tx_to_prost_bytes(tx.0.clone()))
-        .collect::<Vec<Vec<u8>>>();
+    let txs = txs.iter().map(|tx| tx.0.clone()).collect::<Vec<Vec<u8>>>();
 
     TmHash::Sha256(merkle::simple_hash_from_byte_vectors::<
         tendermint::crypto::default::Sha256,
     >(&txs))
+}
+
+#[cfg(test)]
+mod test {
+    use sha2::Digest;
+
+    use super::*;
+
+    #[test]
+    fn txs_to_data_hash_test() {
+        // data_hash is calculated from the txs in a block, where the leaves of the merkle tree are
+        // the sha256 hashes of the txs
+        let tx = Base64String::from_string("CscBCsQBCg0vU2VxdWVuY2VyTXNnErIBCghldGhlcmV1bRJ4Avh1ggU5gIRZaC8AhQUD1cTyglIIlBtwp0/22gQLMRmQwVX9/9u8AvfuiA3gtrOnZAAAgMABoLnRqksJblEaolE6wbsAHYTAiSlA14+B5nvWuFrIfevnoBg+UGcWLC4eg1lZylqLnrL8okBc3vTS4qOO/J5sRtVDGixtZXRybzFsbDJobHAzM3J4eTdwN2s2YXhoeDRjdnFtdGcwY3hkZjZnemY5ahJ0Ck4KRgofL2Nvc21vcy5jcnlwdG8uc2VjcDI1NmsxLlB1YktleRIjCiEDJ/LvaMZTBcGX66geJOEmTm/fyyPTZKMUJoDtMDUmSPkSBAoCCAESGAoQCgV1dGljaxIHMTAwMDAwMBCAlOvcAyIIZXRoZXJldW0aQMhoTCUr84xgTkYxsFWDfHH2k+oHCPsKvbTpz8m5YrHfYMv6gdou6V8oj1v0B9ySD5VjMXQi1kJ9DZN6wD2buo8=".to_string()).unwrap();
+        let mut hasher = sha2::Sha256::new();
+        hasher.update(tx.0);
+        let hash = hasher.finalize();
+
+        let expected_hash =
+            Base64String::from_string("rRDu3aQf1V37yGSTdf2fv9GSPeZ6/p0wJ9pjBl8IqFc=".to_string())
+                .unwrap();
+        let res = txs_to_data_hash(&[Base64String(hash.to_vec())]);
+        assert_eq!(res.as_bytes(), expected_hash.0);
+    }
 }


### PR DESCRIPTION
- pull out the block validator logic into its own `BlockValidator` module (thoughts on naming? maybe `BlockVerifier` is better since validator is already a jargon word?)
- validate blocks received from gossip, as previously only blocks received from DA were fully validated

closes #104 