### PR TITLE
fix(ci): markdown ci fix

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -66,8 +66,8 @@ jobs:
       - uses: DavidAnson/markdownlint-cli2-action@v11
         with:
           globs: |
-            '**/*.md'
-            '#.github'
+            **/*.md
+            #.github
 
   lint:
     needs: [proto, rust, toml, markdown]

--- a/.github/workflows/reusable-run-checker.yml
+++ b/.github/workflows/reusable-run-checker.yml
@@ -64,7 +64,7 @@ jobs:
             lint_workflow:
               - '.github/workflows/lint.yml'
             crates:
-              - 'crates/**'
+              - 'crates/**!(*.md)'
               - 'Cargo.toml'
               - 'Cargo.lock'
               - '.cargo/**'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
   compiles:
     runs-on: buildjet-4vcpu-ubuntu-2204
     needs: run_checker
-    if: ${{ needs.run_checker.outputs.run_tests }}
+    if: needs.run_checker.outputs.run_tests == 'true'
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@1.70.0
@@ -32,7 +32,7 @@ jobs:
   lockfile:
     runs-on: ubuntu-22.04
     needs: run_checker
-    if: ${{ needs.run_checker.outputs.run_tests }}
+    if: needs.run_checker.outputs.run_tests == 'true'
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@1.70.0
@@ -45,7 +45,7 @@ jobs:
   rust:
     runs-on: buildjet-8vcpu-ubuntu-2204
     needs: run_checker
-    if: ${{ needs.run_checker.outputs.run_tests }}
+    if: needs.run_checker.outputs.run_tests == 'true'
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@1.70.0

--- a/crates/astria-composer/tests/blackbox/api.rs
+++ b/crates/astria-composer/tests/blackbox/api.rs
@@ -11,6 +11,6 @@ async fn readyz_with_one_rollup() {
 async fn readyz_with_two_rollups() {
     // spawn_composer hits `/readyz` as part of starting the test
     // environment. If this future return then `readyz` must have
-    // returned `status: ok`.
+    // returned `status: ok`. blah
     let _test_composer = spawn_composer(&["test1", "test2"]).await;
 }

--- a/crates/astria-composer/tests/blackbox/api.rs
+++ b/crates/astria-composer/tests/blackbox/api.rs
@@ -11,6 +11,6 @@ async fn readyz_with_one_rollup() {
 async fn readyz_with_two_rollups() {
     // spawn_composer hits `/readyz` as part of starting the test
     // environment. If this future return then `readyz` must have
-    // returned `status: ok`. blah
+    // returned `status: ok`.
     let _test_composer = spawn_composer(&["test1", "test2"]).await;
 }

--- a/crates/astria-conductor/README.md
+++ b/crates/astria-conductor/README.md
@@ -10,6 +10,7 @@ We use [just](https://just.systems/man/en/chapter_4.html) for convenient project
 specific commands.
 
 ### Configuration
+
 Conductor is configured via environment variables. An example configuration can
 be seen in `local.env.example`.
 

--- a/crates/astria-sequencer-utils/README.md
+++ b/crates/astria-sequencer-utils/README.md
@@ -21,7 +21,9 @@ cargo run -- --genesis-app-state-file=<source json path> \
 ```
 
 For example:
+
 ```sh
-cargo run -- --genesis-app-state-file=../astria-sequencer/test-genesis-app-state.json \
+cargo run -- \
+ --genesis-app-state-file=../astria-sequencer/test-genesis-app-state.json \
  --destination-genesis-file=$HOME/.cometbft/config/genesis.json
 ```

--- a/crates/astria-sequencer/README.md
+++ b/crates/astria-sequencer/README.md
@@ -24,7 +24,6 @@ CC=/usr/bin/gcc-12 CXX=/usr/bin/c++-12 cargo build
 <https://github.com/rust-rocksdb/rust-rocksdb/issues/713>
 <https://github.com/facebook/rocksdb/pull/11118>
 
-
 ## Running the Sequencer
 
 ### Configuration
@@ -85,13 +84,15 @@ I[2023-05-16|16:53:56.786] service start    module=abci-client
 ```
 
 To query an address's balance:
+
 ```sh
-$ abci-cli query --path=accounts/balance/<ADDRESS> 0x00
+abci-cli query --path=accounts/balance/<ADDRESS> 0x00
 ```
 
 To query an address's nonce:
+
 ```sh
-$ abci-cli query --path=accounts/nonce/<ADDRESS> 0x00
+abci-cli query --path=accounts/nonce/<ADDRESS> 0x00
 ```
 
 ### Start the cometbft node
@@ -100,8 +101,11 @@ $ abci-cli query --path=accounts/nonce/<ADDRESS> 0x00
 # initialize the node
 cometbft init
 
-# inside astria-sequencer, update the genesis file to include genesis application state
-../../target/debug/astria-sequencer-utils --genesis-app-state-file=test-genesis-app-state.json  --destination-genesis-file=$HOME/.cometbft/config/genesis.json
+# inside astria-sequencer, update the genesis file to include genesis
+# application state
+../../target/debug/astria-sequencer-utils \
+    --genesis-app-state-file=test-genesis-app-state.json \
+    --destination-genesis-file=$HOME/.cometbft/config/genesis.json
 
 # set the block time to 15s
 sed -i'.bak' 's/timeout_commit = "1s"/timeout_commit = "15s"/g' ~/.cometbft/config/config.toml
@@ -120,4 +124,5 @@ just run-cometbft
 
 ## Testnet
 
-Check out the `TESTNET.md` file for details on how to run a multi-node sequencer testnet.
+Check out the `TESTNET.md` file for details on how to run a multi-node sequencer
+testnet.

--- a/crates/astria-sequencer/TESTNET.md
+++ b/crates/astria-sequencer/TESTNET.md
@@ -76,4 +76,5 @@ Simply stop the testnet and run
 ```sh
 just clean-testnet sequencer_testnet
 ```
+
 where `sequencer_testnet` is the `OUT_DIR` where the testnet files are.

--- a/specs/data-flow-and-verification.md
+++ b/specs/data-flow-and-verification.md
@@ -1,14 +1,18 @@
 # Data flow and verification
 
-This document addresses how rollup data flows throughout the system and is verified before execution.
+This document addresses how rollup data flows throughout the system and is
+verified before execution.
 
 ## Background
 
-The purpose of the Astria sequencer is to batch, order, and commit to data on behalf of rollups. The entry point of data is transactions sent by users, and the exit point is execution by a rollup node.
+The purpose of the Astria sequencer is to batch, order, and commit to data on
+behalf of rollups. The entry point of data is transactions sent by users, and
+the exit point is execution by a rollup node.
 
 ## Entry point
 
-The entry point for rollup data is via a `sequence::Action`, which can become part of a sequencer transaction. The data types are as follows:
+The entry point for rollup data is via a `sequence::Action`, which can become
+part of a sequencer transaction. The data types are as follows:
 
 ```rust
 // sequence::Action
@@ -26,13 +30,19 @@ pub struct Unsigned {
 }
 ```
 
-The `data` field inside the `sequence::Action` is arbitrary bytes, which should be an encoded rollup transaction. The sequencer is agnostic to the transaction format of the rollups using it. The `chain_id` field is an identifier for the rollup the data is destined for.
+The `data` field inside the `sequence::Action` is arbitrary bytes, which should
+be an encoded rollup transaction. The sequencer is agnostic to the transaction
+format of the rollups using it. The `chain_id` field is an identifier for the
+rollup the data is destined for.
 
-To submit rollup data to the system, the user creates a transaction with a `sequence::Action` within it and signs and submits it to the sequencer. The sequencer will then include it in a block, thus finalizing its ordering.
+To submit rollup data to the system, the user creates a transaction with a
+`sequence::Action` within it and signs and submits it to the sequencer. The
+sequencer will then include it in a block, thus finalizing its ordering.
 
 ## Sequencer to data availability
 
-Once a transaction (and the actions within it) is included in a sequencer block, the block data is published via a data availability layer.
+Once a transaction (and the actions within it) is included in a sequencer block,
+the block data is published via a data availability layer.
 
 The block data published is as follows:
 
@@ -53,12 +63,18 @@ pub struct SequencerBlockData {
 }
 ```
 
-When this data is actually published, it's split into multiple structures. Specifically, the data for each rollup is written independently, while a "base" data type which contains the rollup chain IDs  included in the block is also written. This allows each rollup to only require the `SequencerNamespaceData` for the block and the `RollupNamespaceData` for its own rollup transactions. For each block, if there are N rollup chain IDs included, 1 + N structures are written to DA.
+When this data is actually published, it's split into multiple structures.
+Specifically, the data for each rollup is written independently, while a "base"
+data type which contains the rollup chain IDs  included in the block is also
+written. This allows each rollup to only require the `SequencerNamespaceData`
+for the block and the `RollupNamespaceData` for its own rollup transactions. For
+each block, if there are N rollup chain IDs included, 1 + N structures are
+written to DA.
 
 ```rust
 /// SequencerNamespaceData represents the data written to the "base"
-/// sequencer namespace. It contains all the other chain IDs (and thus, namespaces) that were
-/// also written to in the same block.
+/// sequencer namespace. It contains all the other chain IDs (and thus, 
+/// namespaces) that were also written to in the same block.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct SequencerNamespaceData {
     pub block_hash: Hash,
@@ -81,51 +97,97 @@ pub struct RollupNamespaceData {
 }
 ```
 
-These structures contain all the information required for the reader of the rollup data to verify that it is in fact what the sequencer chain finalized; ie. the transactions are in the correct order, there are no transactions missing, or transactions included that were not actually in the block. We can refer to these properties as ordering, completeness, and correctness respectively. It is able to do this *without* requiring the full transaction data of the block, as is explained below.
+These structures contain all the information required for the reader of the
+rollup data to verify that it is in fact what the sequencer chain finalized; ie.
+the transactions are in the correct order, there are no transactions missing, or
+transactions included that were not actually in the block. We can refer to these
+properties as ordering, completeness, and correctness respectively. It is able
+to do this *without* requiring the full transaction data of the block, as is
+explained below.
 
-Note that the `Header` field in `SequencerNamespaceData` is a [Tendermint header](https://github.com/informalsystems/tendermint-rs/blob/4d81b67c28510db7d2d99ed62ebfa9fdf0e02141/tendermint/src/block/header.rs#L25).
+Note that the `Header` field in `SequencerNamespaceData` is a [Tendermint
+header](https://github.com/informalsystems/tendermint-rs/blob/4d81b67c28510db7d2d99ed62ebfa9fdf0e02141/tendermint/src/block/header.rs#L25).
 
 ## Data availability to rollup node
 
-For a rollup node to verify the ordering, completeness, and correctness of the block data it receives, it must verify the following:
+For a rollup node to verify the ordering, completeness, and correctness of the
+block data it receives, it must verify the following:
 
 1. the block was proposed by the correct proposer for that round
-2. the block hash was in fact committed by the sequencer (ie. >2/3 stake voted to commit this block hash to the chain)
+2. the block hash was in fact committed by the sequencer (ie. >2/3 stake voted
+   to commit this block hash to the chain)
 3. the block header correctly hashes to the block hash
-4. the `data_hash` inside the header contains the `action_tree_root` of the block (see [sequencer inclusion proofs](sequencer-inclusion-proofs.md) for details), which is a commitment to the `sequence:Action`s in the block
-5. the `rollup_txs` inside `RollupNamespaceData` is contained within the `action_tree_root`
+4. the `data_hash` inside the header contains the `action_tree_root` of the
+   block (see [sequencer inclusion proofs](sequencer-inclusion-proofs.md) for
+   details), which is a commitment to the `sequence:Action`s in the block
+5. the `rollup_txs` inside `RollupNamespaceData` is contained within the
+   `action_tree_root`
 6. the `chain_ids_commitment` is a valid commitment to `rollup_chain_ids`
 
 Let's go through these one-by-one.
 
-Note: Tendermint validators will also validate all these fields before voting on a block; thus, if a block is committed, we know the majority of validators agreed that these fields are correct.
+Note: Tendermint validators will also validate all these fields before voting on
+a block; thus, if a block is committed, we know the majority of validators
+agreed that these fields are correct.
 
-#### 1. block proposer
+### 1. block proposer
 
-The block header contains the proposer of the block. To verify the expected proposer for a block, we obtain the validator set for that height, which includes the proposer power for each validator. From this, we can calculate the expected proposer for the height, and ensure it matches the proposer of the block at that height.
+The block header contains the proposer of the block. To verify the expected
+proposer for a block, we obtain the validator set for that height, which
+includes the proposer power for each validator. From this, we can calculate the
+expected proposer for the height, and ensure it matches the proposer of the
+block at that height.
 
-#### 2. block hash
+### 2. block hash
 
-Tendermint votes contain the block hash of the block the vote is for. Thus, when verifying the votes for a block, we see what block hash was committed. The block hash is a commitment to the entire block data.
+Tendermint votes contain the block hash of the block the vote is for. Thus, when
+verifying the votes for a block, we see what block hash was committed. The block
+hash is a commitment to the entire block data.
 
-To verify the commit for a block, we obtain the commit somehow (through a sequencer node, or waiting for the next block which contains the commit for the previous block). We also obtain the validator set for that height.
+To verify the commit for a block, we obtain the commit somehow (through a
+sequencer node, or waiting for the next block which contains the commit for the
+previous block). We also obtain the validator set for that height.
 
-#### 3. block header
+### 3. block header
 
-The block hash is a commitment to the block header (specifically, the merkle root of the tree where the leaves are each header field). We then verify that the block header merkleizes to the block hash correctly.
+The block hash is a commitment to the block header (specifically, the merkle
+root of the tree where the leaves are each header field). We then verify that
+the block header merkleizes to the block hash correctly.
 
-#### 4. `action_tree_root`
+### 4. `action_tree_root`
 
-The block's data (transactions) contain the `action_tree_root` of the block (see [sequencer inclusion proofs](sequencer-inclusion-proofs.md) for details), which is a commitment to the `sequence:Action`s in the block. Specifically, the `action_tree_root` is the root of a merkle tree where each leaf is a commitment to the rollup data for one spceific rollup. The block header contains the field `data_hash` which is the merkle root of all the transactions in a block. Since `action_tree_root` is a transaction, we can prove its inclusion inside `data_hash` (the `action_tree_root_inclusion_proof` field inside `SequencerNamespaceData`). Then, in the next step, we can verify that the rollup data we received was included inside `action_tree_root`.
+The block's data (transactions) contain the `action_tree_root` of the block (see
+[sequencer inclusion proofs](sequencer-inclusion-proofs.md) for details), which
+is a commitment to the `sequence:Action`s in the block. Specifically, the
+`action_tree_root` is the root of a merkle tree where each leaf is a commitment
+to the rollup data for one spceific rollup. The block header contains the field
+`data_hash` which is the merkle root of all the transactions in a block. Since
+`action_tree_root` is a transaction, we can prove its inclusion inside
+`data_hash` (the `action_tree_root_inclusion_proof` field inside
+`SequencerNamespaceData`). Then, in the next step, we can verify that the rollup
+data we received was included inside `action_tree_root`.
 
-#### 5. `rollup_txs`
+### 5. `rollup_txs`
 
-We calculate a commitment of the rollup data we receive (`rollup_txs` inside `RollupNamespaceData`). We then verify that this data is included inside `action_tree_root` (via the `inclusion_proof` field inside `RollupNamespaceData`). At this point, we are now certain that the rollup data we received, which is a subset of the entire block's data, was in fact committed by the majority of the sequencer chain's validators.
+We calculate a commitment of the rollup data we receive (`rollup_txs` inside
+`RollupNamespaceData`). We then verify that this data is included inside
+`action_tree_root` (via the `inclusion_proof` field inside
+`RollupNamespaceData`). At this point, we are now certain that the rollup data
+we received, which is a subset of the entire block's data, was in fact committed
+by the majority of the sequencer chain's validators.
 
-#### 6. `chain_ids_commitment`
+### 6. `chain_ids_commitment`
 
-The `SequencerNamespaceData` contains a list of the `rollup_chain_ids` that were included in the block. However, to ensure that chain IDs are not omitted when publishing the data (which would be undetectable to rollup nodes without forcing them to pull the entire block's data), we also add a commitment to the chain IDs in the block inside the block's transaction data. We ensure that the `rollup_chain_ids` inside `SequencerNamespaceData` match the `chain_ids_commitment`.
+The `SequencerNamespaceData` contains a list of the `rollup_chain_ids` that were
+included in the block. However, to ensure that chain IDs are not omitted when
+publishing the data (which would be undetectable to rollup nodes without forcing
+them to pull the entire block's data), we also add a commitment to the chain IDs
+in the block inside the block's transaction data. We ensure that the
+`rollup_chain_ids` inside `SequencerNamespaceData` match the
+`chain_ids_commitment`.
 
 ## Exit point
 
-Once all the verification steps have been completed, the rollup data is simply passed to the rollup node's execution engine, which uses it to create the next rollup block.
+Once all the verification steps have been completed, the rollup data is simply
+passed to the rollup node's execution engine, which uses it to create the next
+rollup block.


### PR DESCRIPTION
## Summary
Markdown CI was not running, this updates to get it running + fixes markdown that was no longer to spec.

## Background
Markdown lint has not been running correctly on CI jobs

## Changes
- Fix glob issue with CI test
- Update all markdown files
- Update tests that were always running
- Markdown changes do not trigger compilation tests

## Testing
Ensuring this passes, and pushing some broken changes to make sure runs as well