### PR TITLE
proto: define sequencer v1alpha1

### DIFF
--- a/crates/astria-proto/proto/astria/sequencer/v1alpha1/block.proto
+++ b/crates/astria-proto/proto/astria/sequencer/v1alpha1/block.proto
@@ -3,21 +3,36 @@ syntax = "proto3";
 package astria.sequencer.v1alpha1;
 
 import "tendermint/types/types.proto";
-import "astria/sequencer/v1alpha1/data.proto";
+import "astria/sequencer/v1alpha1/validation.proto";
 
-// helper type - these should get parsed into a map from namespace to
-// a vector of `IndexedTransactions`
-message NamespacedIndexedTransactions {
-    bytes namespace = 1;
-    repeated IndexedTransaction txs = 2;
+// `RollupTransactions` are a sequence of opaque bytes together with the human
+// readable `chain_id` of the rollup they belong to.
+//
+// The binary encoding is understood as an implementation detail of the
+// services sending and receiving the transactions.
+message RollupTransactions {
+    // Opaque bytes identifying the rollup that these transactions belong to. Must be 32 bytes.
+    bytes chain_id = 1;
+    // The serialized opaque bytes of the rollup transactions.
+    repeated bytes transactions = 2;
 }
 
-// `SequencerBlock`
+// `SequencerBlock` is constructed from a tendermint/cometbft block by
+// converting its opaque `data` bytes into sequencer specific types.
 message SequencerBlock {
+    // The hash of the sequencer block. Must be 32 bytes.
     bytes block_hash = 1;
+    // The original cometbft header that was the input to this sequencer block.
     tendermint.types.Header header = 2;
-    repeated IndexedTransaction sequencer_transactions = 3;
-    // FIXME: the current nested array layout results in bad allocation behavior on deserialization
-    // see https://github.com/astriaorg/astria/issues/31
-    repeated NamespacedIndexedTransactions rollup_transactions = 4;
+    // The commit/set of signatures that commited this block.
+    tendermint.types.Commit last_commit = 3;
+    // The collection of rollup transactions that were included in this block.
+    repeated RollupTransactions rollup_transactions = 4;
+    // The root of the action tree of this block. Must be 32 bytes.
+    bytes action_tree_root = 5;
+    // The proof that the action tree root was included in `header.data_hash`.
+    astria.sequencer.v1alpha1.InclusionProof action_tree_inclusion_proof = 6;
+    // The root of the merkle tree constructed form the chain IDs of the rollup
+    // transactions in this block. Must be 32 bytes.
+    bytes chain_ids_commitment = 7;
 }

--- a/crates/astria-proto/proto/astria/sequencer/v1alpha1/celestia.proto
+++ b/crates/astria-proto/proto/astria/sequencer/v1alpha1/celestia.proto
@@ -1,0 +1,48 @@
+syntax = "proto3";
+
+package astria.sequencer.v1alpha1;
+
+import "tendermint/types/types.proto";
+import "astria/sequencer/v1alpha1/validation.proto";
+
+// A collection of transactions belonging to a specific rollup that are submitted to celestia.
+//
+// The transactions contained in the item belong to a rollup identified
+// by `chain_id`, and were included in the sequencer block identified
+// by `sequencer_block_hash`.
+message CelestiaRollupData {
+    // The hash of the sequencer block. Must be 32 bytes.
+    bytes sequencer_block_hash = 1;
+    // Opaque bytes identifying the rollup that these transactions belong to. Must be 32 bytes.
+    bytes chain_id = 2;
+    // A list of opaque bytes that are serialized rollup transactions.
+    repeated bytes transactions = 3;
+    // The proof that the action tree root was included in
+    // `sequencer_block_header.data_hash` (to be found in `CelestiaSequencerData`).
+    // The inclusion of these transactions in the original sequencer block
+    // can be verified using the action tree root stored in `CelestiaHeader`.
+    astria.sequencer.v1alpha1.InclusionProof action_tree_inclusion_proof = 4;
+}
+
+// The metadata of a sequencer block that is submitted to celestia.
+//
+// It is created by splitting up a `SequencerBlockData` into a "header"
+// (this `CelestiaSequencerData`), and a list of `CelestiaRollupData` items.
+//
+// The original sequencer block is identified by its `block_hash`.
+message CelestiaSequencerData {
+    // The hash of the sequencer block. Must be 32 bytes.
+    bytes sequencer_block_hash = 1;
+    // The original cometbft header that was the input to this sequencer block.
+    tendermint.types.Header sequencer_block_header = 2;
+    // The commit/set of signatures that commited this block.
+    tendermint.types.Commit sequencer_block_last_commit = 3;
+    // The namespaces under which rollup transactions belonging to the sequencer
+    // block identified by `sequencer_block_hash` where submitted to celestia.
+    // The bytes must convert to a celestia v0 namespace.
+    repeated bytes rollup_namespaces = 4;
+    // The root of the action tree of this block. Must be 32 bytes.
+    bytes action_tree_root = 5;
+    // The proof that the action tree root was included in `header.data_hash`.
+    astria.sequencer.v1alpha1.InclusionProof action_tree_inclusion_proof = 6;
+}

--- a/crates/astria-proto/proto/astria/sequencer/v1alpha1/transaction.proto
+++ b/crates/astria-proto/proto/astria/sequencer/v1alpha1/transaction.proto
@@ -44,6 +44,7 @@ message TransferAction {
 // It contains the chain ID of the destination chain, and the
 // opaque transaction data.
 message SequenceAction {
+    // Opaque bytes identifying the rollup that this transaction belong to. Must be 32 bytes.
     bytes chain_id = 1;
     bytes data = 2;
 }

--- a/crates/astria-proto/proto/astria/sequencer/v1alpha1/validation.proto
+++ b/crates/astria-proto/proto/astria/sequencer/v1alpha1/validation.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package astria.sequencer.v1alpha1;
+
+// A merkle proof of inclusion of a leaf at `index` in a tree
+// of size `num_leaves`.
+message InclusionProof {
+    // leaf index of value to be proven
+    uint64 index = 1;
+    // total number of leaves in the tree
+    uint64 num_leaves = 2;
+    // the merkle proof itself. This proof is derived from a RFC 6962 compliant Merkle tree.
+    // must be a multiple of 32 bytes.
+    bytes inclusion_proof = 3;
+}

--- a/crates/astria-proto/src/proto/generated/astria.sequencer.v1alpha1.rs
+++ b/crates/astria-proto/src/proto/generated/astria.sequencer.v1alpha1.rs
@@ -17,6 +17,119 @@ pub struct NonceResponse {
     #[prost(uint32, tag="3")]
     pub nonce: u32,
 }
+/// A merkle proof of inclusion of a leaf at `index` in a tree
+/// of size `num_leaves`.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct InclusionProof {
+    /// leaf index of value to be proven
+    #[prost(uint64, tag="1")]
+    pub index: u64,
+    /// total number of leaves in the tree
+    #[prost(uint64, tag="2")]
+    pub num_leaves: u64,
+    /// the merkle proof itself. This proof is derived from a RFC 6962 compliant Merkle tree.
+    /// must be a multiple of 32 bytes.
+    #[prost(bytes="vec", tag="3")]
+    pub inclusion_proof: ::prost::alloc::vec::Vec<u8>,
+}
+/// `RollupTransactions` are a sequence of opaque bytes together with the human
+/// readable `chain_id` of the rollup they belong to.
+///
+/// The binary encoding is understood as an implementation detail of the
+/// services sending and receiving the transactions.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RollupTransactions {
+    /// Opaque bytes identifying the rollup that these transactions belong to. Must be 32 bytes.
+    #[prost(bytes="vec", tag="1")]
+    pub chain_id: ::prost::alloc::vec::Vec<u8>,
+    /// The serialized opaque bytes of the rollup transactions.
+    #[prost(bytes="vec", repeated, tag="2")]
+    pub transactions: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+}
+/// `SequencerBlock` is constructed from a tendermint/cometbft block by
+/// converting its opaque `data` bytes into sequencer specific types.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SequencerBlock {
+    /// The hash of the sequencer block. Must be 32 bytes.
+    #[prost(bytes="vec", tag="1")]
+    pub block_hash: ::prost::alloc::vec::Vec<u8>,
+    /// The original cometbft header that was the input to this sequencer block.
+    #[prost(message, optional, tag="2")]
+    pub header: ::core::option::Option<::tendermint_proto::types::Header>,
+    /// The commit/set of signatures that commited this block.
+    #[prost(message, optional, tag="3")]
+    pub last_commit: ::core::option::Option<::tendermint_proto::types::Commit>,
+    /// The collection of rollup transactions that were included in this block.
+    #[prost(message, repeated, tag="4")]
+    pub rollup_transactions: ::prost::alloc::vec::Vec<RollupTransactions>,
+    /// The root of the action tree of this block. Must be 32 bytes.
+    #[prost(bytes="vec", tag="5")]
+    pub action_tree_root: ::prost::alloc::vec::Vec<u8>,
+    /// The proof that the action tree root was included in `header.data_hash`.
+    #[prost(message, optional, tag="6")]
+    pub action_tree_inclusion_proof: ::core::option::Option<InclusionProof>,
+    /// The root of the merkle tree constructed form the chain IDs of the rollup
+    /// transactions in this block. Must be 32 bytes.
+    #[prost(bytes="vec", tag="7")]
+    pub chain_ids_commitment: ::prost::alloc::vec::Vec<u8>,
+}
+/// A collection of transactions belonging to a specific rollup that are submitted to celestia.
+///
+/// The transactions contained in the item belong to a rollup identified
+/// by `chain_id`, and were included in the sequencer block identified
+/// by `sequencer_block_hash`.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CelestiaRollupData {
+    /// The hash of the sequencer block. Must be 32 bytes.
+    #[prost(bytes="vec", tag="1")]
+    pub sequencer_block_hash: ::prost::alloc::vec::Vec<u8>,
+    /// Opaque bytes identifying the rollup that these transactions belong to. Must be 32 bytes.
+    #[prost(bytes="vec", tag="2")]
+    pub chain_id: ::prost::alloc::vec::Vec<u8>,
+    /// A list of opaque bytes that are serialized rollup transactions.
+    #[prost(bytes="vec", repeated, tag="3")]
+    pub transactions: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+    /// The proof that the action tree root was included in
+    /// `sequencer_block_header.data_hash` (to be found in `CelestiaSequencerData`).
+    /// The inclusion of these transactions in the original sequencer block
+    /// can be verified using the action tree root stored in `CelestiaHeader`.
+    #[prost(message, optional, tag="4")]
+    pub action_tree_inclusion_proof: ::core::option::Option<InclusionProof>,
+}
+/// The metadata of a sequencer block that is submitted to celestia.
+///
+/// It is created by splitting up a `SequencerBlockData` into a "header"
+/// (this `CelestiaSequencerData`), and a list of `CelestiaRollupData` items.
+///
+/// The original sequencer block is identified by its `block_hash`.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CelestiaSequencerData {
+    /// The hash of the sequencer block. Must be 32 bytes.
+    #[prost(bytes="vec", tag="1")]
+    pub sequencer_block_hash: ::prost::alloc::vec::Vec<u8>,
+    /// The original cometbft header that was the input to this sequencer block.
+    #[prost(message, optional, tag="2")]
+    pub sequencer_block_header: ::core::option::Option<::tendermint_proto::types::Header>,
+    /// The commit/set of signatures that commited this block.
+    #[prost(message, optional, tag="3")]
+    pub sequencer_block_last_commit: ::core::option::Option<::tendermint_proto::types::Commit>,
+    /// The namespaces under which rollup transactions belonging to the sequencer
+    /// block identified by `sequencer_block_hash` where submitted to celestia.
+    /// The bytes must convert to a celestia v0 namespace.
+    #[prost(bytes="vec", repeated, tag="4")]
+    pub rollup_namespaces: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+    /// The root of the action tree of this block. Must be 32 bytes.
+    #[prost(bytes="vec", tag="5")]
+    pub action_tree_root: ::prost::alloc::vec::Vec<u8>,
+    /// The proof that the action tree root was included in `header.data_hash`.
+    #[prost(message, optional, tag="6")]
+    pub action_tree_inclusion_proof: ::core::option::Option<InclusionProof>,
+}
 /// `IndexedTransaction` represents a sequencer transaction along with the index
 /// it was originally in the sequencer block.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -68,31 +181,6 @@ pub struct SignedNamespaceData {
     pub public_key: ::prost::alloc::vec::Vec<u8>,
     #[prost(bytes="vec", tag="3")]
     pub signature: ::prost::alloc::vec::Vec<u8>,
