### PR TITLE
ci: run clippy, doctest tests on buildjet-8vcpu-ubuntu-2204

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,7 @@ jobs:
           --all-targets \
 
   doctest:
-    runs-on: ubuntu-22.04
+    runs-on: buildjet-8vcpu-ubuntu-2204
     needs: run_checker
     if: needs.run_checker.outputs.run_tests == 'true' && needs.run_checker.outputs.run_lint_rust == 'true'
     steps:
@@ -84,11 +84,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@1.72.0
       - uses: Swatinem/rust-cache@v2.6.1
         with:
-          cache-provider: "github"
+          cache-provider: "buildjet"
       - uses: arduino/setup-protoc@v2
         with:
           version: "24.4"
-      - name: Run doctests
+      - name: run doctests
         run: cargo test --doc --all-features
 
   clippy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,7 +92,7 @@ jobs:
         run: cargo test --doc --all-features
 
   clippy:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: buildjet-8vcpu-ubuntu-2204
     needs: run_checker
     if: needs.run_checker.outputs.run_tests == 'true' && needs.run_checker.outputs.run_lint_rust == 'true'
     steps:


### PR DESCRIPTION
## Summary
Upgrades the clippy worker from buildjet-4vcpu-ubuntu-2204 to buildjet-8vcpu-ubuntu-2204

## Background
Clippy builds are pretty heavy and far slower than the regular rust builds because they run on a smaller machine.

## Changes
- Changed the clippy job to run on a bigger buildjet instance.