### PR TITLE
feat(conductor): add re-sync for missed sequencer blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,6 +408,7 @@ dependencies = [
  "futures",
  "hex",
  "humantime",
+ "jsonrpsee",
  "once_cell",
  "prost 0.11.9",
  "prost-types 0.11.9",
@@ -551,10 +552,10 @@ name = "astria-sequencer-types"
 version = "0.1.0"
 dependencies = [
  "astria-proto",
+ "astria-sequencer-types",
  "astria-sequencer-validation",
  "base64 0.21.4",
  "base64-serde",
- "ct-merkle 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519-consensus",
  "hex",
  "prost 0.11.9",
@@ -583,7 +584,7 @@ name = "astria-sequencer-validation"
 version = "0.1.0"
 dependencies = [
  "bytes",
- "ct-merkle 0.1.0 (git+https://github.com/rozbb/ct-merkle?rev=a3f3965c368946944425d59370783b3381a1fb4d)",
+ "ct-merkle",
  "hex",
  "serde",
  "serde_json",
@@ -1465,18 +1466,6 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "ct-merkle"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6920781f1a0d2f2f8bfb3a5023b2095430efb29b86074fe7f5ee86912b1f6d6"
-dependencies = [
- "digest 0.10.7",
- "generic-array",
- "serde",
- "subtle",
 ]
 
 [[package]]

--- a/crates/astria-conductor/Cargo.toml
+++ b/crates/astria-conductor/Cargo.toml
@@ -45,7 +45,9 @@ sequencer-validation = { package = "astria-sequencer-validation", path = "../ast
 telemetry = { package = "astria-telemetry", path = "../astria-telemetry" }
 
 [dev-dependencies]
-astria-sequencer-types = { path = "../astria-sequencer-types", features = ["test-utils"] }
+astria-sequencer-types = { path = "../astria-sequencer-types", features = [
+  "test-utils",
+] }
 once_cell = { workspace = true }
 figment = { workspace = true, features = ["test"] }
 jsonrpsee = { workspace = true, features = ["server"] }

--- a/crates/astria-conductor/Cargo.toml
+++ b/crates/astria-conductor/Cargo.toml
@@ -33,20 +33,22 @@ tokio-util = { workspace = true, features = ["rt"] }
 tonic = { workspace = true }
 tracing = { workspace = true }
 
-celestia_client = { package = "astria-celestia-client", path = "../astria-celestia-client" }
-astria-sequencer-types = { path = "../astria-sequencer-types" }
+celestia-client = { package = "astria-celestia-client", path = "../astria-celestia-client" }
 proto = { package = "astria-proto", path = "../astria-proto", features = [
   "client",
 ] }
 sequencer-client = { package = "astria-sequencer-client", path = "../astria-sequencer-client", features = [
   "websocket",
 ] }
+astria-sequencer-types = { path = "../astria-sequencer-types" }
 sequencer-validation = { package = "astria-sequencer-validation", path = "../astria-sequencer-validation" }
 telemetry = { package = "astria-telemetry", path = "../astria-telemetry" }
 
 [dev-dependencies]
+astria-sequencer-types = { path = "../astria-sequencer-types", features = ["test-utils"] }
 once_cell = { workspace = true }
 figment = { workspace = true, features = ["test"] }
+jsonrpsee = { workspace = true, features = ["server"] }
 regex = { workspace = true }
 
 proto = { package = "astria-proto", path = "../astria-proto", features = [

--- a/crates/astria-conductor/src/executor/mod.rs
+++ b/crates/astria-conductor/src/executor/mod.rs
@@ -46,7 +46,7 @@ mod tests;
 /// The channel for sending commands to the executor task.
 pub(crate) type Sender = UnboundedSender<ExecutorCommand>;
 /// The channel the executor task uses to listen for commands.
-type Receiver = UnboundedReceiver<ExecutorCommand>;
+pub(crate) type Receiver = UnboundedReceiver<ExecutorCommand>;
 
 // Given `Time`, convert to protobuf timestamp
 fn convert_tendermint_to_prost_timestamp(value: Time) -> Result<ProstTimestamp> {

--- a/crates/astria-conductor/src/executor/mod.rs
+++ b/crates/astria-conductor/src/executor/mod.rs
@@ -69,6 +69,14 @@ pub(crate) enum ExecutorCommand {
     FromCelestia(Vec<SequencerBlockSubset>),
 }
 
+impl From<SequencerBlockData> for ExecutorCommand {
+    fn from(block: SequencerBlockData) -> Self {
+        Self::FromSequencer {
+            block: Box::new(block),
+        }
+    }
+}
+
 pub(crate) struct Executor {
     /// Channel on which executor commands are received.
     cmd_rx: Receiver,

--- a/crates/astria-conductor/src/sequencer/mod.rs
+++ b/crates/astria-conductor/src/sequencer/mod.rs
@@ -300,15 +300,16 @@ async fn subscribe_new_blocks(
 /// Forwards a sequencer block to the executor if it contains the expected height, or reschedules
 /// the block for later while fetching blocks for all missing heights.
 ///
-/// The following cases are considered:
+/// The following cases are considered (with `h` the next height expected by the sequencer reader,
+/// and `k` the height recorded in the block):
 ///
-/// 1. if `h == h'` the block is forwarded to the executor. `h+1` is returned as the next expected
+/// 1. if `h == k` the block is forwarded to the executor. `h+1` is returned as the next expected
 ///    height.
-/// 2. if `h < h'` the block is dropped because its height `h'` is below the expected height `h`.
-///    `h` is returned as the next expected height (i.e. no change in the expected height).
-/// 3. if `h > h'` a re-sync is scheduled for the range `h..h'`, the block is pushed to the front of
-///    the queue to be forwarded later. `h'` (the height of the re-scheduled block) is returned as
-///    the next expected height.
+/// 2. if `h < k` the block is dropped. `h` is returned as the next expected height (i.e. there is
+///    no change in the expected height).
+/// 3. if `h > k` a re-sync is scheduled for the range `h..k` (exluding `k`), the block is pushed to
+///    the front of the queue to be forwarded later. `k` (the height of the re-scheduled block) is
+///    returned as the next expected height.
 ///
 /// # Returns
 /// Returns the next expected height, depending on the cases discussed above.

--- a/crates/astria-conductor/src/sequencer/mod.rs
+++ b/crates/astria-conductor/src/sequencer/mod.rs
@@ -136,7 +136,7 @@ impl Reader {
 
         let mut sync_done = Some(sync_done);
         let mut resubscribe = future::Fuse::terminated();
-        let exit_reason = 'reader_loop: loop {
+        'reader_loop: loop {
             select! {
                 shutdown = &mut shutdown => {
                     let ret = match shutdown {
@@ -212,8 +212,7 @@ impl Reader {
                     }
                 }
             }
-        };
-        exit_reason
+        }
     }
 }
 
@@ -340,7 +339,7 @@ fn forward_block_or_resync(
     match expected_height.cmp(&block_height) {
         // received block is at expected height: send to the executor
         std::cmp::Ordering::Equal => {
-            let () = executor_tx
+            executor_tx
                 .send(block.into())
                 .wrap_err("forwarding sequencer block to executor failed")?;
             Ok(expected_height.increment())

--- a/crates/astria-sequencer-client/src/extension_trait.rs
+++ b/crates/astria-sequencer-client/src/extension_trait.rs
@@ -389,11 +389,15 @@ pub trait SequencerClientExt: Client {
     /// - If calling tendermint `abci_query` RPC fails.
     /// - If the bytes contained in the abci query response cannot be read as an
     ///   `astria.sequencer.v1alpha1.BalanceResponse`.
-    async fn get_balance<A: Into<Address> + Send>(
+    async fn get_balance<AddressT, HeightT>(
         &self,
-        address: A,
-        height: u32,
-    ) -> Result<BalanceResponse, Error> {
+        address: AddressT,
+        height: HeightT,
+    ) -> Result<BalanceResponse, Error>
+    where
+        AddressT: Into<Address> + Send,
+        HeightT: Into<tendermint::block::Height> + Send,
+    {
         use proto::Message as _;
         const PREFIX: &[u8] = b"accounts/balance/";
 
@@ -427,23 +431,25 @@ pub trait SequencerClientExt: Client {
     ) -> Result<BalanceResponse, Error> {
         // This makes use of the fact that a height `None` and `Some(0)` are
         // treated the same.
-        self.get_balance(address, 0).await
+        self.get_balance(address, 0u32).await
     }
 
     /// Returns the nonce of the given account at the given height.
-    ///
-    /// If `height = None`, the latest height is used.
     ///
     /// # Errors
     ///
     /// - If calling tendermint `abci_query` RPC fails.
     /// - If the bytes contained in the abci query response cannot be read as an
     ///   `astria.sequencer.v1alpha1.NonceResponse`.
-    async fn get_nonce<A: Into<Address> + Send>(
+    async fn get_nonce<AddressT, HeightT>(
         &self,
-        address: A,
-        height: u32,
-    ) -> Result<NonceResponse, Error> {
+        address: AddressT,
+        height: HeightT,
+    ) -> Result<NonceResponse, Error>
+    where
+        AddressT: Into<Address> + Send,
+        HeightT: Into<tendermint::block::Height> + Send,
+    {
         use proto::Message as _;
         const PREFIX: &[u8] = b"accounts/nonce/";
 
@@ -477,7 +483,7 @@ pub trait SequencerClientExt: Client {
     ) -> Result<NonceResponse, Error> {
         // This makes use of the fact that a height `None` and `Some(0)` are
         // treated the same.
-        self.get_nonce(address, 0).await
+        self.get_nonce(address, 0u32).await
     }
 
     /// Get the latest sequencer block.
@@ -497,9 +503,12 @@ pub trait SequencerClientExt: Client {
     ///
     /// This is a convenience method that converts the result [`Client::block`]
     /// to `SequencerBlockData`.
-    async fn sequencer_block(&self, height: u32) -> Result<SequencerBlockData, Error> {
+    async fn sequencer_block<HeightT>(&self, height: HeightT) -> Result<SequencerBlockData, Error>
+    where
+        HeightT: Into<tendermint::block::Height> + Send,
+    {
         let rsp = self
-            .block(height)
+            .block(height.into())
             .await
             .map_err(|e| Error::tendermint_rpc("block", e))?;
         SequencerBlockData::from_tendermint_block(rsp.block)

--- a/crates/astria-sequencer-client/src/lib.rs
+++ b/crates/astria-sequencer-client/src/lib.rs
@@ -12,6 +12,7 @@ pub use proto::native::sequencer::v1alpha1::{
     NonceResponse,
     SignedTransaction,
 };
+pub use tendermint;
 pub use tendermint_rpc;
 #[cfg(feature = "http")]
 pub use tendermint_rpc::HttpClient;

--- a/crates/astria-sequencer-types/Cargo.toml
+++ b/crates/astria-sequencer-types/Cargo.toml
@@ -27,4 +27,4 @@ rand = { workspace = true, optional = true }
 test-utils = ["dep:ed25519-consensus", "dep:rand"]
 
 [dev-dependencies]
-astria-sequencer-types = { path = ".", features = ["test-utils"]}
+astria-sequencer-types = { path = ".", features = ["test-utils"] }

--- a/crates/astria-sequencer-types/Cargo.toml
+++ b/crates/astria-sequencer-types/Cargo.toml
@@ -20,7 +20,11 @@ tracing = { workspace = true }
 proto = { package = "astria-proto", path = "../astria-proto" }
 sequencer-validation = { package = "astria-sequencer-validation", path = "../astria-sequencer-validation" }
 
+ed25519-consensus = { workspace = true, optional = true }
+rand = { workspace = true, optional = true }
+
+[features]
+test-utils = ["dep:ed25519-consensus", "dep:rand"]
+
 [dev-dependencies]
-ct-merkle = { version = "0.1", features = ["serde"] }
-ed25519-consensus = { workspace = true }
-rand = { workspace = true }
+astria-sequencer-types = { path = ".", features = ["test-utils"]}

--- a/crates/astria-sequencer-types/src/lib.rs
+++ b/crates/astria-sequencer-types/src/lib.rs
@@ -2,6 +2,8 @@ pub mod abci_code;
 pub mod sequencer_block_data;
 pub mod serde;
 pub mod tendermint;
+
+#[cfg(feature = "test-utils")]
 pub mod test_utils;
 
 pub use abci_code::AbciCode;

--- a/crates/astria-sequencer-types/src/sequencer_block_data.rs
+++ b/crates/astria-sequencer-types/src/sequencer_block_data.rs
@@ -559,94 +559,11 @@ mod test {
 
     #[test]
     fn tendermint_block_to_sequencer_block() {
-        let block = create_tendermint_block();
+        let block = crate::test_utils::create_tendermint_block();
         let block_data = SequencerBlockData::from_tendermint_block(block).unwrap();
 
         // convert to raw and back, which performs all necessary validations
         let raw = block_data.into_raw();
         SequencerBlockData::try_from_raw(raw).unwrap();
-    }
-
-    fn create_tendermint_block() -> tendermint::Block {
-        use proto::{
-            native::sequencer::v1alpha1::{
-                SequenceAction,
-                UnsignedTransaction,
-            },
-            Message as _,
-        };
-        use rand::rngs::OsRng;
-        use sha2::Digest as _;
-        use tendermint::{
-            block,
-            chain,
-            evidence,
-            hash::AppHash,
-            merkle::simple_hash_from_byte_vectors,
-            Time,
-        };
-
-        let height = 1u32;
-
-        let signing_key = ed25519_consensus::SigningKey::new(OsRng);
-        let public_key: tendermint::crypto::ed25519::VerificationKey =
-            signing_key.verification_key().as_ref().try_into().unwrap();
-        let proposer_address = tendermint::account::Id::from(public_key);
-
-        let suffix = height.to_string().into_bytes();
-        let chain_id = [b"test_chain_id_", &*suffix].concat();
-        let signed_tx_bytes = UnsignedTransaction {
-            nonce: 1,
-            actions: vec![
-                SequenceAction {
-                    chain_id: chain_id.clone(),
-                    data: [b"hello_world_id_", &*suffix].concat(),
-                }
-                .into(),
-            ],
-        }
-        .into_signed(&signing_key)
-        .into_raw()
-        .encode_to_vec();
-        let action_tree =
-            sequencer_validation::MerkleTree::from_leaves(vec![signed_tx_bytes.clone()]);
-        let chain_ids_commitment = MerkleTree::from_leaves(vec![chain_id]).root();
-        let data = vec![
-            action_tree.root().to_vec(),
-            chain_ids_commitment.to_vec(),
-            signed_tx_bytes,
-        ];
-        let data_hash = Some(Hash::Sha256(simple_hash_from_byte_vectors::<sha2::Sha256>(
-            &data.iter().map(sha2::Sha256::digest).collect::<Vec<_>>(),
-        )));
-
-        let (last_commit_hash, last_commit) = crate::test_utils::make_test_commit_and_hash();
-
-        tendermint::Block::new(
-            block::Header {
-                version: block::header::Version {
-                    block: 0,
-                    app: 0,
-                },
-                chain_id: chain::Id::try_from("test").unwrap(),
-                height: block::Height::from(height),
-                time: Time::now(),
-                last_block_id: None,
-                last_commit_hash: (height > 1).then_some(last_commit_hash),
-                data_hash,
-                validators_hash: Hash::Sha256([0; 32]),
-                next_validators_hash: Hash::Sha256([0; 32]),
-                consensus_hash: Hash::Sha256([0; 32]),
-                app_hash: AppHash::try_from([0; 32].to_vec()).unwrap(),
-                last_results_hash: None,
-                evidence_hash: None,
-                proposer_address,
-            },
-            data,
-            evidence::List::default(),
-            // The first height must not, every height after must contain a last commit
-            (height > 1).then_some(last_commit),
-        )
-        .unwrap()
     }
 }

--- a/crates/astria-sequencer-types/src/test_utils.rs
+++ b/crates/astria-sequencer-types/src/test_utils.rs
@@ -1,3 +1,4 @@
+use sequencer_validation::MerkleTree;
 use tendermint::block::Header;
 
 #[allow(clippy::missing_panics_doc)]
@@ -35,6 +36,89 @@ pub fn default_header() -> Header {
         evidence_hash: None,
         proposer_address: account::Id::try_from([0u8; 20].to_vec()).unwrap(),
     }
+}
+
+pub fn create_tendermint_block() -> tendermint::Block {
+    use proto::{
+        native::sequencer::v1alpha1::{
+            SequenceAction,
+            UnsignedTransaction,
+        },
+        Message as _,
+    };
+    use rand::rngs::OsRng;
+    use sha2::Digest as _;
+    use tendermint::{
+        block,
+        chain,
+        evidence,
+        hash::AppHash,
+        merkle::simple_hash_from_byte_vectors,
+        Hash,
+        Time,
+    };
+
+    let height = 1u32;
+
+    let signing_key = ed25519_consensus::SigningKey::new(OsRng);
+    let public_key: tendermint::crypto::ed25519::VerificationKey =
+        signing_key.verification_key().as_ref().try_into().unwrap();
+    let proposer_address = tendermint::account::Id::from(public_key);
+
+    let suffix = height.to_string().into_bytes();
+    let chain_id = [b"test_chain_id_", &*suffix].concat();
+    let signed_tx_bytes = UnsignedTransaction {
+        nonce: 1,
+        actions: vec![
+            SequenceAction {
+                chain_id: chain_id.clone(),
+                data: [b"hello_world_id_", &*suffix].concat(),
+            }
+            .into(),
+        ],
+    }
+    .into_signed(&signing_key)
+    .into_raw()
+    .encode_to_vec();
+    let action_tree = sequencer_validation::MerkleTree::from_leaves(vec![signed_tx_bytes.clone()]);
+    let chain_ids_commitment = MerkleTree::from_leaves(vec![chain_id]).root();
+    let data = vec![
+        action_tree.root().to_vec(),
+        chain_ids_commitment.to_vec(),
+        signed_tx_bytes,
+    ];
+    let data_hash = Some(Hash::Sha256(simple_hash_from_byte_vectors::<sha2::Sha256>(
+        &data.iter().map(sha2::Sha256::digest).collect::<Vec<_>>(),
+    )));
+
+    let (last_commit_hash, last_commit) = crate::test_utils::make_test_commit_and_hash();
+
+    tendermint::Block::new(
+        block::Header {
+            version: block::header::Version {
+                block: 0,
+                app: 0,
+            },
+            chain_id: chain::Id::try_from("test").unwrap(),
+            height: block::Height::from(height),
+            time: Time::now(),
+            last_block_id: None,
+            last_commit_hash: (height > 1).then_some(last_commit_hash),
+            data_hash,
+            validators_hash: Hash::Sha256([0; 32]),
+            next_validators_hash: Hash::Sha256([0; 32]),
+            consensus_hash: Hash::Sha256([0; 32]),
+            app_hash: AppHash::try_from([0; 32].to_vec()).unwrap(),
+            last_results_hash: None,
+            evidence_hash: None,
+            proposer_address,
+        },
+        data,
+        evidence::List::default(),
+        // The first height must not, every height after must contain a last commit
+        (height > 1).then_some(last_commit),
+    )
+    .unwrap()
 }
 
 // Returns a tendermint commit and hash for testing purposes.

--- a/crates/astria-sequencer-types/src/test_utils.rs
+++ b/crates/astria-sequencer-types/src/test_utils.rs
@@ -1,7 +1,10 @@
+//! Utilities that are intended to be used in tests but not outside of it.
+
+#![allow(clippy::missing_panics_doc)]
+
 use sequencer_validation::MerkleTree;
 use tendermint::block::Header;
 
-#[allow(clippy::missing_panics_doc)]
 #[must_use]
 /// Returns a default tendermint block header for test purposes.
 pub fn default_header() -> Header {


### PR DESCRIPTION
## Summary
Fetch missing sequencer blocks before forwarding to the executor actor.

## Background
If the websocket connection to sequencer drops temporarily (thus not receiving blocks from the `NewBlocks` jsonrpc subscription), blocks for one or more heights might be missed. This is detected by tracking the expected height of the next sequencer block to be forwarded to the executor actor. If the next block taken from the queue of pending blocks has a height greater than the expected height a resync is triggered and the current block rescheduled in front of the queue of regular pending blocks. This patch reuses the sync-mechanism that is run at startup to fetch a contiguous range of missing sequencer blocks. Only after this "re-sync" is completed will regular submission of blocks resume

## Changes
- Track the height of sequencer blocks
- Trigger a resync if there is a mismatch between the height in the next sequencer block and the expected height
- Resume submission of blocks after resync is done

## Testing
Added unit tests for all three forward/resync conditions:
1. forward to executor if block height == expected height
2. drop if block height < expected height
3. sync + reschedule if block height > expected height

No blackbox tests yet. Must be tested on devnet.