### PR TITLE
fix(sequencer): fix tests without `--all-features`

### DIFF
--- a/crates/astria-sequencer/src/config.rs
+++ b/crates/astria-sequencer/src/config.rs
@@ -27,7 +27,6 @@ pub struct Config {
     pub log: String,
     /// Set to true to enable the mint component
     /// Only used if the "mint" feature is enabled
-    #[cfg(feature = "mint")]
     pub enable_mint: bool,
 }
 


### PR DESCRIPTION
## Summary
tests were failing without `--all-features` (they passed on CI because that's enabled)
