### PR TITLE
sequencer: tx nonce must match account nonce

### DIFF
--- a/crates/astria-sequencer/src/app.rs
+++ b/crates/astria-sequencer/src/app.rs
@@ -387,7 +387,7 @@ mod test {
         let bob = address_from_hex_string(BOB_ADDRESS);
         let value = Balance::from(333_333);
         let tx = Unsigned {
-            nonce: Nonce::from(1),
+            nonce: Nonce::from(0),
             actions: vec![Action::TransferAction(Transfer::new(bob.clone(), value))],
         };
         let signed_tx = tx.into_signed(&alice_keypair);
@@ -428,7 +428,7 @@ mod test {
         let alice = Address::from_verification_key(&alice_signing_key.verification_key());
 
         let tx = Unsigned {
-            nonce: Nonce::from(1),
+            nonce: Nonce::from(0),
             actions: vec![Action::SequenceAction(SequenceAction::new(
                 b"testchainid".to_vec(),
                 b"helloworld".to_vec(),

--- a/crates/astria-sequencer/src/transaction/unsigned.rs
+++ b/crates/astria-sequencer/src/transaction/unsigned.rs
@@ -116,7 +116,10 @@ impl ActionHandler for Unsigned {
         // Nonce should be equal to the number of executed transactions before this tx.
         // First tx has nonce 0.
         let curr_nonce = state.get_account_nonce(from).await?;
-        ensure!(curr_nonce == self.nonce, "invalid nonce, tx nonce must match account nonce");
+        ensure!(
+            curr_nonce == self.nonce,
+            "invalid nonce, tx nonce must match account nonce"
+        );
 
         // do we need to make a StateDelta here so we can check the actions on the successive state?
         for action in &self.actions {

--- a/crates/astria-sequencer/src/transaction/unsigned.rs
+++ b/crates/astria-sequencer/src/transaction/unsigned.rs
@@ -116,7 +116,7 @@ impl ActionHandler for Unsigned {
         // Nonce should be equal to the number of executed transactions before this tx.
         // First tx has nonce 0.
         let curr_nonce = state.get_account_nonce(from).await?;
-        ensure!(curr_nonce == self.nonce, "invalid nonce");
+        ensure!(curr_nonce == self.nonce, "invalid nonce, tx nonce must match account nonce");
 
         // do we need to make a StateDelta here so we can check the actions on the successive state?
         for action in &self.actions {

--- a/crates/astria-sequencer/src/transaction/unsigned.rs
+++ b/crates/astria-sequencer/src/transaction/unsigned.rs
@@ -113,8 +113,10 @@ impl ActionHandler for Unsigned {
         state: &S,
         from: &Address,
     ) -> Result<()> {
+        // Nonce should be equal to the number of executed transactions before this tx.
+        // First tx has nonce 0.
         let curr_nonce = state.get_account_nonce(from).await?;
-        ensure!(curr_nonce < self.nonce, "invalid nonce");
+        ensure!(curr_nonce == self.nonce, "invalid nonce");
 
         // do we need to make a StateDelta here so we can check the actions on the successive state?
         for action in &self.actions {


### PR DESCRIPTION
This is a breaking change.

The ethereum whitepaper states that on a transaction:

> nonce: A scalar value equal to the number of transactions sent by the sender

And later:

> the transaction nonce is valid (equivalent to the sender account’s current nonce);

As best I can tell cosmos chains treat [sequences similarly](https://github.com/astriaorg/metro/blob/d12705639f68d5e9d0ec6071748a0a0ec36ec7df/pkg/builder/builder.go#L116), and I don't believe we should differ from these implementations.