### PR TITLE
fix(sequencer): remove unneeded `AppHash` alias

### DIFF
--- a/crates/astria-sequencer/src/app.rs
+++ b/crates/astria-sequencer/src/app.rs
@@ -24,6 +24,7 @@ use tracing::{
 
 use crate::{
     accounts::component::AccountsComponent,
+    app_hash::AppHash,
     component::Component,
     genesis::GenesisState,
     state_ext::{
@@ -32,9 +33,6 @@ use crate::{
     },
     transaction,
 };
-
-/// The application hash, used to verify the application state.
-pub(crate) type AppHash = penumbra_storage::RootHash;
 
 /// The inter-block state being written to by the application.
 type InterBlockState = Arc<StateDelta<Snapshot>>;
@@ -214,7 +212,7 @@ impl App {
             .await
             .expect("must be able to successfully commit to storage");
 
-        let app_hash: AppHash = jmt_root;
+        let app_hash = AppHash::from(jmt_root);
         tracing::debug!(?app_hash, "finished committing state");
 
         // Get the latest version of the state, now that we've committed it.


### PR DESCRIPTION
## Summary
remove unneeded `AppHash` alias as there was an `AppHash` type with domain separator and `AppHash` alias

## Related Issues

closes #348
