### PR TITLE
feat(sequencer): implement basic validator set updates

### DIFF
--- a/crates/astria-sequencer/src/app.rs
+++ b/crates/astria-sequencer/src/app.rs
@@ -310,7 +310,6 @@ mod test {
         Address::from_array(arr)
     }
 
-    // generated with test `generate_default_keys()`
     const ALICE_ADDRESS: &str = "1c0c490f1b5528d8173c5de46d131160e4b2c0c3";
     const BOB_ADDRESS: &str = "34fec43c7fcab9aef3b3cf8aba855e41ee69ca3a";
     const CAROL_ADDRESS: &str = "60709e2d391864b732b4f0f51e387abb76743871";

--- a/crates/astria-sequencer/src/authority/action.rs
+++ b/crates/astria-sequencer/src/authority/action.rs
@@ -1,12 +1,17 @@
-use anyhow::Result;
+use anyhow::{
+    ensure,
+    Context as _,
+    Result,
+};
 use ed25519_consensus::VerificationKey;
 use proto::native::sequencer::v1alpha1::Address;
 use tracing::instrument;
 
 use crate::{
-    accounts::state_ext::{
+    authority::state_ext::{
         StateReadExt,
         StateWriteExt,
+        Validator,
     },
     transaction::action_handler::ActionHandler,
 };
@@ -25,14 +30,36 @@ impl ActionHandler for ValidatorUpdate {
         from: Address,
     ) -> Result<()> {
         // ensure signer is the valid `sudo` key in state
+        let sudo_address = state.get_sudo_address().await?;
+        ensure!(sudo_address == from, "signer is not the sudo key");
+
         // ensure validator to be updated is in the set
+        let validator_set = state.get_validator_set().await?;
+        ensure!(
+            validator_set
+                .0
+                .iter()
+                .any(|v| v.public_key == self.public_key.to_bytes()),
+            "validator to be updated is not in the set"
+        );
         Ok(())
     }
 
     #[instrument(skip_all)]
-    async fn execute<S: StateWriteExt>(&self, state: &mut S, from: Address) -> Result<()> {
+    async fn execute<S: StateWriteExt>(&self, state: &mut S, _: Address) -> Result<()> {
         // add validator update in non-consensus state
         // to be used in end_block
+        let mut validator_updates = state
+            .get_validator_updates()
+            .await
+            .context("failed getting validator updates")?;
+        validator_updates.0.push(Validator {
+            public_key: self.public_key.to_bytes(),
+            voting_power: self.voting_power,
+        });
+
+        state.put_validator_updates(validator_updates)?;
+
         Ok(())
     }
 }

--- a/crates/astria-sequencer/src/authority/action.rs
+++ b/crates/astria-sequencer/src/authority/action.rs
@@ -1,0 +1,38 @@
+use anyhow::Result;
+use ed25519_consensus::VerificationKey;
+use proto::native::sequencer::v1alpha1::Address;
+use tracing::instrument;
+
+use crate::{
+    accounts::state_ext::{
+        StateReadExt,
+        StateWriteExt,
+    },
+    transaction::action_handler::ActionHandler,
+};
+
+// TODO: move to astria-proto
+pub(crate) struct ValidatorUpdate {
+    public_key: VerificationKey,
+    voting_power: u64, // set to 0 to remove validator
+}
+
+#[async_trait::async_trait]
+impl ActionHandler for ValidatorUpdate {
+    async fn check_stateful<S: StateReadExt + 'static>(
+        &self,
+        state: &S,
+        from: Address,
+    ) -> Result<()> {
+        // ensure signer is the valid `sudo` key in state
+        // ensure validator to be updated is in the set
+        Ok(())
+    }
+
+    #[instrument(skip_all)]
+    async fn execute<S: StateWriteExt>(&self, state: &mut S, from: Address) -> Result<()> {
+        // add validator update in non-consensus state
+        // to be used in end_block
+        Ok(())
+    }
+}

