### PR TITLE
use cargo resolver 2, fix used features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,4 @@
 [workspace]
-
 members = [
   "crates/astria-celestia-jsonrpc-client",
   "crates/astria-composer",
@@ -12,6 +11,7 @@ members = [
   "crates/astria-sequencer-utils",
   "crates/astria-test-utils",
 ]
+resolver = "2"
 
 [workspace.dependencies]
 async-trait = "0.1.52"

--- a/crates/astria-composer/Cargo.toml
+++ b/crates/astria-composer/Cargo.toml
@@ -25,7 +25,12 @@ rand = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tendermint = { workspace = true }
-tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time"] }
+tokio = { workspace = true, features = [
+  "macros",
+  "rt-multi-thread",
+  "sync",
+  "time",
+] }
 tracing = { workspace = true, features = ["attributes"] }
 tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
 

--- a/crates/astria-composer/Cargo.toml
+++ b/crates/astria-composer/Cargo.toml
@@ -25,8 +25,7 @@ rand = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tendermint = { workspace = true }
-# FIXME: Don't activate full
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time"] }
 tracing = { workspace = true, features = ["attributes"] }
 tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
 

--- a/crates/astria-sequencer-relayer/Cargo.toml
+++ b/crates/astria-sequencer-relayer/Cargo.toml
@@ -31,7 +31,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tendermint = { workspace = true, features = ["rust-crypto"] }
 tendermint-config = { workspace = true }
-tendermint-rpc = { workspace = true }
+tendermint-rpc = { workspace = true, features = ["http-client"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 tokio = { workspace = true, features = [ "macros", "rt-multi-thread" ] }
@@ -50,7 +50,6 @@ jsonrpsee = { workspace = true, features = ["server"] }
 multiaddr = { workspace = true }
 once_cell = { workspace = true }
 tempfile = { workspace = true }
-tendermint-rpc = { workspace = true, features = ["http-client"] }
 tokio = { workspace = true, features = ["test-util"] }
 wiremock = {workspace = true }
 astria-sequencer = { path = "../astria-sequencer" }


### PR DESCRIPTION
This commit changes the cargo workspace to use resolver version 2. Furthermore, it reduces the tokio features to the ones actually needed in composer, and fixes sequencer-relayer's tendermint-rpc features (which surfaced because of resolver 2).

Unfortunately, there is no good way to enforce (or check) that the `tokio` dependency only uses its minimal set of necessary features. In fact, tokio could be specified just like `tokio = { workspace = true }`. Due to feature unification all necessary features are set through the `astria-sequencer` dependency.