### PR TITLE
ci: cache container image layers in ghcr

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -58,6 +58,6 @@ jobs:
           push: true
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
-          cache-to: type=inline
-          cache-from: type=registry,ref=${{ format('ghcr.io/astriaorg/{0}:pr-200', inputs.package-name) }}
+          cache-from: type=registry,ref=${{ format('ghcr.io/astriaorg/{0}:buildcache', inputs.package-name) }}
+          cache-to: type=registry,ref=${{ format('ghcr.io/astriaorg/{0}:buildcache', inputs.package-name) }},mode=max
         

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -59,5 +59,5 @@ jobs:
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
           cache-to: type=inline
-          cache-from: type=registry,ref=${{ format('ghcr.io/astriaorg/{0}:latest', inputs.package-name) }}
+          cache-from: type=registry,ref=${{ format('ghcr.io/astriaorg/{0}:pr-200', inputs.package-name) }}
         

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -58,4 +58,6 @@ jobs:
           push: true
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
+          cache-to: type=inline
+          cache-from: type=registry,ref=${{ format('ghcr.io/astriaorg/{0}:latest', inputs.package-name) }}
         


### PR DESCRIPTION
Using the GHCR registry cache speeds up docker builds, cutting by about 1/3 with the default github runners. 

By my testing 30m -> 8m for longest build.