### PR TITLE
composer: test multiple rollups

### DIFF
--- a/crates/astria-composer/tests/blackbox/api.rs
+++ b/crates/astria-composer/tests/blackbox/api.rs
@@ -4,5 +4,5 @@ async fn readyz() {
     // spawn_composer hits `/readyz` as part of starting the test
     // environment. If this future return then `readyz` must have
     // returned `status: ok`.
-    let _test_composer = spawn_composer().await;
+    let _test_composer = spawn_composer(&["testtest"]).await;
 }

--- a/crates/astria-composer/tests/blackbox/api.rs
+++ b/crates/astria-composer/tests/blackbox/api.rs
@@ -1,8 +1,16 @@
 use crate::helper::spawn_composer;
 #[tokio::test]
-async fn readyz() {
+async fn readyz_with_one_rollup() {
     // spawn_composer hits `/readyz` as part of starting the test
     // environment. If this future return then `readyz` must have
     // returned `status: ok`.
-    let _test_composer = spawn_composer(&["testtest"]).await;
+    let _test_composer = spawn_composer(&["test1"]).await;
+}
+
+#[tokio::test]
+async fn readyz_with_two_rollups() {
+    // spawn_composer hits `/readyz` as part of starting the test
+    // environment. If this future return then `readyz` must have
+    // returned `status: ok`.
+    let _test_composer = spawn_composer(&["test1", "test2"]).await;
 }

--- a/crates/astria-composer/tests/blackbox/composer.rs
+++ b/crates/astria-composer/tests/blackbox/composer.rs
@@ -21,9 +21,11 @@ use crate::helper::spawn_composer;
 
 #[tokio::test]
 async fn pending_eth_tx_is_submitted_to_sequencer() {
-    let test_composer = spawn_composer().await;
+    let test_composer = spawn_composer(&["testtest"]).await;
     let mock_guard = mount_broadcast_tx_sync_mock(&test_composer.sequencer).await;
-    test_composer.geth.push_tx(Transaction::default()).unwrap();
+    test_composer.geths["testtest"]
+        .push_tx(Transaction::default())
+        .unwrap();
     tokio::time::timeout(
         Duration::from_millis(100),
         mock_guard.wait_until_satisfied(),

--- a/crates/astria-composer/tests/blackbox/composer.rs
+++ b/crates/astria-composer/tests/blackbox/composer.rs
@@ -23,7 +23,7 @@ use crate::helper::spawn_composer;
 async fn tx_from_one_rollup_is_received_by_sequencer() {
     let test_composer = spawn_composer(&["test1"]).await;
     let mock_guard = mount_broadcast_tx_sync_mock(&test_composer.sequencer, "test1").await;
-    test_composer.geths["test1"]
+    test_composer.rollup_nodes["test1"]
         .push_tx(Transaction::default())
         .unwrap();
     tokio::time::timeout(
@@ -41,10 +41,10 @@ async fn tx_from_two_rollups_are_received_by_sequencer() {
     let test_composer = spawn_composer(&["test1", "test2"]).await;
     let test1_guard = mount_broadcast_tx_sync_mock(&test_composer.sequencer, "test1").await;
     let test2_guard = mount_broadcast_tx_sync_mock(&test_composer.sequencer, "test2").await;
-    test_composer.geths["test1"]
+    test_composer.rollup_nodes["test1"]
         .push_tx(Transaction::default())
         .unwrap();
-    test_composer.geths["test2"]
+    test_composer.rollup_nodes["test2"]
         .push_tx(Transaction::default())
         .unwrap();
     let all_guards = join(

--- a/crates/astria-composer/tests/blackbox/helper/mod.rs
+++ b/crates/astria-composer/tests/blackbox/helper/mod.rs
@@ -26,7 +26,7 @@ static TELEMETRY: Lazy<()> = Lazy::new(|| {
 
 pub struct TestComposer {
     pub composer: JoinHandle<()>,
-    pub geths: HashMap<String, mock_geth::MockGeth>,
+    pub rollup_nodes: HashMap<String, mock_geth::MockGeth>,
     pub sequencer: wiremock::MockServer,
 }
 
@@ -43,12 +43,12 @@ pub async fn spawn_composer(rollup_ids: &[&str]) -> TestComposer {
         "must provide at least one rollup ID for tests"
     );
 
-    let mut geths = HashMap::new();
+    let mut rollup_nodes = HashMap::new();
     let mut rollups = String::new();
     for id in rollup_ids {
         let geth = mock_geth::MockGeth::spawn().await;
         let execution_url = format!("ws://{}", geth.local_addr());
-        geths.insert(id.to_string(), geth);
+        rollup_nodes.insert(id.to_string(), geth);
         rollups.push_str(&format!("{id}::{execution_url},"));
     }
     let sequencer = mock_sequencer::start().await;
@@ -73,7 +73,7 @@ pub async fn spawn_composer(rollup_ids: &[&str]) -> TestComposer {
     loop_until_composer_is_ready(composer_addr).await;
     TestComposer {
         composer,
-        geths,
+        rollup_nodes,
         sequencer,
     }
 }


### PR DESCRIPTION
## Summary

Implement blackbox tests for composer ingesting from rollups. This is the third of three patches to allow composer to read from multiple rollup, see related issues below.

## Background

This patch completes the implementation with a test.

## Changes

- added `tx_from_two_rollups_are_received_by_sequencer`
- adjusted `mount_broadcast_tx_sync_mock` to take an expected chain ID and check it against the one received in the broadcast tx sync request.

## Testing

N.A. - this is a test.

## Related Issues

https://github.com/astriaorg/astria/pull/277
https://github.com/astriaorg/astria/pull/278
https://github.com/astriaorg/astria/pull/282 (the present PR)