### PR TITLE
sequencer: remove todo for issue that's done

### DIFF
--- a/crates/astria-sequencer/src/transaction/mod.rs
+++ b/crates/astria-sequencer/src/transaction/mod.rs
@@ -98,8 +98,6 @@ impl ActionHandler for UnsignedTransaction {
         )
     )]
     async fn execute<S: StateWriteExt>(&self, state: &mut S, from: Address) -> anyhow::Result<()> {
-        // TODO(https://github.com/astriaorg/astria/issues/317): make a new StateDelta so this is atomic / can be rolled back in case of error
-
         let from_nonce = state
             .get_account_nonce(from)
             .await


### PR DESCRIPTION
## Summary

this is actually not an issue; the calling function of `execute` already does this:
```rust
        let mut state_tx = self
            .state
            .try_begin_transaction()
            .expect("state Arc should be present and unique");

        transaction::execute(&signed_tx, &mut state_tx)
            .await
            .context("failed executing transaction")?;
        state_tx.apply();
``` 

## Related Issues

closes #317 
