### PR TITLE
fix: don't vendor rocksdb in docker image

### DIFF
--- a/crates/astria-sequencer/Dockerfile
+++ b/crates/astria-sequencer/Dockerfile
@@ -39,6 +39,7 @@ RUN apt-get update \
     librocksdb-dev
 
 ARG TARGETPLATFORM
+env ROCKSDB_LIB_DIR=/usr/lib
 RUN case "$TARGETPLATFORM" in \
     "linux/arm64") target="aarch64-unknown-linux-gnu" ;; \
     "linux/amd64") target="x86_64-unknown-linux-gnu" ;; \


### PR DESCRIPTION
The dockerfile introduced in #141 misses the `ROCKSDB_LIB` env var that PR #96 introduced. That leads to abysmal build times clocking in on 1h.