### PR TITLE
release(conductor): conductor 0.6.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ dependencies = [
 
 [[package]]
 name = "astria-conductor"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "astria-proto",
  "astria-sequencer-client",

--- a/crates/astria-conductor/Cargo.toml
+++ b/crates/astria-conductor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astria-conductor"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.70.0"
 


### PR DESCRIPTION
## Summary
Updates cargo.toml to cut new release of conductor

