### PR TITLE
ci: use BuildJet for faster GH Actions

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: buildjet-8vcpu-ubuntu-2204
     if: ${{ contains(github.ref, 'refs/tags/v') && endsWith(github.ref, format('--{0}', inputs.package-name)) || github.ref == 'refs/heads/main' || github.event_name == 'pull_request' }}
     steps:
       # Checking out the repo

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -56,7 +56,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@1.69.0
-      - uses: Swatinem/rust-cache@v2
+      - uses: astriaorg/buildjet-rust-cache@v2.5.1
       - name: Run doctests
         run: cargo test --doc --all-features
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,11 +11,11 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@1.69.0
-      - uses: Swatinem/rust-cache@v2
+      - uses: joroshiba/rust-cache@v2.5.1
       - name: Install buf cli
         uses: bufbuild/buf-setup-action@v1
         with:
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@1.69.0
-      - uses: Swatinem/rust-cache@v2
+      - uses: joroshiba/rust-cache@v2.5.1
       - name: Build the jsonrpc client tests
         run: cargo test --release --no-run --package astria-celestia-jsonrpc-client
       - name: create kubernetes in docker cluster
@@ -80,7 +80,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@1.69.0
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: joroshiba/rust-cache@v2.5.1
       - uses: bufbuild/buf-setup-action@v1
         with:
           version: "1.17.0"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@1.69.0
-      - uses: joroshiba/rust-cache@v2.5.1
+      - uses: astriaorg/buildjet-rust-cache@v2.5.1
       - name: Install buf cli
         uses: bufbuild/buf-setup-action@v1
         with:
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@1.69.0
-      - uses: joroshiba/rust-cache@v2.5.1
+      - uses: astriaorg/buildjet-rust-cache@v2.5.1
       - name: Build the jsonrpc client tests
         run: cargo test --release --no-run --package astria-celestia-jsonrpc-client
       - name: create kubernetes in docker cluster
@@ -80,7 +80,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@1.69.0
         with:
           components: clippy
-      - uses: joroshiba/rust-cache@v2.5.1
+      - uses: astriaorg/buildjet-rust-cache@v2.5.1
       - uses: bufbuild/buf-setup-action@v1
         with:
           version: "1.17.0"


### PR DESCRIPTION
Introduces BuildJet to our GH actions, utilize 8vCPU for docker builds & 4vCPU for tests. This reduces time for all actions to under 5 minutes.