### PR TITLE
container: install dynamic libs and fix entrypoint

### DIFF
--- a/containerfiles/Dockerfile
+++ b/containerfiles/Dockerfile
@@ -111,5 +111,5 @@ RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
     apt-get clean; \
     rm -rf /var/lib/apt/lists/*;
 COPY --from=builder /build/target/release/$TARGETBINARY /usr/local/bin/$TARGETBINARY
-RUN ln -s $TARGETBINARY /usr/local/bin/entrypoint
+RUN ln -s /usr/local/bin/$TARGETBINARY /usr/local/bin/entrypoint
 ENTRYPOINT ["/usr/local/bin/entrypoint"]

--- a/containerfiles/Dockerfile
+++ b/containerfiles/Dockerfile
@@ -92,8 +92,24 @@ RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCH=aarch64; \
 
 FROM debian:bookworm-slim
 ARG TARGETBINARY
-WORKDIR /app/
-EXPOSE 2450
-RUN apt update && apt install -y wget ca-certificates && apt-get clean && rm -rf /var/lib/apt/lists/*
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
+      if [ "$BUILDPLATFORM" != "linux/arm64" ]; then \
+        dpkg --add-architecture arm64; \
+      fi; \
+      apt update; \
+      apt install -y librocksdb-dev:arm64; \
+    elif [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
+      if [ "$BUILDPLATFORM" != "linux/amd64" ]; then \
+        dpkg --add-architecture amd64; \
+      fi; \
+      apt update; \
+      apt install -y librocksdb-dev:amd64; \
+    fi; \
+    apt install -y wget ca-certificates; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*;
 COPY --from=builder /build/target/release/$TARGETBINARY /usr/local/bin/$TARGETBINARY
-ENTRYPOINT ["/usr/local/bin/$TARGETBINARY"]
+RUN ln -s $TARGETBINARY /usr/local/bin/entrypoint
+ENTRYPOINT ["/usr/local/bin/entrypoint"]


### PR DESCRIPTION
This commit installs rocksdb in the final layer
of the generic containerfile because all binaries
are currently linked to librocksdb.

In addition, as it turns out build args are not expanded in `ENTRYPOINT` lines. To get a stable path that can be used as an argument to `ENTRYPOINT`, this commit crates a softlink to `/usr/bin/local/$TARGETBINARY` and uses that instead.