### PR TITLE
fix(sequencer): Nonces can be equal

### DIFF
--- a/crates/astria-sequencer/src/transaction/mod.rs
+++ b/crates/astria-sequencer/src/transaction/mod.rs
@@ -30,7 +30,7 @@ pub(crate) async fn check_nonce_mempool<S: StateReadExt + 'static>(
         .await
         .context("failed to get account nonce")?;
     ensure!(
-        tx.unsigned_transaction().nonce < curr_nonce,
+        tx.unsigned_transaction().nonce <= curr_nonce,
         "nonce already used by account"
     );
     Ok(())

--- a/crates/astria-sequencer/src/transaction/mod.rs
+++ b/crates/astria-sequencer/src/transaction/mod.rs
@@ -30,7 +30,7 @@ pub(crate) async fn check_nonce_mempool<S: StateReadExt + 'static>(
         .await
         .context("failed to get account nonce")?;
     ensure!(
-        tx.unsigned_transaction().nonce <= curr_nonce,
+        tx.unsigned_transaction().nonce >= curr_nonce,
         "nonce already used by account"
     );
     Ok(())


### PR DESCRIPTION
## Summary
Updated the `check_mempool_nonce` to allow all valid nonces through.

## Background
The nonce ensure function was written backwards as an if instead of as an ensure

## Changes
- changed < to >= for nonce validations
