### PR TITLE
feat(cli): add hostname + namespace

### DIFF
--- a/crates/astria-cli/src/cli/rollup.rs
+++ b/crates/astria-cli/src/cli/rollup.rs
@@ -112,7 +112,7 @@ pub struct ConfigCreateArgs {
     pub hostname: String,
     /// Configures the k8s namespace rollup will be deployed to
     #[clap(long, env = "ROLLUP_NAMESPACE", default_value = DEFAULT_NAMESPACE)]
-    pub(crate) namespace: String,
+    pub namespace: String,
 }
 
 /// `GenesisAccountArg` is a struct that represents a genesis account to be funded.

--- a/crates/astria-cli/src/cli/rollup.rs
+++ b/crates/astria-cli/src/cli/rollup.rs
@@ -11,7 +11,7 @@ const DEFAULT_ROLLUP_CHART_PATH: &str =
     "https://astriaorg.github.io/dev-cluster/astria-evm-rollup-0.4.3.tgz";
 const DEFAULT_SEQUENCER_RPC: &str = "https://rpc.sequencer.dusk-1.devnet.astria.org";
 const DEFAULT_SEQUENCER_WS: &str = "wss://rpc.sequencer.dusk-1.devnet.astria.org/websocket";
-const DEFAULT_LOG_LEVEL: &str = "info";
+const DEFAULT_LOG_LEVEL: &str = "debug";
 const DEFAULT_NETWORK_ID: u64 = 1337;
 const DEFAULT_HOSTNAME: &str = "localdev.me";
 const DEFAULT_NAMESPACE: &str = "astria-dev-cluster";

--- a/crates/astria-cli/src/cli/rollup.rs
+++ b/crates/astria-cli/src/cli/rollup.rs
@@ -106,6 +106,9 @@ pub struct ConfigCreateArgs {
         default_value = DEFAULT_HOSTNAME
     )]
     pub hostname: String,
+    /// Configures the k8s namespace rollup will be deployed to
+    #[clap(long, env = "ROLLUP_NAMESPACE", default_value = DEFAULT_NAMESPACE)]
+    pub(crate) namespace: String,
 }
 
 /// `GenesisAccountArg` is a struct that represents a genesis account to be funded.
@@ -204,9 +207,6 @@ pub struct DeploymentCreateArgs {
     /// Sequencer private key
     #[clap(long, env = "ROLLUP_SEQUENCER_PRIVATE_KEY")]
     pub(crate) sequencer_private_key: String,
-    /// Configures the k8s namespace to deploy to
-    #[clap(long, env = "ROLLUP_NAMESPACE", default_value = DEFAULT_NAMESPACE)]
-    pub(crate) namespace: String,
 }
 
 #[derive(Args, Debug)]

--- a/crates/astria-cli/src/cli/rollup.rs
+++ b/crates/astria-cli/src/cli/rollup.rs
@@ -11,6 +11,8 @@ const DEFAULT_ROLLUP_CHART_PATH: &str =
     "https://astriaorg.github.io/dev-cluster/astria-evm-rollup-0.4.3.tgz";
 const DEFAULT_SEQUENCER_RPC: &str = "https://rpc.sequencer.dusk-1.devnet.astria.org";
 const DEFAULT_SEQUENCER_WS: &str = "wss://rpc.sequencer.dusk-1.devnet.astria.org/websocket";
+const DEFAULT_HOSTNAME: &str = "localdev.me";
+const DEFAULT_NAMESPACE: &str = "astria-dev-cluster";
 
 /// Remove the 0x prefix from a hex string if present
 fn strip_0x_prefix(s: &str) -> &str {
@@ -96,6 +98,14 @@ pub struct ConfigCreateArgs {
         default_value = DEFAULT_SEQUENCER_RPC
     )]
     pub sequencer_rpc: String,
+    /// Optional. Will default to 'localdev.me' for local deployments. Will need to separately
+    /// configure other hosts
+    #[clap(
+        long = "hostname", 
+        env = "ROLLUP_HOSTNAME", 
+        default_value = DEFAULT_HOSTNAME
+    )]
+    pub hostname: String,
 }
 
 /// `GenesisAccountArg` is a struct that represents a genesis account to be funded.
@@ -194,6 +204,9 @@ pub struct DeploymentCreateArgs {
     /// Sequencer private key
     #[clap(long, env = "ROLLUP_SEQUENCER_PRIVATE_KEY")]
     pub(crate) sequencer_private_key: String,
+    /// Configures the k8s namespace to deploy to
+    #[clap(long, env = "ROLLUP_NAMESPACE", default_value = DEFAULT_NAMESPACE)]
+    pub(crate) namespace: String,
 }
 
 #[derive(Args, Debug)]

