### PR TITLE
initial commit of cometbft test utility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,8 +69,8 @@ jobs:
           echo "COMETBFT=$HOME/cometbft/cometbft" >> "$GITHUB_ENV"
       - name: Download and install cometbft
         run: |
+          mkdir $COMETBFT_DIR
           wget https://github.com/cometbft/cometbft/releases/download/v0.37.2/cometbft_0.37.2_linux_amd64.tar.gz
-          mkdir cometbft
           tar -C $COMETBFT_DIR -xvzf cometbft_0.37.2_linux_amd64.tar.gz
           chmod +x $COMETBFT
       - name: Run tests (excluding RPC client, which needs kubernetes)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@ name: Test
 env:
   CI: true
   RUSTFLAGS: "-D warnings -D unreachable-pub --cfg tokio_unstable"
+  COMETBFT_DIR: ${{ env.HOME }}/cometbft
+  COMETBFT: ${{ env.COMETBFT_DIR }}/cometbft
 on: 
   pull_request:
   push:
@@ -46,9 +48,6 @@ jobs:
     runs-on: buildjet-8vcpu-ubuntu-2204
     needs: run_checker
     if: ${{ needs.run_checker.outputs.run_tests }}
-    env:
-      COMETBFT_DIR: ${{ env.HOME }}/cometbft
-      COMETBFT: ${{ env.COMETBFT_DIR }}/cometbft
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@1.70.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,6 @@ name: Test
 env:
   CI: true
   RUSTFLAGS: "-D warnings -D unreachable-pub --cfg tokio_unstable"
-  COMETBFT_DIR: ${{ env.HOME }}/cometbft
-  COMETBFT: ${{ env.COMETBFT_DIR }}/cometbft
 on: 
   pull_request:
   push:
@@ -65,6 +63,10 @@ jobs:
           --all-features \
           --all-targets \
           --exclude astria-celestia-jsonrpc-client
+      - name: Add COMETBFT and COMETBFT_DIR vars to environment
+        run: |
+          echo "COMETBFT_DIR=$HOME/cometbft" >> "$GITHUB_ENV"
+          echo "COMETBFT=$HOME/cometbft/cometbft" >> "$GITHUB_ENV"
       - name: Download and install cometbft
         run: |
           wget https://github.com/cometbft/cometbft/releases/download/v0.37.2/cometbft_0.37.2_linux_amd64.tar.gz

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,9 @@ jobs:
     runs-on: buildjet-8vcpu-ubuntu-2204
     needs: run_checker
     if: ${{ needs.run_checker.outputs.run_tests }}
+    env:
+      COMETBFT_DIR: ${{ env.HOME }}/cometbft
+      COMETBFT: ${{ env.COMETBFT_DIR }}/cometbft
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@1.70.0
@@ -63,6 +66,12 @@ jobs:
           --all-features \
           --all-targets \
           --exclude astria-celestia-jsonrpc-client
+      - name: Download and install cometbft
+        run: |
+          wget https://github.com/cometbft/cometbft/releases/download/v0.37.2/cometbft_0.37.2_linux_amd64.tar.gz
+          mkdir cometbft
+          tar -C $COMETBFT_DIR -xvzf cometbft_0.37.2_linux_amd64.tar.gz
+          chmod +x $COMETBFT
       - name: Run tests (excluding RPC client, which needs kubernetes)
         timeout-minutes: 20
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -231,14 +231,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.72"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "arc-swap"
@@ -943,6 +943,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.66.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
+dependencies = [
+ "bitflags 2.3.3",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.28",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1419,6 +1439,23 @@ name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "cometbft-launcher"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "libc",
+ "libproc",
+ "procfs",
+ "reqwest",
+ "tempfile",
+ "tokio",
+ "tokio-test",
+ "toml_edit",
+ "tryhard",
+ "which",
+]
 
 [[package]]
 name = "concurrent-queue"
@@ -1927,7 +1964,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2147,7 +2184,7 @@ checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3067,7 +3104,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3454,7 +3491,7 @@ checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3465,7 +3502,7 @@ checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
  "socket2 0.5.3",
  "widestring",
- "windows-sys",
+ "windows-sys 0.48.0",
  "winreg 0.50.0",
 ]
 
@@ -3483,7 +3520,7 @@ checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi",
  "rustix 0.38.4",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4321,12 +4358,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "libproc"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fba61dbe003b79fe1af52ff15a489e50b9e66b36c79f945fbcbcf02e895f26d"
