### PR TITLE
fix: rename `prev_state_root` to `prev_block_hash`

### DIFF
--- a/crates/astria-conductor/src/execution_client.rs
+++ b/crates/astria-conductor/src/execution_client.rs
@@ -15,7 +15,7 @@ use tracing::info;
 pub(crate) trait ExecutionClient: crate::private::Sealed {
     async fn call_do_block(
         &mut self,
-        prev_state_root: Vec<u8>,
+        prev_block_hash: Vec<u8>,
         transactions: Vec<Vec<u8>>,
         timestamp: Option<Timestamp>,
     ) -> Result<DoBlockResponse>;
@@ -64,8 +64,7 @@ impl ExecutionClient for ExecutionRpcClient {
         timestamp: Option<Timestamp>,
     ) -> Result<DoBlockResponse> {
         let request = DoBlockRequest {
-            // TODO: this field name should actually be prev_block_hash!
-            prev_state_root: prev_block_hash,
+            prev_block_hash,
             transactions,
             timestamp,
         };

--- a/crates/astria-proto/proto/astria/execution/v1/execution.proto
+++ b/crates/astria-proto/proto/astria/execution/v1/execution.proto
@@ -5,7 +5,7 @@ package astria.execution.v1;
 import "google/protobuf/timestamp.proto";
 
 message DoBlockRequest {
-  bytes prev_state_root = 1;
+  bytes prev_block_hash = 1;
   repeated bytes transactions = 2;
   google.protobuf.Timestamp timestamp = 3;
 }


### PR DESCRIPTION
closes  #49