### PR TITLE
update ct-merkle dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,7 +566,7 @@ dependencies = [
  "astria-sequencer-validation",
  "base64 0.21.2",
  "base64-serde",
- "ct-merkle",
+ "ct-merkle 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "eyre",
  "hex",
  "prost",
@@ -594,7 +594,7 @@ name = "astria-sequencer-validation"
 version = "0.1.0"
 dependencies = [
  "bytes",
- "ct-merkle",
+ "ct-merkle 0.1.0 (git+https://github.com/rozbb/ct-merkle?rev=a3f3965c368946944425d59370783b3381a1fb4d)",
  "eyre",
  "hex",
  "serde",
@@ -1609,7 +1609,19 @@ dependencies = [
 [[package]]
 name = "ct-merkle"
 version = "0.1.0"
-source = "git+https://github.com/astriaorg/ct-merkle.git?rev=58f692640be65ef42bc14f69e52a9e836f407a33#58f692640be65ef42bc14f69e52a9e836f407a33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6920781f1a0d2f2f8bfb3a5023b2095430efb29b86074fe7f5ee86912b1f6d6"
+dependencies = [
+ "digest 0.10.7",
+ "generic-array",
+ "serde",
+ "subtle",
+]
+
+[[package]]
+name = "ct-merkle"
+version = "0.1.0"
+source = "git+https://github.com/rozbb/ct-merkle?rev=a3f3965c368946944425d59370783b3381a1fb4d#a3f3965c368946944425d59370783b3381a1fb4d"
 dependencies = [
  "digest 0.10.7",
  "generic-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,5 +80,3 @@ tendermint = { git = "https://github.com/astriaorg/tendermint-rs.git", rev = "a8
 tendermint-config = { git = "https://github.com/astriaorg/tendermint-rs.git", rev = "a816d6363780c2ed0c3288e6b6e01adee71cf1a5" }
 tendermint-proto = { git = "https://github.com/astriaorg/tendermint-rs.git", rev = "a816d6363780c2ed0c3288e6b6e01adee71cf1a5" }
 tendermint-rpc = { git = "https://github.com/astriaorg/tendermint-rs.git", rev = "a816d6363780c2ed0c3288e6b6e01adee71cf1a5" }
-
-ct-merkle = { git = "https://github.com/astriaorg/ct-merkle.git", rev = "58f692640be65ef42bc14f69e52a9e836f407a33" }

--- a/crates/astria-sequencer-validation/Cargo.toml
+++ b/crates/astria-sequencer-validation/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-ct-merkle = { version = "0.1", features = ["serde"] }
+ct-merkle = { git = "https://github.com/rozbb/ct-merkle", rev = "a3f3965c368946944425d59370783b3381a1fb4d", features = ["serde"] }
 
 bytes = { workspace = true }
 eyre = { workspace = true }


### PR DESCRIPTION
## Summary
my PR for the ct-merkle lib got merged so can remove the patch.
