### PR TITLE
feat(celestia-client): add utility function to access jsonrpc error

### DIFF
--- a/crates/astria-celestia-jsonrpc-client/src/lib.rs
+++ b/crates/astria-celestia-jsonrpc-client/src/lib.rs
@@ -4,6 +4,7 @@ pub mod state;
 
 pub mod rpc_impl;
 
+use jsonrpsee::types::ErrorObject;
 pub use rpc_impl::blob::Blob;
 #[cfg(feature = "server")]
 pub use rpc_impl::state::StateServer;
@@ -69,6 +70,16 @@ impl Error {
     #[must_use]
     pub fn rpc_name(&self) -> &str {
         self.rpc
+    }
+
+    /// Convenience method to access the error returned by a JSONRPC.
+    ///
+    /// Returns `None` if the inner error is not related to the JSONRPC response.
+    pub fn jsonrpc_call(&self) -> Option<&ErrorObject<'_>> {
+        match &self.inner {
+            ErrorKind::Rpc(jsonrpsee::core::Error::Call(err)) => Some(err),
+            _ => None,
+        }
     }
 
     pub(crate) fn deserialization(e: DeserializationError, rpc: &'static str) -> Self {

--- a/crates/astria-celestia-jsonrpc-client/src/lib.rs
+++ b/crates/astria-celestia-jsonrpc-client/src/lib.rs
@@ -75,6 +75,7 @@ impl Error {
     /// Convenience method to access the error returned by a JSONRPC.
     ///
     /// Returns `None` if the inner error is not related to the JSONRPC response.
+    #[must_use]
     pub fn jsonrpc_call(&self) -> Option<&ErrorObject<'_>> {
         match &self.inner {
             ErrorKind::Rpc(jsonrpsee::core::Error::Call(err)) => Some(err),

--- a/crates/astria-celestia-jsonrpc-client/src/lib.rs
+++ b/crates/astria-celestia-jsonrpc-client/src/lib.rs
@@ -75,8 +75,20 @@ impl Error {
     /// Convenience method to access the error returned by a JSONRPC.
     ///
     /// Returns `None` if the inner error is not related to the JSONRPC response.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use astria_celestia_jsonrpc_client::Client;
+    /// # async fn example(client: Client) {
+    /// if let Err(err) = client.header_network_head().await {
+    ///    if let Some(jsonrpc) = err.jsonrpc_response() {
+    ///        println!("JSONRPC returned an error: {}", jsonrpc.message());
+    ///    }
+    /// }
+    /// # }
     #[must_use]
-    pub fn jsonrpc_call(&self) -> Option<&ErrorObject<'_>> {
+    pub fn jsonrpc_response(&self) -> Option<&ErrorObject<'_>> {
         match &self.inner {
             ErrorKind::Rpc(jsonrpsee::core::Error::Call(err)) => Some(err),
             _ => None,


### PR DESCRIPTION
This commit provides the `jsonrpc_call` utility method on `astria-celestia-jsonrpc-client::Error` that returns a jsonrpsee `Option<&ErrorObject<'_>>` only if the underlying is an actual jsonrpc error response.

To be used like so:
```rust
match self.client.blob_get_all(req).await {
    Ok(rsp) => rsp,
    Err(e) => if let Some(jsonrpc_call) = e.jsonrpc_call() {
        println!("jsonrpc returned error response: {}", jsonrpc_call.message());
    }
```