### PR TITLE
fix(sequencer): don't use length-delimited proto serialization

### DIFF
--- a/crates/astria-conductor/src/block_verifier.rs
+++ b/crates/astria-conductor/src/block_verifier.rs
@@ -117,10 +117,11 @@ impl BlockVerifier {
             "a tendermint height (currently non-negative i32) should always fit into a u32",
         );
 
-        // get validator set for this height
+        // get validator set for the previous height, as the commit contained
+        // in the block is for the previous height
         let validator_set = self
             .sequencer_client
-            .get_validator_set(height)
+            .get_validator_set(height - 1)
             .await
             .wrap_err("failed to get validator set")?;
 

--- a/crates/astria-sequencer/src/app.rs
+++ b/crates/astria-sequencer/src/app.rs
@@ -375,7 +375,7 @@ mod test {
             actions: vec![Action::TransferAction(Transfer::new(bob.clone(), value))],
         };
         let signed_tx = tx.into_signed(&alice_keypair);
-        let bytes = signed_tx.to_proto().encode_length_delimited_to_vec();
+        let bytes = signed_tx.to_proto().encode_to_vec();
 
         app.deliver_tx(&bytes).await.unwrap();
         assert_eq!(
@@ -420,7 +420,7 @@ mod test {
         };
 
         let signed_tx = tx.into_signed(&alice_signing_key);
-        let bytes = signed_tx.to_proto().encode_length_delimited_to_vec();
+        let bytes = signed_tx.to_proto().encode_to_vec();
 
         app.deliver_tx(&bytes).await.unwrap();
         assert_eq!(app.state.get_account_nonce(&alice).await.unwrap(), 1);

--- a/crates/astria-sequencer/src/transaction/signed.rs
+++ b/crates/astria-sequencer/src/transaction/signed.rs
@@ -47,7 +47,7 @@ impl Signed {
 
     #[must_use]
     pub fn to_bytes(&self) -> Vec<u8> {
-        self.to_proto().encode_length_delimited_to_vec()
+        self.to_proto().encode_to_vec()
     }
 
     #[must_use]
@@ -111,7 +111,7 @@ impl Signed {
     /// - If the slice cannot be decoded into a protobuf signed transaction
     /// - If the protobuf signed transaction cannot be converted into a `SignedTransaction`
     pub fn try_from_slice(slice: &[u8]) -> Result<Self> {
-        let proto = ProtoSignedTransaction::decode_length_delimited(slice)
+        let proto = ProtoSignedTransaction::decode(slice)
             .context("failed to decode slice to proto signed transaction")?;
         Self::try_from_proto(proto)
     }

--- a/crates/astria-sequencer/src/transaction/unsigned.rs
+++ b/crates/astria-sequencer/src/transaction/unsigned.rs
@@ -88,7 +88,7 @@ impl Unsigned {
 
     /// Returns the sha256 hash of the protobuf-encoded transaction.
     pub(crate) fn hash(&self) -> Vec<u8> {
-        hash(&self.to_proto().encode_length_delimited_to_vec())
+        hash(&self.to_proto().encode_to_vec())
     }
 }
 
@@ -207,7 +207,7 @@ mod test {
         /// - If the value is not a valid transaction type (ie. does not correspond to any
         ///   component)
         fn try_from_slice(bytes: &[u8]) -> Result<Self> {
-            let proto = ProtoUnsignedTransaction::decode_length_delimited(bytes)
+            let proto = ProtoUnsignedTransaction::decode(bytes)
                 .context("failed to decode unsigned transaction")?;
             Self::try_from_proto(&proto)
         }
@@ -222,14 +222,14 @@ mod test {
                 Balance::from(333_333),
             ))],
         };
-        let bytes = tx.to_proto().encode_length_delimited_to_vec();
+        let bytes = tx.to_proto().encode_to_vec();
         let tx2 = Unsigned::try_from_slice(&bytes).unwrap();
         assert_eq!(tx, tx2);
         println!("0x{}", hex::encode(bytes));
 
         let secret_key: SigningKey = SigningKey::new(OsRng);
         let signed = tx.into_signed(&secret_key);
-        let bytes = signed.to_proto().encode_length_delimited_to_vec();
+        let bytes = signed.to_proto().encode_to_vec();
         Signed::try_from_slice(bytes.as_slice()).unwrap();
     }
 }


### PR DESCRIPTION
golang doesn't have support for this :( required for https://github.com/astriaorg/go-ethereum/pull/24