### PR TITLE
cli: refactor network_id to be a string on the serialization side

### DIFF
--- a/crates/astria-cli/src/types.rs
+++ b/crates/astria-cli/src/types.rs
@@ -218,7 +218,7 @@ mod tests {
             log_level: "info".to_string(),
             name: "rollup2".to_string(),
             chain_id: None,
-            network_id: 2211011801,
+            network_id: 2_211_011_801,
             skip_empty_blocks: false,
             genesis_accounts: vec![GenesisAccountArg {
                 address: "0xA5TR14".to_string(),

--- a/crates/astria-cli/src/types.rs
+++ b/crates/astria-cli/src/types.rs
@@ -114,7 +114,7 @@ impl TryFrom<&ConfigCreateArgs> for RollupDeploymentConfig {
 pub struct RollupConfig {
     name: String,
     chain_id: String,
-    // NOTE - String here because
+    // NOTE - String here because yaml will serialize large ints w/ scientific notation
     network_id: String,
     skip_empty_blocks: bool,
     genesis_accounts: Vec<GenesisAccount>,

--- a/crates/astria-cli/src/types.rs
+++ b/crates/astria-cli/src/types.rs
@@ -96,7 +96,7 @@ impl TryFrom<&ConfigCreateArgs> for RollupDeploymentConfig {
             rollup: RollupConfig {
                 name: args.name.clone(),
                 chain_id,
-                network_id: args.network_id,
+                network_id: args.network_id.to_string(),
                 skip_empty_blocks: args.skip_empty_blocks,
                 genesis_accounts,
             },
@@ -114,7 +114,8 @@ impl TryFrom<&ConfigCreateArgs> for RollupDeploymentConfig {
 pub struct RollupConfig {
     name: String,
     chain_id: String,
-    network_id: u64,
+    // NOTE - String here because
+    network_id: String,
     skip_empty_blocks: bool,
     genesis_accounts: Vec<GenesisAccount>,
 }
@@ -184,7 +185,7 @@ mod tests {
                 rollup: RollupConfig {
                     name: "rollup1".to_string(),
                     chain_id: "chain1".to_string(),
-                    network_id: 1,
+                    network_id: "1".to_string(),
                     skip_empty_blocks: true,
                     genesis_accounts: vec![
                         GenesisAccount {
@@ -217,7 +218,7 @@ mod tests {
             log_level: "info".to_string(),
             name: "rollup2".to_string(),
             chain_id: None,
-            network_id: 2,
+            network_id: 2211011801,
             skip_empty_blocks: false,
             genesis_accounts: vec![GenesisAccountArg {
                 address: "0xA5TR14".to_string(),
@@ -235,7 +236,7 @@ mod tests {
                 rollup: RollupConfig {
                     name: "rollup2".to_string(),
                     chain_id: "rollup2-chain".to_string(), // Derived from name
-                    network_id: 2,
+                    network_id: "2211011801".to_string(),
                     skip_empty_blocks: false,
                     genesis_accounts: vec![GenesisAccount {
                         address: "0xA5TR14".to_string(),


### PR DESCRIPTION
## Summary
helm likes to turn big integers into scientific notation, so we serialize as a string to ensure proper parsing in helm land

closes https://github.com/astriaorg/astria/issues/526