### PR TITLE
conductor: spawn driver as task and report exit

### DIFF
--- a/crates/astria-conductor/src/client_provider.rs
+++ b/crates/astria-conductor/src/client_provider.rs
@@ -93,7 +93,7 @@ impl ClientProvider {
         let url_ = url.to_string();
         let _provider_loop = tokio::spawn(async move {
             let mut client = None;
-            let mut driver_fut = futures::future::Fuse::terminated();
+            let mut driver_task = futures::future::Fuse::terminated();
             let mut reconnect = tryhard::retry_fn(|| {
                 let url = url_.clone();
                 async move { WebSocketClient::new(&*url).await }
@@ -107,8 +107,17 @@ impl ClientProvider {
 
             loop {
                 select!(
-                    _ = &mut driver_fut, if !driver_fut.is_terminated() => {
-                        warn!("websocket driver failed, attempting to reconnect");
+                    res = &mut driver_task, if !driver_task.is_terminated() => {
+                        let (reason, err) = match res {
+                            Ok(Ok(())) => ("received exit command", None),
+                            Ok(Err(e)) => ("error", Some(eyre::Report::new(e).wrap_err("driver task exited with error"))),
+                            Err(e) => ("panic", Some(eyre::Report::new(e).wrap_err("driver task failed"))),
+                        };
+                        warn!(
+                            error.message = err.as_ref().map(tracing::field::display),
+                            error.cause = err.as_ref().map(tracing::field::debug),
+                            reason,
+                            "websocket driver exited, attempting to reconnect");
                         client = None;
                         reconnect = tryhard::retry_fn(|| {
                             let url = url_.clone();
@@ -121,7 +130,7 @@ impl ClientProvider {
                         match res {
                             Ok((new_client, driver)) => {
                                 info!("established a new websocket connection; handing out clients to all pending requests");
-                                driver_fut = driver.run().boxed().fuse();
+                                driver_task = tokio::spawn(driver.run()).fuse();
                                 for tx in pending_requests.drain(..) {
                                     let _ = tx.send(Ok(new_client.clone()));
                                 }


### PR DESCRIPTION
## Summary
Spawns the tendermint websocket driver as a
dedicated task and reports why it exited/failed.

## Background
The websocket driver should immediately start
communicating with the remote host, sending keep-alives etc.

Also, the tendermint websocket driver frequently disconnects, but we are ignoring its return value. We should not do that because it might contain valuable information about why it exited.

## Changes
- Spawn the websocket driver as a task
- Add error message and backtrace to event emitted after websocket driver exited, but before it returned.