### PR TITLE
conductor: log task exit

### DIFF
--- a/crates/astria-conductor/src/conductor.rs
+++ b/crates/astria-conductor/src/conductor.rs
@@ -217,8 +217,8 @@ impl Conductor {
 
         sequencer_client_pool.close();
 
-        // wait 5 seconds for all tasks to shut down
-        // put the tasks into an Rc to make them 'static
+        info!("waiting 5 seconds for all tasks to shut down");
+        // put the tasks into an Rc to make them 'static so they can run on a local set
         let mut tasks = Rc::new(tasks);
         let local_set = LocalSet::new();
         local_set
@@ -227,14 +227,19 @@ impl Conductor {
                 let _ = timeout(
                     Duration::from_secs(5),
                     spawn_local(async move {
-                        while Rc::get_mut(&mut tasks)
+                        while let Some((name, res)) = Rc::get_mut(&mut tasks)
                             .expect(
                                 "only one Rc to the conductor tasks should exist; this is a bug",
                             )
                             .join_next()
                             .await
-                            .is_some()
-                        {}
+                        {
+                            match res {
+                                Ok(Ok(())) => info!(task.name = name, "task exited normally"),
+                                Ok(Err(err)) => warn!(task.name = name, error.message = %err, error.cause = ?err, "task exited with error"),
+                                Err(err) => warn!(task.name = name, error.message = %err, error.cause = ?err, "task failed"),
+                            }
+                        }
                     }),
                 )
                 .await;


### PR DESCRIPTION
## Summary
Log the exit reports of the long running conductor tasks.

## Background
The exit messages of the conductor tasks might contain valuable information why they exited. This is important in case there are race conditions between a task exiting (because e.g. its rx channel is closed), and another task delaying its report why it exited.

## Changes
- Added events when joining tasks after issuing shutdown signals.

## Testing
No testable changes.
