### PR TITLE
sequencer-relayer: remove unnecessary hash

### DIFF
--- a/crates/astria-sequencer-relayer/src/types.rs
+++ b/crates/astria-sequencer-relayer/src/types.rs
@@ -219,9 +219,6 @@ impl SequencerBlockData {
             last_commit: b.last_commit,
             rollup_txs,
         };
-
-        data.verify_block_hash()
-            .wrap_err("failed to verify block hash")?;
         Ok(data)
     }
 


### PR DESCRIPTION
The call to `SequencerBlockData::verify_block_hash` performs the same calculation as was done to construct the block hash immediately prior.

So `verify_block_hash` is trivially true and can be skipped.

This was observed while writing #150 but had nothing to do with the PR itself, so was broken out.