--- a/crates/astria-cli/src/commands/rollup.rs
+++ b/crates/astria-cli/src/commands/rollup.rs
@@ -190,7 +190,9 @@ pub(crate) fn create_deployment(args: &DeploymentCreateArgs) -> eyre::Result<()>
         ))
         .arg(rollup.deployment_config.get_chart_release_name())
         .arg(&args.chart_path)
-        .arg(format!("--namespace={}", args.namespace.clone()))
+        .arg("--set")
+        .arg(format!("namespace={}", rollup.namespace))
+        .arg(format!("--namespace={}", rollup.namespace))
         .arg("--create-namespace");
 
     if args.dry_run {
@@ -237,7 +239,8 @@ pub(crate) fn delete_deployment(args: &DeploymentDeleteArgs) -> eyre::Result<()>
     let helm = helm_from_env();
     let mut cmd = Command::new(helm.clone());
     cmd.arg("uninstall")
-        .arg(rollup.deployment_config.get_chart_release_name());
+        .arg(rollup.deployment_config.get_chart_release_name())
+        .arg(format!("--namespace={}", rollup.namespace));
 
     match cmd.output() {
         Err(e) => {
@@ -307,6 +310,8 @@ mod test {
             sequencer_websocket: String::new(),
             sequencer_rpc: String::new(),
             log_level: String::new(),
+            hostname: String::new(),
+            namespace: String::new(),
         }
     }
 

--- a/crates/astria-cli/src/commands/rollup.rs
+++ b/crates/astria-cli/src/commands/rollup.rs
@@ -189,7 +189,9 @@ pub(crate) fn create_deployment(args: &DeploymentCreateArgs) -> eyre::Result<()>
             args.sequencer_private_key.clone()
         ))
         .arg(rollup.deployment_config.get_chart_release_name())
