### PR TITLE
proto: extract sequencer and sequencer-relayer types are protobuf

### DIFF
--- a/crates/astria-conductor/src/block_verifier.rs
+++ b/crates/astria-conductor/src/block_verifier.rs
@@ -118,7 +118,10 @@ impl BlockVerifier {
             action_tree_root,
             action_tree_root_inclusion_proof,
         } = block.clone().into_raw();
-        let rollup_namespaces = rollup_data.into_keys().collect::<Vec<Namespace>>();
+        let rollup_namespaces = rollup_data
+            .into_keys()
+            .map(|chain_id| Namespace::from_slice(chain_id.as_ref()))
+            .collect::<Vec<Namespace>>();
         let data = SequencerNamespaceData {
             block_hash,
             header,

--- a/crates/astria-conductor/src/executor.rs
+++ b/crates/astria-conductor/src/executor.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use astria_sequencer_types::{
+    ChainId,
     Namespace,
     SequencerBlockData,
 };
@@ -51,7 +52,7 @@ pub(crate) async fn spawn(conf: &Config) -> Result<(JoinHandle, Sender)> {
     let execution_rpc_client = ExecutionRpcClient::new(&conf.execution_rpc_url).await?;
     let (mut executor, executor_tx) = Executor::new(
         execution_rpc_client,
-        Namespace::from_slice(conf.chain_id.as_bytes()),
+        ChainId::new(conf.chain_id.as_bytes().to_vec()),
     )
     .await?;
     let join_handle = task::spawn(async move { executor.run().await });
@@ -92,7 +93,10 @@ struct Executor<C> {
     /// The execution rpc client that we use to send messages to the execution service
     execution_rpc_client: C,
 
-    /// Namespace ID
+    /// Chain ID
+    chain_id: ChainId,
+
+    /// Namespace ID, derived from chain ID
     namespace: Namespace,
 
     /// Tracks the state of the execution chain
@@ -111,7 +115,7 @@ struct Executor<C> {
 }
 
 impl<C: ExecutionClient> Executor<C> {
-    async fn new(mut execution_rpc_client: C, namespace: Namespace) -> Result<(Self, Sender)> {
+    async fn new(mut execution_rpc_client: C, chain_id: ChainId) -> Result<(Self, Sender)> {
         let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
         let init_state_response = execution_rpc_client.call_init_state().await?;
         let execution_state = init_state_response.block_hash;
@@ -119,7 +123,8 @@ impl<C: ExecutionClient> Executor<C> {
             Self {
                 cmd_rx,
                 execution_rpc_client,
-                namespace,
+                chain_id: chain_id.clone(),
+                namespace: Namespace::from_slice(chain_id.as_ref()),
                 execution_state,
                 sequencer_hash_to_execution_hash: HashMap::new(),
             },
@@ -136,7 +141,7 @@ impl<C: ExecutionClient> Executor<C> {
                     block,
                 } => {
                     let Some(block_subset) =
-                        SequencerBlockSubset::from_sequencer_block_data(*block, self.namespace)
+                        SequencerBlockSubset::from_sequencer_block_data(*block, &self.chain_id)
                     else {
                         info!(namespace = %self.namespace, "block did not contain data for namespace; skipping");
                         continue;
@@ -368,8 +373,8 @@ mod test {
 
     #[tokio::test]
     async fn execute_block_with_relevant_txs() {
-        let namespace = Namespace::from_slice(b"test");
-        let (mut executor, _) = Executor::new(MockExecutionClient::new(), namespace)
+        let chain_id = ChainId::new(b"test".to_vec());
+        let (mut executor, _) = Executor::new(MockExecutionClient::new(), chain_id)
             .await
             .unwrap();
 
@@ -387,8 +392,8 @@ mod test {
 
     #[tokio::test]
     async fn execute_block_without_relevant_txs() {
-        let namespace = Namespace::from_slice(b"test");
-        let (mut executor, _) = Executor::new(MockExecutionClient::new(), namespace)
+        let chain_id = ChainId::new(b"test".to_vec());
+        let (mut executor, _) = Executor::new(MockExecutionClient::new(), chain_id)
             .await
             .unwrap();
 
@@ -399,12 +404,12 @@ mod test {
 
     #[tokio::test]
     async fn handle_block_received_from_data_availability_not_yet_executed() {
-        let namespace = Namespace::from_slice(b"test");
+        let chain_id = ChainId::new(b"test".to_vec());
         let finalized_blocks = Arc::new(Mutex::new(HashSet::new()));
         let execution_client = MockExecutionClient {
             finalized_blocks: finalized_blocks.clone(),
         };
-        let (mut executor, _) = Executor::new(execution_client, namespace).await.unwrap();
+        let (mut executor, _) = Executor::new(execution_client, chain_id).await.unwrap();
 
         let mut block = get_test_block_subset();
         block.rollup_transactions.push(b"test_transaction".to_vec());
@@ -432,12 +437,12 @@ mod test {
 
     #[tokio::test]
     async fn handle_block_received_from_data_availability_no_relevant_transactions() {
-        let namespace = Namespace::from_slice(b"test");
+        let chain_id = ChainId::new(b"test".to_vec());
         let finalized_blocks = Arc::new(Mutex::new(HashSet::new()));
         let execution_client = MockExecutionClient {
             finalized_blocks: finalized_blocks.clone(),
         };
-        let (mut executor, _) = Executor::new(execution_client, namespace).await.unwrap();
+        let (mut executor, _) = Executor::new(execution_client, chain_id).await.unwrap();
 
         let block: SequencerBlockSubset = get_test_block_subset();
         let previous_execution_state = executor.execution_state.clone();

--- a/crates/astria-conductor/src/types.rs
+++ b/crates/astria-conductor/src/types.rs
@@ -1,5 +1,5 @@
 use astria_sequencer_types::{
-    Namespace,
+    ChainId,
     RawSequencerBlockData,
     SequencerBlockData,
 };
@@ -21,7 +21,7 @@ pub struct SequencerBlockSubset {
 impl SequencerBlockSubset {
     pub(crate) fn from_sequencer_block_data(
         data: SequencerBlockData,
-        namespace: Namespace,
+        chain_id: &ChainId,
     ) -> Option<Self> {
         // we don't need to verify the action tree root here,
         // as [`SequencerBlockData`] would not be constructable
@@ -34,11 +34,11 @@ impl SequencerBlockSubset {
             ..
         } = data.into_raw();
 
-        let our_rollup_data = rollup_data.remove(&namespace)?;
+        let rollup_transactions = rollup_data.remove(chain_id)?;
         Some(Self {
             block_hash,
             header,
-            rollup_transactions: our_rollup_data.transactions,
+            rollup_transactions,
         })
     }
 }

--- a/crates/astria-proto/proto/astria/sequencer/v1alpha2/block.proto
+++ b/crates/astria-proto/proto/astria/sequencer/v1alpha2/block.proto
@@ -1,0 +1,35 @@
+syntax = "proto3";
+
+package astria.sequencer.v1alpha2;
+
+import "tendermint/types/types.proto";
+import "astria/sequencer/v1alpha2/validation.proto";
+
+// `RollupTransactions` are a sequence of opaque bytes together with the human
+// readable `chain_id` of the rollup they belong to.
+//
+// The binary encoding is understood as an implementation detail of the
+// services sending and receiving the transactions.
+message RollupTransactions {
+    // The human readable name of the rollup these transactions belong to.
+    string chain_id = 1;
+    // The serialized opaque bytes of the rollup transactions.
+    repeated bytes transactions = 2;
+}
+
+// `SequencerBlock` is constructed from a tendermint/cometbft block by
+// converting its opaque `data` bytes into sequencer specific types.
+message SequencerBlock {
+    // The hash of the sequencer block. Must be 32 bytes.
+    bytes block_hash = 1;
+    // The original cometbft header that was the input to this sequencer block.
+    tendermint.types.Header header = 2;
+    // The commit/set of signatures that commited this block.
+    tendermint.types.Commit last_commit = 3;
+    // The collection of rollup transactions that were included in this block.
+    RollupTransactions rollup_transactions = 4;
+    // The root of the action tree of this block. Must be 32 bytes.
+    bytes action_tree_root = 5;
+    // The proof that the action tree root was included in `header.data_hash`.
+    astria.sequencer.v1alpha2.InclusionProof action_tree_inclusion_proof = 6;
+}

--- a/crates/astria-proto/proto/astria/sequencer/v1alpha2/celestia.proto
+++ b/crates/astria-proto/proto/astria/sequencer/v1alpha2/celestia.proto
@@ -1,0 +1,50 @@
+syntax = "proto3";
+
+package astria.sequencer.v1alpha2;
+
+import "tendermint/types/types.proto";
+import "astria/sequencer/v1alpha2/validation.proto";
+
+// An "item blob" of rollup transactions submitted to celestia.
+//
+// The transactions contained in the item belong to a rollup identified
+// by `chain_id`, and were included in the sequencer block identified
+// by `sequencer_block_hash`.
+message CelestiaItem {
+    // The hash of the sequencer block. Must be 32 bytes.
+    bytes sequencer_block_hash = 1;
+    // The human readable chain ID identifiying the rollup these transactions belong to.
+    string chain_id = 2;
+    // A list of opaque bytes that are serialized rollup transactions.
+    repeated bytes transactions = 3;
+    // The proof that the action tree root was included in
+    // `sequencer_block_header.data_hash` (to be found in `CelestiaHeader`).
+    // The inclusion of these transactions in the original sequencer block
+    // can be verified using the action tree root stored in `CelestiaHeader`.
+    astria.sequencer.v1alpha2.InclusionProof action_tree_inclusion_proof = 4;
+}
+
+// The "header blob" that is submitted to celestia under a sequencer-specific
+// celestia namespace.
+//
+// It is created by splitting up `SequencerBlockData` into a header
+// and a list of rollup blobs, where one blob contains a sequence of
+// rollup transactions for one specific rollup.
+//
+// The original sequencer block is identified by its `block_hash`.
+message CelestiaHeader {
+    // The hash of the sequencer block. Must be 32 bytes.
+    bytes sequencer_block_hash = 1;
+    // The original cometbft header that was the input to this sequencer block.
+    tendermint.types.Header sequencer_block_header = 2;
+    // The commit/set of signatures that commited this block.
+    tendermint.types.Commit sequencer_bock_last_commit = 3;
+    // The namespaces under which rollup transactions belonging to the sequencer
+    // block identified by `sequencer_block_hash` where submitted to celestia.
+    // The bytes must convert to a celestia v0 namespace.
+    repeated bytes rollup_namespaces = 4;
+    // The root of the action tree of this block. Must be 32 bytes.
+    bytes action_tree_root = 5;
+    // The proof that the action tree root was included in `header.data_hash`.
+    astria.sequencer.v1alpha2.InclusionProof action_tree_inclusion_proof = 6;
+}

--- a/crates/astria-proto/proto/astria/sequencer/v1alpha2/validation.proto
+++ b/crates/astria-proto/proto/astria/sequencer/v1alpha2/validation.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+package astria.sequencer.v1alpha2;
+
+// A merkle proof of inclusion of a leaf at `index` in a tree
+// of size `num_leaves`.
+message InclusionProof {
+    // leaf index of value to be proven
+    uint64 index = 1;
+    // total number of leaves in the tree
+    uint64 num_leaves = 2;
+    // the merkle proof itself; must be 32 bytes.
+    bytes inclusion_proof = 3;
+}

--- a/crates/astria-proto/src/proto/generated/astria.sequencer.v1alpha2.rs
+++ b/crates/astria-proto/src/proto/generated/astria.sequencer.v1alpha2.rs
@@ -1,0 +1,112 @@
+// @generated
+/// A merkle proof of inclusion of a leaf at `index` in a tree
+/// of size `num_leaves`.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct InclusionProof {
+    /// leaf index of value to be proven
+    #[prost(uint64, tag="1")]
+    pub index: u64,
+    /// total number of leaves in the tree
+    #[prost(uint64, tag="2")]
+    pub num_leaves: u64,
+    /// the merkle proof itself; must be 32 bytes.
+    #[prost(bytes="vec", tag="3")]
+    pub inclusion_proof: ::prost::alloc::vec::Vec<u8>,
+}
+/// `RollupTransactions` are a sequence of opaque bytes together with the human
+/// readable `chain_id` of the rollup they belong to.
+///
+/// The binary encoding is understood as an implementation detail of the
+/// services sending and receiving the transactions.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RollupTransactions {
+    /// The human readable name of the rollup these transactions belong to.
+    #[prost(string, tag="1")]
+    pub chain_id: ::prost::alloc::string::String,
+    /// The serialized opaque bytes of the rollup transactions.
+    #[prost(bytes="vec", repeated, tag="2")]
+    pub transactions: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+}
+/// `SequencerBlock` is constructed from a tendermint/cometbft block by
+/// converting its opaque `data` bytes into sequencer specific types.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SequencerBlock {
+    /// The hash of the sequencer block. Must be 32 bytes.
+    #[prost(bytes="vec", tag="1")]
+    pub block_hash: ::prost::alloc::vec::Vec<u8>,
+    /// The original cometbft header that was the input to this sequencer block.
+    #[prost(message, optional, tag="2")]
+    pub header: ::core::option::Option<::tendermint_proto::types::Header>,
+    /// The commit/set of signatures that commited this block.
+    #[prost(message, optional, tag="3")]
+    pub last_commit: ::core::option::Option<::tendermint_proto::types::Commit>,
+    /// The collection of rollup transactions that were included in this block.
+    #[prost(message, optional, tag="4")]
+    pub rollup_transactions: ::core::option::Option<RollupTransactions>,
+    /// The root of the action tree of this block. Must be 32 bytes.
+    #[prost(bytes="vec", tag="5")]
+    pub action_tree_root: ::prost::alloc::vec::Vec<u8>,
+    /// The proof that the action tree root was included in `header.data_hash`.
+    #[prost(message, optional, tag="6")]
+    pub action_tree_inclusion_proof: ::core::option::Option<InclusionProof>,
+}
+/// An "item blob" of rollup transactions submitted to celestia.
+///
+/// The transactions contained in the item belong to a rollup identified
+/// by `chain_id`, and were included in the sequencer block identified
+/// by `sequencer_block_hash`.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CelestiaItem {
+    /// The hash of the sequencer block. Must be 32 bytes.
+    #[prost(bytes="vec", tag="1")]
+    pub sequencer_block_hash: ::prost::alloc::vec::Vec<u8>,
+    /// The human readable chain ID identifiying the rollup these transactions belong to.
+    #[prost(string, tag="2")]
+    pub chain_id: ::prost::alloc::string::String,
+    /// A list of opaque bytes that are serialized rollup transactions.
+    #[prost(bytes="vec", repeated, tag="3")]
+    pub transactions: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+    /// The proof that the action tree root was included in
+    /// `sequencer_block_header.data_hash` (to be found in `CelestiaHeader`).
+    /// The inclusion of these transactions in the original sequencer block
+    /// can be verified using the action tree root stored in `CelestiaHeader`.
+    #[prost(message, optional, tag="4")]
+    pub action_tree_inclusion_proof: ::core::option::Option<InclusionProof>,
+}
+/// The "header blob" that is submitted to celestia under a sequencer-specific
+/// celestia namespace.
+///
+/// It is created by splitting up `SequencerBlockData` into a header
+/// and a list of rollup blobs, where one blob contains a sequence of
+/// rollup transactions for one specific rollup.
+///
+/// The original sequencer block is identified by its `block_hash`.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CelestiaHeader {
+    /// The hash of the sequencer block. Must be 32 bytes.
+    #[prost(bytes="vec", tag="1")]
+    pub sequencer_block_hash: ::prost::alloc::vec::Vec<u8>,
+    /// The original cometbft header that was the input to this sequencer block.
+    #[prost(message, optional, tag="2")]
+    pub sequencer_block_header: ::core::option::Option<::tendermint_proto::types::Header>,
+    /// The commit/set of signatures that commited this block.
+    #[prost(message, optional, tag="3")]
+    pub sequencer_bock_last_commit: ::core::option::Option<::tendermint_proto::types::Commit>,
+    /// The namespaces under which rollup transactions belonging to the sequencer
+    /// block identified by `sequencer_block_hash` where submitted to celestia.
+    /// The bytes must convert to a celestia v0 namespace.
+    #[prost(bytes="vec", repeated, tag="4")]
+    pub rollup_namespaces: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+    /// The root of the action tree of this block. Must be 32 bytes.
+    #[prost(bytes="vec", tag="5")]
+    pub action_tree_root: ::prost::alloc::vec::Vec<u8>,
+    /// The proof that the action tree root was included in `header.data_hash`.
+    #[prost(message, optional, tag="6")]
+    pub action_tree_inclusion_proof: ::core::option::Option<InclusionProof>,
+}
+// @@protoc_insertion_point(module)

--- a/crates/astria-proto/src/proto/mod.rs
+++ b/crates/astria-proto/src/proto/mod.rs
@@ -27,5 +27,8 @@ pub mod generated {
     pub mod sequencer {
         #[path = "astria.sequencer.v1alpha1.rs"]
         pub mod v1alpha1;
+
+        #[path = "astria.sequencer.v1alpha2.rs"]
+        pub mod v1alpha2;
     }
 }

--- a/crates/astria-sequencer-relayer/src/relayer.rs
+++ b/crates/astria-sequencer-relayer/src/relayer.rs
@@ -7,7 +7,7 @@ use eyre::{
 };
 use humantime::format_duration;
 use sequencer_types::{
-    serde::NamespaceToTxCount,
+    serde::ChainIdToTxCount,
     SequencerBlockData,
 };
 use tendermint_rpc::{
@@ -216,7 +216,7 @@ impl Relayer {
                     block_hash = hex::encode(sequencer_block_data.block_hash()),
                     proposer = %sequencer_block_data.header().proposer_address,
                     num_contained_namespaces = sequencer_block_data.rollup_data().len(),
-                    namespaces_to_tx_count = %NamespaceToTxCount::new(sequencer_block_data.rollup_data()),
+                    chain_id_to_tx_count = %ChainIdToTxCount::new(sequencer_block_data.rollup_data()),
                     "gossiping sequencer block",
                 );
                 if self

--- a/crates/astria-sequencer-types/src/lib.rs
+++ b/crates/astria-sequencer-types/src/lib.rs
@@ -8,7 +8,7 @@ pub use namespace::{
     DEFAULT_NAMESPACE,
 };
 pub use sequencer_block_data::{
+    ChainId,
     RawSequencerBlockData,
-    RollupData,
     SequencerBlockData,
 };

--- a/crates/astria-sequencer-types/src/serde.rs
+++ b/crates/astria-sequencer-types/src/serde.rs
@@ -1,5 +1,5 @@
 //! Utilities for serializing and deserializing bytes
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use base64_serde::base64_serde_type;
 use serde::{
@@ -7,35 +7,33 @@ use serde::{
     Serialize,
 };
 
-use crate::{
-    ChainId,
-};
+use crate::ChainId;
 
 base64_serde_type!(pub Base64Standard, base64::engine::general_purpose::STANDARD);
 
-pub struct ChainIdToTxCount<'a>(pub(crate) &'a HashMap<ChainId, Vec<Vec<u8>>>);
+pub struct ChainIdToTxCount<'a>(pub(crate) &'a BTreeMap<ChainId, Vec<Vec<u8>>>);
 
 impl<'a> ChainIdToTxCount<'a> {
     #[must_use]
-    pub fn new(rollup_data: &HashMap<ChainId, Vec<Vec<u8>>>) -> ChainIdToTxCount {
+    pub fn new(rollup_data: &BTreeMap<ChainId, Vec<Vec<u8>>>) -> ChainIdToTxCount {
         ChainIdToTxCount(rollup_data)
     }
 }
 
-impl<'a> Serialize for NamespaceToTxCount<'a> {
+impl<'a> Serialize for ChainIdToTxCount<'a> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
         let mut map = serializer.serialize_map(Some(self.0.len()))?;
         for (ns, data) in self.0 {
-            map.serialize_entry(&ns, &data.transactions.len())?;
+            map.serialize_entry(&ns, &data.len())?;
         }
         map.end()
     }
 }
 
-impl<'a> std::fmt::Display for NamespaceToTxCount<'a> {
+impl<'a> std::fmt::Display for ChainIdToTxCount<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // This cannot fail because we are only serializing into a string (unless the system is
         // OOM).

--- a/crates/astria-sequencer-types/src/serde.rs
+++ b/crates/astria-sequencer-types/src/serde.rs
@@ -8,18 +8,17 @@ use serde::{
 };
 
 use crate::{
-    Namespace,
-    RollupData,
+    ChainId,
 };
 
 base64_serde_type!(pub Base64Standard, base64::engine::general_purpose::STANDARD);
 
-pub struct NamespaceToTxCount<'a>(pub(crate) &'a HashMap<Namespace, RollupData>);
+pub struct ChainIdToTxCount<'a>(pub(crate) &'a HashMap<ChainId, Vec<Vec<u8>>>);
 
-impl<'a> NamespaceToTxCount<'a> {
+impl<'a> ChainIdToTxCount<'a> {
     #[must_use]
-    pub fn new(rollup_data: &HashMap<Namespace, RollupData>) -> NamespaceToTxCount {
-        NamespaceToTxCount(rollup_data)
+    pub fn new(rollup_data: &HashMap<ChainId, Vec<Vec<u8>>>) -> ChainIdToTxCount {
+        ChainIdToTxCount(rollup_data)
     }
 }
 

--- a/crates/astria-sequencer-validation/src/utils.rs
+++ b/crates/astria-sequencer-validation/src/utils.rs
@@ -5,13 +5,13 @@ use crate::MerkleTree;
 /// Groups the `sequence::Action`s within the transactions by their `chain_id`.
 /// The `BTreeMap` key is the chain ID and value is the transactions.
 #[must_use]
-pub fn generate_action_tree_leaves(
-    chain_id_to_txs: BTreeMap<Vec<u8>, Vec<Vec<u8>>>,
+pub fn generate_action_tree_leaves<T: AsRef<[u8]>>(
+    chain_id_to_txs: BTreeMap<T, Vec<Vec<u8>>>,
 ) -> Vec<Vec<u8>> {
     let mut leaves = Vec::new();
     for (chain_id, txs) in chain_id_to_txs {
         let root = MerkleTree::from_leaves(txs).root();
-        let mut leaf = chain_id.clone();
+        let mut leaf = chain_id.as_ref().to_vec();
         leaf.append(&mut root.to_vec());
         leaves.push(leaf);
     }


### PR DESCRIPTION
## Summary
This patch defines protobuf versions of various types that are currently only defined in Rust and exchange as json-serialized text. 

## Background
`astria-proto` is intended to be the single source of truth for the wire format of data that is exchanged between services. At the moment `SequencerBlockData`, `SequencerNamespaceData`, `RollupNamespaceData` and `InclusionProof` are only defined in Rust. Some older versions of these exist as protobuf but were never used in the public interfaces.

## Changes
- Define a sequencer `v1alpha2` API for sequencer block, inclusion proof, and celestia blobs (called `CelestiaItem` and `CelestiaHeader`).

## Testing
- N/A; currently these are just protobuf definitions.

## Related Issues

https://github.com/astriaorg/astria/pull/12 originally defined sequencer blocks and transactions as protobuf, but these were never actually implemented.

https://github.com/astriaorg/astria/issues/86 is the reason this effort was started.
