### PR TITLE
wip: better logging on bad data ingestion from DA

### DIFF
--- a/crates/astria-conductor/src/reader.rs
+++ b/crates/astria-conductor/src/reader.rs
@@ -217,9 +217,12 @@ impl Reader {
                     .validate_signed_namespace_data(&data)
                     .await
                 {
-                    // FIXME: provide more information here to identify the particular block?
+                    let block_height = data.data.header.height;
+                    let block_hash = data.data.block_hash;
                     warn!(
                         error = ?e,
+                        block.height = ?block_height,
+                        block.hash = ?block_hash,
                         "failed to validate signed namespace data; skipping"
                     );
                     continue 'get_sequencer_blocks;

--- a/crates/astria-sequencer-relayer/src/data_availability.rs
+++ b/crates/astria-sequencer-relayer/src/data_availability.rs
@@ -373,7 +373,7 @@ impl CelestiaClient {
                 match SignedNamespaceData::<SequencerNamespaceData>::from_bytes(&blob.data) {
                     Ok(data) => Some(data),
                     Err(e) => {
-                        warn!(error.msg = %e, error.cause_chain = ?e, "failed deserializing sequencer namespace data from bytes stored in retrieved celestia blob");
+                        warn!(error.msg = %e, error.cause_chain = ?e, height = %height, blob.data = ?blob.data, "failed deserializing sequencer namespace data from bytes stored in retrieved celestia blob");
                         None
                     }
                 }
@@ -528,8 +528,7 @@ fn filter_and_convert_rollup_data_blobs(
             if let Ok(data) = SignedNamespaceData::<RollupNamespaceData>::from_bytes(&blob.data) {
                 Some((Namespace::new(blob.namespace_id), data))
             } else {
-                // FIXME: provide some info to identify the rollup namespace data?
-                warn!("failed to deserialize rollup namespace data");
+                warn!(blob.namespace_id = ?blob.namespace_id, blob.data = ?blob.data, "failed to deserialize rollup namespace data");
                 None
             }
         })


### PR DESCRIPTION
## Summary
This pr adds additional logging for when data is being parsed from DA. The goal of this pr is to be able to use the data in the logs to be able to manually fetch the blocks with issues.

## Background
Currently there are errors and some tracing in place for logging issue that occur when deserializing and parsing data the comes from DA, but these logs don't provide enough information about which block any issues occurred in.

## Changes
- Added additional data to warning in `get_new_blocks()` in Reader
- Added data to warning in `filter_and_convert_rollup_data_blobs()` and `get_sequencer_namespace_data()` in the `CelestiaClient`

## Testing
How are these changes tested?

## Related Issues
part of #313 

closes #231 
