### PR TITLE
conductor: reconnect to sequencer websocket with backoff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,6 +251,7 @@ dependencies = [
  "tokio-util 0.7.9",
  "tonic",
  "tracing",
+ "tryhard",
 ]
 
 [[package]]
@@ -5641,6 +5642,17 @@ name = "try-lock"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
+
+[[package]]
+name = "tryhard"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9f0a709784e86923586cff0d872dba54cd2d2e116b3bc57587d15737cfce9d"
+dependencies = [
+ "futures",
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "tungstenite"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,7 +243,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.8",
- "sync_wrapper",
  "tendermint",
  "tendermint-proto",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,6 +233,7 @@ dependencies = [
  "figment",
  "futures",
  "hex",
+ "humantime",
  "once_cell",
  "prost",
  "prost-types",

--- a/crates/astria-composer/src/searcher/executor.rs
+++ b/crates/astria-composer/src/searcher/executor.rs
@@ -24,7 +24,7 @@ use secrecy::{
     Zeroize as _,
 };
 use sequencer_client::{
-    tendermint::endpoint::broadcast::tx_sync,
+    tendermint_rpc::endpoint::broadcast::tx_sync,
     Address,
     NonceResponse,
     SequencerClientExt,

--- a/crates/astria-conductor/Cargo.toml
+++ b/crates/astria-conductor/Cargo.toml
@@ -42,6 +42,7 @@ sequencer-client = { package = "astria-sequencer-client", path = "../astria-sequ
 sequencer-validation = { package = "astria-sequencer-validation", path = "../astria-sequencer-validation" }
 telemetry = { package = "astria-telemetry", path = "../astria-telemetry" }
 tryhard = "0.5.1"
+humantime.workspace = true
 
 [dev-dependencies]
 once_cell = { workspace = true }

--- a/crates/astria-conductor/Cargo.toml
+++ b/crates/astria-conductor/Cargo.toml
@@ -41,6 +41,7 @@ sequencer-client = { package = "astria-sequencer-client", path = "../astria-sequ
 ] }
 sequencer-validation = { package = "astria-sequencer-validation", path = "../astria-sequencer-validation" }
 telemetry = { package = "astria-telemetry", path = "../astria-telemetry" }
+tryhard = "0.5.1"
 
 [dev-dependencies]
 once_cell = { workspace = true }

--- a/crates/astria-conductor/Cargo.toml
+++ b/crates/astria-conductor/Cargo.toml
@@ -5,8 +5,9 @@ edition = "2021"
 rust-version = "1.70.0"
 
 [dependencies]
-sync_wrapper = "0.1.2"
 async-trait = "0.1.73"
+tryhard = "0.5.1"
+
 base64 = { workspace = true }
 color-eyre = { workspace = true }
 deadpool = { version = "0.10.0", default-features = false, features = [
@@ -16,6 +17,7 @@ ed25519-consensus = { workspace = true }
 figment = { workspace = true, features = ["env"] }
 futures = { workspace = true }
 hex = { workspace = true }
+humantime = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
 rand = { workspace = true }
@@ -41,8 +43,6 @@ sequencer-client = { package = "astria-sequencer-client", path = "../astria-sequ
 ] }
 sequencer-validation = { package = "astria-sequencer-validation", path = "../astria-sequencer-validation" }
 telemetry = { package = "astria-telemetry", path = "../astria-telemetry" }
-tryhard = "0.5.1"
-humantime.workspace = true
 
 [dev-dependencies]
 once_cell = { workspace = true }

--- a/crates/astria-conductor/src/block_verifier.rs
+++ b/crates/astria-conductor/src/block_verifier.rs
@@ -18,7 +18,7 @@ use ed25519_consensus::{
 };
 use prost::Message;
 use sequencer_client::{
-    tendermint::endpoint::validators,
+    tendermint_rpc::endpoint::validators,
     Client as _,
 };
 use tendermint::{
@@ -64,7 +64,7 @@ impl BlockVerifier {
             .get()
             .await
             .wrap_err("failed getting a client from the pool to get the current validator set")?
-            .validators(height, sequencer_client::tendermint::Paging::Default)
+            .validators(height, sequencer_client::tendermint_rpc::Paging::Default)
             .await
             .wrap_err("failed to get validator set")?;
 
@@ -78,7 +78,10 @@ impl BlockVerifier {
             .get()
             .await
             .wrap_err("failed getting a client from the pool to get the previous validator set")?
-            .validators(height - 1, sequencer_client::tendermint::Paging::Default)
+            .validators(
+                height - 1,
+                sequencer_client::tendermint_rpc::Paging::Default,
+            )
             .await
             .wrap_err("failed to get validator set")?;
 

--- a/crates/astria-conductor/src/client_provider.rs
+++ b/crates/astria-conductor/src/client_provider.rs
@@ -63,7 +63,7 @@ impl ClientProvider {
         let (client_tx, mut client_rx): (ClientTx, ClientRx) = mpsc::unbounded_channel();
 
         info!(
-            max_attempts = 1024,
+            max_attempts = Self::RECONNECTION_ATTEMPTS,
             strategy = "exponential backoff",
             "connecting to sequencer websocket"
         );

--- a/crates/astria-sequencer-client/src/lib.rs
+++ b/crates/astria-sequencer-client/src/lib.rs
@@ -12,7 +12,7 @@ pub use proto::native::sequencer::v1alpha1::{
     NonceResponse,
     SignedTransaction,
 };
-pub use tendermint_rpc as tendermint;
+pub use tendermint_rpc;
 #[cfg(feature = "http")]
 pub use tendermint_rpc::HttpClient;
 #[cfg(feature = "websocket")]

--- a/crates/astria-sequencer-client/src/tests/http.rs
+++ b/crates/astria-sequencer-client/src/tests/http.rs
@@ -28,7 +28,7 @@ use wiremock::{
 };
 
 use crate::{
-    tendermint::endpoint::broadcast::tx_sync,
+    tendermint_rpc::endpoint::broadcast::tx_sync,
     HttpClient,
     SequencerClientExt as _,
 };


### PR DESCRIPTION
## Summary
After losing its websocket connection to sequener conductor now tries to reconnect up to 1024 times with exponential backoff.

## Background
Conductor only tried to reestablish its websocket connection to sequencer up to one time, bailing afterwards. This is not enough to overcome network issues, leading to conductor being unnecessarily flaky and bailing too early.

## Changes
- use exponential backoff to reestablish the sequencer websocket connection (up to 1024 attempts)
- merge the startup and reconnect logic as they are essentially the same thing.

## Testing
Testing this is tough and not done here. This is tough to implement and was not done here. Issue to track this: https://github.com/astriaorg/astria/issues/482
