### PR TITLE
feat(conductor): replace formatted error backtraces by value impl

### DIFF
--- a/crates/astria-conductor/src/client_provider.rs
+++ b/crates/astria-conductor/src/client_provider.rs
@@ -79,12 +79,13 @@ impl ClientProvider {
                         .map(humantime::format_duration)
                         .map(tracing::field::display);
                     async move {
+                        let error = &error as &(dyn std::error::Error + 'static);
                         warn!(
                             attempt,
                             wait_duration,
-                            error.message = %error,
-                            error.cause = ?error,
-                            "attempt to connect to sequencer websocket failed; retrying after backoff",
+                            error,
+                            "attempt to connect to sequencer websocket failed; retrying after \
+                             backoff",
                         );
                     }
                 },
@@ -113,9 +114,9 @@ impl ClientProvider {
                             Ok(Err(e)) => ("error", Some(eyre::Report::new(e).wrap_err("driver task exited with error"))),
                             Err(e) => ("panic", Some(eyre::Report::new(e).wrap_err("driver task failed"))),
                         };
+                        let error: Option<&(dyn std::error::Error + 'static)> = err.as_ref().map(|e| e.as_ref());
                         warn!(
-                            error.message = err.as_ref().map(tracing::field::display),
-                            error.cause = err.as_ref().map(tracing::field::debug),
+                            error,
                             reason,
                             "websocket driver exited, attempting to reconnect");
                         client = None;
@@ -137,9 +138,9 @@ impl ClientProvider {
                                 client = Some(new_client);
                             }
                             Err(e) => {
+                                let error = &e as &(dyn std::error::Error + 'static);
                                 warn!(
-                                    error.message = %e,
-                                    error.cause = ?e,
+                                    error,
                                     attempts = Self::RECONNECTION_ATTEMPTS,
                                     "repeatedly failed to re-establish websocket connection; giving up",
                                 );

--- a/crates/astria-conductor/src/conductor.rs
+++ b/crates/astria-conductor/src/conductor.rs
@@ -197,7 +197,10 @@ impl Conductor {
                 res = &mut sync_done, if !sync_done.is_terminated() => {
                     match res {
                         Ok(()) => info!("received sync-complete signal from sequencer reader"),
-                        Err(e) => warn!(error.message = %e, error.cause = ?e, "sync-complete channel failed prematurely"),
+                        Err(e) => {
+                            let error = &e as &(dyn std::error::Error + 'static);
+                            warn!(error, "sync-complete channel failed prematurely");
+                        }
                     }
                     if let Some(data_availability_reader) = data_availability_reader.take() {
                         info!("starting data availability reader");
@@ -211,8 +214,14 @@ impl Conductor {
                 Some((name, res)) = tasks.join_next() => {
                     match res {
                         Ok(Ok(())) => error!(task.name = name, "task exited unexpectedly, shutting down"),
-                        Ok(Err(e)) => error!(task.name = name, error.message = %e, error.cause = ?e, "task exited with error; shutting down"),
-                        Err(e) => error!(task.name = name, error.message = %e, error.cause = ?e, "task failed; shutting down"),
+                        Ok(Err(e)) => {
+                            let error: &(dyn std::error::Error + 'static) = e.as_ref();
+                            error!(task.name = name, error, "task exited with error; shutting down");
+                        }
+                        Err(e) => {
+                            let error = &e as &(dyn std::error::Error + 'static);
+                            error!(task.name = name, error, "task failed; shutting down");
+                        }
                     }
                 }
             }
@@ -244,8 +253,14 @@ impl Conductor {
                         {
                             match res {
                                 Ok(Ok(())) => info!(task.name = name, "task exited normally"),
-                                Ok(Err(err)) => warn!(task.name = name, error.message = %err, error.cause = ?err, "task exited with error"),
-                                Err(err) => warn!(task.name = name, error.message = %err, error.cause = ?err, "task failed"),
+                                Ok(Err(e)) => {
+                                    let error: &(dyn std::error::Error + 'static) = e.as_ref();
+                                    error!(task.name = name, error, "task exited with error");
+                                }
+                                Err(e) => {
+                                    let error = &e as &(dyn std::error::Error + 'static);
+                                    error!(task.name = name, error, "task failed");
+                                }
                             }
                         }
                     }),

--- a/crates/astria-conductor/src/executor/mod.rs
+++ b/crates/astria-conductor/src/executor/mod.rs
@@ -175,11 +175,8 @@ impl Executor {
                                 .execute_and_finalize_blocks_from_celestia(blocks)
                                 .await
                             {
-                                error!(
-                                    error.message = %e,
-                                    error.cause = ?e,
-                                    "failed to finalize block; stopping executor"
-                                );
+                                let error: &(dyn std::error::Error + 'static) = e.as_ref();
+                                error!(error, "failed to finalize block; stopping executor");
                                 break;
                             }
                         }

--- a/crates/astria-conductor/src/main.rs
+++ b/crates/astria-conductor/src/main.rs
@@ -40,14 +40,16 @@ async fn main() -> ExitCode {
 
     let conductor = match Conductor::new(cfg).await {
         Err(e) => {
-            error!(error.msg = %e, error.cause = ?e, "failed initializing conductor");
+            let error: &(dyn std::error::Error + 'static) = e.as_ref();
+            error!(error, "failed initializing conductor");
             return ExitCode::FAILURE;
         }
         Ok(conductor) => conductor,
     };
 
     if let Err(e) = conductor.run_until_stopped().await {
-        error!(error.msg = %e, error.cause = ?e, "conductor stopped unexpectedly");
+        let error: &(dyn std::error::Error + 'static) = e.as_ref();
+        error!(error, "conductor stopped unexpectedly");
         return ExitCode::FAILURE;
     }
 

--- a/crates/astria-conductor/src/sequencer/mod.rs
+++ b/crates/astria-conductor/src/sequencer/mod.rs
@@ -141,7 +141,8 @@ impl Reader {
                 shutdown = &mut shutdown => {
                     let ret = match shutdown {
                         Err(e) => {
-                            warn!(error.message = %e, "shutdown channel closed unexpectedly; shutting down");
+                            let error = &e as &(dyn std::error::Error + 'static);
+                            warn!(error, "shutdown channel closed unexpectedly; shutting down");
                             Err(e).wrap_err("shut down channel closed unexpectedly")
                         }
                         Ok(()) => {
@@ -154,7 +155,8 @@ impl Reader {
 
                 res = &mut sync, if !sync.is_terminated() => {
                     if let Err(e) = res {
-                        warn!(error.message = %e, error.cause = ?e, "sync failed; continuing with normal operation");
+                        let error: &(dyn std::error::Error + 'static) = e.as_ref();
+                        warn!(error, "sync failed; continuing with normal operation");
                     } else {
                         info!("sync finished successfully");
                     }

--- a/crates/astria-conductor/src/sequencer/sync.rs
+++ b/crates/astria-conductor/src/sequencer/sync.rs
@@ -30,7 +30,7 @@ enum Error {
     Request(#[from] sequencer_client::extension_trait::Error),
 }
 
-#[instrument(skip(client_pool))]
+#[instrument(name = "sync sequencer", skip(client_pool, executor))]
 pub(super) async fn run(
     start: Height,
     end: Height,
@@ -68,8 +68,9 @@ pub(super) async fn run(
 
             Some((height, res)) = block_stream.next() => {
                 match res {
-                    Err(Error::Request(e)) => {
-                        warn!(height, error.message = %e, error.cause = ?e, "failed getting sequencer block; rescheduling");
+                    Err(Error::Request(error)) => {
+                        let error = &error as &(dyn std::error::Error + 'static);
+                        warn!(height, error, "failed getting sequencer block; rescheduling");
                         let pool = client_pool.clone();
                         block_stream.push_front(async move {
                             get_client_then_block(pool, height).await
@@ -77,14 +78,16 @@ pub(super) async fn run(
                     }
 
                     Err(Error::Pool(e)) => {
-                        error!(height, error.message = %e, error.cause = ?e, "failed getting a client from the pool; aborting sync");
+                        let error = &e as &(dyn std::error::Error + 'static);
+                        error!(height, error, "failed getting a client from the pool; aborting sync");
                         break 'sync Err(e).wrap_err("failed getting a client from the pool");
                     }
 
                     Ok(block) => {
                         let block = Box::new(block);
                         if let Err(e) = executor.send(crate::executor::ExecutorCommand::FromSequencer { block }) {
-                            error!(height, error.message = %e, error.cause = ?e, "failed forwarding block to executor; aborting async");
+                            let error = &e as &(dyn std::error::Error + 'static);
+                            error!(height, error, "failed forwarding block to executor; aborting async");
                             break 'sync Err(e).wrap_err("failed forwarding block to executor");
                         }
                     }


### PR DESCRIPTION
## Summary
This replaces explicit instrument formatting using the `?` and `%` sigils by the `tracing::Value` impl for `dyn std::error::Error` giving nicer tracing events.

## Background
So war we were emitting tracing events for errors like `warn!(error.message = %err, error.cause = ?err, "failed to do something");`, which lead to formatted multiline errors that did not match well with normal tracing subscriber formatting. This patch uses the `tracing::Value` implementation for `std::error::Error` trait objects, giving error backtraces in form of a list and. Unfortunately errors have to be explicitly made into trait objects (either through `&err as &dyn Error` or using a binding like `let error: &dyn Error = eyre_report.as_ref()` for eyre reports).

## Changes
- Replace all tracing events using `%` and `?` sigils for error formatting by the `tracing::Value` implementation on their trait objects.