### PR TITLE
conductor: added execution commit level v2

### DIFF
--- a/crates/astria-conductor/local.env.example
+++ b/crates/astria-conductor/local.env.example
@@ -17,8 +17,12 @@ ASTRIA_CONDUCTOR_CHAIN_ID="ethereum"
 # Execution RPC URL
 ASTRIA_CONDUCTOR_EXECUTION_RPC_URL="http://127.0.0.1:50051"
 
-# disable block finalization
-ASTRIA_CONDUCTOR_DISABLE_FINALIZATION=false
+# Set the origin where blocks are pulled from and sent to the execution layer
+# Setting options:
+# - "SoftOnly" -> blocks are only pulled from the sequencer
+# - "FirmOnly" -> blocks are only pulled from DA
+# - "SoftAndFirm" -> blocks are pulled from both the sequencer and DA
+ASTRIA_CONDUCTOR_EXECUTION_COMMIT_LEVEL="SoftAndFirm"
 
 # The URL to a fully trusted CometBFT/Sequencer to issue cometbft RPCs. Example
 # RPCs are subscribing to new blocks, fetching blocks at a given level, or

--- a/crates/astria-conductor/src/config.rs
+++ b/crates/astria-conductor/src/config.rs
@@ -9,6 +9,13 @@ use serde::{
     Serialize,
 };
 
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub enum CommitLevel {
+    SoftOnly,
+    FirmOnly,
+    SoftAndFirm,
+}
+
 pub fn get() -> Result<Config, figment::Error> {
     Config::from_environment("ASTRIA_CONDUCTOR_")
 }
@@ -31,9 +38,6 @@ pub struct Config {
     /// Address of the RPC server for execution
     pub execution_rpc_url: String,
 
-    /// Disable reading from the DA layer and block finalization
-    pub disable_finalization: bool,
-
     /// log directive to use for telemetry.
     pub log: String,
 
@@ -42,6 +46,10 @@ pub struct Config {
 
     /// The Sequencer block height that the rollup genesis block was in
     pub initial_sequencer_block_height: u32,
+
+    /// The execution commit level used for controlling how blocks are sent to
+    /// the execution layer.
+    pub execution_commit_level: CommitLevel,
 }
 
 impl Config {

--- a/crates/astria-conductor/src/config.rs
+++ b/crates/astria-conductor/src/config.rs
@@ -16,6 +16,16 @@ pub enum CommitLevel {
     SoftAndFirm,
 }
 
+impl CommitLevel {
+    pub fn is_soft_only(&self) -> bool {
+        matches!(self, Self::SoftOnly)
+    }
+
+    pub fn is_firm_only(&self) -> bool {
+        matches!(self, Self::FirmOnly)
+    }
+}
+
 pub fn get() -> Result<Config, figment::Error> {
     Config::from_environment("ASTRIA_CONDUCTOR_")
 }

--- a/crates/astria-conductor/src/data_availability.rs
+++ b/crates/astria-conductor/src/data_availability.rs
@@ -113,6 +113,8 @@ impl Reader {
     pub(crate) async fn run_until_stopped(mut self) -> eyre::Result<()> {
         info!("Starting reader event loop.");
 
+        // TODO ghi(https://github.com/astriaorg/astria/issues/470): add sync functionality to data availability reader
+
         let mut interval = tokio::time::interval(self.celestia_poll_interval);
         loop {
             select!(

--- a/crates/astria-sequencer-types/src/namespace.rs
+++ b/crates/astria-sequencer-types/src/namespace.rs
@@ -40,6 +40,10 @@ impl Namespace {
 
     /// returns an 10-byte namespace given a byte slice by hashing
     /// the bytes with sha256 and returning the first 10 bytes.
+    ///
+    /// # Panics
+    ///
+    /// * If the hash is not 32 bytes
     #[must_use]
     pub fn from_slice(bytes: &[u8]) -> Namespace {
         let mut hasher = Sha256::new();

--- a/crates/astria-sequencer-types/src/sequencer_block_data.rs
+++ b/crates/astria-sequencer-types/src/sequencer_block_data.rs
@@ -137,6 +137,10 @@ impl SequencerBlockData {
     /// - if the block's action tree root inclusion proof cannot be verified
     /// - if the block's height is >1 and it does not contain a last commit or last commit hash
     /// - if the block's last commit hash does not match the one calculated from the block's commit
+    ///
+    /// # Panics
+    ///
+    /// - if `last_commit` is not set and `last_commit_hash` is set
     pub fn try_from_raw(raw: RawSequencerBlockData) -> Result<Self, Error> {
         use sha2::Digest as _;
 


### PR DESCRIPTION
## Summary
Add a setting that allows rollup user to configure the origin of blocks that get sent to the rollup.

## Background
Currently Conductor sends all blocks from all sources (sequencer and DA). Rollup user may want to change this functionality and chose to only ingest blocks from DA and/or the sequencer.

## Changes
- [x] Add `execution_commit_level` to `Config`
- [x] Add `EXECUTION_COMMIT_LEVEL` env var to local.env.example
- [x] Remove `ASTRIA_CONDUCTOR_DISABLE_FINALIZATION` as an env var to be replaced with `EXECUTION_COMMIT_LEVEL`
- [x] Update Conductor initialization to use `execution_commit_level`

## Testing
- [x] existing tests pass

## Related Issues
replaces #342 because https://github.com/astriaorg/astria/pull/455 got merged

closes #250 
closes #345 
