### PR TITLE
fix: add astria-sequencer-types crate to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
   "crates/astria-sequencer",
   "crates/astria-sequencer-client",
   "crates/astria-sequencer-relayer",
+  "crates/astria-sequencer-types",
   "crates/astria-sequencer-utils",
   "crates/astria-telemetry",
   "crates/astria-test-utils",


### PR DESCRIPTION
## Summary

- add tastria-sequencer-ypes crate to Cargo.toml

## Background

- should have been done before
