### PR TITLE
sequencer: use tendermint hash type instead of opaque bytes

### DIFF
--- a/crates/astria-conductor/src/block_verifier.rs
+++ b/crates/astria-conductor/src/block_verifier.rs
@@ -134,7 +134,7 @@ impl BlockVerifier {
         block: &SequencerBlockData,
     ) -> eyre::Result<()> {
         self.validate_sequencer_block_header_and_last_commit(
-            block.block_hash(),
+            block.block_hash().as_bytes(),
             block.header(),
             block.last_commit(),
         )

--- a/crates/astria-conductor/src/block_verifier.rs
+++ b/crates/astria-conductor/src/block_verifier.rs
@@ -105,7 +105,7 @@ impl BlockVerifier {
 
     pub async fn validate_rollup_data(
         &self,
-        block_hash: &[u8],
+        block_hash: Hash,
         header: &Header,
         last_commit: &Option<Commit>,
         _rollup_data: &RollupNamespaceData,
@@ -134,7 +134,7 @@ impl BlockVerifier {
         block: &SequencerBlockData,
     ) -> eyre::Result<()> {
         self.validate_sequencer_block_header_and_last_commit(
-            block.block_hash().as_bytes(),
+            block.block_hash(),
             block.header(),
             block.last_commit(),
         )
@@ -146,7 +146,7 @@ impl BlockVerifier {
 
     async fn validate_sequencer_block_header_and_last_commit(
         &self,
-        block_hash: &[u8],
+        block_hash: Hash,
         header: &Header,
         last_commit: &Option<Commit>,
     ) -> eyre::Result<()> {
@@ -215,7 +215,7 @@ impl BlockVerifier {
         // validate the block header matches the block hash
         let block_hash_from_header = header.hash();
         ensure!(
-            block_hash_from_header.as_bytes() == block_hash,
+            block_hash_from_header == block_hash,
             "block hash calculated from tendermint header does not match block hash stored in \
              sequencer block",
         );

--- a/crates/astria-conductor/src/reader.rs
+++ b/crates/astria-conductor/src/reader.rs
@@ -232,7 +232,7 @@ impl Reader {
                 if let Err(e) = self
                     .block_verifier
                     .validate_rollup_data(
-                        data.data.block_hash.as_bytes(),
+                        data.data.block_hash,
                         &data.data.header,
                         &data.data.last_commit,
                         &rollup_data,

--- a/crates/astria-conductor/src/reader.rs
+++ b/crates/astria-conductor/src/reader.rs
@@ -232,7 +232,7 @@ impl Reader {
                 if let Err(e) = self
                     .block_verifier
                     .validate_rollup_data(
-                        &data.data.block_hash,
+                        data.data.block_hash.as_bytes(),
                         &data.data.header,
                         &data.data.last_commit,
                         &rollup_data,
@@ -244,15 +244,8 @@ impl Reader {
                     warn!(error.msg = %e, error.cause_chain = ?e, "failed to validate sequencer block");
                     continue 'get_sequencer_blocks;
                 }
-                let block_hash = match data.data.block_hash.try_into() {
-                    Ok(block_hash) => block_hash,
-                    Err(e) => {
-                        warn!(error.msg = %e, error.cause_chain = ?e, "failed to convert block hash, skipping block");
-                        continue 'get_sequencer_blocks;
-                    }
-                };
                 blocks.push(SequencerBlockSubset {
-                    block_hash,
+                    block_hash: data.data.block_hash,
                     header: data.data.header,
                     rollup_transactions: rollup_data.rollup_txs,
                 });

--- a/crates/astria-conductor/src/reader.rs
+++ b/crates/astria-conductor/src/reader.rs
@@ -244,8 +244,15 @@ impl Reader {
                     warn!(error.msg = %e, error.cause_chain = ?e, "failed to validate sequencer block");
                     continue 'get_sequencer_blocks;
                 }
+                let block_hash = match data.data.block_hash.try_into() {
+                    Ok(block_hash) => block_hash,
+                    Err(e) => {
+                        warn!(error.msg = %e, error.cause_chain = ?e, "failed to convert block hash, skipping block");
+                        continue 'get_sequencer_blocks;
+                    }
+                };
                 blocks.push(SequencerBlockSubset {
-                    block_hash: data.data.block_hash,
+                    block_hash,
                     header: data.data.header,
                     rollup_transactions: rollup_data.rollup_txs,
                 });

--- a/crates/astria-conductor/src/types.rs
+++ b/crates/astria-conductor/src/types.rs
@@ -2,14 +2,17 @@ use astria_sequencer_types::{
     Namespace,
     SequencerBlockData,
 };
-use tendermint::block::Header;
+use tendermint::{
+    block::Header,
+    Hash,
+};
 
 /// `SequencerBlockSubset` is a subset of a SequencerBlock that contains
 /// information required for transaction data verification, and the transactions
 /// for one specific rollup.
 #[derive(Clone, Debug)]
 pub struct SequencerBlockSubset {
-    pub(crate) block_hash: Vec<u8>,
+    pub(crate) block_hash: Hash,
     pub(crate) header: Header,
     pub(crate) rollup_transactions: Vec<Vec<u8>>,
 }

--- a/crates/astria-sequencer-relayer/src/data_availability.rs
+++ b/crates/astria-sequencer-relayer/src/data_availability.rs
@@ -456,7 +456,12 @@ impl CelestiaClient {
             .collect();
         Ok(Some(
             SequencerBlockData::new(
-                namespace_data.data.block_hash.clone(),
+                namespace_data
+                    .data
+                    .block_hash
+                    .clone()
+                    .try_into()
+                    .wrap_err("failed to convert namespace data block hash to tendermint Hash")?,
                 namespace_data.data.header.clone(),
                 namespace_data.data.last_commit.clone(),
                 rollup_txs,
@@ -535,7 +540,7 @@ fn assemble_blobs_from_sequencer_block_data(
 
     for (namespace, txs) in rollup_txs {
         let rollup_namespace_data = RollupNamespaceData {
-            block_hash: block_hash.clone(),
+            block_hash: block_hash.clone().as_bytes().to_vec(),
             rollup_txs: txs,
         };
         let data = rollup_namespace_data
@@ -551,7 +556,7 @@ fn assemble_blobs_from_sequencer_block_data(
     }
 
     let sequencer_namespace_data = SequencerNamespaceData {
-        block_hash,
+        block_hash: block_hash.clone().as_bytes().to_vec(),
         header,
         last_commit,
         rollup_namespaces: namespaces,

--- a/crates/astria-sequencer-types/src/sequencer_block_data.rs
+++ b/crates/astria-sequencer-types/src/sequencer_block_data.rs
@@ -20,6 +20,7 @@ use tendermint::{
         Header,
     },
     Block,
+    Hash,
 };
 use thiserror::Error;
 use tracing::debug;
@@ -36,9 +37,7 @@ pub enum Error {
 /// to be submitted to the DA layer.
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct SequencerBlockData {
-    // TODO: change to tendermint::Hash
-    #[serde(with = "crate::serde::Base64Standard")]
-    pub(crate) block_hash: Vec<u8>,
+    pub(crate) block_hash: Hash,
     pub(crate) header: Header,
     /// This field should be set for every block with height > 1.
     pub(crate) last_commit: Option<Commit>,
@@ -53,7 +52,7 @@ impl SequencerBlockData {
     ///
     /// - if the block hash does not correspond to the hashed header provided
     pub fn new(
-        block_hash: Vec<u8>,
+        block_hash: Hash,
         header: Header,
         last_commit: Option<Commit>,
         rollup_txs: HashMap<Namespace, Vec<Vec<u8>>>,
@@ -70,8 +69,8 @@ impl SequencerBlockData {
     }
 
     #[must_use]
-    pub fn block_hash(&self) -> &[u8] {
-        &self.block_hash
+    pub fn block_hash(&self) -> Hash {
+        self.block_hash
     }
 
     #[must_use]
@@ -94,7 +93,7 @@ impl SequencerBlockData {
     pub fn into_values(
         self,
     ) -> (
-        Vec<u8>,
+        Hash,
         Header,
         Option<Commit>,
         HashMap<Namespace, Vec<Vec<u8>>>,
@@ -169,7 +168,7 @@ impl SequencerBlockData {
         }
 
         let data = Self {
-            block_hash: b.header.hash().as_bytes().to_vec(),
+            block_hash: b.header.hash(),
             header: b.header,
             last_commit: b.last_commit,
             rollup_txs,
@@ -187,7 +186,7 @@ impl SequencerBlockData {
     fn verify_block_hash(&self) -> eyre::Result<()> {
         let block_hash = self.header.hash();
         ensure!(
-            block_hash.as_bytes() == self.block_hash,
+            block_hash == self.block_hash,
             "block hash calculated from tendermint header does not match block hash stored in \
              sequencer block",
         );
@@ -207,7 +206,7 @@ mod test {
         let header = crate::test_utils::default_header();
         let block_hash = header.hash();
         let mut expected = SequencerBlockData {
-            block_hash: block_hash.as_bytes().to_vec(),
+            block_hash,
             header,
             last_commit: None,
             rollup_txs: HashMap::new(),


### PR DESCRIPTION
Update `SequencerBlockData`, `SequencerNamespaceData`, and `RollupNamespaceData` to use a `tendermint::Hash` instead of `Vec<u8>`. This cuts down on the amount of type conversions needed when validating and comparing hashes when trying to execute blocks. This also simplifies and fixes the (de)serialization of all types mentioned.