### PR TITLE
Update rollup chart

### DIFF
--- a/crates/astria-cli/src/cli/rollup.rs
+++ b/crates/astria-cli/src/cli/rollup.rs
@@ -8,7 +8,7 @@ use color_eyre::eyre;
 use serde::Serialize;
 
 const DEFAULT_ROLLUP_CHART_PATH: &str =
-    "https://astriaorg.github.io/dev-cluster/astria-evm-rollup-0.4.2.tgz";
+    "https://astriaorg.github.io/dev-cluster/astria-evm-rollup-0.4.3.tgz";
 const DEFAULT_SEQUENCER_RPC: &str = "https://rpc.sequencer.dusk-1.devnet.astria.org";
 const DEFAULT_SEQUENCER_WS: &str = "wss://rpc.sequencer.dusk-1.devnet.astria.org/websocket";
 


### PR DESCRIPTION
## Summary
Updates the rollup chart in the CLI

## Background
Minor changes to chart made to improve remote deployment.

## Changes
- update rollup chart version from `0.4.2` to `0.4.3`
