### PR TITLE
Conductor: fix config loading from environment to have more control

### DIFF
--- a/crates/astria-conductor/src/config.rs
+++ b/crates/astria-conductor/src/config.rs
@@ -84,7 +84,7 @@ mod tests {
 
     const EXAMPLE_ENV: &str = include_str!("../local.env.example");
 
-    fn populate_environment_from_example(jail: &mut Jail, envar_prefix: &str) {
+    fn populate_environment_from_example(jail: &mut Jail, test_envar_prefix: &str) {
         static RE_START: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[[:space:]]+").unwrap());
         static RE_END: Lazy<Regex> = Lazy::new(|| Regex::new(r"[[:space:]]+$").unwrap());
         for line in EXAMPLE_ENV.lines() {
@@ -92,7 +92,7 @@ mod tests {
                 if RE_END.is_match(key) || RE_START.is_match(val) {
                     panic!("env vars must not contain spaces in assignment\n{line}");
                 }
-                let prefixed_key = format!("{}_{}", envar_prefix, key);
+                let prefixed_key = format!("{}_{}", test_envar_prefix, key);
                 jail.set_env(prefixed_key, val);
             }
         }


### PR DESCRIPTION
## Summary
This PR refactors how we load values from the environment so that we have more control on which envars are used.
We can now define the `envar_prefix` we want as well as a `test_envar_prefix` so that we have full control over which envar names should be part of the config.

## Background
A user's locally loaded environment should not affect test outcomes.

## Changes
- added `envar_prefix` argument to `from_environment`
- added `test_envar_prefix` to `populate_environment_from_example`

## Testing
- I fixed the test that was erroneously failing previously.

## Breaking Changelist
- You must now pass in an `envar_prefix` to `Config::from_environment`

closes https://github.com/astriaorg/astria/issues/386