-        .arg(&args.chart_path);
+        .arg(&args.chart_path)
+        .arg(format!("--namespace={}", args.namespace.clone()))
+        .arg("--create-namespace");
 
     if args.dry_run {
         cmd.arg("--dry-run");

--- a/crates/astria-cli/src/commands/rollup.rs
+++ b/crates/astria-cli/src/commands/rollup.rs
@@ -273,7 +273,7 @@ pub(crate) fn list_deployments() {
     let helm = helm_from_env();
     let mut cmd = Command::new(helm.clone());
     // FIXME - right now it lists all helm releases, not just rollup release
-    cmd.arg("list");
+    cmd.arg("list").arg("-A");
 
     match cmd.output() {
         Err(e) => {

--- a/crates/astria-cli/src/types.rs
+++ b/crates/astria-cli/src/types.rs
@@ -179,9 +179,9 @@ mod tests {
     };
 
     #[test]
-    fn test_from_cli_args() -> eyre::Result<()> {
+    fn test_from_all_cli_args() -> eyre::Result<()> {
         // Case 1: All args provided
-        let args1 = ConfigCreateArgs {
+        let args = ConfigCreateArgs {
             use_tty: true,
             log_level: "debug".to_string(),
             name: "rollup1".to_string(),
@@ -205,7 +205,7 @@ mod tests {
             namespace: "test-cluster".to_string(),
         };
 
-        let expected_config1 = Rollup {
+        let expected_config = Rollup {
             namespace: "test-cluster".to_string(),
             deployment_config: RollupDeploymentConfig {
                 use_tty: true,
@@ -237,14 +237,19 @@ mod tests {
             },
         };
 
-        let result1 = Rollup::try_from(&args1)?;
-        assert_eq!(result1, expected_config1);
+        let result = Rollup::try_from(&args)?;
+        assert_eq!(result, expected_config);
 
-        // Case 2: No `Option` wrapped args provided. Tests defaults that are decided
+        Ok(())
+    }
+
+    #[test]
+    fn test_from_minimum_cli_args() -> eyre::Result<()> {
+        // No `Option` wrapped args provided. Tests defaults that are decided
         //  explicitly in the `try_from` impl.
         // NOTE - there are some defaults that are handled in the arg struct,
         //  like the sequencer ws and rpc urls, so we still must pass them in here.
-        let args2 = ConfigCreateArgs {
+        let args = ConfigCreateArgs {
             use_tty: false,
             log_level: "info".to_string(),
             name: "rollup2".to_string(),
@@ -262,7 +267,7 @@ mod tests {
             namespace: "astria-dev-cluster".to_string(),
         };
 
-        let expected_config2 = Rollup {
+        let expected_config = Rollup {
             namespace: "astria-dev-cluster".to_string(),
             deployment_config: RollupDeploymentConfig {
                 use_tty: false,
@@ -288,8 +293,8 @@ mod tests {
             },
         };
 
-        let result2 = Rollup::try_from(&args2)?;
-        assert_eq!(result2, expected_config2);
+        let result = Rollup::try_from(&args)?;
+        assert_eq!(result, expected_config);
 
         Ok(())
     }

--- a/crates/astria-cli/src/types.rs
+++ b/crates/astria-cli/src/types.rs
@@ -53,7 +53,7 @@ pub struct RollupDeploymentConfig {
     use_tty: bool,
     log_level: String,
     rollup: RollupConfig,
-    sequencer: SequencerConfig
+    sequencer: SequencerConfig,
 }
 
 impl RollupDeploymentConfig {
@@ -76,7 +76,7 @@ impl RollupDeploymentConfig {
 impl From<&ConfigCreateArgs> for IngressConfig {
     fn from(args: &ConfigCreateArgs) -> Self {
         Self {
-            hostname: args.hostname.clone()
+            hostname: args.hostname.clone(),
         }
     }
 }

--- a/crates/astria-cli/src/types.rs
+++ b/crates/astria-cli/src/types.rs
@@ -16,6 +16,7 @@ pub struct Rollup {
     // TODO - namespace
     #[serde(rename = "config")]
     pub(crate) deployment_config: RollupDeploymentConfig,
+    pub(crate) namespace: String,
 }
 
 impl TryFrom<&ConfigCreateArgs> for Rollup {
@@ -26,6 +27,7 @@ impl TryFrom<&ConfigCreateArgs> for Rollup {
 
         Ok(Self {
             deployment_config,
+            namespace: args.namespace.clone(),
         })
     }
 }

--- a/crates/astria-cli/src/types.rs
+++ b/crates/astria-cli/src/types.rs
@@ -50,6 +50,7 @@ pub struct RollupDeploymentConfig {
     log_level: String,
     rollup: RollupConfig,
     sequencer: SequencerConfig,
+    ingress: IngressConfig,
 }
 
 impl RollupDeploymentConfig {
@@ -105,6 +106,9 @@ impl TryFrom<&ConfigCreateArgs> for RollupDeploymentConfig {
                 websocket: args.sequencer_websocket.clone(),
                 rpc: args.sequencer_rpc.clone(),
             },
+            ingress: IngressConfig {
+                hostname: args.hostname.clone(),
+            },
         })
     }
 }
@@ -145,6 +149,12 @@ struct SequencerConfig {
     rpc: String,
 }
 
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IngressConfig {
+    hostname: String,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -176,6 +186,7 @@ mod tests {
             sequencer_initial_block_height: Some(10),
             sequencer_websocket: "ws://localhost:8080".to_string(),
             sequencer_rpc: "http://localhost:8081".to_string(),
+            hostname: "test.com".to_string(),
         };
 
         let expected_config1 = Rollup {
@@ -203,6 +214,9 @@ mod tests {
                     websocket: "ws://localhost:8080".to_string(),
                     rpc: "http://localhost:8081".to_string(),
                 },
+                ingress: IngressConfig {
+                    hostname: "test.com".to_string(),
+                },
             },
         };
 
@@ -227,6 +241,7 @@ mod tests {
             sequencer_initial_block_height: None,
             sequencer_websocket: "ws://localhost:8082".to_string(),
             sequencer_rpc: "http://localhost:8083".to_string(),
+            hostname: "localdev.me".to_string(),
         };
 
         let expected_config2 = Rollup {
@@ -247,6 +262,9 @@ mod tests {
                     initial_block_height: 0, // Default value
                     websocket: "ws://localhost:8082".to_string(),
                     rpc: "http://localhost:8083".to_string(),
+                },
+                ingress: IngressConfig {
+                    hostname: "localdev.me".to_string(), // default value
                 },
             },
         };


### PR DESCRIPTION
## Summary
Adds the hostname flag into CLI, and makes the namespace configurable.

## Background
We updated charts, and currently deploying to cloud providers requires manual intervention.

## Changes
- Added the `--hostname` config flag and `ROLLUP_HOSTNAME` env var
- Added the `--namespace` config flag and `ROLLUP_NAMESPACE` env var
- Updated the `astria-cli rollup deployments list` command to list across all namespaces

## Testing
Updated automated tests.