### PR TITLE
conductor: don't panic on empty blocks

### DIFF
--- a/crates/astria-conductor/src/executor/mod.rs
+++ b/crates/astria-conductor/src/executor/mod.rs
@@ -242,7 +242,7 @@ impl Executor {
     ) -> Result<()> {
         // FIXME: actually process all blocks.
         let Some(block) = blocks.get(0).cloned() else {
-            info!("received a message from data availability without; skipping execution");
+            info!("received a message from data availability without blocks; skipping execution");
             return Ok(());
         };
         let sequencer_block_hash = block.block_hash;


### PR DESCRIPTION
## Summary
Replace `Vec::remove(0)` by `Vec::get(0)` to not panic if executor receives empty blocks from the DA reader.

## Background
If the data availability reader filtered all blocks resulting in an empty payload, executor would panic.

## Changes
- Replace `Vec::remove(0)` by `Vec::get(0).cloned()`.
- Move the entire execution logic into a handler and out of the select arm.

## Testing
Added a test that ensures the the handler passes and leaves the internal executor state unchanged.