### PR TITLE
feat: implement celestia json rpc client

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -59,6 +59,10 @@ jobs:
       - run: just perform-prepull
       - run: just wait-for-ingress-controller
       - run: just wait-for-prepull
+      - run: just start-celestia-jsonrpc-test-deployment
+      - run: just wait-for-celestia-jsonrpc-test-deployment
+      - name: wait 5 seconds for ingress to pick up rules, services
+        run: sleep 5
       - name: Run heavy tests
         run: |
           cargo test --release \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,6 +320,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "astria-celestia-jsonrpc-client"
+version = "0.1.0"
+dependencies = [
+ "astria-test-utils",
+ "base64 0.21.0",
+ "base64-serde",
+ "http",
+ "jsonrpsee",
+ "serde",
+ "serde_json",
+ "serial_test",
+ "tokio",
+]
+
+[[package]]
 name = "astria-conductor"
 version = "0.1.0"
 dependencies = [
@@ -521,6 +536,15 @@ dependencies = [
  "eyre",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "astria-test-utils"
+version = "0.1.0"
+dependencies = [
+ "k8s-openapi",
+ "kube",
+ "tokio",
 ]
 
 [[package]]
@@ -747,6 +771,15 @@ name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bincode"
@@ -1311,6 +1344,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.12.3",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core 0.9.7",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1840,6 +1886,10 @@ name = "futures-timer"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+dependencies = [
+ "gloo-timers",
+ "send_wrapper",
+]
 
 [[package]]
 name = "futures-util"
@@ -1924,6 +1974,51 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "gloo-net"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9902a044653b26b99f7e3693a42f171312d9be8b26b5697bd1e43ad1f8a35e10"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-sink",
+ "gloo-utils",
+ "js-sys",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "gloo-utils"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037fcb07216cb3a30f7292bd0176b050b7b9a052ba830ef7d5d65f6dc64ba58e"
+dependencies = [
+ "js-sys",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "web-sys",
+]
 
 [[package]]
 name = "group"
@@ -2509,6 +2604,137 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpsee"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1822d18e4384a5e79d94dc9e4d1239cfa9fad24e55b44d2efeff5b394c9fece4"
+dependencies = [
+ "jsonrpsee-client-transport",
+ "jsonrpsee-core",
+ "jsonrpsee-http-client",
+ "jsonrpsee-proc-macros",
+ "jsonrpsee-types",
+ "jsonrpsee-wasm-client",
+ "jsonrpsee-ws-client",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-client-transport"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11aa5766d5c430b89cb26a99b88f3245eb91534be8126102cea9e45ee3891b22"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "gloo-net",
+ "http",
+ "jsonrpsee-core",
+ "pin-project",
+ "rustls-native-certs 0.6.2",
+ "soketto",
+ "thiserror",
+ "tokio",
+ "tokio-rustls 0.24.0",
+ "tokio-util 0.7.5",
+ "tracing",
+ "webpki-roots 0.23.1",
+]
+
+[[package]]
+name = "jsonrpsee-core"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64c6832a55f662b5a6ecc844db24b8b9c387453f923de863062c60ce33d62b81"
+dependencies = [
+ "anyhow",
+ "async-lock",
+ "async-trait",
+ "beef",
+ "futures-timer",
+ "futures-util",
+ "hyper",
+ "jsonrpsee-types",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "jsonrpsee-http-client"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1705c65069729e3dccff6fd91ee431d5d31cabcf00ce68a62a2c6435ac713af9"
+dependencies = [
+ "async-trait",
+ "hyper",
+ "hyper-rustls 0.24.0",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-proc-macros"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6027ac0b197ce9543097d02a290f550ce1d9432bf301524b013053c0b75cc94"
+dependencies = [
+ "heck",
+ "proc-macro-crate 1.1.3",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "jsonrpsee-types"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e5bf6c75ce2a4217421154adfc65a24d2b46e77286e59bba5d9fa6544ccc8f4"
+dependencies = [
+ "anyhow",
+ "beef",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-wasm-client"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34e6ea7c6d862e60f8baebd946c037b70c6808a4e4e31e792a4029184e3ce13a"
+dependencies = [
+ "jsonrpsee-client-transport",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+]
+
+[[package]]
+name = "jsonrpsee-ws-client"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64b2589680ba1ad7863f279cd2d5083c1dc0a7c0ea959d22924553050f8ab9f"
+dependencies = [
+ "http",
+ "jsonrpsee-client-transport",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+]
+
+[[package]]
 name = "k8s-openapi"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2568,6 +2794,7 @@ dependencies = [
  "kube-core",
  "pem",
  "pin-project",
+ "rand 0.8.5",
  "rustls 0.21.1",
  "rustls-pemfile",
  "secrecy",
@@ -2576,6 +2803,7 @@ dependencies = [
  "serde_yaml",
  "thiserror",
  "tokio",
+ "tokio-tungstenite",
  "tokio-util 0.7.5",
  "tower",
  "tower-http",
@@ -4635,6 +4863,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
+name = "send_wrapper"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
+
+[[package]]
 name = "serde"
 version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4739,6 +4973,31 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "serial_test"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e56dd856803e253c8f298af3f4d7eb0ae5e23a737252cd90bb4f3b435033b2d"
+dependencies = [
+ "dashmap",
+ "futures",
+ "lazy_static",
+ "log",
+ "parking_lot 0.12.1",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -4879,6 +5138,21 @@ checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "soketto"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d1c5305e39e09653383c2c7244f2f78b3bcae37cf50c64cb4789c9f5096ec2"
+dependencies = [
+ "base64 0.13.1",
+ "bytes",
+ "futures",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha-1",
 ]
 
 [[package]]
@@ -5290,6 +5564,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54319c93411147bced34cb5609a80e0a8e44c5999c93903a81cd866630ec0bfd"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5634,6 +5920,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
+name = "tungstenite"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ee6ab729cd4cf0fd55218530c4522ed30b7b6081752839b68fcec8d0960788"
+dependencies = [
+ "base64 0.13.1",
+ "byteorder",
+ "bytes",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror",
+ "url",
+ "utf-8",
+]
+
+[[package]]
 name = "turn"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5759,6 +6064,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8parse"
@@ -5979,6 +6290,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki 0.22.0",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b03058f88386e5ff5310d9111d53f48b17d732b401aeb83a8d5190f2ac459338"
+dependencies = [
+ "rustls-webpki",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 
 members = [
+  "crates/astria-celestia-jsonrpc-client",
   "crates/astria-conductor",
   "crates/astria-conductor-test",
   "crates/astria-gossipnet",
@@ -11,6 +12,7 @@ members = [
   "crates/astria-sequencer-relayer",
   "crates/astria-sequencer-relayer-test",
   "crates/astria-sequencer-utils",
+  "crates/astria-test-utils",
 ]
 
 [workspace.dependencies]

--- a/crates/astria-celestia-jsonrpc-client/Cargo.toml
+++ b/crates/astria-celestia-jsonrpc-client/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "astria-celestia-jsonrpc-client"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+base64.workspace = true
+base64-serde = "0.7.0"
+http = "0.2.9"
+jsonrpsee = { version = "0.18.2", features = ["macros", "client"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true, features = ["raw_value"] }
+
+[dev-dependencies]
+astria-test-utils = { path = "../astria-test-utils" }
+serial_test = "2.0.0"
+tokio = { workspace = true, features = ["rt", "macros"] }

--- a/crates/astria-celestia-jsonrpc-client/README.md
+++ b/crates/astria-celestia-jsonrpc-client/README.md
@@ -1,0 +1,16 @@
+# Celestia JSON RPC client
+
+This crate provides a high level API to interact with the
+Celestia JSON RPC.
+
+# Testing
+
+The API is checked against an instance of `celestia-node:v0.11.0-rc7`.
+For local testing, a kubernetes cluster must be present and running.
+From the root of the monorepo:
+```sh
+$ kind create --cluster --config kubernetes-ci/cluster-config.yml
+$ kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
+$ kubectl apply -k crates/astria-celestia-jsonrpc-client/k8s/
+$ cargo test -p astria-celestia-jsonrpc-client -- --ignored
+```

--- a/crates/astria-celestia-jsonrpc-client/k8s/config-maps.yml
+++ b/crates/astria-celestia-jsonrpc-client/k8s/config-maps.yml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: celestia-config
+data:
+  coins: "1000000000000000utia"
+  validator_stake: "5000000000utia"
+  chainid: "test"
+  keyring_backend: "test"
+  validator_key_name: "validator"
+  # evm address corresponds to private key:
+  # da6ed55cb2894ac2c9c10209c09de8e8b9d109b910338d5bf3d747a7e1fc9eb9
+  evm_address: "0x966e6f22781EF6a6A82BBB4DB3df8E225DfD9488"
+  home_dir: "/home/celestia"
+---

--- a/crates/astria-celestia-jsonrpc-client/k8s/deployment.yml
+++ b/crates/astria-celestia-jsonrpc-client/k8s/deployment.yml
@@ -1,0 +1,99 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: astria-celestia-jsonrpc-client-test
+  labels:
+    app.kubernetes.io/name: astria-celestia-jsonrpc-client-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: astria-celestia-jsonrpc-client-test
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: astria-celestia-jsonrpc-client-test
+    spec:
+      securityContext:
+        runAsUser: 10001
+        fsGroup: 10001
+        fsGroupChangePolicy: "OnRootMismatch"
+      initContainers:
+        - name: init-celestia-app
+          command: 
+          - /scripts/init-celestia-appd.sh
+          image: "ghcr.io/celestiaorg/celestia-app:v1.0.0-rc7"
+          volumeMounts:
+            - mountPath: /scripts
+              name: celestia-appd-scripts-volume
+              readOnly: true
+            - mountPath: /home/celestia
+              name: celestia-home
+          envFrom:
+            - configMapRef:
+                name: celestia-config
+        - command:
+          - /scripts/init-bridge.sh
+          name: init-bridge
+          image: "ghcr.io/astriaorg/test-images-celestia-node:v0.11.0-rc7"
+          volumeMounts:
+            - mountPath: /scripts/
+              name: bridge-scripts-volume
+              readOnly: true
+            - mountPath: /home/celestia
+              name: celestia-home
+          envFrom:
+            - configMapRef:
+                name: celestia-config
+      containers:
+        - name: celestia-app
+          command: ["/scripts/start-celestia-appd.sh"]
+          image: "ghcr.io/celestiaorg/celestia-app:v1.0.0-rc7"
+          envFrom:
+            - configMapRef:
+                name: celestia-config
+          volumeMounts:
+          - mountPath: /scripts/
+            name: celestia-appd-scripts-volume
+            readOnly: true
+          - mountPath: /home/celestia
+            name: celestia-home
+        - name: celestia-bridge
+          command:
+          - /scripts/start-bridge.sh
+          image: "ghcr.io/astriaorg/test-images-celestia-node:v0.11.0-rc7"
+          volumeMounts:
+            - mountPath: /scripts/
+              name: bridge-scripts-volume
+              readOnly: true
+            - mountPath: /home/celestia
+              name: celestia-home
+          envFrom:
+            - configMapRef:
+                name: celestia-config
+          ports:
+            - containerPort: 26659
+              name: bridge-rest
+            - containerPort: 26658
+              name: bridge-jsonrpc
+          startupProbe:
+            httpGet:
+              path: /header/1
+              port: bridge-rest
+            failureThreshold: 30
+            periodSeconds: 10
+          lifecycle:
+            postStart:
+              exec:
+                command: ["/scripts/generate-token.sh"]
+      volumes:
+      - name: bridge-scripts-volume
+        configMap:
+          name: bridge-scripts
+          defaultMode: 0550
+      - name: celestia-appd-scripts-volume
+        configMap:
+          name: celestia-appd-scripts
+          defaultMode: 0550
+      - emptyDir: {}
+        name: celestia-home

--- a/crates/astria-celestia-jsonrpc-client/k8s/ingress.yml
+++ b/crates/astria-celestia-jsonrpc-client/k8s/ingress.yml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: astria-celestia-jsonrpc-client-test
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+spec:
+  rules: 
+  - host: astria-celestia-jsonrpc-client-test.localdev.me
+    http:
+      paths:
+        - path: /bridge/(.*)
+          pathType: ImplementationSpecific
+          backend:
+            service:
+              name: astria-celestia-jsonrpc-client-test
+              port:
+                name: bridge-rest
+        - path: /jsonrpc/(.*)
+          pathType: ImplementationSpecific
+          backend:
+            service:
+              name: astria-celestia-jsonrpc-client-test
+              port:
+                name: bridge-jsonrpc
+---

--- a/crates/astria-celestia-jsonrpc-client/k8s/kustomization.yml
+++ b/crates/astria-celestia-jsonrpc-client/k8s/kustomization.yml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: astria-celestia-jsonrpc-client-test
+resources:
+- config-maps.yml
+- deployment.yml
+- service.yml
+- ingress.yml
+- namespace.yml
+configMapGenerator:
+- name: celestia-appd-scripts
+  files:
+  - scripts/init-celestia-appd.sh
+  - scripts/start-celestia-appd.sh
+- name: bridge-scripts
+  files:
+  - scripts/init-bridge.sh
+  - scripts/start-bridge.sh
+  - scripts/generate-token.sh

--- a/crates/astria-celestia-jsonrpc-client/k8s/namespace.yml
+++ b/crates/astria-celestia-jsonrpc-client/k8s/namespace.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: filled.by.kustomize

--- a/crates/astria-celestia-jsonrpc-client/k8s/scripts/generate-token.sh
+++ b/crates/astria-celestia-jsonrpc-client/k8s/scripts/generate-token.sh
@@ -1,0 +1,4 @@
+#!/bin/sh -x
+celestia bridge auth admin \
+  --node.store "$home_dir/bridge" \
+  --keyring.accname validator > "$home_dir"/.admin_token

--- a/crates/astria-celestia-jsonrpc-client/k8s/scripts/init-bridge.sh
+++ b/crates/astria-celestia-jsonrpc-client/k8s/scripts/init-bridge.sh
@@ -1,0 +1,8 @@
+#!/bin/sh -x
+
+set -o errexit -o nounset
+
+celestia bridge init \
+  --node.store "$home_dir/bridge" \
+  --core.ip 127.0.0.1
+cp -r "$home_dir/keyring-test" "$home_dir/bridge/keys/"

--- a/crates/astria-celestia-jsonrpc-client/k8s/scripts/init-celestia-appd.sh
+++ b/crates/astria-celestia-jsonrpc-client/k8s/scripts/init-celestia-appd.sh
@@ -1,0 +1,31 @@
+#!/bin/sh -x
+
+set -o errexit -o nounset
+
+rm -rf "$home_dir"/*
+
+
+celestia-appd init "$chainid" \
+  --chain-id "$chainid" \
+  --home "$home_dir"
+
+celestia-appd keys add \
+  "$validator_key_name" \
+  --keyring-backend="$keyring_backend" \
+  --home "$home_dir"
+
+validator_key=$(celestia-appd keys show "$validator_key_name" -a --keyring-backend="$keyring_backend" --home "$home_dir")
+celestia-appd add-genesis-account \
+  "$validator_key" \
+  --home "$home_dir" \
+  "$coins"
+
+celestia-appd gentx \
+  "$validator_key_name" \
+  "$validator_stake" \
+  --keyring-backend="$keyring_backend" \
+  --chain-id "$chainid" \
+  --home "$home_dir" \
+  --evm-address "$evm_address"
+
+celestia-appd collect-gentxs --home "$home_dir"

--- a/crates/astria-celestia-jsonrpc-client/k8s/scripts/start-bridge.sh
+++ b/crates/astria-celestia-jsonrpc-client/k8s/scripts/start-bridge.sh
@@ -1,0 +1,20 @@
+#!/bin/sh -x
+
+set -o errexit -o nounset -o pipefail
+
+if genesis_hash=$(curl -s -S -X GET "http://127.0.0.1:26657/block?height=1" | jq -er '.result.block_id.hash');
+then
+  : "genesis hash received successfully"
+else
+  echo "did not receive genesis hash from celestia; exiting"
+  exit 1
+fi
+
+echo "using genesis hash: $genesis_hash"
+
+export GOLOG_LOG_LEVEL="debug"
+export CELESTIA_CUSTOM="test:$genesis_hash"
+exec celestia bridge start \
+  --node.store "$home_dir/bridge" \
+  --gateway \
+  --keyring.accname "$validator_key_name"

--- a/crates/astria-celestia-jsonrpc-client/k8s/scripts/start-celestia-appd.sh
+++ b/crates/astria-celestia-jsonrpc-client/k8s/scripts/start-celestia-appd.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -o errexit -o nounset
+
+# Start the celestia-app
+exec celestia-appd start --home "${home_dir}"

--- a/crates/astria-celestia-jsonrpc-client/k8s/service.yml
+++ b/crates/astria-celestia-jsonrpc-client/k8s/service.yml
@@ -1,0 +1,14 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: astria-celestia-jsonrpc-client-test
+spec: 
+  selector:
+    app.kubernetes.io/name: astria-celestia-jsonrpc-client-test
+  ports:
+    - name: bridge-rest
+      port: 26659
+      targetPort: bridge-rest
+    - name: bridge-jsonrpc
+      port: 26658
+      targetPort: bridge-jsonrpc

--- a/crates/astria-celestia-jsonrpc-client/src/blob.rs
+++ b/crates/astria-celestia-jsonrpc-client/src/blob.rs
@@ -1,0 +1,251 @@
+use serde::Deserialize;
+
+pub use crate::rpc_impl::blob::NAMESPACE_ID_AVAILABLE_LEN;
+use crate::{
+    rpc_impl::blob::{
+        Blob as RawBlob,
+        BlobClient as _,
+        Namespace,
+        NAMESPACE_VERSION_LEN,
+        NAMESPACE_VERSION_ZERO_PREFIX_LEN,
+    },
+    Client,
+    DeserializationError,
+    Error,
+};
+
+/// A wrapper around the raw blob object submitted to the celestia JSON RPC.
+///
+/// See [`rpc_impl::blob::Blob`] for the whole thing.
+#[derive(Debug, Default, Deserialize)]
+#[serde(from = "RawBlob")]
+pub struct Blob {
+    pub namespace_id: [u8; NAMESPACE_ID_AVAILABLE_LEN],
+    pub data: Vec<u8>,
+}
+
+impl From<RawBlob> for Blob {
+    fn from(raw_blob: RawBlob) -> Self {
+        Blob::from_raw_blob(raw_blob)
+    }
+}
+
+impl Blob {
+    fn from_raw_blob(raw_blob: RawBlob) -> Self {
+        let RawBlob {
+            namespace,
+            data,
+            ..
+        } = raw_blob;
+        let mut namespace_id = [0u8; NAMESPACE_ID_AVAILABLE_LEN];
+        namespace_id.copy_from_slice(
+            &(*namespace)[NAMESPACE_VERSION_LEN + NAMESPACE_VERSION_ZERO_PREFIX_LEN..],
+        );
+        Self {
+            namespace_id,
+            data,
+        }
+    }
+
+    /// Construct a new blob with a zero namespace ID and
+    /// empty data.
+    ///
+    /// Note that the default namespace ID (all zeros) falls in the
+    /// reserved range and will result in an error from the JSON RPC
+    /// endpoint. See [`Blob::namespace_id`].
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the namespace ID to the given value.
+    ///
+    /// At the moment the length of a celestia namespace is 10 bytes long.
+    ///
+    /// Note that this client performs no extra verification. If the provided namespace ID
+    /// falls into the reserved region then the celestia JSON RPC service will likely return
+    /// an error.
+    ///
+    /// As of rev 71e5006 the reserved namespace are all slices that match
+    /// `[0, 0, 0, 0, 0, 0, 0, 0, 0, x]`, with x falling in the range from to 255.
+    /// See also [`Namespace.IsReserved`] and [`namespace.MaxReservedNamespace`]
+    ///
+    /// [`Namespace.IsReserved`]: https://github.com/celestiaorg/celestia-app/blob/71e500611d51c9f6444748ff8655415eaae03356/pkg/namespace/namespace.go#L124
+    /// [`namespace.MaxReservedNamespace`]: https://github.com/celestiaorg/celestia-app/blob/71e500611d51c9f6444748ff8655415eaae03356/pkg/namespace/consts.go#L56
+    pub fn set_namespace_id(
+        &mut self,
+        namespace_id: [u8; NAMESPACE_ID_AVAILABLE_LEN],
+    ) -> &mut Self {
+        self.namespace_id = namespace_id;
+        self
+    }
+
+    /// Sets the data in the blob to the provided value.
+    pub fn set_data(&mut self, data: Vec<u8>) -> &mut Self {
+        self.data = data;
+        self
+    }
+
+    /// Overwrites the data in the blob with the bytes in the provided slice.
+    pub fn set_data_from_slice(&mut self, data: &[u8]) -> &mut Self {
+        self.data.clear();
+        self.data.extend_from_slice(data);
+        self
+    }
+
+    #[must_use]
+    pub fn into_raw_blob(self) -> crate::rpc_impl::blob::Blob {
+        use crate::rpc_impl::blob::Blob;
+        let Self {
+            namespace_id,
+            data,
+        } = self;
+        Blob {
+            namespace: Namespace::new_v0(namespace_id),
+            data,
+            ..Blob::default()
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct GetAllRequest {
+    pub height: u64,
+    pub namespace_ids: Vec<[u8; NAMESPACE_ID_AVAILABLE_LEN]>,
+}
+
+#[derive(Debug)]
+pub struct GetAllResponse {
+    pub blobs: Vec<Blob>,
+}
+
+#[derive(Debug)]
+pub struct SubmitRequest {
+    pub blobs: Vec<Blob>,
+}
+
+#[derive(Debug)]
+pub struct SubmitResponse {
+    pub height: u64,
+}
+
+impl Client {
+    /// Issue a `blob.GetAll` JSON RPC.
+    ///
+    /// # Errors
+    /// Returns an error if the JSON RPC was not successful, or if the
+    /// response could not be deserialized into a [`GetAllResponse`].
+    pub async fn blob_get_all(&self, request: GetAllRequest) -> Result<GetAllResponse, Error> {
+        const RPC_NAME: &str = "blob.GetAll";
+        let GetAllRequest {
+            height,
+            namespace_ids,
+        } = request;
+        let namespaces = namespace_ids
+            .into_iter()
+            .map(Namespace::new_v0)
+            .collect::<Vec<_>>();
+        let raw_json = self
+            .inner
+            .get_all(height, &namespaces)
+            .await
+            .map_err(|e| Error::rpc(e, RPC_NAME))?;
+        let blobs: Vec<Blob> = serde_json::from_str(raw_json.get())
+            .map_err(|e| DeserializationError {
+                source: e,
+                rpc: RPC_NAME,
+                deser_target: "GetAllResponse",
+                raw_json: raw_json.clone(),
+            })
+            .map_err(|e| Error::deserialization(e, RPC_NAME))?;
+        Ok(GetAllResponse {
+            blobs,
+        })
+    }
+
+    /// Call the `blob.Submit` RPC.
+    ///
+    /// This is a high level API for the celestia `blob.Submit` method.
+    ///
+    /// # Errors
+    /// This has the same errors conditions as using the lower level
+    /// [`BlobClient::submit`].
+    pub async fn blob_submit(&self, request: SubmitRequest) -> Result<SubmitResponse, Error> {
+        const RPC_NAME: &str = "blob.Submit";
+        let raw_blobs: Vec<_> = request.blobs.into_iter().map(Blob::into_raw_blob).collect();
+        let raw_json = self
+            .inner
+            .submit(&raw_blobs)
+            .await
+            .map_err(|e| Error::rpc(e, RPC_NAME))?;
+        let height: u64 = serde_json::from_str(raw_json.get())
+            .map_err(|e| DeserializationError {
+                source: e,
+                rpc: RPC_NAME,
+                deser_target: "SubmitResponse",
+                raw_json: raw_json.clone(),
+            })
+            .map_err(|e| Error::deserialization(e, RPC_NAME))?;
+        let rsp = SubmitResponse {
+            height,
+        };
+        Ok(rsp)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        Blob,
+        SubmitRequest,
+    };
+    use crate::{
+        blob::GetAllRequest,
+        test_utils::make_client,
+    };
+
+    #[tokio::test]
+    #[serial_test::serial]
+    #[ignore = "this needs to be run against a running celestia cluster"]
+    async fn blob_submit_works() {
+        let client = make_client().await;
+        let req = SubmitRequest {
+            blobs: vec![
+                Blob {
+                    namespace_id: *b"shrd-sqncr",
+                    data: b"helloworld".to_vec(),
+                },
+                Blob {
+                    namespace_id: *b"shrd-sqncr",
+                    data: b"helloworld".to_vec(),
+                },
+            ],
+        };
+        let _rsp = client.blob_submit(req).await.unwrap();
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    #[ignore = "this needs to be run against a running celestia cluster"]
+    async fn blob_get_all_works() {
+        let data = b"helloworld";
+        let client = make_client().await;
+        // First submit a blob for inclusion
+        let req = SubmitRequest {
+            blobs: vec![Blob {
+                namespace_id: *b"shrd-sqncr",
+                data: data.to_vec(),
+            }],
+        };
+        let rsp = client.blob_submit(req).await.unwrap();
+        // Then retrieve it using `blob.GetAll`
+        let req = GetAllRequest {
+            height: rsp.height,
+            namespace_ids: vec![*b"shrd-sqncr"],
+        };
+        let rsp = client.blob_get_all(req).await.unwrap();
+        assert_eq!(1, rsp.blobs.len());
+        let received_data = &*rsp.blobs[0].data;
+        assert_eq!(data, received_data);
+    }
+}

--- a/crates/astria-celestia-jsonrpc-client/src/header.rs
+++ b/crates/astria-celestia-jsonrpc-client/src/header.rs
@@ -1,0 +1,72 @@
+use serde::Deserialize;
+
+use crate::{
+    rpc_impl::header::HeaderClient as _,
+    Client,
+    DeserializationError,
+    Error,
+};
+
+#[derive(Debug, Deserialize)]
+pub struct Commit {
+    pub height: u64,
+    #[serde(flatten)]
+    pub rest: serde_json::Value,
+}
+
+/// The response of the `header.NetworkHead` JSON RPC.
+#[derive(Debug, Deserialize)]
+pub struct NetworkHeaderResponse {
+    pub commit: Commit,
+    #[serde(flatten)]
+    pub inner: serde_json::Value,
+}
+
+impl NetworkHeaderResponse {
+    /// Return the current height of the network as reported by the response.
+    ///
+    /// This function returns the `.commit.height` field of the response received from
+    /// the `header.NetworkHead` RPC call.
+    #[must_use]
+    pub fn height(&self) -> u64 {
+        self.commit.height
+    }
+}
+
+impl Client {
+    /// Issue a `header.NetworkHead` JSON RPC.
+    ///
+    /// # Errors
+    /// Returns an error if the JSON RPC was not successful, or if the
+    /// response could not be deserialized into a [`NetworkHeaderResponse`].
+    pub async fn header_network_head(&self) -> Result<NetworkHeaderResponse, Error> {
+        const RPC_NAME: &str = "header.NetworkHead";
+        let raw_json = self
+            .inner
+            .network_head()
+            .await
+            .map_err(|e| Error::rpc(e, RPC_NAME))?;
+        let rsp: NetworkHeaderResponse = serde_json::from_str(raw_json.get())
+            .map_err(|e| DeserializationError {
+                source: e,
+                rpc: RPC_NAME,
+                deser_target: "NetworkHeaderResponse",
+                raw_json: raw_json.clone(),
+            })
+            .map_err(|e| Error::deserialization(e, RPC_NAME))?;
+        Ok(rsp)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_utils;
+
+    #[tokio::test]
+    #[serial_test::parallel]
+    #[ignore = "this needs to be run against a running celestia cluster"]
+    async fn network_head_works() {
+        let client = test_utils::make_client().await;
+        let _rsp = client.header_network_head().await.unwrap();
+    }
+}

--- a/crates/astria-celestia-jsonrpc-client/src/lib.rs
+++ b/crates/astria-celestia-jsonrpc-client/src/lib.rs
@@ -1,0 +1,379 @@
+pub mod blob;
+pub mod header;
+pub mod state;
+
+pub mod rpc_impl;
+
+pub use rpc_impl::blob::Blob;
+pub(crate) mod serde;
+#[cfg(test)]
+pub(crate) mod test_utils;
+
+#[derive(Debug)]
+pub struct DeserializationError {
+    pub(crate) source: serde_json::Error,
+    pub(crate) rpc: &'static str,
+    pub(crate) deser_target: &'static str,
+    pub(crate) raw_json: Box<serde_json::value::RawValue>,
+}
+
+impl DeserializationError {
+    #[must_use]
+    pub fn raw_json(&self) -> &serde_json::value::RawValue {
+        &self.raw_json
+    }
+
+    #[must_use]
+    pub fn source(&self) -> &serde_json::Error {
+        &self.source
+    }
+}
+
+impl std::fmt::Display for DeserializationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "failed to deserialize response from `{rpc}` as `{deser_target}`; see \
+             error.raw_json() for server response",
+            rpc = self.rpc,
+            deser_target = self.deser_target,
+        )
+    }
+}
+
+impl std::error::Error for DeserializationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
+#[derive(Debug)]
+pub struct Error {
+    inner: ErrorKind,
+    rpc: &'static str,
+}
+
+impl Error {
+    pub(crate) fn deserialization(e: DeserializationError, rpc: &'static str) -> Self {
+        Self {
+            inner: ErrorKind::Deserialization(e),
+            rpc,
+        }
+    }
+
+    pub(crate) fn rpc(e: jsonrpsee::core::Error, rpc: &'static str) -> Self {
+        Self {
+            inner: ErrorKind::Rpc(e),
+            rpc,
+        }
+    }
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "`{}` RPC failed", self.rpc)
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self.inner.source())
+    }
+}
+
+#[derive(Debug)]
+pub enum ErrorKind {
+    Rpc(jsonrpsee::core::Error),
+    Deserialization(DeserializationError),
+}
+
+impl ErrorKind {
+    fn source(&self) -> &(dyn std::error::Error + 'static) {
+        match self {
+            Self::Rpc(e) => e,
+            Self::Deserialization(e) => e,
+        }
+    }
+}
+
+/// A celestia JSON RPC client.
+#[derive(Clone, Debug)]
+pub struct Client {
+    inner: jsonrpsee::http_client::HttpClient,
+}
+
+impl Client {
+    /// Construct a celestia client using a predefined [`HttpClient`].
+    pub fn from_jsonrpsee_client(inner: jsonrpsee::http_client::HttpClient) -> Self {
+        Self {
+            inner,
+        }
+    }
+
+    /// Construct a celestia client using the builder pattern.
+    #[must_use]
+    pub fn builder() -> ClientBuilder {
+        ClientBuilder::new()
+    }
+}
+
+/// Builder for the celestia JSON RPC client.
+///
+/// Configurable options:
+/// + bearer token (required)
+/// + endpoint (required)
+#[derive(Debug, Default)]
+pub struct ClientBuilder {
+    bearer_token: Option<String>,
+    endpoint: Option<String>,
+}
+
+impl ClientBuilder {
+    /// Return a celestia client builder with all fields initialized to `None`.
+    fn new() -> Self {
+        Self::default()
+    }
+
+    /// Consume the celestia client builder, returning a celestia client.
+    ///
+    /// # Errors
+    /// This methid will return errors in the following scenarios:
+    /// + if the bearer token is not set;
+    /// + if the endpoint is not set;
+    /// + if the bearer token contains invalid characters;
+    ///   + this method has the same error conditions as [`HeaderValue::from_str`];
+    /// + if building the underlying jsonrpc client failed;
+    ///   + this method has the same error conditions as
+    ///     [`jsonrpsee::http_client::HttpClientBuilder::build`].
+    pub fn build(self) -> Result<Client, BuildError> {
+        use jsonrpsee::http_client::{
+            HeaderMap,
+            HeaderValue,
+            HttpClientBuilder,
+        };
+        let Self {
+            bearer_token,
+            endpoint,
+        } = self;
+        let Some(bearer_token) = bearer_token else {
+            return Err(BuildError::missing_bearer_token());
+        };
+        let Some(endpoint) = endpoint else {
+            return Err(BuildError::missing_endpoint());
+        };
+        let mut headers = HeaderMap::new();
+        let bearer_token_value = HeaderValue::from_str(&format!("Bearer {bearer_token}"))
+            .map_err(BuildError::invalid_bearer_token)?;
+        headers.insert("Authorization", bearer_token_value);
+        let inner = HttpClientBuilder::default()
+            .set_headers(headers)
+            .build(endpoint)
+            .map_err(BuildError::jsonrpsee_builder)?;
+        Ok(Client::from_jsonrpsee_client(inner))
+    }
+
+    /// Sets the bearer token for the JSON RPC http client.
+    #[must_use]
+    pub fn bearer_token(self, bearer_token: &str) -> Self {
+        self.set_bearer_token(Some(bearer_token.to_string()))
+    }
+
+    /// Sets or unsets the bearer token for the JSON RPC http client.
+    #[must_use]
+    pub fn set_bearer_token(self, bearer_token: Option<String>) -> Self {
+        Self {
+            bearer_token,
+            ..self
+        }
+    }
+
+    /// Sets the endpoint that the client will connect to.
+    ///
+    /// Note that the string must be a valid URI with a port number.
+    /// Otherwise `ClientBuilder::build` will fail.
+    #[must_use]
+    pub fn endpoint(self, endpoint: &str) -> Self {
+        self.set_endpoint(Some(endpoint.to_string()))
+    }
+
+    /// Sets or unsets the endpoint that the client will connect to.
+    ///
+    /// Note that the string must be a valid URI with a port number.
+    /// Otherwise `ClientBuilder::build` will fail.
+    #[must_use]
+    pub fn set_endpoint(self, endpoint: Option<String>) -> Self {
+        Self {
+            endpoint,
+            ..self
+        }
+    }
+}
+
+/// The errors that can occur while configuring the celestia client.
+#[derive(Debug)]
+pub struct BuildError {
+    inner: Errors,
+}
+
+impl BuildError {
+    /// Utility function to construct a `BuildError` containing an `InvalidBearerToken`
+    fn invalid_bearer_token(e: http::header::InvalidHeaderValue) -> Self {
+        Self {
+            inner: Errors::InvalidBearerToken(InvalidBearerToken {
+                inner: e,
+            }),
+        }
+    }
+
+    /// Utility function to construct a `BuildError` containing a `jsonrpsee::core::Error`
+    fn jsonrpsee_builder(e: jsonrpsee::core::Error) -> Self {
+        Self {
+            inner: Errors::JsonRpseeBuilder(JsonRpseeBuilder {
+                inner: e,
+            }),
+        }
+    }
+
+    /// Utility function to construct a `BuildError` containing a `MissingBearerToken`
+    fn missing_bearer_token() -> Self {
+        Self {
+            inner: Errors::MissingBearerToken(MissingBearerToken {
+                _inner: (),
+            }),
+        }
+    }
+
+    /// Utility function to construct a `BuildError` containing a `MissingEndpoint`
+    fn missing_endpoint() -> Self {
+        Self {
+            inner: Errors::MissingEndpoint(MissingEndpoint {
+                _inner: (),
+            }),
+        }
+    }
+}
+
+impl std::fmt::Display for BuildError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.inner.fmt(f)
+    }
+}
+
+impl std::error::Error for BuildError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.inner.source()
+    }
+}
+
+/// All errors that are contained inside `BuildError`.
+///
+/// Used to delegate various trait impls.
+#[derive(Debug)]
+enum Errors {
+    InvalidBearerToken(InvalidBearerToken),
+    JsonRpseeBuilder(JsonRpseeBuilder),
+    MissingBearerToken(MissingBearerToken),
+    MissingEndpoint(MissingEndpoint),
+}
+
+impl std::fmt::Display for Errors {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Errors::InvalidBearerToken(inner) => inner.fmt(f),
+            Errors::JsonRpseeBuilder(inner) => inner.fmt(f),
+            Errors::MissingBearerToken(inner) => inner.fmt(f),
+            Errors::MissingEndpoint(inner) => inner.fmt(f),
+        }
+    }
+}
+
+impl std::error::Error for Errors {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Errors::InvalidBearerToken(inner) => inner.source(),
+            Errors::JsonRpseeBuilder(inner) => inner.source(),
+            Errors::MissingBearerToken(inner) => inner.source(),
+            Errors::MissingEndpoint(inner) => inner.source(),
+        }
+    }
+}
+
+/// If the bearer token contained non-ascii characters.
+#[derive(Debug)]
+struct InvalidBearerToken {
+    inner: http::header::InvalidHeaderValue,
+}
+
+/// If building the inner jsonrpsee client failed.
+///
+/// This usually happens if there is a problem with the underlying transport.
+#[derive(Debug)]
+struct JsonRpseeBuilder {
+    inner: jsonrpsee::core::Error,
+}
+
+/// If the bearer token was not set on the client builder.
+#[derive(Debug)]
+struct MissingBearerToken {
+    _inner: (),
+}
+
+/// If the endpoint was not set on the client builder.
+#[derive(Debug)]
+struct MissingEndpoint {
+    _inner: (),
+}
+
+impl std::fmt::Display for InvalidBearerToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let msg = "bearer token contained invalid characters";
+        f.write_str(msg)
+    }
+}
+
+impl std::fmt::Display for JsonRpseeBuilder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let msg = "failed constructing underlying http client";
+        f.write_str(msg)
+    }
+}
+
+impl std::fmt::Display for MissingBearerToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let msg = "bearer token not set on client builder: all requests to the celestia Node API \
+                   must have a bearer token";
+        f.write_str(msg)
+    }
+}
+
+impl std::fmt::Display for MissingEndpoint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let msg = "missing endpoint; an endpoint must be provided so that the client knows where \
+                   to connect";
+        f.write_str(msg)
+    }
+}
+
+impl std::error::Error for InvalidBearerToken {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.inner)
+    }
+}
+
+impl std::error::Error for JsonRpseeBuilder {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.inner)
+    }
+}
+
+impl std::error::Error for MissingBearerToken {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        None
+    }
+}
+
+impl std::error::Error for MissingEndpoint {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        None
+    }
+}

--- a/crates/astria-celestia-jsonrpc-client/src/rpc_impl/blob.rs
+++ b/crates/astria-celestia-jsonrpc-client/src/rpc_impl/blob.rs
@@ -1,0 +1,132 @@
+//! The Celestia JSON RPC blob API.
+//!
+//! Many of the constants are taken from these two sources:
+//!
+//! + [celestia-app:965eaf global_consts.go](https://github.com/celestiaorg/celestia-app/blob/965eafb4357376aec31f84f3628f7703c5587f9a/pkg/appconsts/global_consts.go)
+//! + [celestia-app:965eaf namespace/consts.go](https://github.com/celestiaorg/celestia-app/blob/965eafb4357376aec31f84f3628f7703c5587f9a/pkg/namespace/consts.go)
+use jsonrpsee::proc_macros::rpc;
+use serde::{
+    Deserialize,
+    Serialize,
+};
+
+use crate::serde::Base64Standard;
+
+/// The full theoretical length of the celestia namespace ID in bytes.
+///
+/// In practice the actual length available (at least for version 0 of the namespace
+/// API) is [`NAMESPACE_ID_ACTUAL_LEN`] (currently 10 bytes).
+///
+/// From [celestia-app:965eaf global_consts.go#L22](https://github.com/celestiaorg/celestia-app/blob/965eafb4357376aec31f84f3628f7703c5587f9a/pkg/appconsts/global_consts.go#L22)
+const NAMESPACE_ID_LEN: usize = 28;
+
+/// The length of the celestia namespace version in bytes.
+///
+/// From [celestia-app:965eaf global_consts.go#L16](https://github.com/celestiaorg/celestia-app/blob/965eafb4357376aec31f84f3628f7703c5587f9a/pkg/appconsts/global_consts.go#L16)
+pub(crate) const NAMESPACE_VERSION_LEN: usize = 1;
+
+/// The total length of the celestia namespace byte slice as ingested by their API.
+///
+/// Currently defined as the length of the namespace ID and the length of the namespace version.
+/// From [celestia-app:965eaf global_consts.go#L25](https://github.com/celestiaorg/celestia-app/blob/965eafb4357376aec31f84f3628f7703c5587f9a/pkg/appconsts/global_consts.go#L25)
+const NAMESPACE_LEN: usize = NAMESPACE_ID_LEN + NAMESPACE_VERSION_LEN;
+
+/// The number of zeros that the namespace ID is prefixed withe for version 0 of the namespace API.
+///
+/// From [celestia-app:965eaf namespace/consts.go#L28](https://github.com/celestiaorg/celestia-app/blob/965eafb4357376aec31f84f3628f7703c5587f9a/pkg/namespace/consts.go#L28)
+pub(crate) const NAMESPACE_VERSION_ZERO_PREFIX_LEN: usize = 18;
+
+/// The actual number of bytes that is available to the user to construct a namespace.
+///
+/// From [celestia-app:965eaf namespace/consts.go#L32](https://github.com/celestiaorg/celestia-app/blob/965eafb4357376aec31f84f3628f7703c5587f9a/pkg/namespace/consts.go#L32)
+pub const NAMESPACE_ID_AVAILABLE_LEN: usize = NAMESPACE_ID_LEN - NAMESPACE_VERSION_ZERO_PREFIX_LEN;
+
+/// The commitment of a blob.
+///
+/// At this time it is not clear how this is constructed, so should probably be left empty.
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct Commitment(#[serde(with = "Base64Standard")] Vec<u8>);
+
+impl Commitment {
+    /// Construct an empty commitment.
+    #[must_use]
+    pub fn empty() -> Self {
+        Commitment::default()
+    }
+}
+
+/// The celestia namespace.
+///
+/// Currently defined as a version byte + a 28 bytes.
+#[derive(Debug, Default, Serialize)]
+pub struct Namespace(#[serde(serialize_with = "Base64Standard::serialize")] [u8; NAMESPACE_LEN]);
+
+impl Namespace {
+    /// Constructs a new version 0 namespace with the given a namespace ID.
+    #[must_use]
+    pub fn new_v0(id: [u8; NAMESPACE_ID_AVAILABLE_LEN]) -> Self {
+        let mut namespace = [0u8; NAMESPACE_LEN];
+        namespace[NAMESPACE_VERSION_LEN + NAMESPACE_VERSION_ZERO_PREFIX_LEN..].copy_from_slice(&id);
+        Self(namespace)
+    }
+}
+
+impl std::ops::Deref for Namespace {
+    type Target = [u8; NAMESPACE_LEN];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for Namespace {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de::Error as _;
+        let buf: Vec<u8> = Base64Standard::deserialize(deserializer)?;
+        let namespace = match buf.try_into() {
+            Err(_) => {
+                return Err(D::Error::custom(
+                    "received a namespace of length other than 29 bytes",
+                ));
+            }
+            Ok(namespace) => namespace,
+        };
+        Ok(Self(namespace))
+    }
+}
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct Blob {
+    pub namespace: Namespace,
+    #[serde(with = "Base64Standard")]
+    pub data: Vec<u8>,
+    /// Currently only a share version of 0 seems to be supported.
+    ///
+    /// From: [https://github.com/celestiaorg/celestia-app/blob/965eafb4357376aec31f84f3628f7703c5587f9a/x/blob/types/payforblob.go#L114C1]
+    pub share_version: u32,
+    pub commitment: Commitment,
+}
+
+#[rpc(client)]
+pub trait Blob {
+    #[method(name = "blob.Get")]
+    async fn get(
+        &self,
+        height: u64,
+        namespace: Namespace,
+        commitment: Commitment,
+    ) -> Result<serde_json::Value, Error>;
+
+    #[method(name = "blob.GetAll")]
+    async fn get_all(
+        &self,
+        height: u64,
+        namespace: &[Namespace],
+    ) -> Result<Box<serde_json::value::RawValue>, Error>;
+
+    #[method(name = "blob.Submit")]
+    async fn submit(&self, blobs: &[Blob]) -> Result<Box<serde_json::value::RawValue>, Error>;
+}

--- a/crates/astria-celestia-jsonrpc-client/src/rpc_impl/header.rs
+++ b/crates/astria-celestia-jsonrpc-client/src/rpc_impl/header.rs
@@ -1,0 +1,11 @@
+/// The Celestia JSON RPC header API.
+///
+/// This currently only provides a wrapper for the `header.Network` RPC method.
+/// It is not completely clear what value `fee` should take. According to the
+use jsonrpsee::proc_macros::rpc;
+
+#[rpc(client)]
+pub trait Header {
+    #[method(name = "header.NetworkHead")]
+    async fn network_head(&self) -> Result<Box<serde_json::value::RawValue>, Error>;
+}

--- a/crates/astria-celestia-jsonrpc-client/src/rpc_impl/mod.rs
+++ b/crates/astria-celestia-jsonrpc-client/src/rpc_impl/mod.rs
@@ -1,0 +1,3 @@
+pub mod blob;
+pub mod header;
+pub mod state;

--- a/crates/astria-celestia-jsonrpc-client/src/rpc_impl/state.rs
+++ b/crates/astria-celestia-jsonrpc-client/src/rpc_impl/state.rs
@@ -1,0 +1,52 @@
+/// The Celestia JSON RPC state API.
+///
+/// This currently only provides a wrapper for the `state.SubmitPayForBlob` RPC method.
+/// It is not completely clear what value `fee` should take. According to the
+/// [go submitter interface] this is a cosmos-sdk/math.Int which wraps big.Int.
+///
+/// This implementation follows cosmrs's choice to use `u128` to
+/// represent amounts. See their [`cosmrs::Amount`] type, and the discussion in [cosmos-rust
+/// PR#235].
+///
+/// [go submitter interface]: https://github.com/celestiaorg/celestia-node/blob/beaf6dbdc73fd43b73a98578330a7a5ad422c3c8/blob/service.go#L31
+/// [`cosmrs::Amount`]: https://github.com/cosmos/cosmos-rust/blob/aef5c708e6dddeec4ad1ba2672c7874a40b9bfc1/cosmrs/src/base.rs#L10
+/// [cosmos-rust PR#235]: https://github.com/cosmos/cosmos-rust/pull/235
+use jsonrpsee::proc_macros::rpc;
+use serde::{
+    Serialize,
+    Serializer,
+};
+
+use crate::rpc_impl::blob::Blob;
+
+/// Newtype wrapper around a `u128` to serialize it as a string.
+///
+/// This is necessary because the `state.SubmitPayForBlob` endpoint requires
+/// a String object and is not able to directly unmarshal a json number to a
+/// `math.Int`.
+#[derive(Debug, Serialize)]
+pub struct Fee(#[serde(serialize_with = "serialize_u128_as_str")] u128);
+
+fn serialize_u128_as_str<S: Serializer>(val: &u128, ser: S) -> Result<S::Ok, S::Error> {
+    let val = val.to_string();
+    val.serialize(ser)
+}
+
+impl Fee {
+    /// Construct a new `Fee` from a `u128`.
+    #[must_use]
+    pub fn from_u128(val: u128) -> Self {
+        Self(val)
+    }
+}
+
+#[rpc(client)]
+pub trait State {
+    #[method(name = "state.SubmitPayForBlob")]
+    async fn submit_pay_for_blob(
+        &self,
+        fee: Fee,
+        gas_limit: u64,
+        blobs: &[Blob],
+    ) -> Result<Box<serde_json::value::RawValue>, Error>;
+}

--- a/crates/astria-celestia-jsonrpc-client/src/serde.rs
+++ b/crates/astria-celestia-jsonrpc-client/src/serde.rs
@@ -1,0 +1,3 @@
+use base64_serde::base64_serde_type;
+
+base64_serde_type!(pub(crate) Base64Standard, base64::engine::general_purpose::STANDARD);

--- a/crates/astria-celestia-jsonrpc-client/src/state.rs
+++ b/crates/astria-celestia-jsonrpc-client/src/state.rs
@@ -1,0 +1,91 @@
+use serde::Deserialize;
+
+use crate::{
+    blob::Blob,
+    rpc_impl::state::StateClient as _,
+    Client,
+    DeserializationError,
+    Error,
+};
+
+#[derive(Debug)]
+pub struct SubmitPayForBlobRequest {
+    pub fee: u128,
+    pub gas_limit: u64,
+    pub blobs: Vec<Blob>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SubmitPayForBlobResponse {
+    pub height: u64,
+    #[serde(flatten)]
+    pub rest: serde_json::Value,
+}
+
+impl Client {
+    /// Issue a `state.SubmitPayForBlob` JSON RPC.
+    ///
+    /// This is a high level API for the celestia `blob.Submit` method.
+    ///
+    /// # Errors
+    /// This has the same errors conditions as using the lower level
+    /// [`StateClient::submit_pay_for_blob`].
+    pub async fn state_submit_pay_for_blob(
+        &self,
+        request: SubmitPayForBlobRequest,
+    ) -> Result<SubmitPayForBlobResponse, Error> {
+        use crate::rpc_impl::state::Fee;
+        const RPC_NAME: &str = "state.SubmitPayForBlob";
+
+        let SubmitPayForBlobRequest {
+            fee,
+            gas_limit,
+            blobs,
+        } = request;
+        let raw_blobs: Vec<_> = blobs.into_iter().map(Blob::into_raw_blob).collect();
+        let raw_json = self
+            .inner
+            .submit_pay_for_blob(Fee::from_u128(fee), gas_limit, &raw_blobs)
+            .await
+            .map_err(|e| Error::rpc(e, RPC_NAME))?;
+        let rsp: SubmitPayForBlobResponse = serde_json::from_str(raw_json.get())
+            .map_err(|e| DeserializationError {
+                source: e,
+                rpc: RPC_NAME,
+                deser_target: "SubmitPayForBlobResponse",
+                raw_json: raw_json.clone(),
+            })
+            .map_err(|e| Error::deserialization(e, RPC_NAME))?;
+        Ok(rsp)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        Blob,
+        SubmitPayForBlobRequest,
+    };
+    use crate::test_utils::make_client;
+    #[tokio::test]
+    #[serial_test::serial]
+    #[ignore = "this needs to be run against a running celestia cluster"]
+    async fn submit_pay_for_blob_works() {
+        let client = make_client().await;
+        let req = SubmitPayForBlobRequest {
+            fee: 10_000,
+            gas_limit: 100_000,
+            blobs: vec![
+                Blob {
+                    namespace_id: *b"shrd-sqncr",
+                    data: b"helloworld".to_vec(),
+                },
+                Blob {
+                    namespace_id: *b"shrd-sqncr",
+                    data: b"helloworld".to_vec(),
+                },
+            ],
+        };
+        let _rsp = client.state_submit_pay_for_blob(req).await.unwrap();
+    }
+}

--- a/crates/astria-celestia-jsonrpc-client/src/test_utils.rs
+++ b/crates/astria-celestia-jsonrpc-client/src/test_utils.rs
@@ -1,0 +1,26 @@
+//! Utilities that are shared between all tests.
+use astria_test_utils::extract_bearer_token_from_celestia_node;
+
+/// The namespace of the kubernetes deployment used to run the jsonrpc tests.
+/// recorded in [../k8s/deployment.yml].
+const TEST_K8S_NAMESPACE: &str = "astria-celestia-jsonrpc-client-test";
+
+/// Generate a client with the celestia JSON RPC endpoint and bearer token set.
+///
+/// [`TEST_ENDPOINT`] is the default endpoint against which RPCs are called, and
+/// [`TEST_K8S_NAMESPACE`] is the default kubernetes namespace within which the celestia
+/// node is deployed and from where the bearer token is extracted.
+///
+/// Namespace and json rpc endpoint can be configured with the environment variables
+/// `NAMESPACE` and `ENDPOINT` (useful for debugging).
+pub(crate) async fn make_client() -> crate::Client {
+    let namespace = std::env::var("NAMESPACE").unwrap_or_else(|_| TEST_K8S_NAMESPACE.to_string());
+    let endpoint = std::env::var("ENDPOINT")
+        .unwrap_or_else(|_| format!("http://{namespace}.localdev.me:80/jsonrpc/"));
+    let token = extract_bearer_token_from_celestia_node(&namespace).await;
+    crate::Client::builder()
+        .bearer_token(&token)
+        .endpoint(&endpoint)
+        .build()
+        .unwrap()
+}

--- a/crates/astria-test-utils/Cargo.toml
+++ b/crates/astria-test-utils/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "astria-test-utils"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+k8s-openapi = { workspace = true }
+kube = { workspace = true, features = ["client", "runtime", "ws"] }
+tokio = { workspace = true, features = ["io-util"] }

--- a/crates/astria-test-utils/src/lib.rs
+++ b/crates/astria-test-utils/src/lib.rs
@@ -1,0 +1,71 @@
+//! Utility functions that are mainly useful when setting up and running tests.
+
+/// The path to the admin token in the celestia node container. Usually defined
+/// in `/scripts/generate-token.sh`.
+const ADMIN_TOKEN_PATH: &str = "/home/celestia/.admin_token";
+
+/// The name of the container running the celestia node service.
+/// Usually defined in `kubernetes/deployment.yml`.
+const CELESTIA_NODE_CONTAINER_NAME: &str = "celestia-bridge";
+
+/// Extract the bearer token from the celestia-node client using the
+/// kubernetes REST API.
+///
+/// # Panics
+/// This function is intended to be used within tests. As such it does not
+/// provide error handling in favour of panics pointing to the exact line that
+/// failed.
+pub async fn extract_bearer_token_from_celestia_node(namespace: &str) -> String {
+    use k8s_openapi::api::core::v1::Pod;
+    use kube::{
+        api::{
+            Api,
+            AttachParams,
+            ListParams,
+            ResourceExt as _,
+        },
+        Client,
+    };
+    use tokio::io::AsyncReadExt as _;
+    let client = Client::try_default()
+        .await
+        .expect("should be able to connect to a k8s cluster; is it running?");
+    // the namespace is recorded in `k8s/deployment.yml`
+    let pod_api: Api<Pod> = Api::namespaced(client.clone(), namespace);
+
+    let pods_msg: &str = "should have been able to list pods in the \
+                          `astria-celestia-jsonrpc-client-test` namespace; was the deployment in \
+                          k8s/ applied?";
+    let mut pods = pod_api
+        .list(&ListParams::default())
+        .await
+        .expect(pods_msg)
+        .into_iter();
+    let our_pod = pods.next().expect(
+        "should have been able to get deployed pod namespace if it exists. Check why the \
+         `astria-celestia-jsonrpc-client-test` namespace is empty?",
+    );
+    let None = pods.next() else {
+        panic!("namespace should not have contained more than one pod")
+    };
+    let mut cat_token = pod_api
+        .exec(
+            &our_pod.name_any(),
+            vec!["cat", ADMIN_TOKEN_PATH],
+            &AttachParams::default()
+                .stderr(false)
+                .container(CELESTIA_NODE_CONTAINER_NAME),
+        )
+        .await
+        .expect(
+            "should have been able to cat the auth token from celestia bridge; was it generated?",
+        );
+    let mut token_bytes = Vec::new();
+    cat_token
+        .stdout()
+        .expect("stdout on attached process should exist by default if not disabled")
+        .read_to_end(&mut token_bytes)
+        .await
+        .expect("should have been able to read token from pod");
+    String::from_utf8(token_bytes).expect("token should have contained only utf8 bytes")
+}

--- a/justfile
+++ b/justfile
@@ -10,8 +10,14 @@ deploy-ingress-controller:
 perform-prepull:
   kubectl apply -f ./kubernetes-ci/prepull-daemon-set.yml
 
+start-celestia-jsonrpc-test-deployment:
+  kubectl apply -k crates/astria-celestia-jsonrpc-client/k8s/
+
 wait-for-ingress-controller:
   kubectl wait --namespace ingress-nginx --for=condition=ready pod --selector=app.kubernetes.io/component=controller --timeout=600s
 
 wait-for-prepull:
   kubectl wait --for=condition=ready pod --selector=name=astria-test-prepull --timeout=600s
+
+wait-for-celestia-jsonrpc-test-deployment:
+  kubectl wait --namespace astria-celestia-jsonrpc-client-test deployment --for=condition=Available --selector=app.kubernetes.io/name=astria-celestia-jsonrpc-client-test --timeout=600s


### PR DESCRIPTION
This commit replaces `astria-rs-cnc` with the
`astria-celestia-jsonrpc-client` crate.

The only endpoint currently implemented is
`blob.Submit`, which allows atomically submitting
several data blobs under different namespaces.

**NOTE**: This is still WIP but it wasn't set to draft to get CI going (also WIP).