### PR TITLE
Enable breaking proto checker

### DIFF
--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -33,12 +33,11 @@ jobs:
       - uses: bufbuild/buf-lint-action@v1
         with:
           input: "crates/astria-proto"
-      # TODO(GH-29): Uncomment out after reaching any production stage
-      # - uses: bufbuild/buf-breaking-action@v1
-      #   with:
-      #     # The 'main' branch of the GitHub repository that defines the module.
-      #     input: "crates/astria-proto/proto"
-      #     against: "https://github.com/astriaorg/astria.git#branch=main,ref=HEAD~1,subdir=crates/astria-proto/proto"
+      - uses: bufbuild/buf-breaking-action@v1
+        with:
+          # The 'main' branch of the GitHub repository that defines the module.
+          input: "crates/astria-proto/proto"
+          against: "https://github.com/astriaorg/astria.git#branch=main,ref=HEAD~1,subdir=crates/astria-proto/proto"
   push:
     runs-on: ubuntu-latest
     environment: BUF

--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           # The 'main' branch of the GitHub repository that defines the module.
           input: "crates/astria-proto/proto"
-          against: "https://github.com/astriaorg/astria.git#branch=main,ref=HEAD~1,subdir=crates/astria-proto/proto"
+          against: "https://github.com/astriaorg/astria.git#branch=main,ref=HEAD,subdir=crates/astria-proto/proto"
   push:
     runs-on: ubuntu-latest
     environment: BUF

--- a/crates/astria-proto/proto/astria/execution/v1alpha1/execution.proto
+++ b/crates/astria-proto/proto/astria/execution/v1alpha1/execution.proto
@@ -11,7 +11,7 @@ message DoBlockRequest {
 }
 
 message DoBlockResponse {
-  bytes block_hash = 1;
+  bytes block_hash2 = 1;
 }
 
 message FinalizeBlockRequest {

--- a/crates/astria-proto/proto/astria/execution/v1alpha1/execution.proto
+++ b/crates/astria-proto/proto/astria/execution/v1alpha1/execution.proto
@@ -11,7 +11,7 @@ message DoBlockRequest {
 }
 
 message DoBlockResponse {
-  bytes block_hash2 = 1;
+  bytes block_hash = 1;
 }
 
 message FinalizeBlockRequest {


### PR DESCRIPTION
#195 moved us to using better version naming, this re-enables breaking change checker in checks to ensure we don't push breaking versions.

This change is validated via test breaking change [here](https://github.com/astriaorg/astria/actions/runs/5675193625/job/15380066698)