--- a/crates/astria-sequencer/src/authority/component.rs
+++ b/crates/astria-sequencer/src/authority/component.rs
@@ -13,7 +13,10 @@ use tendermint::{
 };
 use tracing::instrument;
 
-use super::state_ext::StateWriteExt;
+use super::state_ext::{
+    StateWriteExt,
+    ValidatorSet,
+};
 use crate::{
     component::Component,
     genesis::GenesisState,
@@ -33,7 +36,7 @@ impl Component for AuthorityComponent {
             .put_sudo_address(app_state.0.authority_sudo_key)
             .context("failed to set sudo key")?;
         state
-            .put_validator_set(app_state.1.clone().try_into()?)
+            .put_validator_set(ValidatorSet(app_state.1.clone()))
             .context("failed to set validator set")?;
         Ok(())
     }

--- a/crates/astria-sequencer/src/authority/component.rs
+++ b/crates/astria-sequencer/src/authority/component.rs
@@ -1,0 +1,50 @@
+use std::sync::Arc;
+
+use anyhow::{
+    Context,
+    Result,
+};
+use tendermint::{
+    abci::request::{
+        BeginBlock,
+        EndBlock,
+    },
+    validator,
+};
+use tracing::instrument;
+
+use super::state_ext::StateWriteExt;
+use crate::{
+    component::Component,
+    genesis::GenesisState,
+};
+
+#[derive(Default)]
+pub(crate) struct AuthorityComponent;
+
+#[async_trait::async_trait]
+impl Component for AuthorityComponent {
+    type AppState = (GenesisState, Vec<validator::Update>);
+
+    #[instrument(name = "AuthorityComponent:init_chain", skip(state))]
+    async fn init_chain<S: StateWriteExt>(mut state: S, app_state: &Self::AppState) -> Result<()> {
+        // set sudo key and initial validator set
+        state
+            .put_sudo_address(app_state.0.authority_sudo_key)
+            .context("failed to set sudo key")?;
+        state
+            .put_validator_set(app_state.1.clone().try_into()?)
+            .context("failed to set validator set")?;
+        Ok(())
+    }
+
+    #[instrument(name = "AuthorityComponent:begin_block", skip(_state))]
+    async fn begin_block<S: StateWriteExt + 'static>(
+        _state: &mut Arc<S>,
+        _begin_block: &BeginBlock,
+    ) {
+    }
+
+    #[instrument(name = "AuthorityComponent:end_block", skip(_state))]
+    async fn end_block<S: StateWriteExt + 'static>(_state: &mut Arc<S>, _end_block: &EndBlock) {}
+}

--- a/crates/astria-sequencer/src/authority/mod.rs
+++ b/crates/astria-sequencer/src/authority/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod action;
+pub(crate) mod state_ext;

--- a/crates/astria-sequencer/src/authority/mod.rs
+++ b/crates/astria-sequencer/src/authority/mod.rs
@@ -1,2 +1,3 @@
 pub(crate) mod action;
+pub(crate) mod component;
 pub(crate) mod state_ext;

