### PR TITLE
WIP: v1alpha2 of sequencer

### DIFF
--- a/crates/astria-proto/proto/astria/sequencer/v1alpha2/account.proto
+++ b/crates/astria-proto/proto/astria/sequencer/v1alpha2/account.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package astria.sequencer.v1alpha2;
+
+import "astria/primitive/v1/types.proto";
+
+// A response containing the balance of an account.
+message BalanceResponse {
+  uint64 height = 2;
+  astria.primitive.v1.Uint128 balance = 3;
+}
+
+// A response containing the current nonce for an account.
+message NonceResponse {
+  uint64 height = 2;
+  uint32 nonce = 3;
+}

--- a/crates/astria-proto/proto/astria/sequencer/v1alpha2/block.proto
+++ b/crates/astria-proto/proto/astria/sequencer/v1alpha2/block.proto
@@ -1,0 +1,23 @@
+syntax = "proto3";
+
+package astria.sequencer.v1alpha2;
+
+import "tendermint/types/types.proto";
+import "astria/sequencer/v1alpha1/data.proto";
+
+// helper type - these should get parsed into a map from namespace to
+// a vector of `IndexedTransactions`
+message NamespacedIndexedTransactions {
+    bytes namespace = 1;
+    repeated IndexedTransaction txs = 2;
+}
+
+// `SequencerBlock`
+message SequencerBlock {
+    bytes block_hash = 1;
+    tendermint.types.Header header = 2;
+    repeated IndexedTransaction sequencer_transactions = 3;
+    // FIXME: the current nested array layout results in bad allocation behavior on deserialization
+    // see https://github.com/astriaorg/astria/issues/31
+    repeated NamespacedIndexedTransactions rollup_transactions = 4;
+}

--- a/crates/astria-proto/proto/astria/sequencer/v1alpha2/block.proto
+++ b/crates/astria-proto/proto/astria/sequencer/v1alpha2/block.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 package astria.sequencer.v1alpha2;
 
 import "tendermint/types/types.proto";
-import "astria/sequencer/v1alpha1/data.proto";
+import "astria/sequencer/v1alpha2/data.proto";
 
 // helper type - these should get parsed into a map from namespace to
 // a vector of `IndexedTransactions`

--- a/crates/astria-proto/proto/astria/sequencer/v1alpha2/data.proto
+++ b/crates/astria-proto/proto/astria/sequencer/v1alpha2/data.proto
@@ -1,0 +1,38 @@
+syntax = "proto3";
+
+package astria.sequencer.v1alpha2;
+
+import "tendermint/types/types.proto";
+
+// `IndexedTransaction` represents a sequencer transaction along with the index
+// it was originally in the sequencer block.
+message IndexedTransaction {
+    uint64 block_index = 1; // TODO: this is usize - how to define for variable size?
+    bytes transaction = 2;
+}
+
+message RollupNamespace {
+    uint64 block_height = 1;
+    bytes namespace = 2;
+}
+
+// `RollupNamespaceData`
+message RollupNamespaceData {
+    bytes block_hash = 1;
+    repeated IndexedTransaction rollup_txs = 2;
+}
+
+// `SequencerNamespaceData`
+message SequencerNamespaceData {
+    bytes block_hash = 1;
+    tendermint.types.Header header = 2;
+    repeated IndexedTransaction sequencer_txs = 3;
+    repeated RollupNamespace rollup_namespaces = 4;
+}
+
+// `SignedNamespaceData?`
+message SignedNamespaceData {
+    bytes data = 1;
+    bytes public_key = 2;
+    bytes signature = 3;
+}

--- a/crates/astria-proto/proto/astria/sequencer/v1alpha2/transaction.proto
+++ b/crates/astria-proto/proto/astria/sequencer/v1alpha2/transaction.proto
@@ -1,0 +1,58 @@
+syntax = "proto3";
+
+package astria.sequencer.v1alpha2;
+
+import "astria/primitive/v1/types.proto";
+
+// `SignedTransaction` contains an encoded transaction together with its
+// signature and verification key derived from the signing key that produced
+// the signature.
+//
+// The encoded transaction is expected to be decodable to a `Transaction`.
+// `Signature` is expected to be a slice of 64 bytes, and `verification_key`
+// a slice of 32 bytes that can be converted to an ed25519 verification key.
+//
+// The transaction bytes must be verifiab le given the signature and key.
+message SignedTransaction {
+    bytes signature = 1;
+    // FIXME: What's the point of sending the verification key along with
+    // the transaction? If Anna sends us a transaction and its signature,
+    // shouldn't we have exchanged keys through a different channel so
+    // that we can independently verify that the transaction is indeed
+    // signed by her?
+    bytes verification_key = 2;
+    bytes transaction = 3;
+}
+
+// `Transaction` contains a nonce and a list of actions.
+message Transaction {
+    uint32 nonce = 1;
+    repeated Action actions = 2;
+}
+
+// `Action` is the collection of all actions that can be part of a `Transaction`.
+//
+// Note that an unset oneof `value` is ignored.
+message Action {
+    oneof value {
+        TransferAction transfer_action = 1;
+        SequenceAction sequence_action = 2;
+    }   
+}
+
+// `TransferAction` represents a value transfer transaction.
+//
+// `to` is expected to a slice of 20 bytes representating an astria address.
+message TransferAction {
+    bytes to = 1;
+    astria.primitive.v1.Uint128 amount = 2;
+}
+
+// `SequenceAction` represents a transaction destined for another chain.
+//
+// `to` is expected to be a slice of 32 bytes representatin an astria chain ID.
+// `data` is treated as an opaque buffer of bytes.
+message SequenceAction {
+    bytes chain_id = 1;
+    bytes data = 2;
+}

--- a/crates/astria-proto/proto/astria/sequencer/v1alpha2/transaction.proto
+++ b/crates/astria-proto/proto/astria/sequencer/v1alpha2/transaction.proto
@@ -50,9 +50,9 @@ message TransferAction {
 
 // `SequenceAction` represents a transaction destined for another chain.
 //
-// `to` is expected to be a slice of 32 bytes representatin an astria chain ID.
+// `chain_id` is a plain text identifier of the chain that `data` belongs to.
 // `data` is treated as an opaque buffer of bytes.
 message SequenceAction {
-    bytes chain_id = 1;
+    string chain_id = 1;
     bytes data = 2;
 }


### PR DESCRIPTION
## Summary

Add a `sequencer.v1alpha2` protobuf package to have signed transactions contain the raw bytes of the transaction that it claims to sign.

## Background

Protobuf serialization is not deterministic, so verification of signed transactions has to happen before decoding into a rust memory representation (and subsequent re-encoding to bytes for verification, where the non-determinism now matters).

## Changes

- Added an `astria.sequencer.v1alpha2` protobuf package.
- changed `SignedTransaction.transaction` field to `bytes` (from `UnsignedTransaction`)
- changed `SequenceTransaction.chain_id` field to `string` (from `bytes`)
  
## Testing

How are these changes tested?

## Breaking Changelist

- Bulleted list of breaking changes, any notes on migration. Delete section if none.

## Related Issues

Tracking issue: #310 
