### PR TITLE
ci: bump rust to 1.72

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     if: needs.run_checker.outputs.run_tests == 'true'
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@1.70.0
+      - uses: dtolnay/rust-toolchain@1.72.0
       - uses: taiki-e/install-action@v2.15.2
         with:
           tool: cargo-hack@0.5.29
@@ -35,7 +35,7 @@ jobs:
     if: needs.run_checker.outputs.run_tests == 'true'
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@1.70.0
+      - uses: dtolnay/rust-toolchain@1.72.0
       - uses: Swatinem/rust-cache@v2.6.1
         with:
           cache-provider: "github"
@@ -48,7 +48,7 @@ jobs:
     if: needs.run_checker.outputs.run_tests == 'true'
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@1.70.0
+      - uses: dtolnay/rust-toolchain@1.72.0
       - uses: Swatinem/rust-cache@v2.6.1
         with:
           cache-provider: "buildjet"
@@ -77,7 +77,7 @@ jobs:
     if: needs.run_checker.outputs.run_tests == 'true'
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@1.70.0
+      - uses: dtolnay/rust-toolchain@1.72.0
       - uses: Swatinem/rust-cache@v2.6.1
         with:
           cache-provider: "github"
@@ -110,7 +110,7 @@ jobs:
     if: needs.run_checker.outputs.run_tests == 'true' && needs.run_checker.outputs.run_lint_rust == 'true'
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@1.70.0
+      - uses: dtolnay/rust-toolchain@1.72.0
       - uses: Swatinem/rust-cache@v2.6.1
         with:
           cache-provider: "github"
@@ -123,7 +123,7 @@ jobs:
     if: needs.run_checker.outputs.run_tests == 'true' && needs.run_checker.outputs.run_lint_rust == 'true'
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@1.70.0
+      - uses: dtolnay/rust-toolchain@1.72.0
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2.6.1

--- a/containerfiles/Dockerfile
+++ b/containerfiles/Dockerfile
@@ -1,5 +1,5 @@
 # build stage
-FROM --platform=$BUILDPLATFORM lukemathwalker/cargo-chef:0.1.61-rust-1.70.0-bookworm AS chef
+FROM --platform=$BUILDPLATFORM lukemathwalker/cargo-chef:0.1.62-rust-1.72.0-bookworm AS chef
 
 WORKDIR /build/
 


### PR DESCRIPTION
## Summary
Update Rust from 1.70 to 1.72 in CI and Docker.

## Background

1.70 was giving the error

```bash
cargo +1.70 hack check --all --all-features
info: running `cargo check --all-features` on astria-celestia-jsonrpc-client (1/14)
error: Package `astria-utils v0.1.0 (/Users/astria/dev/astria/astria/crates/astria-utils)` does not have feature `figment`. It has an optional dependency with that name, but that dependency uses the "dep:" syntax in the features table, so it does not have an implicit feature with that name.
error: process didn't exit successfully: `/Users/astria/.rustup/toolchains/1.70-aarch64-apple-darwin/bin/cargo check --all-features --manifest-path crates/astria-celestia-jsonrpc-client/Cargo.toml` (exit status: 101)
```
