### PR TITLE
bump tendermint-rs to 0.32, penumbra to 0.54.1 and tower-abci to 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3446,7 +3446,7 @@ dependencies = [
 [[package]]
 name = "penumbra-storage"
 version = "0.54.1"
-source = "git+https://github.com/astriaorg/penumbra.git?rev=78153d8645bc0a382ec4bc8c494306809a69d9be#78153d8645bc0a382ec4bc8c494306809a69d9be"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=d8d5cd0b00876380147d7ddc7f3005178e3d9ae0#d8d5cd0b00876380147d7ddc7f3005178e3d9ae0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3471,7 +3471,7 @@ dependencies = [
 [[package]]
 name = "penumbra-tower-trace"
 version = "0.54.1"
-source = "git+https://github.com/astriaorg/penumbra.git?rev=78153d8645bc0a382ec4bc8c494306809a69d9be#78153d8645bc0a382ec4bc8c494306809a69d9be"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=d8d5cd0b00876380147d7ddc7f3005178e3d9ae0#d8d5cd0b00876380147d7ddc7f3005178e3d9ae0"
 dependencies = [
  "futures",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3446,7 +3446,7 @@ dependencies = [
 [[package]]
 name = "penumbra-storage"
 version = "0.54.1"
-source = "git+https://github.com/astriaorg/penumbra.git?branch=noot/fix-trace#78153d8645bc0a382ec4bc8c494306809a69d9be"
+source = "git+https://github.com/astriaorg/penumbra.git?rev=78153d8645bc0a382ec4bc8c494306809a69d9be#78153d8645bc0a382ec4bc8c494306809a69d9be"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3471,7 +3471,7 @@ dependencies = [
 [[package]]
 name = "penumbra-tower-trace"
 version = "0.54.1"
-source = "git+https://github.com/astriaorg/penumbra.git?branch=noot/fix-trace#78153d8645bc0a382ec4bc8c494306809a69d9be"
+source = "git+https://github.com/astriaorg/penumbra.git?rev=78153d8645bc0a382ec4bc8c494306809a69d9be#78153d8645bc0a382ec4bc8c494306809a69d9be"
 dependencies = [
  "futures",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -328,8 +328,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.6",
- "tendermint 0.30.0",
- "tendermint-proto 0.30.0",
+ "tendermint",
+ "tendermint-proto",
  "tokio",
  "tonic 0.9.2",
  "tracing",
@@ -372,7 +372,7 @@ version = "0.1.0"
 dependencies = [
  "prost",
  "prost-types",
- "tendermint-proto 0.30.0",
+ "tendermint-proto",
  "tonic 0.9.2",
  "which",
 ]
@@ -409,8 +409,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.6",
- "tendermint 0.31.1",
- "tendermint-proto 0.31.1",
+ "tendermint",
+ "tendermint-proto",
  "tokio",
  "tower",
  "tower-abci",
@@ -444,7 +444,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.6",
- "tendermint 0.30.0",
+ "tendermint",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -3445,8 +3445,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-storage"
-version = "0.53.1"
-source = "git+https://github.com/astriaorg/penumbra.git?branch=noot/fix-trace-v0.53.1#713a26c20f7a6bde3d2f7c6cea1f54bcca01fe40"
+version = "0.54.1"
+source = "git+https://github.com/astriaorg/penumbra.git?branch=noot/fix-trace#78153d8645bc0a382ec4bc8c494306809a69d9be"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3462,7 +3462,7 @@ dependencies = [
  "sha2 0.10.6",
  "smallvec",
  "tempfile",
- "tendermint 0.31.1",
+ "tendermint",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -3470,8 +3470,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-tower-trace"
-version = "0.53.1"
-source = "git+https://github.com/astriaorg/penumbra.git?branch=noot/fix-trace-v0.53.1#713a26c20f7a6bde3d2f7c6cea1f54bcca01fe40"
+version = "0.54.1"
+source = "git+https://github.com/astriaorg/penumbra.git?branch=noot/fix-trace#78153d8645bc0a382ec4bc8c494306809a69d9be"
 dependencies = [
  "futures",
  "hex",
@@ -3479,8 +3479,8 @@ dependencies = [
  "pin-project",
  "pin-project-lite",
  "sha2 0.9.9",
- "tendermint 0.31.1",
- "tendermint-proto 0.31.1",
+ "tendermint",
+ "tendermint-proto",
  "tokio",
  "tokio-stream",
  "tokio-util 0.7.5",
@@ -4717,38 +4717,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90c3c1e32352551f0f1639ce765e4c66ce250c733d4b9ba1aff81130437465c"
-dependencies = [
- "bytes",
- "digest 0.10.6",
- "ed25519 1.5.3",
- "ed25519-consensus",
- "flex-error",
- "futures",
- "num-traits",
- "once_cell",
- "prost",
- "prost-types",
- "serde",
- "serde_bytes",
- "serde_json",
- "serde_repr",
- "sha2 0.10.6",
- "signature 1.6.4",
- "subtle",
- "subtle-encoding",
- "tendermint-proto 0.30.0",
- "time",
- "zeroize",
-]
-
-[[package]]
-name = "tendermint"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1b58bdb6c44a2621b8b6bd0585d5912ba32546317604130a42410bcc813ef16"
+checksum = "a46ec6b25b028097ab682ffae11d09d64fe1e2535833b902f26a278a0f88a705"
 dependencies = [
  "bytes",
  "digest 0.10.6",
@@ -4768,34 +4739,16 @@ dependencies = [
  "signature 2.1.0",
  "subtle",
  "subtle-encoding",
- "tendermint-proto 0.31.1",
+ "tendermint-proto",
  "time",
  "zeroize",
 ]
 
 [[package]]
 name = "tendermint-proto"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e553ed65874c3f35a71eb60d255edfea956274b5af37a0297d54bba039fe45e3"
-dependencies = [
- "bytes",
- "flex-error",
- "num-derive",
- "num-traits",
- "prost",
- "prost-types",
- "serde",
- "serde_bytes",
- "subtle-encoding",
- "time",
-]
-
-[[package]]
-name = "tendermint-proto"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f15666993e193fa4d2b2479aa1e4f1bbe41283c820812df8dd618f41ca3f7a"
+checksum = "6ce23c8ff0e6634eb4c3c4aeed45076dc97dac91aac5501a905a67fa222e165b"
 dependencies = [
  "bytes",
  "flex-error",
@@ -5075,16 +5028,16 @@ dependencies = [
 
 [[package]]
 name = "tower-abci"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaddfcab2a1c77ba634491e710b04653c4b53ae1a541c56a02c5c3fc9facc80c"
+checksum = "8e1ae4967b2fa1d153c226dd9ca5d42b36749a35c6b57f0fe03e342390664d82"
 dependencies = [
  "bytes",
  "futures",
  "pin-project",
  "prost",
- "tendermint 0.31.1",
- "tendermint-proto 0.31.1",
+ "tendermint",
+ "tendermint-proto",
  "tokio",
  "tokio-stream",
  "tokio-util 0.6.10",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,5 +52,5 @@ uuid = "1.3.1"
 which = "4.4.0"
 
 [patch."https://github.com/penumbra-zone/penumbra.git"]
-penumbra-storage = { git = "https://github.com/astriaorg/penumbra.git", branch = "noot/fix-trace" }
-penumbra-tower-trace = { git = "https://github.com/astriaorg/penumbra.git", branch = "noot/fix-trace" }
+penumbra-storage = { git = "https://github.com/astriaorg/penumbra.git", rev = "78153d8645bc0a382ec4bc8c494306809a69d9be" }
+penumbra-tower-trace = { git = "https://github.com/astriaorg/penumbra.git", rev = "78153d8645bc0a382ec4bc8c494306809a69d9be" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,3 @@ tracing = "0.1"
 tracing-subscriber = "0.3"
 uuid = "1.3.1"
 which = "4.4.0"
-
-[patch."https://github.com/penumbra-zone/penumbra.git"]
-penumbra-storage = { git = "https://github.com/astriaorg/penumbra.git", rev = "78153d8645bc0a382ec4bc8c494306809a69d9be" }
-penumbra-tower-trace = { git = "https://github.com/astriaorg/penumbra.git", rev = "78153d8645bc0a382ec4bc8c494306809a69d9be" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,8 @@ rand = "0.7"
 # in the entire workspace
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
 tempfile = "3.5.0"
-tendermint = "0.30"
-tendermint-proto = "0.30"
+tendermint = "0.32"
+tendermint-proto = "0.32"
 tokio = "1.28"
 tonic = "0.9"
 tracing = "0.1"
@@ -52,5 +52,5 @@ uuid = "1.3.1"
 which = "4.4.0"
 
 [patch."https://github.com/penumbra-zone/penumbra.git"]
-penumbra-storage = { git = "https://github.com/astriaorg/penumbra.git", branch = "noot/fix-trace-v0.53.1" }
-penumbra-tower-trace = { git = "https://github.com/astriaorg/penumbra.git", branch = "noot/fix-trace-v0.53.1" }
+penumbra-storage = { git = "https://github.com/astriaorg/penumbra.git", branch = "noot/fix-trace" }
+penumbra-tower-trace = { git = "https://github.com/astriaorg/penumbra.git", branch = "noot/fix-trace" }

--- a/crates/astria-sequencer/Cargo.toml
+++ b/crates/astria-sequencer/Cargo.toml
@@ -7,12 +7,10 @@ edition = "2021"
 anyhow = "1"
 borsh = "0.10.3"
 is-terminal = "0.4.7"
-penumbra-storage = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.53.1" }
-penumbra-tower-trace = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.53.1" }
-tendermint-proto = "0.31"
-tendermint = "0.31"
+penumbra-storage = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.54.1" }
+penumbra-tower-trace = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.54.1" }
 tower = "0.4"
-tower-abci = "0.7.0"
+tower-abci = "0.8.0"
 tower-actor = "0.1.0"
 
 async-trait = { workspace = true }
@@ -22,6 +20,8 @@ futures = { workspace = true }
 hex = { workspace = true }
 serde = { workspace = true, features = ["derive"]  }
 serde_json = { workspace = true }
+tendermint-proto = { workspace = true }
+tendermint = { workspace = true }
 tokio = { workspace = true, features = [ "rt", "tracing" ] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["ansi", "env-filter", "json"] }

--- a/crates/astria-sequencer/Cargo.toml
+++ b/crates/astria-sequencer/Cargo.toml
@@ -7,8 +7,9 @@ edition = "2021"
 anyhow = "1"
 borsh = "0.10.3"
 is-terminal = "0.4.7"
-penumbra-storage = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.54.1" }
-penumbra-tower-trace = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.54.1" }
+# commit builds off v0.54.1
+penumbra-storage = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "d8d5cd0b00876380147d7ddc7f3005178e3d9ae0" }
+penumbra-tower-trace = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "d8d5cd0b00876380147d7ddc7f3005178e3d9ae0" }
 tower = "0.4"
 tower-abci = "0.8.0"
 tower-actor = "0.1.0"


### PR DESCRIPTION
version bumps, will allow us to use https://github.com/penumbra-zone/penumbra/pull/2723 when/if it's merged so we can remove the patch