### PR TITLE
conductor: added `skip_empty_blocks` flag, updated executor to toggle empty block execution based on flag

### DIFF
--- a/crates/astria-conductor/src/bin/astria-conductor.rs
+++ b/crates/astria-conductor/src/bin/astria-conductor.rs
@@ -57,6 +57,11 @@ async fn run() -> Result<()> {
     info!("Using Celestia node at {}", conf.celestia_node_url);
     info!("Using execution node at {}", conf.execution_rpc_url);
     info!("Using Tendermint node at {}", conf.tendermint_url);
+    if !conf.skip_empty_blocks {
+        info!("Executing empty blocks");
+    } else {
+        info!("Not executing empty blocks");
+    }
 
     let SignalReceiver {
         mut reload_rx,

--- a/crates/astria-conductor/src/cli.rs
+++ b/crates/astria-conductor/src/cli.rs
@@ -39,4 +39,8 @@ pub struct Cli {
 
     #[arg(long = "disable-finalization")]
     pub disable_finalization: bool,
+
+    /// Flag to skip or execute empty blocks
+    #[arg(long = "skip-empty-blocks")]
+    pub skip_empty_blocks: bool,
 }

--- a/crates/astria-conductor/src/config.rs
+++ b/crates/astria-conductor/src/config.rs
@@ -46,6 +46,10 @@ pub struct Config {
 
     /// log directive to use for telemetry.
     pub log: Option<String>,
+
+    /// Flag to skip or execute empty blocks
+    #[serde(default)]
+    pub skip_empty_blocks: bool,
 }
 
 fn bootnodes_deserialize<'de, D>(deserializer: D) -> Result<Option<Vec<String>>, D::Error>

--- a/crates/astria-conductor/src/executor.rs
+++ b/crates/astria-conductor/src/executor.rs
@@ -497,7 +497,7 @@ mod test {
                 .get(&executor.execution_state)
                 .is_none()
         );
-        assert_eq!(previous_execution_state, executor.execution_state,);
+        assert_eq!(previous_execution_state, executor.execution_state);
         // should be empty because nothing was executed
         assert!(executor.sequencer_hash_to_execution_hash.is_empty());
     }
@@ -532,7 +532,7 @@ mod test {
                 .get(&executor.execution_state)
                 .is_some()
         );
-        assert_eq!(expected_execution_state, executor.execution_state,);
+        assert_eq!(expected_execution_state, executor.execution_state);
         // should be empty because the block was executed AND finalized
         assert!(executor.sequencer_hash_to_execution_hash.is_empty());
     }


### PR DESCRIPTION
## Summary
Added the option to choose wether or not Conductor will send empty blocks to the execution layer.

## Background
Historically we were ignoring all empty blocks. It was determined that this is not something many users like.
Thus, adding in the option to execute empty block or not was required.

## Changes
- Added `skip_empty_blocks` flag. Defaults to false.
- Updated cli.rs and config.rs to add the flag
- Updated `execute_block()` to accommodate the flag
- Added new tests to Executor to verify the functionality difference between `skip_empty_blocks` settings

## Testing
Run `cargo test`

## Related Issues
closes #285 