--- a/crates/astria-sequencer/src/authority/state_ext.rs
+++ b/crates/astria-sequencer/src/authority/state_ext.rs
@@ -76,7 +76,7 @@ pub(crate) trait StateReadExt: StateRead {
             .await
             .context("failed reading raw validator updates from state")?
         else {
-            return Err(anyhow!("validator updates not found"));
+            return Ok(ValidatorSet(vec![]));
         };
 
         let validator_updates: ValidatorSet =

--- a/crates/astria-sequencer/src/authority/state_ext.rs
+++ b/crates/astria-sequencer/src/authority/state_ext.rs
@@ -25,7 +25,7 @@ struct ValidatorSet(Vec<Validator>);
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
 struct Validator {
     public_key: [u8; 32],
-    voting_power: u64, // set to 0 to remove validator
+    voting_power: u64,
 }
 
 const SUDO_STORAGE_KEY: &str = "sudo";

--- a/crates/astria-sequencer/src/authority/state_ext.rs
+++ b/crates/astria-sequencer/src/authority/state_ext.rs
@@ -1,4 +1,5 @@
 use anyhow::{
+    anyhow,
     Context,
     Result,
 };
@@ -7,47 +8,105 @@ use borsh::{
     BorshDeserialize,
     BorshSerialize,
 };
-use ed25519_consensus::VerificationKey;
 use penumbra_storage::{
     StateRead,
     StateWrite,
 };
+use proto::native::sequencer::v1alpha1::{
+    Address,
+    ADDRESS_LEN,
+};
 use tracing::instrument;
 
-/// Newtype wrapper to read and write a 32-byte array from rocksdb.
+/// Newtype wrapper to read and write an address from rocksdb.
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
-struct SudoPublicKey([u8; 32]);
+struct SudoAddress([u8; ADDRESS_LEN]);
 
 /// Newtype wrapper to read and write a validator set from rocksdb.
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
-struct ValidatorSet(Vec<Validator>);
+pub(crate) struct ValidatorSet(pub(crate) Vec<Validator>);
+
+impl TryFrom<Vec<tendermint::validator::Update>> for ValidatorSet {
+    type Error = anyhow::Error;
+
+    fn try_from(updates: Vec<tendermint::validator::Update>) -> Result<Self> {
+        Ok(ValidatorSet(
+            updates
+                .into_iter()
+                .map(|update| {
+                    let public_key = update
+                        .pub_key
+                        .to_bytes()
+                        .try_into()
+                        .map_err(|_| anyhow!("public key must be 32 bytes"))?;
+                    Ok(Validator {
+                        public_key,
+                        voting_power: update.power.into(),
+                    })
+                })
+                .collect::<Result<Vec<Validator>>>()?,
+        ))
+    }
+}
+
+/// Newtype wrapper to read and write a validator update from rocksdb.
+#[derive(BorshSerialize, BorshDeserialize, Debug)]
+pub(crate) struct ValidatorUpdates(pub(crate) Vec<Validator>);
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
-struct Validator {
-    public_key: [u8; 32],
-    voting_power: u64,
+pub(crate) struct Validator {
+    pub(crate) public_key: [u8; 32],
+    pub(crate) voting_power: u64,
 }
 
 const SUDO_STORAGE_KEY: &str = "sudo";
 const VALIDATOR_SET_STORAGE_KEY: &str = "valset";
+const VALIDATOR_UPDATES_KEY: &[u8] = b"valupdates";
 
 #[async_trait]
 pub(crate) trait StateReadExt: StateRead {
     #[instrument(skip(self))]
-    async fn get_sudo_key(&self) -> Result<Option<VerificationKey>> {
+    async fn get_sudo_address(&self) -> Result<Address> {
         let Some(bytes) = self
             .get_raw(SUDO_STORAGE_KEY)
             .await
             .context("failed reading raw sudo key from state")?
         else {
-            // TODO: should this panic?
-            return Ok(None);
+            return Err(anyhow!("sudo key not found"));
         };
-        let SudoPublicKey(key) =
-            SudoPublicKey::try_from_slice(&bytes).context("invalid sudo key bytes")?;
-        Ok(Some(
-            VerificationKey::try_from(key).context("invalid sudo key")?,
-        ))
+        let SudoAddress(address) =
+            SudoAddress::try_from_slice(&bytes).context("invalid sudo key bytes")?;
+        Ok(Address(address))
+    }
+
+    #[instrument(skip(self))]
+    async fn get_validator_set(&self) -> Result<ValidatorSet> {
+        let Some(bytes) = self
+            .get_raw(VALIDATOR_SET_STORAGE_KEY)
+            .await
+            .context("failed reading raw validator set from state")?
+        else {
+            return Err(anyhow!("validator set not found"));
+        };
+
+        let ValidatorSet(validator_set) =
+            ValidatorSet::try_from_slice(&bytes).context("invalid validator set bytes")?;
+        Ok(ValidatorSet(validator_set))
+    }
+
+    #[instrument(skip(self))]
+    async fn get_validator_updates(&self) -> Result<ValidatorUpdates> {
+        let Some(bytes) = self
+            .nonconsensus_get_raw(VALIDATOR_UPDATES_KEY)
+            .await
+            .context("failed reading raw validator updates from state")?
+        else {
+            return Err(anyhow!("validator updates not found"));
+        };
+
+        let validator_updates: ValidatorUpdates =
+            ValidatorUpdates::try_from_slice(&bytes).context("invalid validator updates bytes")?;
+        Ok(validator_updates)
     }
 }
 
@@ -56,9 +115,29 @@ impl<T: StateRead> StateReadExt for T {}
 #[async_trait]
 pub(crate) trait StateWriteExt: StateWrite {
     #[instrument(skip(self))]
-    fn put_sudo_key(&mut self, key: VerificationKey) -> Result<()> {
-        let key = SudoPublicKey(key.to_bytes());
-        self.put_raw(SUDO_STORAGE_KEY.to_string(), key.try_to_vec()?);
+    fn put_sudo_address(&mut self, address: Address) -> Result<()> {
+        self.put_raw(
+            SUDO_STORAGE_KEY.to_string(),
+            SudoAddress(address.0).try_to_vec()?,
+        );
+        Ok(())
+    }
+
+    #[instrument(skip(self))]
+    fn put_validator_set(&mut self, validator_set: ValidatorSet) -> Result<()> {
+        self.put_raw(
+            VALIDATOR_SET_STORAGE_KEY.to_string(),
+            validator_set.try_to_vec()?,
+        );
+        Ok(())
+    }
+
+    #[instrument(skip(self))]
+    fn put_validator_updates(&mut self, validator_updates: ValidatorUpdates) -> Result<()> {
+        self.nonconsensus_put_raw(
+            VALIDATOR_UPDATES_KEY.to_vec(),
+            validator_updates.try_to_vec()?,
+        );
         Ok(())
     }
 }

--- a/crates/astria-sequencer/src/authority/state_ext.rs
+++ b/crates/astria-sequencer/src/authority/state_ext.rs
@@ -47,6 +47,7 @@ pub(crate) trait StateReadExt: StateRead {
             .await
             .context("failed reading raw sudo key from state")?
         else {
+            // return error because sudo key must be set
             return Err(anyhow!("sudo key not found"));
         };
         let SudoAddress(address) =
@@ -61,6 +62,7 @@ pub(crate) trait StateReadExt: StateRead {
             .await
             .context("failed reading raw validator set from state")?
         else {
+            // return error because validator set must be set
             return Err(anyhow!("validator set not found"));
         };
 
@@ -76,6 +78,7 @@ pub(crate) trait StateReadExt: StateRead {
             .await
             .context("failed reading raw validator updates from state")?
         else {
+            // return empty set because validator updates are optional
             return Ok(ValidatorSet(vec![]));
         };
 

--- a/crates/astria-sequencer/src/authority/state_ext.rs
+++ b/crates/astria-sequencer/src/authority/state_ext.rs
@@ -1,0 +1,66 @@
+use anyhow::{
+    Context,
+    Result,
+};
+use async_trait::async_trait;
+use borsh::{
+    BorshDeserialize,
+    BorshSerialize,
+};
+use ed25519_consensus::VerificationKey;
+use penumbra_storage::{
+    StateRead,
+    StateWrite,
+};
+use tracing::instrument;
+
+/// Newtype wrapper to read and write a 32-byte array from rocksdb.
+#[derive(BorshSerialize, BorshDeserialize, Debug)]
+struct SudoPublicKey([u8; 32]);
+
+/// Newtype wrapper to read and write a validator set from rocksdb.
+#[derive(BorshSerialize, BorshDeserialize, Debug)]
+struct ValidatorSet(Vec<Validator>);
+
+#[derive(BorshSerialize, BorshDeserialize, Debug)]
+struct Validator {
+    public_key: [u8; 32],
+    voting_power: u64, // set to 0 to remove validator
+}
+
+const SUDO_STORAGE_KEY: &str = "sudo";
+const VALIDATOR_SET_STORAGE_KEY: &str = "valset";
+
+#[async_trait]
+pub(crate) trait StateReadExt: StateRead {
+    #[instrument(skip(self))]
+    async fn get_sudo_key(&self) -> Result<Option<VerificationKey>> {
+        let Some(bytes) = self
+            .get_raw(SUDO_STORAGE_KEY)
+            .await
+            .context("failed reading raw sudo key from state")?
+        else {
+            // TODO: should this panic?
+            return Ok(None);
+        };
+        let SudoPublicKey(key) =
+            SudoPublicKey::try_from_slice(&bytes).context("invalid sudo key bytes")?;
+        Ok(Some(
+            VerificationKey::try_from(key).context("invalid sudo key")?,
+        ))
+    }
+}
+
+impl<T: StateRead> StateReadExt for T {}
+
+#[async_trait]
+pub(crate) trait StateWriteExt: StateWrite {
+    #[instrument(skip(self))]
+    fn put_sudo_key(&mut self, key: VerificationKey) -> Result<()> {
+        let key = SudoPublicKey(key.to_bytes());
+        self.put_raw(SUDO_STORAGE_KEY.to_string(), key.try_to_vec()?);
+        Ok(())
+    }
+}
+
+impl<T: StateWrite> StateWriteExt for T {}

--- a/crates/astria-sequencer/src/genesis.rs
+++ b/crates/astria-sequencer/src/genesis.rs
@@ -11,9 +11,20 @@ use serde::{
 };
 
 /// The genesis state for the application.
-#[derive(Debug, Deserialize, Default)]
+#[derive(Debug, Deserialize)]
 pub(crate) struct GenesisState {
     pub(crate) accounts: Vec<Account>,
+    #[serde(deserialize_with = "deserialize_address")]
+    pub(crate) authority_sudo_key: Address,
+}
+
+impl Default for GenesisState {
+    fn default() -> Self {
+        Self {
+            accounts: vec![],
+            authority_sudo_key: Address::from([0; 20]),
+        }
+    }
 }
 
 impl GenesisState {

--- a/crates/astria-sequencer/src/lib.rs
+++ b/crates/astria-sequencer/src/lib.rs
@@ -1,6 +1,7 @@
 pub(crate) mod accounts;
 pub(crate) mod app;
 pub(crate) mod app_hash;
+pub(crate) mod authority;
 pub(crate) mod component;
 pub mod config;
 pub(crate) mod genesis;

--- a/crates/astria-sequencer/src/sequencer.rs
+++ b/crates/astria-sequencer/src/sequencer.rs
@@ -26,10 +26,8 @@ pub struct Sequencer;
 impl Sequencer {
     #[instrument(skip_all)]
     pub async fn run_until_stopped(config: Config) -> Result<()> {
-        let genesis_state = GenesisState::from_path(config.genesis_file).context(
-            "failed reading genesis
-        state",
-        )?;
+        let genesis_state =
+            GenesisState::from_path(config.genesis_file).context("failed reading genesis state")?;
 
         if config
             .db_filepath

--- a/crates/astria-sequencer/src/sequencer.rs
+++ b/crates/astria-sequencer/src/sequencer.rs
@@ -26,8 +26,11 @@ pub struct Sequencer;
 impl Sequencer {
     #[instrument(skip_all)]
     pub async fn run_until_stopped(config: Config) -> Result<()> {
-        let genesis_state =
-            GenesisState::from_path(config.genesis_file).context("failed reading genesis state")?;
+        let genesis_state = GenesisState::from_path(config.genesis_file).context(
+            "failed reading genesis
+        state",
+        )?;
+
         if config
             .db_filepath
             .try_exists()
@@ -48,7 +51,9 @@ impl Sequencer {
             .context("failed to load storage backing chain state")?;
         let snapshot = storage.latest_snapshot();
         let mut app = App::new(snapshot);
-        app.init_chain(genesis_state)
+
+        // TODO(https://github.com/astriaorg/astria/issues/227): don't call init_chain here
+        app.init_chain(genesis_state, vec![])
             .await
             .context("failed initializing app with genesis state")?;
 

--- a/crates/astria-sequencer/src/service/consensus.rs
+++ b/crates/astria-sequencer/src/service/consensus.rs
@@ -153,14 +153,6 @@ impl Consensus {
         &mut self,
         begin_block: request::BeginBlock,
     ) -> anyhow::Result<response::BeginBlock> {
-        // if self.storage.latest_version() == u64::MAX {
-        //     // TODO: why isn't tendermint calling init_chain before the first block?
-        //     self.app
-        //         .init_chain(GenesisState::default())
-        //         .await
-        //         .expect("init_chain must succeed");
-        // }
-
         let events = self.app.begin_block(&begin_block).await;
         Ok(response::BeginBlock {
             events,
@@ -189,11 +181,7 @@ impl Consensus {
         &mut self,
         end_block: request::EndBlock,
     ) -> anyhow::Result<response::EndBlock> {
-        let events = self.app.end_block(&end_block).await;
-        Ok(response::EndBlock {
-            events,
-            ..Default::default()
-        })
+        Ok(self.app.end_block(&end_block).await)
     }
 
     #[instrument(skip(self))]

--- a/crates/astria-sequencer/src/service/consensus.rs
+++ b/crates/astria-sequencer/src/service/consensus.rs
@@ -132,10 +132,20 @@ impl Consensus {
         let genesis_state: GenesisState = serde_json::from_slice(&init_chain.app_state_bytes)
             .expect("can parse app_state in genesis file");
 
-        self.app.init_chain(genesis_state).await?;
+        self.app
+            .init_chain(genesis_state, init_chain.validators)
+            .await?;
 
-        // TODO: return the genesis app hash
-        Ok(response::InitChain::default())
+        // commit the state and return the app hash
+        let app_hash = self.app.commit(self.storage.clone()).await;
+        Ok(response::InitChain {
+            app_hash: app_hash
+                .0
+                .to_vec()
+                .try_into()
+                .context("failed to convert app hash")?,
+            ..Default::default()
+        })
     }
 
     #[instrument(skip(self))]
@@ -143,13 +153,13 @@ impl Consensus {
         &mut self,
         begin_block: request::BeginBlock,
     ) -> anyhow::Result<response::BeginBlock> {
-        if self.storage.latest_version() == u64::MAX {
-            // TODO: why isn't tendermint calling init_chain before the first block?
-            self.app
-                .init_chain(GenesisState::default())
-                .await
-                .expect("init_chain must succeed");
-        }
+        // if self.storage.latest_version() == u64::MAX {
+        //     // TODO: why isn't tendermint calling init_chain before the first block?
+        //     self.app
+        //         .init_chain(GenesisState::default())
+        //         .await
+        //         .expect("init_chain must succeed");
+        // }
 
         let events = self.app.begin_block(&begin_block).await;
         Ok(response::BeginBlock {

--- a/crates/astria-sequencer/test-genesis.json
+++ b/crates/astria-sequencer/test-genesis.json
@@ -12,5 +12,6 @@
             "address": "60709e2d391864b732b4f0f51e387abb76743871",
             "balance": 1000000000000000000
         }
-    ]
+    ],
+    "authority_sudo_key": "1c0c490f1b5528d8173c5de46d131160e4b2c0c3"
 }


### PR DESCRIPTION
## Summary
 implement basic validator set updates using a sudo key set at genesis 

for a follow up:
- allow this sudo key to be updated as well
- #227

## Background
we need a way to update validators for devnet

## Changes
- implement `authority` module, contains one action `validator::Update` (from the tendermint type) which must be sent by the sudo key. set the `power` to 0 to remove the validator.
- module also contains `AuthorityComponent` which sets the sudo key and validator set at genesis
- validator set updates are stored in the non-consensus storage while the block txs are executing, then the batch of validator updates are returned during `end_block`

## Testing
unit tests (todo)
ran the sequencer node (todo)

## Breaking Changelist
- sequencer genesis file must contain `authority_sudo_key`

## Related Issues

closes #68
