### PR TITLE
ci: check toml formatting

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -79,6 +79,18 @@ jobs:
         # or `cargo +nightly-2023-07-07 fmt` for specifying the exactly release.
         run: cargo fmt --all -- --check
 
+  fmt-toml:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: download taplo
+        run: |
+          curl -fsSL https://github.com/tamasfe/taplo/releases/download/0.8.1/taplo-full-linux-x86_64.gz \
+          | gzip -d - \
+          | install -m 755 /dev/stdin /usr/local/bin/taplo
+      - name: run taplo
+        run: taplo format --check
+
   clippy:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -178,6 +178,24 @@ cargo test
 Note that the `astria-proto` generates its code by running tests (and verifying that nothing changed).
 In order for its tests to run you also need [Buf](https://buf.build/docs/installation/) installed.
 
+## Formatting
+
+This project uses rustfmt to format rust sources, and [taplo](https://github.com/tamasfe/taplo)
+to format toml files. To install and run rustfmt:
+```sh
+$ rustup +nightly-2023-07-07 component add rustfmt
+$ cargo +nightly-2023-07-07 fmt --all
+```
+Download taplo from their release page or use your system's package manager:
+```sh
+# macOS
+$ brew install taplo
+# Arch Linux
+$ sudo pacman -S taplo
+# Run
+$ taplo format
+````
+
 ## Contributing
 
 Pull requests should be created against the `main` branch. In general, we follow the "fork-and-pull" Git workflow.

--- a/crates/astria-conductor/Cargo.toml
+++ b/crates/astria-conductor/Cargo.toml
@@ -31,7 +31,9 @@ tracing-subscriber = { workspace = true, features = ["ansi", "json"] }
 
 astria-proto = { path = "../astria-proto", features = ["client"] }
 astria-gossipnet = { path = "../astria-gossipnet" }
-astria-sequencer-client = { path = "../astria-sequencer-client", features = ["http"] }
+astria-sequencer-client = { path = "../astria-sequencer-client", features = [
+  "http",
+] }
 astria-sequencer-relayer = { path = "../astria-sequencer-relayer" }
 
 [dev-dependencies]

--- a/crates/astria-gossipnet/Cargo.toml
+++ b/crates/astria-gossipnet/Cargo.toml
@@ -4,7 +4,18 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-libp2p = { version = "0.51", features = ["kad", "gossipsub", "identify", "mdns", "noise", "macros", "ping", "tcp", "tokio", "yamux"] }
+libp2p = { version = "0.51", features = [
+  "kad",
+  "gossipsub",
+  "identify",
+  "mdns",
+  "noise",
+  "macros",
+  "ping",
+  "tcp",
+  "tokio",
+  "yamux",
+] }
 
 color-eyre = { workspace = true }
 futures = { workspace = true }
@@ -15,4 +26,9 @@ tracing = { workspace = true }
 [dev-dependencies]
 tempfile = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
-tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal", "sync"] }
+tokio = { workspace = true, features = [
+  "macros",
+  "rt-multi-thread",
+  "signal",
+  "sync",
+] }

--- a/crates/astria-sequencer-relayer/Cargo.toml
+++ b/crates/astria-sequencer-relayer/Cargo.toml
@@ -34,7 +34,7 @@ tendermint-config = { workspace = true }
 tendermint-rpc = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
-tokio = { workspace = true, features = [ "macros", "rt-multi-thread" ] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 astria-celestia-jsonrpc-client = { path = "../astria-celestia-jsonrpc-client" }
 astria-gossipnet = { path = "../astria-gossipnet" }
@@ -42,8 +42,10 @@ astria-proto = { path = "../astria-proto" }
 astria-sequencer = { path = "../astria-sequencer" }
 
 [dev-dependencies]
-astria-celestia-jsonrpc-client = { path = "../astria-celestia-jsonrpc-client", features = ["server"] }
-rand_core = { version = "0.6", features = [ "getrandom" ] }
+astria-celestia-jsonrpc-client = { path = "../astria-celestia-jsonrpc-client", features = [
+  "server",
+] }
+rand_core = { version = "0.6", features = ["getrandom"] }
 
 figment = { workspace = true, features = ["test"] }
 jsonrpsee = { workspace = true, features = ["server"] }
@@ -52,5 +54,5 @@ once_cell = { workspace = true }
 tempfile = { workspace = true }
 tendermint-rpc = { workspace = true, features = ["http-client"] }
 tokio = { workspace = true, features = ["test-util"] }
-wiremock = {workspace = true }
+wiremock = { workspace = true }
 astria-sequencer = { path = "../astria-sequencer" }

--- a/crates/astria-sequencer/Cargo.toml
+++ b/crates/astria-sequencer/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-astria-proto = {path = "../astria-proto"}
+astria-proto = { path = "../astria-proto" }
 
 anyhow = "1"
 penumbra-storage = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.56.0" }
@@ -23,11 +23,15 @@ hex = { workspace = true, features = ["serde"] }
 is-terminal = { workspace = true }
 prost = { workspace = true }
 rand = { workspace = true }
-serde = { workspace = true, features = ["derive"]  }
+serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
 tendermint-proto = { workspace = true }
 tendermint = { workspace = true }
-tokio = { workspace = true, features = [ "rt", "tracing" ] }
+tokio = { workspace = true, features = ["rt", "tracing"] }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true, features = ["ansi", "env-filter", "json"] }
+tracing-subscriber = { workspace = true, features = [
+  "ansi",
+  "env-filter",
+  "json",
+] }


### PR DESCRIPTION
This commit adds a github workflow job to
standardize toml formatting across the
monorepo. Because contributors use different
editors (some with and some without toml
formatting built in), this should help reduce
churn.

https://github.com/tamasfe/taplo version 0.8.1
is downloaded and put into /usr/local/bin and run
with as `taplo format --check`, failing if some
toml files were not formatted.