### PR TITLE
composer: report cause of failed nonce fetch

### DIFF
--- a/crates/astria-sequencer-types/src/namespace.rs
+++ b/crates/astria-sequencer-types/src/namespace.rs
@@ -47,6 +47,7 @@ impl Namespace {
     #[must_use]
     #[allow(clippy::missing_panics_doc)]
     pub fn from_slice(bytes: &[u8]) -> Namespace {
+        #[allow(clippy::assertions_on_constants)]
         const _: () = assert!(
             NAMESPACE_ID_AVAILABLE_LEN <= 32,
             "this can only be violated if celestia had a breaking change fundamentally altering \
@@ -56,7 +57,6 @@ impl Namespace {
         let mut hasher = Sha256::new();
         hasher.update(bytes);
         let result = hasher.finalize();
-        #[allow(clippy::assertions_on_constants)]
         Namespace(
             result[0..NAMESPACE_ID_AVAILABLE_LEN]
                 .to_owned()

--- a/crates/astria-sequencer-types/src/namespace.rs
+++ b/crates/astria-sequencer-types/src/namespace.rs
@@ -45,11 +45,12 @@ impl Namespace {
     ///
     /// * If the hash is not 32 bytes
     #[must_use]
-    #[allow(clippy::missing_panic_docs)]
+    #[allow(clippy::missing_panics_docs)]
     pub fn from_slice(bytes: &[u8]) -> Namespace {
         let mut hasher = Sha256::new();
         hasher.update(bytes);
         let result = hasher.finalize();
+        #[allow(clippy::assertions_on_constants)]
         const _: () = assert!(
             NAMESPACE_ID_AVAILABLE_LEN <= 32,
             "this can only be violated if celestia had a breaking change fundamentally altering \

--- a/crates/astria-sequencer-types/src/namespace.rs
+++ b/crates/astria-sequencer-types/src/namespace.rs
@@ -40,10 +40,6 @@ impl Namespace {
 
     /// returns an 10-byte namespace given a byte slice by hashing
     /// the bytes with sha256 and returning the first 10 bytes.
-    ///
-    /// # Panics
-    ///
-    /// * If the hash is not 32 bytes
     #[must_use]
     #[allow(clippy::missing_panics_doc)]
     pub fn from_slice(bytes: &[u8]) -> Namespace {

--- a/crates/astria-sequencer-types/src/namespace.rs
+++ b/crates/astria-sequencer-types/src/namespace.rs
@@ -45,15 +45,21 @@ impl Namespace {
     ///
     /// * If the hash is not 32 bytes
     #[must_use]
+    #[allow(clippy::missing_panic_docs)]
     pub fn from_slice(bytes: &[u8]) -> Namespace {
         let mut hasher = Sha256::new();
         hasher.update(bytes);
         let result = hasher.finalize();
+        const _: () = assert!(
+            NAMESPACE_ID_AVAILABLE_LEN <= 32,
+            "this can only be violated if celestia had a breaking change fundamentally altering \
+             the size of its namespace"
+        );
         Namespace(
             result[0..NAMESPACE_ID_AVAILABLE_LEN]
                 .to_owned()
                 .try_into()
-                .expect("cannot fail as hash is always 32 bytes"),
+                .expect("should not never fail unless sha256 no longer returns 32 bytes"),
         )
     }
 }

--- a/crates/astria-sequencer-types/src/namespace.rs
+++ b/crates/astria-sequencer-types/src/namespace.rs
@@ -45,17 +45,18 @@ impl Namespace {
     ///
     /// * If the hash is not 32 bytes
     #[must_use]
-    #[allow(clippy::missing_panics_docs)]
+    #[allow(clippy::missing_panics_doc)]
     pub fn from_slice(bytes: &[u8]) -> Namespace {
-        let mut hasher = Sha256::new();
-        hasher.update(bytes);
-        let result = hasher.finalize();
-        #[allow(clippy::assertions_on_constants)]
         const _: () = assert!(
             NAMESPACE_ID_AVAILABLE_LEN <= 32,
             "this can only be violated if celestia had a breaking change fundamentally altering \
              the size of its namespace"
         );
+
+        let mut hasher = Sha256::new();
+        hasher.update(bytes);
+        let result = hasher.finalize();
+        #[allow(clippy::assertions_on_constants)]
         Namespace(
             result[0..NAMESPACE_ID_AVAILABLE_LEN]
                 .to_owned()

--- a/crates/astria-sequencer-types/src/sequencer_block_data.rs
+++ b/crates/astria-sequencer-types/src/sequencer_block_data.rs
@@ -57,6 +57,8 @@ pub enum Error {
     NoData,
     #[error("block has no data hash")]
     MissingDataHash,
+    #[error("last_commit field was unset even though last_commit_hash was set")]
+    MissingLastCommit,
     #[error("block has no last commit hash")]
     MissingLastCommitHash,
     #[error("failed decoding bytes to protobuf signed transaction")]
@@ -183,11 +185,8 @@ impl SequencerBlockData {
             .last_commit_hash
             .ok_or(Error::MissingLastCommitHash)?;
 
-        let calculated_last_commit_hash = calculate_last_commit_hash(
-            last_commit
-                .as_ref()
-                .expect("last_commit must be set if last_commit_hash is set"),
-        );
+        let calculated_last_commit_hash =
+            calculate_last_commit_hash(last_commit.as_ref().ok_or(Error::MissingLastCommit)?);
         if calculated_last_commit_hash != last_commit_hash {
             return Err(Error::LastCommitHashMismatch)?;
         }

--- a/crates/astria-sequencer-types/src/sequencer_block_data.rs
+++ b/crates/astria-sequencer-types/src/sequencer_block_data.rs
@@ -139,10 +139,6 @@ impl SequencerBlockData {
     /// - if the block's action tree root inclusion proof cannot be verified
     /// - if the block's height is >1 and it does not contain a last commit or last commit hash
     /// - if the block's last commit hash does not match the one calculated from the block's commit
-    ///
-    /// # Panics
-    ///
-    /// - if `last_commit` is not set and `last_commit_hash` is set
     pub fn try_from_raw(raw: RawSequencerBlockData) -> Result<Self, Error> {
         use sha2::Digest as _;
 


### PR DESCRIPTION
## Summary
Report the error backtrace when fetching the initial nonce from the sequencer.

## Background
Composer only logged the superficial error reporting what failed, but not why.

## Changes
- log the error source/backtrace when getting the initial nonce from sequencer
- pretty-print the address using display (instead of debug + a format string)
- unrelated: some fixes because clippy started complaining with the bump to 1.72

## Testing
Not applicable.

## Breaking Changelist
- Bulleted list of breaking changes, any notes on migration. Delete section if none.

## Related Issues
Investigating https://github.com/astriaorg/astria/issues/489 revealed that our events were lacking information to understand what's going on.
