### PR TITLE
sequencer: use penumbra's `Storage` instead of `TempStorage`

### DIFF
--- a/crates/astria-sequencer/src/config.rs
+++ b/crates/astria-sequencer/src/config.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use clap::Parser;
 use serde::{
     Deserialize,
@@ -16,7 +18,7 @@ pub struct Config {
     pub(crate) genesis_file: String,
     /// The path to penumbra storage db.
     #[arg(long)]
-    pub(crate) db_datadir: String,
+    pub(crate) db_filepath: PathBuf,
 }
 
 impl Config {

--- a/crates/astria-sequencer/src/config.rs
+++ b/crates/astria-sequencer/src/config.rs
@@ -14,6 +14,9 @@ pub struct Config {
     /// The path to the json encoded genesis file with a list of accounts.
     #[arg(long)]
     pub(crate) genesis_file: String,
+    /// The path to penumbra storage db.
+    #[arg(long)]
+    pub(crate) db_filepath: String,
 }
 
 impl Config {

--- a/crates/astria-sequencer/src/config.rs
+++ b/crates/astria-sequencer/src/config.rs
@@ -16,7 +16,7 @@ pub struct Config {
     pub(crate) genesis_file: String,
     /// The path to penumbra storage db.
     #[arg(long)]
-    pub(crate) db_filepath: String,
+    pub(crate) db_datadir: String,
 }
 
 impl Config {

--- a/crates/astria-sequencer/src/sequencer.rs
+++ b/crates/astria-sequencer/src/sequencer.rs
@@ -29,8 +29,8 @@ impl Sequencer {
     pub async fn run_until_stopped(config: Config) -> Result<()> {
         let genesis_state =
             GenesisState::from_path(config.genesis_file).context("failed reading genesis state")?;
-        let db_filepath = PathBuf::from(config.db_datadir);
-        let storage = penumbra_storage::Storage::load(db_filepath.clone())
+        let db_path = PathBuf::from(config.db_datadir);
+        let storage = penumbra_storage::Storage::load(db_path.clone())
             .await
             .context("failed to load storage backing chain state")?;
         let snapshot = storage.latest_snapshot();

--- a/crates/astria-sequencer/src/sequencer.rs
+++ b/crates/astria-sequencer/src/sequencer.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 use anyhow::{
     anyhow,
     Context as _,
@@ -30,8 +28,18 @@ impl Sequencer {
     pub async fn run_until_stopped(config: Config) -> Result<()> {
         let genesis_state =
             GenesisState::from_path(config.genesis_file).context("failed reading genesis state")?;
-        let db_path = PathBuf::from(config.db_datadir);
-        let storage = penumbra_storage::Storage::load(db_path.clone())
+        if config.db_filepath.try_exists()? {
+            info!(
+                path = config.db_filepath.display().to_string(),
+                "opening storage db"
+            );
+        } else {
+            info!(
+                path = config.db_filepath.display().to_string(),
+                "creating storage db"
+            );
+        }
+        let storage = penumbra_storage::Storage::load(config.db_filepath.clone())
             .await
             .context("failed to load storage backing chain state")?;
         let snapshot = storage.latest_snapshot();

--- a/crates/astria-sequencer/src/sequencer.rs
+++ b/crates/astria-sequencer/src/sequencer.rs
@@ -28,14 +28,18 @@ impl Sequencer {
     pub async fn run_until_stopped(config: Config) -> Result<()> {
         let genesis_state =
             GenesisState::from_path(config.genesis_file).context("failed reading genesis state")?;
-        if config.db_filepath.try_exists()? {
+        if config
+            .db_filepath
+            .exists()
+            .context("failed checking for existence of db storage file")?
+        {
             info!(
-                path = config.db_filepath.display().to_string(),
+                path = %config.db_filepath.display(),
                 "opening storage db"
             );
         } else {
             info!(
-                path = config.db_filepath.display().to_string(),
+                path = %config.db_filepath.display(),
                 "creating storage db"
             );
         }

--- a/crates/astria-sequencer/src/sequencer.rs
+++ b/crates/astria-sequencer/src/sequencer.rs
@@ -29,7 +29,7 @@ impl Sequencer {
     pub async fn run_until_stopped(config: Config) -> Result<()> {
         let genesis_state =
             GenesisState::from_path(config.genesis_file).context("failed reading genesis state")?;
-        let db_filepath = PathBuf::from(config.db_filepath);
+        let db_filepath = PathBuf::from(config.db_datadir);
         let storage = penumbra_storage::Storage::load(db_filepath.clone())
             .await
             .context("failed to load storage backing chain state")?;

--- a/crates/astria-sequencer/src/sequencer.rs
+++ b/crates/astria-sequencer/src/sequencer.rs
@@ -30,7 +30,7 @@ impl Sequencer {
             GenesisState::from_path(config.genesis_file).context("failed reading genesis state")?;
         if config
             .db_filepath
-            .exists()
+            .try_exists()
             .context("failed checking for existence of db storage file")?
         {
             info!(

--- a/crates/astria-sequencer/src/sequencer.rs
+++ b/crates/astria-sequencer/src/sequencer.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use anyhow::{
     anyhow,
     Context as _,
@@ -28,9 +29,10 @@ impl Sequencer {
     pub async fn run_until_stopped(config: Config) -> Result<()> {
         let genesis_state =
             GenesisState::from_path(config.genesis_file).context("failed reading genesis state")?;
-        let storage = penumbra_storage::TempStorage::new()
+        let db_filepath = PathBuf::from(config.db_filepath);
+        let storage = penumbra_storage::Storage::load(db_filepath.clone())
             .await
-            .context("failed to create temp storage backing chain state")?;
+            .context("failed to load storage backing chain state")?;
         let snapshot = storage.latest_snapshot();
         let mut app = App::new(snapshot);
         app.init_chain(genesis_state)

--- a/crates/astria-sequencer/src/sequencer.rs
+++ b/crates/astria-sequencer/src/sequencer.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+
 use anyhow::{
     anyhow,
     Context as _,


### PR DESCRIPTION
This PR changes the storage type we are using in `sequencer`. It is being changed from `penumbra_storage::TempStorage` to `penumbra_storage::Storage`. I also added a config value to define the path of the penumbra database file.

Resolves #254 