### PR TITLE
sequencer-relayer: more sophisticated telemetry setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,6 +464,7 @@ dependencies = [
  "futures",
  "hex",
  "http",
+ "is-terminal",
  "prost",
  "rand_core 0.6.4",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ eyre = "0.6"
 figment = "0.10.8"
 futures = "0.3"
 hex = "0.4"
+is-terminal = "0.4"
 # marking k8s as using k8s 1.26 here to make it clear that we are targetting 1.26
 # in the tests
 k8s-openapi = { version = "0.18.0", features = ["v1_26"] }

--- a/crates/astria-conductor/Cargo.toml
+++ b/crates/astria-conductor/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-is-terminal = "0.4.7"
 sync_wrapper = "0.1.2"
 
 async-trait = { workspace = true }
@@ -14,6 +13,7 @@ ed25519-consensus = { workspace = true }
 figment = { workspace = true, features = ["toml", "env"] }
 futures = { workspace = true }
 hex = { workspace = true }
+is-terminal = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }

--- a/crates/astria-sequencer-relayer/Cargo.toml
+++ b/crates/astria-sequencer-relayer/Cargo.toml
@@ -37,6 +37,7 @@ tendermint-config.workspace = true
 ed25519-consensus = { workspace = true }
 subtle-encoding = "0.5.1"
 serde_path_to_error = "0.1.13"
+is-terminal.workspace = true
 
 [dev-dependencies]
 astria-sequencer-relayer-test = { path = "../astria-sequencer-relayer-test"}

--- a/crates/astria-sequencer-relayer/src/lib.rs
+++ b/crates/astria-sequencer-relayer/src/lib.rs
@@ -5,6 +5,7 @@ pub mod data_availability;
 pub mod network;
 pub mod relayer;
 pub mod sequencer_relayer;
+pub mod telemetry;
 pub mod transaction;
 pub mod types;
 pub mod utils;

--- a/crates/astria-sequencer-relayer/src/telemetry.rs
+++ b/crates/astria-sequencer-relayer/src/telemetry.rs
@@ -1,0 +1,53 @@
+use eyre::WrapErr as _;
+use is_terminal::IsTerminal as _;
+use tracing_subscriber::{
+    filter::{
+        EnvFilter,
+        LevelFilter,
+    },
+    fmt::{
+        self,
+        MakeWriter,
+    },
+    layer::SubscriberExt as _,
+    registry,
+    util::SubscriberInitExt as _,
+};
+
+/// Register a global tracing subscriber.
+///
+/// # Errors
+///
+/// Returns the same errors as [`SubscriberInitExt::try_init`] called
+/// on a [`tracing_subscriber::Registry`].
+pub fn init<S>(sink: S, filter_directives: &str) -> eyre::Result<()>
+where
+    S: for<'a> MakeWriter<'a> + Send + Sync + 'static,
+{
+    let env_filter =
+        init_env_filter(filter_directives).wrap_err("failed initializing telemetry env filter")?;
+    let (json_log, stdout_log) = if std::io::stdout().is_terminal() {
+        eprintln!("service is attached to tty; using human readable formatting");
+        (None, Some(fmt::layer().with_writer(sink)))
+    } else {
+        eprintln!("service is not attached to tty; using json formatting");
+        (
+            Some(fmt::layer().json().flatten_event(true).with_writer(sink)),
+            None,
+        )
+    };
+
+    registry()
+        .with(stdout_log)
+        .with(json_log)
+        .with(env_filter)
+        .try_init()
+        .wrap_err("failed initializing telemetry stack")
+}
+
+fn init_env_filter(dirs: &str) -> eyre::Result<EnvFilter> {
+    let builder = EnvFilter::builder().with_default_directive(LevelFilter::INFO.into());
+    builder
+        .parse(dirs)
+        .wrap_err("failed parsing configured filter directives")
+}

--- a/crates/astria-sequencer/Cargo.toml
+++ b/crates/astria-sequencer/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 astria-proto = {path = "../astria-proto"}
 
 anyhow = "1"
-is-terminal = "0.4.7"
 # commit builds off v0.54.1
 penumbra-storage = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "d8d5cd0b00876380147d7ddc7f3005178e3d9ae0" }
 penumbra-tower-trace = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "d8d5cd0b00876380147d7ddc7f3005178e3d9ae0" }
@@ -23,6 +22,7 @@ clap = { workspace = true, features = ["derive"] }
 ed25519-consensus = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true, features = ["serde"] }
+is-terminal = { workspace = true }
 prost = { workspace = true }
 serde = { workspace = true, features = ["derive"]  }
 serde_json = { workspace = true }


### PR DESCRIPTION
This commit changes telemetry to output a human readable format only if connected to a tty, and json otherwise. It also allows configuring env filters via command line arguments in addition to environment variables.

This commit was broken out of #150. It was time to upgrade the tracing setup either way, so it made sense to make it a separate PR.