### PR TITLE
conductor: added execution commit level to config and executor

### DIFF
--- a/crates/astria-conductor/README.md
+++ b/crates/astria-conductor/README.md
@@ -11,6 +11,7 @@ Coordinates blocks between the data availability layer and the execution layer.
   tendermint_url = "http://localhost:1318"
   chain_id = "ethereum"
   execution_rpc_url = "http://localhost:50051"
+  execution_commit_level = "head"
   ```
 
 * run `cargo run`

--- a/crates/astria-conductor/src/bin/astria-conductor.rs
+++ b/crates/astria-conductor/src/bin/astria-conductor.rs
@@ -57,6 +57,10 @@ async fn run() -> Result<()> {
     info!("Using Celestia node at {}", conf.celestia_node_url);
     info!("Using execution node at {}", conf.execution_rpc_url);
     info!("Using Tendermint node at {}", conf.tendermint_url);
+    info!(
+        "Execution commit level set to: {}",
+        conf.execution_commit_level
+    );
 
     let SignalReceiver {
         mut reload_rx,

--- a/crates/astria-conductor/src/cli.rs
+++ b/crates/astria-conductor/src/cli.rs
@@ -8,6 +8,7 @@ pub struct Cli {
     #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub celestia_node_url: Option<String>,
 
+    /// URL of the Tendermint node (sequencer/metro).
     #[arg(long = "tendermint-url")]
     #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub tendermint_url: Option<String>,
@@ -33,10 +34,18 @@ pub struct Cli {
     #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub libp2p_private_key: Option<String>,
 
+    /// Port to listen on for libp2p
     #[arg(long = "libp2p-port")]
     #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub libp2p_port: Option<u16>,
 
+    /// Disable reading from the DA layer and block finalization
     #[arg(long = "disable-finalization")]
     pub disable_finalization: bool,
+
+    /// The Execution commit level for controlling the amount of finality of blocks sent
+    /// to the execution layer.
+    #[arg(long = "execution-commit-level")]
+    #[serde(skip_serializing_if = "::std::option::Option::is_none")]
+    pub execution_commit_level: Option<String>,
 }

--- a/crates/astria-conductor/src/config.rs
+++ b/crates/astria-conductor/src/config.rs
@@ -46,6 +46,11 @@ pub struct Config {
 
     /// log directive to use for telemetry.
     pub log: Option<String>,
+
+    /// The Execution commit level for controlling the amount of finality of blocks sent
+    /// to the execution layer.
+    #[serde(default = "default_execution_commit_level")]
+    pub execution_commit_level: String,
 }
 
 fn bootnodes_deserialize<'de, D>(deserializer: D) -> Result<Option<Vec<String>>, D::Error>
@@ -86,4 +91,8 @@ fn default_execution_rpc_url() -> String {
 
 fn default_libp2p_port() -> u16 {
     2451
+}
+
+fn default_execution_commit_level() -> String {
+    "head".to_string()
 }

--- a/crates/astria-conductor/src/config.rs
+++ b/crates/astria-conductor/src/config.rs
@@ -94,5 +94,5 @@ fn default_libp2p_port() -> u16 {
 }
 
 fn default_execution_commit_level() -> String {
-    "head".to_string()
+    "soft".to_string()
 }

--- a/crates/astria-conductor/src/executor.rs
+++ b/crates/astria-conductor/src/executor.rs
@@ -112,7 +112,7 @@ struct Executor<C> {
 
     /// The Execution commit level for controlling the finality level of blocks
     /// sent to the execution layer.
-    execution_commit_level: String,
+    _execution_commit_level: String,
 }
 
 impl<C: ExecutionClient> Executor<C> {
@@ -131,7 +131,7 @@ impl<C: ExecutionClient> Executor<C> {
                 namespace,
                 execution_state,
                 sequencer_hash_to_execution_hash: HashMap::new(),
-                execution_commit_level,
+                _execution_commit_level: execution_commit_level,
             },
             cmd_tx,
         ))

--- a/crates/astria-conductor/src/executor.rs
+++ b/crates/astria-conductor/src/executor.rs
@@ -212,6 +212,8 @@ impl<C: ExecutionClient> Executor<C> {
         let timestamp = convert_tendermint_to_prost_timestamp(block.header.time)
             .wrap_err("failed parsing str as protobuf timestamp")?;
 
+        // TODO (https://github.com/astriaorg/astria/issues/345): reminder to
+        // update this once other issues are resolved. see link.
         let response = self
             .execution_rpc_client
             .call_do_block(prev_block_hash, block.rollup_transactions, Some(timestamp))


### PR DESCRIPTION
## Summary
Added in an additional config/cli arg option to set the execution commit level of the Conductor, or more specifically the Executor actor within the conductor.

## Background
Historically, the Conductor has just passed on every block it receives to the execution layer/rollup. We want more flexibility here for rollups to be able to decide what "finality" level the blocks they are receiving from the Conductor are at.
This setting allows for that choice.

## Changes
- Added `execution_commit_level` to config.rs
- Added `execution_commit_level` to cli.rs
- Updated the `Executor::new()` fn to take an `execution_commit_level` arg
- Added `execution_commit_level` to the Executor actor.

## Testing
Currently this addition changes nothing about the functionality of the Conductor, it just adds the setting.
So running the current tests is sufficient.
Once more work has been completed on implementing the new api (#205 #207) and the removal of gossipnet (#325), then specific functionality for what the different `execution_commit_level` settings will do, can be added.

## Related Issues
#230 

closes #250 
