### PR TITLE
conductor: never recycle websocket clients

### DIFF
--- a/crates/astria-conductor/src/client_provider.rs
+++ b/crates/astria-conductor/src/client_provider.rs
@@ -181,6 +181,8 @@ impl managed::Manager for ClientProvider {
         _obj: &mut Self::Type,
         _: &managed::Metrics,
     ) -> managed::RecycleResult<Self::Error> {
-        Ok(())
+        Err(deadpool::managed::RecycleError::StaticMessage(
+            "client automatically invalidated",
+        ))
     }
 }


### PR DESCRIPTION
## Summary
Websocket clients to sequencer are never returned to the object pool and instead freshly created

## Background
Websocket clients were returned to the object pool even though their underlying websocket driver was long dead. This meant that a new driver never received any requests because its clients were never used, while actors using the old clients immediately errored.

## Changes
- Implement the `deadpool::managed::Manager::recycle` trait method to always return an error.

## Testing
- Conductor is now able to communicate after a websocket/tcp resets. It was not able before.
