### PR TITLE
chore: update rustfmt to recent nightly

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -72,9 +72,11 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2023-07-01
+          toolchain: nightly-2023-07-07
           components: rustfmt
       - name: run rustfmt
+        # note: for local development usually `cargo +nightly fmt` is sufficient;
+        # or `cargo +nightly-2023-07-07 fmt` for specifying the exactly release.
         run: cargo fmt --all -- --check
 
   clippy:


### PR DESCRIPTION
Rustfmt 1.6.0 has been released and is now part
of rust nightly. This broke CI. This commit sets
CI to a fixed rust nightly release so that this
won't happen again.