### PR TITLE
fix(conductor): update rollup chain id in conductor example env to match composer

### DIFF
--- a/crates/astria-conductor/local.env.example
+++ b/crates/astria-conductor/local.env.example
@@ -12,7 +12,7 @@ ASTRIA_CONDUCTOR_CELESTIA_NODE_URL="http://127.0.0.1:26659"
 
 # The chain id of the chain that is being read from the astria-sequencer or the
 # Data Availability layer
-ASTRIA_CONDUCTOR_CHAIN_ID="ethereum"
+ASTRIA_CONDUCTOR_CHAIN_ID="astriachain"
 
 # Execution RPC URL
 ASTRIA_CONDUCTOR_EXECUTION_RPC_URL="http://127.0.0.1:50051"


### PR DESCRIPTION
## Summary
very small fix to have the rollup chain id in conductor example env to match composer's example env rollup chain id (both are now "astriachain")
