### PR TITLE
ci: Update to reusable success, nested names

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -56,12 +56,6 @@ jobs:
       target-binary: astria-sequencer-relayer
     secrets: inherit
 
-  success:
-    runs-on: ubuntu-latest
+  docker:
     needs: [composer, conductor, sequencer, sequencer-relayer]
-    if: ${{ always() && !cancelled() }}
-    steps:
-      - if: ${{ contains(needs.*.result, 'failure') }}
-        run: exit 1
-      - if: ${{ !contains(needs.*.result, 'failure') }}
-        run: exit 0
+    uses: ./.github/workflows/reusable-success.yml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -57,12 +57,6 @@ jobs:
       - name: run taplo
         run: taplo format --check
 
-  success:
-    runs-on: ubuntu-latest
+  lint:
     needs: [proto, rust, toml]
-    if: ${{ always() && !cancelled() }}
-    steps:
-      - if: ${{ contains(needs.*.result, 'failure') }}
-        run: exit 1
-      - if: ${{ !contains(needs.*.result, 'failure') }}
-        run: exit 0
+    uses: ./.github/workflows/reusable-success.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,12 +26,6 @@ jobs:
           input: "crates/astria-proto/proto"
           buf_token: ${{ secrets.BUF_TOKEN }}
 
-  success:
-    runs-on: ubuntu-latest
+  release:
     needs: [proto]
-    if: ${{ always() && !cancelled() }}
-    steps:
-      - if: ${{ contains(needs.*.result, 'failure') }}
-        run: exit 1
-      - if: ${{ !contains(needs.*.result, 'failure') }}
-        run: exit 0
+    uses: ./.github/workflows/reusable-success.yml

--- a/.github/workflows/reusable-success.yml
+++ b/.github/workflows/reusable-success.yml
@@ -1,0 +1,14 @@
+name: Reusable Success Check
+
+on:
+  workflow_call:
+
+jobs:
+  success:
+    runs-on: ubuntu-latest
+    if: ${{ always() && !cancelled() }}
+    steps:
+      - if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1
+      - if: ${{ !contains(needs.*.result, 'failure') }}
+        run: exit 0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -137,12 +137,6 @@ jobs:
           --all-features \
           -- --deny warnings
 
-  success:
-    runs-on: ubuntu-latest
+  test:
     needs: [compiles, rust, rpc_client, doctest, clippy]
-    if: ${{ always() && !cancelled() }}
-    steps:
-      - if: ${{ contains(needs.*.result, 'failure') }}
-        run: exit 1
-      - if: ${{ !contains(needs.*.result, 'failure') }}
-        run: exit 0
+    uses: ./.github/workflows/reusable-success.yml


### PR DESCRIPTION
## Summary

Makes the success a reusable command, and uses sub names for identification

## Background

All the success being the same name causing issues with required jobs if all tests haven't finished.

## Changes

- move to reusable success action

## Testing

tested on this pr action workflow running

