### PR TITLE
sequencer-validation: type errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,7 +595,6 @@ version = "0.1.0"
 dependencies = [
  "bytes",
  "ct-merkle",
- "eyre",
  "hex",
  "serde",
  "serde_json",

--- a/crates/astria-sequencer-relayer/src/data_availability.rs
+++ b/crates/astria-sequencer-relayer/src/data_availability.rs
@@ -185,8 +185,10 @@ impl RollupNamespaceData {
         let rollup_data_root = rollup_data_tree.root();
         let mut leaf = self.chain_id.clone();
         leaf.append(&mut rollup_data_root.to_vec());
-
-        self.inclusion_proof.verify(&leaf, root_hash)
+        self.inclusion_proof.verify(&leaf, root_hash).wrap_err(
+            "failed to verify rollup transactions against the contained inclusion proof with the \
+             provided root hash",
+        )
     }
 }
 

--- a/crates/astria-sequencer-validation/Cargo.toml
+++ b/crates/astria-sequencer-validation/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 ct-merkle = { version = "0.1", features = ["serde"] }
 
 bytes = { workspace = true }
-eyre = { workspace = true }
 hex = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
 sha2 = { workspace = true }


### PR DESCRIPTION
## Summary
Replace all untyped errors in sequencer-validation by typed errors.

## Background
`sequencer-validation` has to be made a dependency of `sequencer-client`, which only uses typed errors. Therefore `sequencer-validation` must have typed errors (because otherwise `sequencer-client` would be "infected" by eyre, which would require changing all of sequencer-client to also use eyre :-/ ).

## Changes
- Replace `eyre` reports by typed errors
- Fix `MerkleTree::prove_inclusion` to actually return an error: the docs said it would error, but it actually panicked if `index` was out of bounds.
- Add eyre error context to sequencer-relayer: because the error in it wasn't properly wrapped, changing the sequencer-validation types caused it to no longer compile

## Testing
Added a test to check for out of bounds inclusion proof index. The other error type is just a wrapper.

## Related Issues
This is done as part of #332, which now requires extra trait methods in the `SequencerClientExt` and `SequencerSubscriptionClientExt` extension traits.
