### PR TITLE
ci: doctests are tests and should not be skipped

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,7 +78,7 @@ jobs:
   doctest:
     runs-on: ubuntu-22.04
     needs: run_checker
-    if: needs.run_checker.outputs.run_tests == 'true' && needs.run_checker.outputs.run_lint_rust == 'true'
+    if: needs.run_checker.outputs.run_tests == 'true'
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@1.72.0


### PR DESCRIPTION
## Summary
Always run doctests if normal rust tests are also ran.

## Background
Our CI treated doctests as lints, where they are actually full tests and should be run alongside normal rust tests.

## Changes
- Removed the lint conditional from the doctest job.