+dependencies = [
+ "bindgen 0.66.1",
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "librocksdb-sys"
 version = "0.8.3+7.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "557b255ff04123fcc176162f56ed0c9cd42d8f357cf55b3fabeb60f7413741b3"
 dependencies = [
- "bindgen",
+ "bindgen 0.64.0",
  "bzip2-sys",
  "cc",
  "glob",
@@ -4351,6 +4399,12 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "linux-raw-sys"
@@ -4508,7 +4562,7 @@ checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4976,7 +5030,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.3.5",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
@@ -5254,9 +5308,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.10"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c40d25201921e5ff0c862a505c6557ea88568a4e3ace775ab55e93f2f4f9d57"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pin-utils"
@@ -5309,7 +5363,7 @@ dependencies = [
  "libc",
  "log",
  "pin-project-lite",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5446,6 +5500,21 @@ dependencies = [
  "syn 2.0.28",
  "version_check",
  "yansi 1.0.0-rc",
+]
+
+[[package]]
+name = "procfs"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "943ca7f9f29bab5844ecd8fdb3992c5969b6622bb9609b9502fef9b4310e3f1f"
+dependencies = [
+ "bitflags 1.3.2",
+ "byteorder",
+ "chrono",
+ "flate2",
+ "hex",
+ "lazy_static",
+ "rustix 0.36.15",
 ]
 
 [[package]]
@@ -5971,6 +6040,20 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.36.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c37f1bd5ef1b5422177b7646cba67430579cfe2ace80f284fee876bca52ad941"
+dependencies = [
+ "bitflags 1.3.2",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.1.4",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "rustix"
 version = "0.37.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06"
@@ -5980,7 +6063,7 @@ dependencies = [
  "io-lifetimes",
  "libc",
  "linux-raw-sys 0.3.8",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5993,7 +6076,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.5",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6157,7 +6240,7 @@ version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6591,7 +6674,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6835,15 +6918,15 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.7.0"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5486094ee78b2e5038a6382ed7645bc084dc2ec433426ca4c3cb61e2007b8998"
+checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
  "cfg-if",
  "fastrand 2.0.0",
  "redox_syscall 0.3.5",
  "rustix 0.38.4",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -7044,11 +7127,10 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.29.1"
+version = "1.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
+checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
 dependencies = [
- "autocfg",
  "backtrace",
  "bytes",
  "libc",
@@ -7057,10 +7139,10 @@ dependencies = [
  "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.4.9",
+ "socket2 0.5.3",
  "tokio-macros",
  "tracing",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -7546,6 +7628,17 @@ name = "try-lock"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
+
+[[package]]
+name = "tryhard"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9f0a709784e86923586cff0d872dba54cd2d2e116b3bc57587d15737cfce9d"
+dependencies = [
+ "futures",
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "tungstenite"
@@ -8240,7 +8333,16 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -8249,7 +8351,22 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.1",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -8258,14 +8375,20 @@ version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
 dependencies = [
- "windows_aarch64_gnullvm",
+ "windows_aarch64_gnullvm 0.48.0",
  "windows_aarch64_msvc 0.48.0",
  "windows_i686_gnu 0.48.0",
  "windows_i686_msvc 0.48.0",
  "windows_x86_64_gnu 0.48.0",
- "windows_x86_64_gnullvm",
+ "windows_x86_64_gnullvm 0.48.0",
  "windows_x86_64_msvc 0.48.0",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -8281,6 +8404,12 @@ checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
@@ -8290,6 +8419,12 @@ name = "windows_i686_gnu"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -8305,6 +8440,12 @@ checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
@@ -8317,9 +8458,21 @@ checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -8332,6 +8485,12 @@ name = "windows_x86_64_msvc"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -8364,7 +8523,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,22 +1,12 @@
 [workspace]
 members = [
-  "crates/astria-celestia-jsonrpc-client",
-  "crates/astria-composer",
-  "crates/astria-conductor",
-  "crates/astria-gossipnet",
-  "crates/astria-proto",
-  "crates/astria-sequencer",
-  "crates/astria-sequencer-client",
-  "crates/astria-sequencer-relayer",
-  "crates/astria-sequencer-types",
-  "crates/astria-sequencer-utils",
-  "crates/astria-sequencer-validation",
-  "crates/astria-telemetry",
-  "crates/astria-test-utils",
+  "crates/astria-*",
+  "crates/test/*",
 ]
 resolver = "2"
 
 [workspace.dependencies]
+anyhow = "1"
 async-trait = "0.1.52"
 axum = "0.6.16"
 backon = "0.4.1"
@@ -63,6 +53,7 @@ tendermint-config = "0.32"
 tendermint-proto = "0.32"
 tendermint-rpc = "0.32"
 tokio = "1.28"
+tokio-test = "0.4.2"
 tonic = "0.9"
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,5 @@
 [workspace]
-members = [
-  "crates/astria-*",
-  "crates/test/*",
-]
+members = ["crates/astria-*", "crates/test/*"]
 resolver = "2"
 
 [workspace.dependencies]

--- a/crates/astria-composer/Cargo.toml
+++ b/crates/astria-composer/Cargo.toml
@@ -48,9 +48,8 @@ features = ["http"]
 proto = { package = "astria-proto", path = "../astria-proto" }
 
 impl-serde = "0.4.0"
-tokio-test = "0.4.2"
-
 figment = { workspace = true, features = ["test"] }
 jsonrpsee = { workspace = true, features = ["macros", "server"] }
 tendermint-rpc = { workspace = true }
+tokio-test = { workspace = true }
 wiremock = { workspace = true }

--- a/crates/astria-sequencer-client/Cargo.toml
+++ b/crates/astria-sequencer-client/Cargo.toml
@@ -23,5 +23,5 @@ regex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tokio = { workspace = true }
-tokio-test = "0.4.2"
+tokio-test = { workspace = true }
 wiremock = { workspace = true }

--- a/crates/test/cometbft-launcher/Cargo.toml
+++ b/crates/test/cometbft-launcher/Cargo.toml
@@ -2,13 +2,13 @@
 name = "cometbft-launcher"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.64.0"
+rust-version = "1.65"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 anyhow = { workspace = true }
-reqwest = {workspace = true}
+reqwest = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["fs", "process", "rt"] }
 toml_edit = "0.19.14"

--- a/crates/test/cometbft-launcher/Cargo.toml
+++ b/crates/test/cometbft-launcher/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "cometbft-launcher"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.64.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = { workspace = true }
+reqwest = {workspace = true}
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["fs", "process", "rt"] }
+toml_edit = "0.19.14"
+tryhard = "0.5.1"
+which = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+procfs = "0.15.1"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+libc = "0.2.62"
+libproc = "0.14.1"
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio-test = { workspace = true }

--- a/crates/test/cometbft-launcher/README.md
+++ b/crates/test/cometbft-launcher/README.md
@@ -1,0 +1,30 @@
+# Launch cometbft in tests
+
+This crate launches cometbft as a subprocess. It is intended to be used in tests.
+
+Example usage:
+
+```rust
+use std::time::Duration;
+
+use cometbft_launcher::CometBft;
+use reqwest::Client;
+
+#[tokio::main]
+async fn main() {
+    let cometbft = CometBft::builder()
+        .proxy_app("noop")
+        .launch()
+        .await
+        .expect("should be able to start cometbft if installed");
+    let cometbft_rpc = cometbft.rpc_listen_addr;
+    let client = Client::new();
+    let rsp = client
+        .get(format!("http://{cometbft_rpc}/status"))
+        .timeout(Duration::from_millis(500))
+        .send()
+        .await
+        .expect("if cometbft launched it should respond to status requests");
+    assert!(rsp.status().is_success());
+}
+```

--- a/crates/test/cometbft-launcher/examples/run_noop.rs
+++ b/crates/test/cometbft-launcher/examples/run_noop.rs
@@ -1,0 +1,18 @@
+use cometbft_launcher::CometBft;
+
+#[tokio::main]
+async fn main() {
+    let cometbft = CometBft::builder()
+        .proxy_app("noop")
+        .launch()
+        .await
+        .unwrap();
+    let cometbft_rpc = cometbft.rpc_listen_addr;
+    let status = reqwest::get(format!("http://{cometbft_rpc}/status"))
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+    println!("cometbft status response:\n{status}");
+}

--- a/crates/test/cometbft-launcher/src/lib.rs
+++ b/crates/test/cometbft-launcher/src/lib.rs
@@ -5,7 +5,7 @@
 //! # tokio_test::block_on(async {
 //! use cometbft_launcher::CometBft;
 //! let cometbft = CometBft::builder()
-//!     .proxy_app("http://127.0.0.1:26657")
+//!     .proxy_app("tcp://127.0.0.1:26657")
 //!     .launch()
 //!     .await
 //!     .unwrap();

--- a/crates/test/cometbft-launcher/src/lib.rs
+++ b/crates/test/cometbft-launcher/src/lib.rs
@@ -1,0 +1,318 @@
+//! Launch cometbft as a subprocess for running tests.
+//!
+//! # Examples
+//! ```no_run
+//! # tokio_test::block_on(async {
+//! use cometbft_launcher::CometBft;
+//! let cometbft = CometBft::builder()
+//!     .proxy_app("http://127.0.0.1:26657")
+//!     .launch()
+//!     .await
+//!     .unwrap();
+//! # })
+
+use std::{
+    ffi::{
+        OsStr,
+        OsString,
+    },
+    net::SocketAddr,
+    path::Path,
+    process::Stdio,
+    time::Duration,
+};
+
+use anyhow::{
+    ensure,
+    Context as _,
+};
+use tempfile::TempDir;
+use tokio::process::{
+    Child,
+    Command,
+};
+
+/// CometBFT running in a subprocess.
+pub struct CometBft {
+    /// The temporary directory within cometbft created its config files.
+    pub home: TempDir,
+    /// A handle to the subprocess running cometbft.
+    pub process: Child,
+    /// The local TCP socket address on which cometbft is serving RPCs.
+    pub rpc_listen_addr: SocketAddr,
+}
+
+impl CometBft {
+    /// Configure a cometbft instance.
+    pub fn builder() -> CometBftBuilder {
+        CometBftBuilder::new()
+    }
+}
+
+/// A builder struct to configure how cometbft is launched.
+#[derive(Default)]
+pub struct CometBftBuilder {
+    proxy_app: Option<OsString>,
+}
+
+impl CometBftBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Will pass `proxy_app` to `cometbft start --proxy_app`.
+    ///
+    /// Default is to pass `cometbft start --proxy_app=noop`. `proxy_app` will
+    /// be passed as-is without extra verification.
+    pub fn proxy_app(self, proxy_app: impl AsRef<OsStr>) -> Self {
+        Self {
+            proxy_app: Some(proxy_app.as_ref().to_os_string()),
+            ..self
+        }
+    }
+
+    /// Launches cometbft in a subprocess consuming the builder.
+    pub async fn launch(self) -> anyhow::Result<CometBft> {
+        let Self {
+            proxy_app,
+        } = self;
+        let executable = find_cometbft_executable().await.context(
+            "could not find cometbft executable; set the env var COMETBFT=path/to/cometbft or add \
+             it to PATH; see this url for how to install: https://github.com/cometbft/cometbft/blob/6a7dfb40d0302de5cdbca51cc4daede74b6d44c2/docs/guides/install.md"
+        )?;
+
+        let home = tempfile::tempdir()
+            .context("failed creating a tempdir to store cometbft config files in")?;
+
+        init_cometbft(&executable, home.path().as_os_str())
+            .await
+            .context("failed to initialize cometbft")?;
+
+        set_listen_addresses(home.path())
+            .await
+            .context("failed setting listen addresses")?;
+
+        let proxy_app = proxy_app.as_deref().unwrap_or("noop".as_ref());
+        let process = start_cometbft(&executable, home.path().as_os_str(), proxy_app)
+            .context("failed starting cometbft")?;
+
+        let rpc_listen_addr = find_rpc_listen_address(&process)
+            .await
+            .context("failed finding ports cometbft is listening on")?;
+        Ok(CometBft {
+            home,
+            process,
+            rpc_listen_addr,
+        })
+    }
+}
+
+/// Returns the cometbft rpc listenaddress by sending a HTTP GET using the /status endpoint.
+async fn find_rpc_listen_address(process: &Child) -> anyhow::Result<SocketAddr> {
+    let pid = process.id().context(
+        "cometbft process did not have a PID; this can only happen if it already completed",
+    )? as i32;
+
+    let rpc_listen_addr = tryhard::retry_fn(move || async move {
+        let addrs = tokio::task::spawn_blocking(move || enumerate_local_tcp_socket_addrs(pid))
+            .await
+            .context("task panicked looking for ports cometbft is listening on")?
+            .context("failed looking for local ports")?;
+        let client = reqwest::Client::new();
+        for addr in addrs {
+            let Ok(response) = client
+                .get(format!("http://{addr}/status"))
+                .timeout(Duration::from_millis(100))
+                .send()
+                .await
+            else {
+                continue;
+            };
+            if response.status().is_success() {
+                return Ok(addr);
+            }
+        }
+        Err(anyhow::anyhow!(
+            "no cometbft tcp socket found that responds to /status"
+        ))
+    })
+    .retries(9)
+    .fixed_backoff(Duration::from_secs(1))
+    .await
+    .context("finding local tcp addresses failed after 10 attempts")?;
+
+    Ok(rpc_listen_addr)
+}
+
+/// Returns all TCP socket addresses of the process identified by `pid`.
+#[cfg(target_os = "macos")]
+fn enumerate_local_tcp_socket_addrs(pid: i32) -> anyhow::Result<Vec<SocketAddr>> {
+    use std::net::{
+        IpAddr,
+        Ipv4Addr,
+        Ipv6Addr,
+    };
+
+    use anyhow::Error;
+    use libc::{
+        AF_INET,
+        AF_INET6,
+    };
+    use libproc::libproc::{
+        bsd_info::BSDInfo,
+        file_info::{
+            pidfdinfo,
+            ListFDs,
+            ProcFDType,
+        },
+        net_info::{
+            SocketFDInfo,
+            SocketInfoKind,
+        },
+        proc_pid::{
+            listpidinfo,
+            pidinfo,
+        },
+    };
+
+    let info = pidinfo::<BSDInfo>(pid, 0)
+        .map_err(Error::msg)
+        .context("failed getting process info")?;
+    let mut local_addresses = vec![];
+    for fd in listpidinfo::<ListFDs>(pid, info.pbi_nfiles as usize)
+        .map_err(Error::msg)
+        .context("failed listing file descriptors associated with pid")?
+    {
+        if let ProcFDType::Socket = fd.proc_fdtype.into() {
+            let socket = pidfdinfo::<SocketFDInfo>(pid, fd.proc_fd)
+                .map_err(Error::msg)
+                .context("failed getting info on socket fd")?;
+            if let SocketInfoKind::Tcp = socket.psi.soi_kind.into() {
+                // unsafe ok because union is discriminated by soi_kind
+                let info = unsafe { socket.psi.soi_proto.pri_tcp };
+                let port = u16::from_be(info.tcpsi_ini.insi_lport as u16);
+                // For reference on accessing union fields:
+                // https://github.com/apple-oss-distributions/lsof/blob/a26b67d2f0c6600d269f0b33233a2cb4b877b279/lsof/dialects/darwin/libproc/dsock.c#L144
+                let ip_addr: IpAddr = match socket.psi.soi_family {
+                    AF_INET => {
+                        // unsafe access ok because the union in insi_laddr is discriminated
+                        // by soi_family
+                        let wire_addr = unsafe { info.tcpsi_ini.insi_laddr.ina_46.i46a_addr4 };
+                        // the stored laddr is big endian, but the From<u32> for Ipv4Addr
+                        // impl assumes host endianness.
+                        // u32::to_le_bytes fixes this with a hack putting the bytes in the
+                        // "correct" order. Note that this only makes sense
+                        // on little endian machines.
+                        let addr: Ipv4Addr = wire_addr.s_addr.to_le_bytes().into();
+                        addr.into()
+                    }
+                    AF_INET6 => {
+                        let wire_addr = unsafe { info.tcpsi_ini.insi_laddr.ina_6 };
+                        let addr: Ipv6Addr = wire_addr.s6_addr.into();
+                        addr.into()
+                    }
+                    _ => continue,
+                };
+                let socket_addr = (ip_addr, port).into();
+                local_addresses.push(socket_addr);
+            }
+        }
+    }
+    Ok(local_addresses)
+}
+
+/// Returns all TCP socket addresses of the process identified by `pid`.
+#[cfg(target_os = "linux")]
+fn enumerate_local_tcp_socket_addrs(pid: i32) -> anyhow::Result<Vec<SocketAddr>> {
+    use procfs::process::Process;
+    let process = Process::new(pid).context("failed getting process")?;
+    let local_ipv4_addresses = process
+        .tcp()
+        .context("failed reading v4 tcp addresses of process")?;
+    let local_ipv6_addresses = process
+        .tcp6()
+        .context("failed reading v6 tcp addresses of process")?;
+    Ok(local_ipv4_addresses
+        .into_iter()
+        .chain(local_ipv6_addresses)
+        .map(|entry| entry.local_address)
+        .collect())
+}
+
+/// Sets cometbft config RPC laddr and P2P laddr to 127.0.0.1:0.
+async fn set_listen_addresses(dir: &Path) -> anyhow::Result<()> {
+    use toml_edit::{
+        Document,
+        Item,
+        Value,
+    };
+    let cfg_path = dir.join("config/config.toml");
+    let toml = tokio::fs::read_to_string(&cfg_path)
+        .await
+        .context("failed reading config file to buffer")?;
+    let mut doc = toml
+        .parse::<Document>()
+        .context("could not parse config toml")?;
+    let rpc_laddr = doc
+        .get_mut("rpc")
+        .context("config did not contain rpc table")?
+        .get_mut("laddr")
+        .context("config did not contain laddr field in rpc table")?;
+    *rpc_laddr = Item::Value(Value::from("tcp://127.0.0.1:0"));
+    let p2p_laddr = doc
+        .get_mut("p2p")
+        .context("config did not contain p2p table")?
+        .get_mut("laddr")
+        .context("config did not contain laddr field in p2p table")?;
+    *p2p_laddr = Item::Value(Value::from("tcp://127.0.0.1:0"));
+    tokio::fs::write(&cfg_path, doc.to_string())
+        .await
+        .context("failed writing updated cfg toml to disk")?;
+    Ok(())
+}
+
+/// Runs `cometbft init` in the provided home directory.
+async fn init_cometbft(executable: &OsStr, home: &OsStr) -> anyhow::Result<()> {
+    let init_out = Command::new(executable)
+        .arg("init")
+        .arg("--home")
+        .arg(home)
+        .output()
+        .await
+        .context("failed to execute `cometbft init`")?;
+
+    ensure!(
+        init_out.status.success(),
+        "cometbft exited with non-zero code: {}\nstdout: {}\nstderr: {}",
+        init_out.status,
+        String::from_utf8_lossy(&init_out.stdout),
+        String::from_utf8_lossy(&init_out.stderr),
+    );
+
+    Ok(())
+}
+
+/// Runs `cometbft start` in the provided home directory and using `proxy_app`.
+fn start_cometbft(executable: &OsStr, home: &OsStr, proxy_app: &OsStr) -> anyhow::Result<Child> {
+    Command::new(&executable)
+        .arg("start")
+        .arg("--home")
+        .arg(home)
+        .arg("--proxy_app")
+        .arg(proxy_app)
+        .kill_on_drop(true)
+        .stdout(Stdio::null())
+        .spawn()
+        .context("failed executing `cometbft start`")
+}
+
+async fn find_cometbft_executable() -> anyhow::Result<OsString> {
+    if let Some(exec) = std::env::var_os("COMETBFT") {
+        return Ok(exec);
+    }
+    tokio::task::spawn_blocking(|| which::which("cometbft"))
+        .await
+        .context("thread panicked looking for `cometbft` in PATH")?
+        .context("could not finding cometbft executable in PATH")
+        .map(Into::into)
+}

--- a/crates/test/cometbft-launcher/tests/simple.rs
+++ b/crates/test/cometbft-launcher/tests/simple.rs
@@ -1,0 +1,21 @@
+use std::time::Duration;
+
+use cometbft_launcher::CometBft;
+
+#[tokio::test]
+async fn cometbft_is_launched_and_responds() {
+    let cometbft = CometBft::builder()
+        .proxy_app("noop")
+        .launch()
+        .await
+        .expect("should be able to start cometbft if installed");
+    let cometbft_rpc = cometbft.rpc_listen_addr;
+    let client = reqwest::Client::new();
+    let rsp = client
+        .get(format!("http://{cometbft_rpc}/status"))
+        .timeout(Duration::from_millis(500))
+        .send()
+        .await
+        .expect("if cometbft launched it should respond to status requests");
+    assert!(rsp.status().is_success());
+}


### PR DESCRIPTION
## Summary
Added a crate to launch cometbft as a subprocess.

## Background
PR https://github.com/astriaorg/astria/pull/327 runs tests against the output of cometbft. It manually adds magic hex strings that are then processed with functions it defines. This is not optimal because there is no easy way to reproduce the strings nor can the code be run against actual responses from cometbft.

This utility allows launching cometbft as a subprocess in tests with its rpc server bound to a random port `0`. The launcher returns successfully if it was able to find the TCP port on which cometbft is serving requests.

## Changes
* Added a `cometbft-launcher` crate
* Added a step in the rust test job to install cometbft v0.37.2 

## Testing
* For now only the functionality of the crate is tested using a blackbox test.

## Related Issues
This is useful in PR https://github.com/astriaorg/astria/pull/327.

