### PR TITLE
feat(cli): grab block height from sequencer + minimize required create inputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5418,6 +5418,7 @@ version = "0.1.0"
 dependencies = [
  "once_cell",
  "tempfile",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/astria-cli/src/cli/rollup.rs
+++ b/crates/astria-cli/src/cli/rollup.rs
@@ -11,6 +11,8 @@ const DEFAULT_ROLLUP_CHART_PATH: &str =
     "https://astriaorg.github.io/dev-cluster/astria-evm-rollup-0.4.0.tgz";
 const DEFAULT_SEQUENCER_RPC: &str = "https://rpc.sequencer.dusk-1.devnet.astria.org";
 const DEFAULT_SEQUENCER_WS: &str = "wss://rpc.sequencer.dusk-1.devnet.astria.org/websocket";
+const DEFAULT_LOG_LEVEL: &str = "info";
+const DEFAULT_NETWORK_ID: u64 = 1337;
 
 /// Remove the 0x prefix from a hex string if present
 fn strip_0x_prefix(s: &str) -> &str {
@@ -51,7 +53,7 @@ pub enum ConfigCommand {
 pub struct ConfigCreateArgs {
     #[clap(long, env = "ROLLUP_USE_TTY")]
     pub use_tty: bool,
-    #[clap(long, env = "ROLLUP_LOG_LEVEL")]
+    #[clap(long, env = "ROLLUP_LOG_LEVEL", default_value = DEFAULT_LOG_LEVEL)]
     pub log_level: String,
 
     // rollup config
@@ -61,8 +63,10 @@ pub struct ConfigCreateArgs {
     /// Optional. Will be derived from the rollup name if not provided
     #[clap(long = "rollup.chain-id", env = "ROLLUP_CHAIN_ID", required = false)]
     pub chain_id: Option<String>,
-    #[clap(long = "rollup.network-id", env = "ROLLUP_NETWORK_ID")]
+    /// The Network ID for the EVM chain
+    #[clap(long = "rollup.network-id", env = "ROLLUP_NETWORK_ID", default_value_t = DEFAULT_NETWORK_ID)]
     pub network_id: u64,
+    /// When enabled, rollup will skip blocks which contain zero transactions.
     #[clap(long = "rollup.skip-empty-blocks", env = "ROLLUP_SKIP_EMPTY_BLOCKS")]
     pub skip_empty_blocks: bool,
 
@@ -76,7 +80,7 @@ pub struct ConfigCreateArgs {
     pub genesis_accounts: Vec<GenesisAccountArg>,
 
     // sequencer config
-    /// Optional. If not set, will be determined from the current block height of the sequencer
+    /// Optional. If not set, will be default to the first block.
     #[clap(
         long = "sequencer.initial-block-height",
         env = "ROLLUP_SEQUENCER_INITIAL_BLOCK_HEIGHT"

--- a/crates/astria-cli/src/cli/rollup.rs
+++ b/crates/astria-cli/src/cli/rollup.rs
@@ -80,7 +80,7 @@ pub struct ConfigCreateArgs {
     pub genesis_accounts: Vec<GenesisAccountArg>,
 
     // sequencer config
-    /// Optional. If not set, will be default to a fetch of latest sequencer block.
+    /// Optional. If not set, will be determined from the current block height of the sequencer
     #[clap(
         long = "sequencer.initial-block-height",
         env = "ROLLUP_SEQUENCER_INITIAL_BLOCK_HEIGHT"

--- a/crates/astria-cli/src/cli/rollup.rs
+++ b/crates/astria-cli/src/cli/rollup.rs
@@ -49,7 +49,7 @@ pub enum ConfigCommand {
     Delete(ConfigDeleteArgs),
 }
 
-#[derive(Args, Debug, Serialize)]
+#[derive(Args, Debug, Serialize, Clone)]
 pub struct ConfigCreateArgs {
     #[clap(long, env = "ROLLUP_USE_TTY")]
     pub use_tty: bool,

--- a/crates/astria-cli/src/cli/rollup.rs
+++ b/crates/astria-cli/src/cli/rollup.rs
@@ -80,7 +80,7 @@ pub struct ConfigCreateArgs {
     pub genesis_accounts: Vec<GenesisAccountArg>,
 
     // sequencer config
-    /// Optional. If not set, will be default to the first block.
+    /// Optional. If not set, will be default to a fetch of latest sequencer block.
     #[clap(
         long = "sequencer.initial-block-height",
         env = "ROLLUP_SEQUENCER_INITIAL_BLOCK_HEIGHT"

--- a/crates/astria-cli/src/commands/mod.rs
+++ b/crates/astria-cli/src/commands/mod.rs
@@ -52,7 +52,7 @@ pub async fn run(cli: Cli) -> eyre::Result<()> {
                 RollupCommand::Config {
                     command,
                 } => match command {
-                    ConfigCommand::Create(args) => rollup::create_config(&args)?,
+                    ConfigCommand::Create(args) => rollup::create_config(&args).await?,
                     ConfigCommand::Edit(args) => rollup::edit_config(&args)?,
                     ConfigCommand::Delete(args) => rollup::delete_config(&args)?,
                 },

--- a/crates/astria-cli/src/commands/rollup.rs
+++ b/crates/astria-cli/src/commands/rollup.rs
@@ -105,7 +105,7 @@ fn update_yaml_value(
 /// * If the yaml cannot be written to the file
 pub(crate) async fn create_config(args: &ConfigCreateArgs) -> eyre::Result<()> {
     // create rollup from args
-    let mut conf = (*args).clone();
+    let mut conf = args.clone();
 
     // Fetch the latest block from sequencer if none specified.
     if conf.sequencer_initial_block_height.is_none() {

--- a/crates/astria-cli/src/commands/rollup.rs
+++ b/crates/astria-cli/src/commands/rollup.rs
@@ -107,6 +107,7 @@ pub(crate) async fn create_config(args: &ConfigCreateArgs) -> eyre::Result<()> {
     // create rollup from args
     let mut rollup = Rollup::try_from(args)?;
 
+    // Height 0 is invalid, but can be used to mark "latest"
     if rollup.deployment_config.get_initial_sequencer_height() == 0 {
         let sequencer_client = HttpClient::new(args.sequencer_rpc.as_str())
             .wrap_err("failed constructing http sequencer client")?;

--- a/crates/astria-cli/src/commands/rollup.rs
+++ b/crates/astria-cli/src/commands/rollup.rs
@@ -337,7 +337,8 @@ mod test {
 
             let file_path = PathBuf::from("test-rollup-conf.yaml");
             assert!(file_path.exists());
-        }).await;
+        })
+        .await;
     }
 
     #[test]
@@ -371,7 +372,8 @@ mod test {
             let file = File::open(&file_path).unwrap();
             let rollup: Rollup = serde_yaml::from_reader(file).unwrap();
             assert_eq!(rollup.deployment_config.get_rollup_name(), "bugbug");
-        }).await;
+        })
+        .await;
     }
 
     #[tokio::test]
@@ -387,7 +389,8 @@ mod test {
                 value: "bugbug".to_string(),
             };
             assert!(edit_config(&args).is_err());
-        }).await;
+        })
+        .await;
     }
 
     #[test]

--- a/crates/astria-cli/src/types.rs
+++ b/crates/astria-cli/src/types.rs
@@ -80,7 +80,7 @@ impl TryFrom<&ConfigCreateArgs> for RollupDeploymentConfig {
 
         let sequencer_initial_block_height = args.sequencer_initial_block_height.unwrap_or({
             // TODO - get current block height from sequencer
-            0
+            1
         });
 
         let genesis_accounts = args

--- a/crates/astria-cli/src/types.rs
+++ b/crates/astria-cli/src/types.rs
@@ -87,9 +87,8 @@ impl TryFrom<&ConfigCreateArgs> for RollupDeploymentConfig {
             .clone()
             .unwrap_or(format!("{}-chain", args.name));
 
-        let sequencer_initial_block_height = args.sequencer_initial_block_height.unwrap_or({
-            0 // Invalid sequencer height, can be fetched later
-        });
+        // Set to block 1 if nothing set.
+        let sequencer_initial_block_height = args.sequencer_initial_block_height.unwrap_or(1);
 
         let genesis_accounts = args
             .genesis_accounts

--- a/crates/astria-cli/src/types.rs
+++ b/crates/astria-cli/src/types.rs
@@ -88,8 +88,7 @@ impl TryFrom<&ConfigCreateArgs> for RollupDeploymentConfig {
             .unwrap_or(format!("{}-chain", args.name));
 
         let sequencer_initial_block_height = args.sequencer_initial_block_height.unwrap_or({
-            // TODO - get current block height from sequencer
-            0
+            0 // Invalid sequencer height, can be fetched later
         });
 
         let genesis_accounts = args

--- a/crates/astria-cli/src/types.rs
+++ b/crates/astria-cli/src/types.rs
@@ -251,7 +251,7 @@ mod tests {
                     }],
                 },
                 sequencer: SequencerConfig {
-                    initial_block_height: 0, // Default value
+                    initial_block_height: 1, // Default value
                     websocket: "ws://localhost:8082".to_string(),
                     rpc: "http://localhost:8083".to_string(),
                 },

--- a/crates/astria-cli/src/types.rs
+++ b/crates/astria-cli/src/types.rs
@@ -67,6 +67,15 @@ impl RollupDeploymentConfig {
     pub fn get_rollup_name(&self) -> String {
         self.rollup.name.clone()
     }
+
+    #[must_use]
+    pub fn get_initial_sequencer_height(&self) -> u64 {
+        self.sequencer.initial_block_height
+    }
+
+    pub fn set_initial_sequencer_height(&mut self, new_height: u64) {
+        self.sequencer.initial_block_height = new_height;
+    }
 }
 
 impl TryFrom<&ConfigCreateArgs> for RollupDeploymentConfig {
@@ -80,7 +89,7 @@ impl TryFrom<&ConfigCreateArgs> for RollupDeploymentConfig {
 
         let sequencer_initial_block_height = args.sequencer_initial_block_height.unwrap_or({
             // TODO - get current block height from sequencer
-            1
+            0
         });
 
         let genesis_accounts = args

--- a/crates/astria-cli/test-utils/Cargo.toml
+++ b/crates/astria-cli/test-utils/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2021"
 [dependencies]
 once_cell = { workspace = true }
 tempfile = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ['sync'] }

--- a/crates/astria-cli/test-utils/Cargo.toml
+++ b/crates/astria-cli/test-utils/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2021"
 [dependencies]
 once_cell = { workspace = true }
 tempfile = { workspace = true }
+tokio = { workspace = true }

--- a/crates/astria-cli/test-utils/src/lib.rs
+++ b/crates/astria-cli/test-utils/src/lib.rs
@@ -38,6 +38,16 @@ where
     temp_dir.close().unwrap();
 }
 
+
+/// Run an async closure with a temporary directory as the current directory.
+/// This is useful for cleaning up after tests that test code that creates files.
+///
+/// A mutex is required because `set_current_env` is not thread safe, which
+/// causes flaky tests when run in parallel and it's called in multiple tests.
+///
+/// # Panics
+///
+/// Panics if the current directory cannot be set to the temporary directory.
 pub async fn with_temp_directory_async<F>(closure: impl FnOnce(&TempDir) -> F)
 where
     F: Future<Output = ()>,

--- a/crates/astria-cli/test-utils/src/lib.rs
+++ b/crates/astria-cli/test-utils/src/lib.rs
@@ -38,7 +38,6 @@ where
     temp_dir.close().unwrap();
 }
 
-
 /// Run an async closure with a temporary directory as the current directory.
 /// This is useful for cleaning up after tests that test code that creates files.
 ///

--- a/crates/astria-cli/test-utils/src/lib.rs
+++ b/crates/astria-cli/test-utils/src/lib.rs
@@ -1,15 +1,15 @@
 use std::{
     env,
+    future::Future,
     sync::{
         Mutex,
         PoisonError,
-    }, future::Future,
+    },
 };
-
-use tokio::sync::Mutex as AsyncMutex;
 
 use once_cell::sync::Lazy;
 use tempfile::TempDir;
+use tokio::sync::Mutex as AsyncMutex;
 
 static CURRENT_DIR_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 static ASYNC_CURRENT_DIR_LOCK: Lazy<AsyncMutex<()>> = Lazy::new(|| AsyncMutex::new(()));


### PR DESCRIPTION
## Summary
Setting more defaults, making less things required.

## Background
Trying to simplify the number of things which must be set, while still enabling more power when needed.

## Changes
- sequencer block height grab from sequencer
- default network id to `1337`
- Add some docs for commands

## Testing
Running CLI locally + CI on this PR

## Issues
closes https://github.com/astriaorg/astria/issues/513