### PR TITLE
fix(ci): success test proper reporting

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -65,3 +65,5 @@ jobs:
     if: ${{ always() && !cancelled() }}
     needs: [composer, conductor, sequencer, sequencer-relayer]
     uses: ./.github/workflows/reusable-success.yml
+    with:
+      success: ${{ !contains(needs.*.result, 'failure') }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -73,3 +73,5 @@ jobs:
     needs: [proto, rust, toml, markdown]
     if: ${{ always() && !cancelled() }}
     uses: ./.github/workflows/reusable-success.yml
+    with:
+      success: ${{ !contains(needs.*.result, 'failure') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,3 +63,5 @@ jobs:
     needs: [proto, conductor, composer, sequencer, sequencer-relayer]
     if: ${{ always() && !cancelled() }}
     uses: ./.github/workflows/reusable-success.yml
+    with:
+      success: ${{ !contains(needs.*.result, 'failure') }}

--- a/.github/workflows/reusable-success.yml
+++ b/.github/workflows/reusable-success.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ always() && !cancelled() }}
     steps:
-      - if: !inputs.success
+      - if: ${{ !inputs.success }}
         run: exit 1
-      - if: inputs.success
+      - if: ${{ inputs.success }}
         run: exit 0

--- a/.github/workflows/reusable-success.yml
+++ b/.github/workflows/reusable-success.yml
@@ -2,14 +2,17 @@ name: Reusable Success Check
 
 on:
   workflow_call:
+    inputs:
+      success:
+        required: true
+        type: boolean
 
 jobs:
   success:
     runs-on: ubuntu-latest
     if: ${{ always() && !cancelled() }}
     steps:
-      - run: echo ${{ toJson(needs) }}
-      - if: ${{ contains(needs.*.result, 'failure') }}
+      - if: !inputs.success
         run: exit 1
-      - if: ${{ !contains(needs.*.result, 'failure') }}
+      - if: inputs.success
         run: exit 0

--- a/.github/workflows/reusable-success.yml
+++ b/.github/workflows/reusable-success.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ always() && !cancelled() }}
     steps:
+      - run: echo ${{ toJson(needs) }}
       - if: ${{ contains(needs.*.result, 'failure') }}
         run: exit 1
       - if: ${{ !contains(needs.*.result, 'failure') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,3 +130,5 @@ jobs:
     if: ${{ always() && !cancelled() }}
     needs: [compiles, rust, doctest, clippy, lockfile]
     uses: ./.github/workflows/reusable-success.yml
+    with:
+      success: ${{ !contains(needs.*.result, 'failure') }}

--- a/crates/astria-cli/src/cli/mod.rs
+++ b/crates/astria-cli/src/cli/mod.rs
@@ -44,3 +44,5 @@ pub enum Command {
         command: SequencerCommand,
     },
 }
+
+make it angry

--- a/crates/astria-cli/src/cli/mod.rs
+++ b/crates/astria-cli/src/cli/mod.rs
@@ -44,5 +44,3 @@ pub enum Command {
         command: SequencerCommand,
     },
 }
-
-make it angry


### PR DESCRIPTION
## Summary
Fixes the "success" reusable job which was always passing.

## Background
When migrated to reusable version, started always passing. This fixes, the reusable action didn't have access to the `needs` values.

## Changes
- Pass in success value.

## Testing
On PR tests