-}
-/// helper type - these should get parsed into a map from namespace to
-/// a vector of `IndexedTransactions`
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct NamespacedIndexedTransactions {
-    #[prost(bytes="vec", tag="1")]
-    pub namespace: ::prost::alloc::vec::Vec<u8>,
-    #[prost(message, repeated, tag="2")]
-    pub txs: ::prost::alloc::vec::Vec<IndexedTransaction>,
-}
-/// `SequencerBlock`
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct SequencerBlock {
-    #[prost(bytes="vec", tag="1")]
-    pub block_hash: ::prost::alloc::vec::Vec<u8>,
-    #[prost(message, optional, tag="2")]
-    pub header: ::core::option::Option<::tendermint_proto::types::Header>,
-    #[prost(message, repeated, tag="3")]
-    pub sequencer_transactions: ::prost::alloc::vec::Vec<IndexedTransaction>,
-    /// FIXME: the current nested array layout results in bad allocation behavior on deserialization
-    /// see <https://github.com/astriaorg/astria/issues/31>
-    #[prost(message, repeated, tag="4")]
-    pub rollup_transactions: ::prost::alloc::vec::Vec<NamespacedIndexedTransactions>,
 }
 /// `SignedTransaction` is a transaction that has
 /// been signed by the given public key.
@@ -156,6 +244,7 @@ pub struct TransferAction {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SequenceAction {
+    /// Opaque bytes identifying the rollup that this transaction belong to. Must be 32 bytes.
     #[prost(bytes="vec", tag="1")]
     pub chain_id: ::prost::alloc::vec::Vec<u8>,
     #[prost(bytes="vec", tag="2")]


### PR DESCRIPTION
This patch extracts Rust types that are used in communication between sequencer, sequencer-relayer, conductor, and celestia (as the data availability layer). The resulting protobuf types are intended to be the only way that services exchange data, making the current json-based wire format obsolete.

The former protobuf definitions defined in sequencer.v1alpha1 are overriden. This does not constitute a breaking change because these types were never used.

## Summary
Brief summary of the changes made, ie "what?"

## Background
Brief background on why these changes were made, ie "why?"

## Changes
- List changes which were made.

## Testing
How are these changes tested?

## Breaking Changelist
- Bulleted list of breaking changes, any notes on migration. Delete section if none.

## Related Issues
Link any issues that are related, prefer full github links.

closes <!-- list any issues closed here -->
