### PR TITLE
chore(cli): rollup chart version 0.4.4

### DIFF
--- a/crates/astria-cli/src/cli/rollup.rs
+++ b/crates/astria-cli/src/cli/rollup.rs
@@ -8,7 +8,7 @@ use color_eyre::eyre;
 use serde::Serialize;
 
 const DEFAULT_ROLLUP_CHART_PATH: &str =
-    "https://astriaorg.github.io/dev-cluster/astria-evm-rollup-0.4.3.tgz";
+    "https://astriaorg.github.io/dev-cluster/astria-evm-rollup-0.4.4.tgz";
 const DEFAULT_SEQUENCER_RPC: &str = "https://rpc.sequencer.dusk-1.devnet.astria.org";
 const DEFAULT_SEQUENCER_WS: &str = "wss://rpc.sequencer.dusk-1.devnet.astria.org/websocket";
 const DEFAULT_LOG_LEVEL: &str = "debug";


### PR DESCRIPTION
Updating the rollup chart version after newest release.
