### PR TITLE
ci: run docker builds less frequently + minors

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -13,11 +13,6 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+--[a-z]+**"
   # trigger on pull request updates when target is `main` branch
   pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - labeled
     branches:
       - "main"
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -13,6 +13,11 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+--[a-z]+**"
   # trigger on pull request updates when target is `main` branch
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
     branches:
       - "main"
 

--- a/.github/workflows/reusable-run-checker.yml
+++ b/.github/workflows/reusable-run-checker.yml
@@ -8,7 +8,7 @@ on:
         value: ${{ jobs.changes.outputs.test_workflow == 'true' || jobs.changes.outputs.crates == 'true' }}
       run_docker:
         description: If docker workflow needs to be run, will be 'true'
-        value: ${{ jobs.changes.outputs.docker_workflow == 'true' || jobs.changes.outputs.crates == 'true' || contains(github.ref, 'refs/tags/v') }}
+        value: ${{ jobs.changes.outputs.docker_workflow == 'true' || github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'docker-build') }}
       run_lint_proto:
         description: If lint for protos needs to be run, will be 'true'
         value: ${{ jobs.changes.outputs.lint_workflow == 'true' || jobs.changes.outputs.proto == 'true' }}

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-* @joroshiba @noot @SuperFluffy
+*	@joroshiba @noot @SuperFluffy
 
-/.github/ @astriaorg/infra
-/containerfiles/ @astriaorg/infra
+/.github/	@astriaorg/infra
+/containerfiles/	@astriaorg/infra

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,4 @@
-*	@joroshiba @noot @SuperFluffy
+* @joroshiba @noot @SuperFluffy
+
+/.github/ @astriaorg/infra
+/containerfiles/ @astriaorg/infra

--- a/justfile
+++ b/justfile
@@ -36,5 +36,5 @@ fmt-toml:
 lint-toml:
   taplo format --check
 
-lint-yaml:
+lint-md:
   markdownlint-cli2 "**/*.md" "#target" "#.github"


### PR DESCRIPTION
## Summary
Changes when docker builds run, so they don't run on every pull request.

## Background
Docker builds take time and compute resources, are often not necessary.

## Changes
- change docker builds to run on pull requests only when: a) docker build related files changed b) docker-build tag is on PR
- updates codeowners for build/ci related changes
- fix incorrectly named just command

## Testing
This PR will have a couple changes added to test correct builds run

