### PR TITLE
fix(cli): genesis account lists now being parsed correctly from envars

### DIFF
--- a/crates/astria-cli/src/cli/rollup.rs
+++ b/crates/astria-cli/src/cli/rollup.rs
@@ -67,7 +67,12 @@ pub struct ConfigCreateArgs {
     pub skip_empty_blocks: bool,
 
     /// List of genesis accounts to fund, in the form of `address:balance`
-    #[clap(long = "rollup.genesis-accounts", env = "ROLLUP_GENESIS_ACCOUNTS", num_args = 1..)]
+    #[clap(
+        long = "rollup.genesis-accounts", 
+        env = "ROLLUP_GENESIS_ACCOUNTS", 
+        num_args = 1..,
+        value_delimiter = ','
+    )]
     pub genesis_accounts: Vec<GenesisAccountArg>,
 
     // sequencer config

--- a/crates/astria-cli/tests/integration_test.rs
+++ b/crates/astria-cli/tests/integration_test.rs
@@ -19,7 +19,8 @@ fn test_envars_are_parsed_for_config_create() {
             .env("ROLLUP_SKIP_EMPTY_BLOCKS", "true")
             .env(
                 "ROLLUP_GENESIS_ACCOUNTS",
-                "0xaC21B97d35Bf75A7dAb16f35b111a50e78A72F30:1000",
+                "0xaC21B97d35Bf75A7dAb16f35b111a50e78A72F30:1000,\
+                 aC21B97d35Bf75A7dAb16f35b111a50e78A72F30:1000",
             )
             .env("ROLLUP_SEQUENCER_INITIAL_BLOCK_HEIGHT", "10")
             .env("ROLLUP_SEQUENCER_WEBSOCKET", "ws://localhost:8080")


### PR DESCRIPTION
## Summary
Fixes bug where a list of genesis accounts was not being parsed correctly when they came from an envar.

## Changes
- Adds `value_delimiter` to `genesis_accounts` argument 

## Testing
- Added a list of genesis accounts in an envar to the integration test.

closes https://github.com/astriaorg/astria/issues/511
