### PR TITLE
fix(conductor): continue to execution when block subset empty

### DIFF
--- a/crates/astria-conductor/src/executor.rs
+++ b/crates/astria-conductor/src/executor.rs
@@ -162,14 +162,9 @@ impl<C: ExecutionClient> Executor<C> {
                     block,
                 } => {
                     let height = block.header().height.value();
-                    let Some(block_subset) =
-                        SequencerBlockSubset::from_sequencer_block_data(*block, &self.chain_id)
-                    else {
-                        error!(
-                            "there was an issue deriving rollup block subset from sequencer block"
-                        );
-                        continue;
-                    };
+                    let block_subset =
+                        SequencerBlockSubset::from_sequencer_block_data(*block, &self.chain_id);
+
                     if let Err(e) = self.execute_block(block_subset).await {
                         error!(
                             height = height,

--- a/crates/astria-conductor/src/executor.rs
+++ b/crates/astria-conductor/src/executor.rs
@@ -165,9 +165,8 @@ impl<C: ExecutionClient> Executor<C> {
                     let Some(block_subset) =
                         SequencerBlockSubset::from_sequencer_block_data(*block, &self.chain_id)
                     else {
-                        info!(
-                            namespace = %self.namespace,
-                            "block did not contain data for namespace; skipping"
+                        error!(
+                            "there was an issue deriving rollup block subset from sequencer block"
                         );
                         continue;
                     };

--- a/crates/astria-conductor/src/types.rs
+++ b/crates/astria-conductor/src/types.rs
@@ -19,10 +19,7 @@ pub(crate) struct SequencerBlockSubset {
 }
 
 impl SequencerBlockSubset {
-    pub(crate) fn from_sequencer_block_data(
-        data: SequencerBlockData,
-        chain_id: &ChainId,
-    ) -> Option<Self> {
+    pub(crate) fn from_sequencer_block_data(data: SequencerBlockData, chain_id: &ChainId) -> Self {
         // we don't need to verify the action tree root here,
         // as [`SequencerBlockData`] would not be constructable
         // if it was invalid
@@ -34,15 +31,12 @@ impl SequencerBlockSubset {
             ..
         } = data.into_raw();
 
-        let rollup_transactions = match rollup_data.remove(chain_id) {
-            Some(txs) => txs,
-            None => vec![],
-        };
+        let rollup_transactions = rollup_data.remove(chain_id).unwrap_or_default();
 
-        Some(Self {
+        Self {
             block_hash,
             header,
             rollup_transactions,
-        })
+        }
     }
 }

--- a/crates/astria-conductor/src/types.rs
+++ b/crates/astria-conductor/src/types.rs
@@ -34,8 +34,12 @@ impl SequencerBlockSubset {
             ..
         } = data.into_raw();
 
-        let rollup_transactions = rollup_data.remove(chain_id)?;
-        Some(Self {
+        let rollup_transactions = match rollup_data.remove(chain_id) {
+            Some(txs) => txs,
+            None => vec![],
+        };
+       
+       Some(Self {
             block_hash,
             header,
             rollup_transactions,

--- a/crates/astria-conductor/src/types.rs
+++ b/crates/astria-conductor/src/types.rs
@@ -38,8 +38,8 @@ impl SequencerBlockSubset {
             Some(txs) => txs,
             None => vec![],
         };
-       
-       Some(Self {
+
+        Some(Self {
             block_hash,
             header,
             rollup_transactions,


### PR DESCRIPTION
## Summary
Allow empty blocks to make it to executor

## Background
We added a setting for executor to execute empty blocks in astriaorg/astria#373, however we didn't fix that run short circuits before getting there

## Changes
- update to allow blocks with no transactions be converted
- add an error if problem converting to block subset

## Testing
Manually tested with dev-cluster

