### PR TITLE
feat(composer): read sequencer private key from env and track nonce

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,6 +368,7 @@ dependencies = [
  "async-trait",
  "axum",
  "backon",
+ "borsh",
  "color-eyre",
  "ed25519-consensus",
  "ethers",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,6 +382,7 @@ dependencies = [
  "once_cell",
  "rand 0.8.5",
  "reqwest",
+ "secrecy",
  "serde",
  "serde_json",
  "tendermint",

--- a/crates/astria-composer/Cargo.toml
+++ b/crates/astria-composer/Cargo.toml
@@ -13,6 +13,7 @@ ethers = { version = "2.0.7", features = ["ws"] }
 async-trait = { workspace = true }
 axum = { workspace = true }
 backon = { workspace = true }
+borsh = { workspace = true }
 color-eyre = { workspace = true }
 ed25519-consensus = { workspace = true }
 figment = { workspace = true, features = ["env"] }

--- a/crates/astria-composer/Cargo.toml
+++ b/crates/astria-composer/Cargo.toml
@@ -14,7 +14,6 @@ secrecy = "0.8"
 async-trait = { workspace = true }
 axum = { workspace = true }
 backon = { workspace = true }
-borsh = { workspace = true }
 color-eyre = { workspace = true }
 ed25519-consensus = { workspace = true }
 figment = { workspace = true, features = ["env"] }
@@ -45,6 +44,7 @@ features = ["http"]
 impl-serde = "0.4.0"
 tokio-test = "0.4.2"
 
+borsh = { workspace = true }
 figment = { workspace = true, features = ["test"] }
 jsonrpsee = { workspace = true, features = ["macros", "server"] }
 once_cell = { workspace = true }

--- a/crates/astria-composer/Cargo.toml
+++ b/crates/astria-composer/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 astria-sequencer = { path = "../astria-sequencer" }
 
 ethers = { version = "2.0.7", features = ["ws"] }
+secrecy = "0.8"
 
 async-trait = { workspace = true }
 axum = { workspace = true }

--- a/crates/astria-composer/env.example
+++ b/crates/astria-composer/env.example
@@ -14,4 +14,5 @@ ASTRIA_COMPOSER_CHAIN_ID="912559"
 ASTRIA_COMPOSER_EXECUTION_URL="ws://127.0.0.1:8545"
 
 # Private key for the sequencer account used for signing transactions
+# Must be a hex-encoded 32-byte array (64-character hex string)
 ASTRIA_COMPOSER_PRIVATE_KEY="2bd806c97f0e00af1a1fc3328fa763a9269723c8db8fac4f93af71db186d6e90"

--- a/crates/astria-composer/env.example
+++ b/crates/astria-composer/env.example
@@ -12,3 +12,6 @@ ASTRIA_COMPOSER_CHAIN_ID="912559"
 
 # Address of the RPC server for execution
 ASTRIA_COMPOSER_EXECUTION_URL="ws://127.0.0.1:8545"
+
+# Private key for the sequencer account used for signing transactions
+ASTRIA_COMPOSER_PRIVATE_KEY="2bd806c97f0e00af1a1fc3328fa763a9269723c8db8fac4f93af71db186d6e90"

--- a/crates/astria-composer/env.example
+++ b/crates/astria-composer/env.example
@@ -14,5 +14,4 @@ ASTRIA_COMPOSER_CHAIN_ID="912559"
 ASTRIA_COMPOSER_EXECUTION_URL="ws://127.0.0.1:8545"
 
 # Private key for the sequencer account used for signing transactions
-# Note that this corresponds to the funded "Alice" test key in sequencer
 ASTRIA_COMPOSER_PRIVATE_KEY="2bd806c97f0e00af1a1fc3328fa763a9269723c8db8fac4f93af71db186d6e90"

--- a/crates/astria-composer/env.example
+++ b/crates/astria-composer/env.example
@@ -14,4 +14,5 @@ ASTRIA_COMPOSER_CHAIN_ID="912559"
 ASTRIA_COMPOSER_EXECUTION_URL="ws://127.0.0.1:8545"
 
 # Private key for the sequencer account used for signing transactions
+# Note that this corresponds to the funded "Alice" test key in sequencer
 ASTRIA_COMPOSER_PRIVATE_KEY="2bd806c97f0e00af1a1fc3328fa763a9269723c8db8fac4f93af71db186d6e90"

--- a/crates/astria-composer/src/config.rs
+++ b/crates/astria-composer/src/config.rs
@@ -5,6 +5,7 @@ use figment::{
     Figment,
 };
 use secrecy::{
+    zeroize::ZeroizeOnDrop,
     ExposeSecret as _,
     SecretString,
 };
@@ -66,6 +67,8 @@ impl Config {
             .extract()
     }
 }
+
+impl ZeroizeOnDrop for Config {}
 
 fn serialize_private_key<S>(key: &SecretString, s: S) -> Result<S::Ok, S::Error>
 where

--- a/crates/astria-composer/src/config.rs
+++ b/crates/astria-composer/src/config.rs
@@ -40,6 +40,9 @@ pub struct Config {
 
     /// Address of the RPC server for execution
     pub execution_url: String,
+
+    /// Private key for the sequencer account used for signing transactions
+    pub private_key: String,
 }
 
 impl Config {

--- a/crates/astria-composer/tests/blackbox/helper/mock_sequencer.rs
+++ b/crates/astria-composer/tests/blackbox/helper/mock_sequencer.rs
@@ -71,6 +71,7 @@ async fn mount_abci_query_mock(server: &MockServer, query_path: &str, response: 
                 .set_body_json(&wrapper)
                 .append_header("Content-Type", "application/json"),
         )
+        .expect(1)
         .mount(server)
         .await;
 }

--- a/crates/astria-composer/tests/blackbox/helper/mock_sequencer.rs
+++ b/crates/astria-composer/tests/blackbox/helper/mock_sequencer.rs
@@ -1,3 +1,7 @@
+use astria_sequencer::accounts::{
+    query,
+    types::Nonce,
+};
 use serde_json::json;
 use tendermint::{
     abci,
@@ -9,7 +13,10 @@ use tendermint_rpc::{
     Id,
 };
 use wiremock::{
-    matchers::body_partial_json,
+    matchers::{
+        body_partial_json,
+        body_string_contains,
+    },
     Mock,
     MockServer,
     ResponseTemplate,
@@ -18,6 +25,12 @@ use wiremock::{
 pub async fn start() -> MockServer {
     let server = MockServer::start().await;
     mount_abci_info_mock(&server).await;
+    mount_abci_query_mock(
+        &server,
+        "accounts/nonce",
+        &query::Response::NonceResponse(Nonce::from(0)),
+    )
+    .await;
     server
 }
 
@@ -35,6 +48,29 @@ async fn mount_abci_info_mock(server: &MockServer) {
     Mock::given(body_partial_json(json!({"method": "abci_info"})))
         .respond_with(ResponseTemplate::new(200).set_body_json(abci_response))
         .expect(1..)
+        .mount(server)
+        .await;
+}
+
+async fn mount_abci_query_mock(server: &MockServer, query_path: &str, response: &query::Response) {
+    use borsh::BorshSerialize as _;
+    let expected_body = json!({
+        "method": "abci_query"
+    });
+    let response = tendermint_rpc::endpoint::abci_query::Response {
+        response: tendermint_rpc::endpoint::abci_query::AbciQuery {
+            value: response.try_to_vec().unwrap(),
+            ..Default::default()
+        },
+    };
+    let wrapper = response::Wrapper::new_with_id(Id::Num(1), Some(response), None);
+    Mock::given(body_partial_json(&expected_body))
+        .and(body_string_contains(query_path))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(&wrapper)
+                .append_header("Content-Type", "application/json"),
+        )
         .mount(server)
         .await;
 }

--- a/crates/astria-composer/tests/blackbox/helper/mod.rs
+++ b/crates/astria-composer/tests/blackbox/helper/mod.rs
@@ -47,6 +47,7 @@ pub async fn spawn_composer() -> TestComposer {
         chain_id: "testtest".into(),
         sequencer_url,
         execution_url,
+        private_key: "2bd806c97f0e00af1a1fc3328fa763a9269723c8db8fac4f93af71db186d6e90".to_string(),
     };
     let (composer_addr, composer) = {
         let composer = Composer::from_config(&config).await.unwrap();

--- a/crates/astria-composer/tests/blackbox/helper/mod.rs
+++ b/crates/astria-composer/tests/blackbox/helper/mod.rs
@@ -47,7 +47,7 @@ pub async fn spawn_composer() -> TestComposer {
         chain_id: "testtest".into(),
         sequencer_url,
         execution_url,
-        private_key: "2bd806c97f0e00af1a1fc3328fa763a9269723c8db8fac4f93af71db186d6e90".to_string(),
+        private_key: "2bd806c97f0e00af1a1fc3328fa763a9269723c8db8fac4f93af71db186d6e90".to_string().into(),
     };
     let (composer_addr, composer) = {
         let composer = Composer::from_config(&config).await.unwrap();

--- a/crates/astria-composer/tests/blackbox/helper/mod.rs
+++ b/crates/astria-composer/tests/blackbox/helper/mod.rs
@@ -47,7 +47,9 @@ pub async fn spawn_composer() -> TestComposer {
         chain_id: "testtest".into(),
         sequencer_url,
         execution_url,
-        private_key: "2bd806c97f0e00af1a1fc3328fa763a9269723c8db8fac4f93af71db186d6e90".to_string().into(),
+        private_key: "2bd806c97f0e00af1a1fc3328fa763a9269723c8db8fac4f93af71db186d6e90"
+            .to_string()
+            .into(),
     };
     let (composer_addr, composer) = {
         let composer = Composer::from_config(&config).await.unwrap();

--- a/crates/astria-sequencer/src/accounts/types.rs
+++ b/crates/astria-sequencer/src/accounts/types.rs
@@ -37,7 +37,8 @@ impl Address {
 
     /// Returns the address of the account associated with the given verification key,
     /// which is calculated as the first 20 bytes of the sha256 hash of the verification key.
-    pub(crate) fn from_verification_key(public_key: &crate::crypto::VerificationKey) -> Self {
+    #[must_use]
+    pub fn from_verification_key(public_key: &crate::crypto::VerificationKey) -> Self {
         let bytes = crate::hash(public_key.as_bytes());
         let arr: [u8; ADDRESS_LEN] = bytes[0..ADDRESS_LEN]
             .try_into()


### PR DESCRIPTION
- needed so i can merge #206
- reads sequencer private key from env; decided to do this instead of reading from a file since we already have a .env file, so felt a bit duplicative
- also track nonce for this account. note this PR doesn't add handling if a tx is rejected, so if any tx is rejected for some reason the nonce may get out of whack. will open an issue fix this by either resetting the nonce every sequencer block, or re-submitting transactions with the nonce that was rejected

closes  #215