### PR TITLE
ci: remove unused excludes, use --all-features everywhere

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,6 +24,8 @@ jobs:
       - name: Run tests (excluding RPC client, which needs kubernetes)
         run: |
           cargo test --release --workspace \
+          --all-features \
+          --all-targets \
           --exclude astria-celestia-jsonrpc-client
 
   test_rpc_client:
@@ -49,7 +51,11 @@ jobs:
       - name: wait 5 seconds for ingress to pick up rules, services
         run: sleep 5
       - name: Run the jsonrpc client tests
-        run: cargo test --release --package astria-celestia-jsonrpc-client -- --ignored
+        run: |
+          cargo test --release \
+          --package astria-celestia-jsonrpc-client \
+          --all-features \
+          -- --ignored
 
   doctest:
     runs-on: ubuntu-22.04
@@ -93,6 +99,11 @@ jobs:
           --exclude astria-conductor \
           --exclude astria-sequencer-relayer \
           --exclude astria-gossipnet \
-          -- -W clippy::pedantic -D warnings
+          -- --warn clippy::pedantic \
+             --deny warnings
       - name: run default clippy
-        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+        run: |
+          cargo clippy --workspace \
+          --all-targets \
+          --all-features \
+          -- --deny warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -87,12 +87,12 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: run pedantic clippy
         run: |
-          cargo clippy --workspace --all-targets \
+          cargo clippy --workspace \
+          --all-targets \
+          --all-features \
           --exclude astria-conductor \
-          --exclude astria-conductor-test \
           --exclude astria-sequencer-relayer \
-          --exclude astria-sequencer-relayer-test \
           --exclude astria-gossipnet \
           -- -W clippy::pedantic -D warnings
       - name: run default clippy
-        run: cargo clippy --workspace --all-targets -- -D warnings
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings

--- a/crates/astria-sequencer-client/src/tests/http.rs
+++ b/crates/astria-sequencer-client/src/tests/http.rs
@@ -24,7 +24,14 @@ use wiremock::{
     ResponseTemplate,
 };
 
-use crate::*;
+use crate::{
+    tx_sync,
+    Address,
+    Balance,
+    Height,
+    Nonce,
+    SequencerClientExt as _,
+};
 
 // see astria-sequencer/src/crypto.rs for how these keys/addresses were generated
 const ALICE_ADDRESS: &str = "1c0c490f1b5528d8173c5de46d131160e4b2c0c3";


### PR DESCRIPTION
`astria-conductor-test` and `sequencer-relayer-test` no longer exist and can be removed from the clippy exludes list.

Also, clippy should be run against all features.