### PR TITLE
feat(cli): improve sequencer command set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -344,6 +344,7 @@ name = "astria-cli"
 version = "0.1.0"
 dependencies = [
  "assert_cmd",
+ "astria-proto",
  "astria-sequencer-client",
  "clap",
  "color-eyre",

--- a/crates/astria-cli/Cargo.toml
+++ b/crates/astria-cli/Cargo.toml
@@ -10,6 +10,8 @@ bench = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+proto = { package = "astria-proto", path = "../astria-proto" }
+
 clap = { workspace = true, features = ["derive", "env"] }
 color-eyre = { workspace = true }
 ed25519-consensus = { workspace = true }

--- a/crates/astria-cli/src/cli/rollup.rs
+++ b/crates/astria-cli/src/cli/rollup.rs
@@ -8,7 +8,7 @@ use color_eyre::eyre;
 use serde::Serialize;
 
 const DEFAULT_ROLLUP_CHART_PATH: &str =
-    "https://astriaorg.github.io/dev-cluster/astria-evm-rollup-0.4.3.tgz";
+    "https://astriaorg.github.io/dev-cluster/astria-evm-rollup-0.4.4.tgz";
 const DEFAULT_SEQUENCER_RPC: &str = "https://rpc.sequencer.dusk-1.devnet.astria.org";
 const DEFAULT_SEQUENCER_WS: &str = "wss://rpc.sequencer.dusk-1.devnet.astria.org/websocket";
 const DEFAULT_LOG_LEVEL: &str = "debug";

--- a/crates/astria-cli/src/cli/rollup.rs
+++ b/crates/astria-cli/src/cli/rollup.rs
@@ -205,10 +205,18 @@ pub struct DeploymentCreateArgs {
     /// Set if you want to do a dry run of the deployment
     #[clap(long, env = "ROLLUP_DRY_RUN", default_value = "false")]
     pub(crate) dry_run: bool,
+    // TODO: https://github.com/astriaorg/astria/issues/594
+    // Don't use a plain text private, prefer wrapper like from
+    // the secrecy crate with specialized `Debug` and `Drop` implementations
+    // that overwrite the key on drop and don't reveal it when printing.
     /// Faucet private key
     #[clap(long, env = "ROLLUP_FAUCET_PRIVATE_KEY")]
     pub(crate) faucet_private_key: String,
     /// Sequencer private key
+    // TODO: https://github.com/astriaorg/astria/issues/594
+    // Don't use a plain text private, prefer wrapper like from
+    // the secrecy crate with specialized `Debug` and `Drop` implementations
+    // that overwrite the key on drop and don't reveal it when printing.
     #[clap(long, env = "ROLLUP_SEQUENCER_PRIVATE_KEY")]
     pub(crate) sequencer_private_key: String,
 }

--- a/crates/astria-cli/src/cli/sequencer.rs
+++ b/crates/astria-cli/src/cli/sequencer.rs
@@ -32,7 +32,7 @@ pub enum Command {
         command: BlockHeightCommand,
     },
     /// Command for sending balance between accounts
-    Transfer(TransferArgs)
+    Transfer(TransferArgs),
 }
 
 #[derive(Debug, Subcommand)]

--- a/crates/astria-cli/src/cli/sequencer.rs
+++ b/crates/astria-cli/src/cli/sequencer.rs
@@ -10,6 +10,8 @@ use color_eyre::{
     eyre::Context,
 };
 
+const DEFAULT_SEQUENCER_RPC: &str = "https://rpc.sequencer.dusk-1.devnet.astria.org";
+
 /// Interact with a Sequencer node
 #[derive(Debug, Subcommand)]
 pub enum Command {
@@ -29,27 +31,54 @@ pub enum Command {
         #[clap(subcommand)]
         command: BlockHeightCommand,
     },
+    /// Command for sending balance between accounts
+    Transfer(TransferArgs)
 }
 
 #[derive(Debug, Subcommand)]
 pub enum AccountCommand {
     /// Create a new Sequencer account
     Create,
+    Balance(BasicAccountArgs),
+    Nonce(BasicAccountArgs),
 }
 
 #[derive(Debug, Subcommand)]
 pub enum BalanceCommand {
     /// Get the balance of a Sequencer account
-    Get(BalanceGetArgs),
+    Get(BasicAccountArgs),
 }
 
 #[derive(Args, Debug)]
-pub struct BalanceGetArgs {
+pub struct BasicAccountArgs {
     /// The url of the Sequencer node
-    #[clap(long)]
+    #[clap(
+        long,
+        env = "SEQUENCER_URL", 
+        default_value = DEFAULT_SEQUENCER_RPC
+    )]
     pub(crate) sequencer_url: String,
     /// The address of the Sequencer account
     pub(crate) address: SequencerAddressArg,
+}
+
+#[derive(Args, Debug)]
+pub struct TransferArgs {
+    // The address of the Sequencer account to send amount to
+    pub(crate) to_address: SequencerAddressArg,
+    // The amount being sent
+    #[clap(long)]
+    pub(crate) amount: u128,
+    /// The private key of account being sent from
+    #[clap(long, env = "SEQUENCER_PRIVATE_KEY")]
+    pub(crate) private_key: String,
+    /// The url of the Sequencer node
+    #[clap(
+        long,
+        env = "SEQUENCER_URL", 
+        default_value = DEFAULT_SEQUENCER_RPC
+    )]
+    pub(crate) sequencer_url: String,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/crates/astria-cli/src/cli/sequencer.rs
+++ b/crates/astria-cli/src/cli/sequencer.rs
@@ -71,6 +71,10 @@ pub struct TransferArgs {
     pub(crate) amount: u128,
     /// The private key of account being sent from
     #[clap(long, env = "SEQUENCER_PRIVATE_KEY")]
+    // TODO: https://github.com/astriaorg/astria/issues/594
+    // Don't use a plain text private, prefer wrapper like from
+    // the secrecy crate with specialized `Debug` and `Drop` implementations
+    // that overwrite the key on drop and don't reveal it when printing.
     pub(crate) private_key: String,
     /// The url of the Sequencer node
     #[clap(

--- a/crates/astria-cli/src/commands/mod.rs
+++ b/crates/astria-cli/src/commands/mod.rs
@@ -7,26 +7,20 @@ use color_eyre::{
 };
 use tracing::instrument;
 
-use crate::{
-    cli::{
-        rollup::{
-            Command as RollupCommand,
-            ConfigCommand,
-            DeploymentCommand,
-        },
-        sequencer::{
-            AccountCommand,
-            BalanceCommand,
-            BlockHeightCommand,
-            Command as SequencerCommand,
-        },
-        Cli,
-        Command,
+use crate::cli::{
+    rollup::{
+        Command as RollupCommand,
+        ConfigCommand,
+        DeploymentCommand,
     },
-    commands::sequencer::{
-        get_balance,
-        get_block_height,
+    sequencer::{
+        AccountCommand,
+        BalanceCommand,
+        BlockHeightCommand,
+        Command as SequencerCommand,
     },
+    Cli,
+    Command,
 };
 
 /// Checks what function needs to be run and calls it with the appropriate arguments
@@ -71,16 +65,19 @@ pub async fn run(cli: Cli) -> eyre::Result<()> {
                     command,
                 } => match command {
                     AccountCommand::Create => sequencer::create_account(),
+                    AccountCommand::Balance(args) => sequencer::get_balance(&args).await?,
+                    AccountCommand::Nonce(args) => sequencer::get_nonce(&args).await?,
                 },
                 SequencerCommand::Balance {
                     command,
                 } => match command {
-                    BalanceCommand::Get(args) => get_balance(&args).await?,
+                    BalanceCommand::Get(args) => sequencer::get_balance(&args).await?,
                 },
+                SequencerCommand::Transfer(args) => sequencer::send_amount(&args).await?,
                 SequencerCommand::BlockHeight {
                     command,
                 } => match command {
-                    BlockHeightCommand::Get(args) => get_block_height(&args).await?,
+                    BlockHeightCommand::Get(args) => sequencer::get_block_height(&args).await?,
                 },
             },
         }

--- a/crates/astria-cli/src/commands/mod.rs
+++ b/crates/astria-cli/src/commands/mod.rs
@@ -73,7 +73,7 @@ pub async fn run(cli: Cli) -> eyre::Result<()> {
                 } => match command {
                     BalanceCommand::Get(args) => sequencer::get_balance(&args).await?,
                 },
-                SequencerCommand::Transfer(args) => sequencer::send_amount(&args).await?,
+                SequencerCommand::Transfer(args) => sequencer::send_transfer(&args).await?,
                 SequencerCommand::BlockHeight {
                     command,
                 } => match command {

--- a/crates/astria-cli/src/commands/rollup.rs
+++ b/crates/astria-cli/src/commands/rollup.rs
@@ -197,11 +197,15 @@ pub(crate) fn create_deployment(args: &DeploymentCreateArgs) -> eyre::Result<()>
         .arg("--debug")
         .arg("--values")
         .arg(rollup.deployment_config.get_filename())
+        // TODO: https://github.com/astriaorg/astria/issues/594
+        // Use a secret manager or inject the private key into the environment
         .arg("--set")
         .arg(format!(
             "config.faucet.privateKey={}",
             args.faucet_private_key.clone()
         ))
+        // TODO: https://github.com/astriaorg/astria/issues/594
+        // Use a secret manager or inject the private key into the environment
         .arg("--set")
         .arg(format!(
             "config.sequencer.privateKey={}",

--- a/crates/astria-cli/src/commands/sequencer.rs
+++ b/crates/astria-cli/src/commands/sequencer.rs
@@ -176,7 +176,9 @@ pub(crate) async fn send_transfer(args: &TransferArgs) -> eyre::Result<()> {
         actions: vec![Action::Transfer(TransferAction {
             to: to_address,
             amount: args.amount,
+            asset_id: proto::native::sequencer::asset::default_native_asset_id(),
         })],
+        fee_asset_id: proto::native::sequencer::asset::default_native_asset_id(),
     }
     .into_signed(&sequencer_key);
     let res = sequencer_client

--- a/crates/astria-cli/src/commands/sequencer.rs
+++ b/crates/astria-cli/src/commands/sequencer.rs
@@ -57,6 +57,8 @@ pub(crate) fn create_account() {
 
     println!("Create Sequencer Account");
     println!();
+    // TODO: don't print private keys to CLI, prefer writing to file:
+    // https://github.com/astriaorg/astria/issues/594
     println!("Private Key: {private_key_pretty:?}");
     println!("Public Key:  {public_key_pretty:?}");
     println!("Address:     {address_pretty:?}");

--- a/crates/astria-cli/src/commands/sequencer.rs
+++ b/crates/astria-cli/src/commands/sequencer.rs
@@ -5,14 +5,20 @@ use astria_sequencer_client::{
 };
 use color_eyre::{
     eyre,
-    eyre::Context,
+    eyre::eyre,
+    eyre::{Context, ensure},
 };
 use ed25519_consensus::SigningKey;
 use rand::rngs::OsRng;
 
 use crate::cli::sequencer::{
-    BalanceGetArgs,
+    BasicAccountArgs,
     BlockHeightGetArgs,
+    TransferArgs,
+};
+use proto::native::sequencer::v1alpha1::{
+    Action,
+    TransferAction, UnsignedTransaction,
 };
 
 /// Generate a new signing key (this is also called a secret key by other implementations)
@@ -62,7 +68,7 @@ pub(crate) fn create_account() {
 ///
 /// * If the http client cannot be created
 /// * If the balance cannot be retrieved
-pub(crate) async fn get_balance(args: &BalanceGetArgs) -> eyre::Result<()> {
+pub(crate) async fn get_balance(args: &BasicAccountArgs) -> eyre::Result<()> {
     let address = &args.address;
     let sequencer_client = HttpClient::new(args.sequencer_url.as_str())
         .wrap_err("failed constructing http sequencer client")?;
@@ -74,6 +80,32 @@ pub(crate) async fn get_balance(args: &BalanceGetArgs) -> eyre::Result<()> {
 
     println!("Balance for address {}:", address.0);
     println!("    {}", res.balance);
+
+    Ok(())
+}
+
+// Gets the balance of a Sequencer account
+///
+/// # Arguments
+///
+/// * `args` - The arguments passed to the command
+///
+/// # Errors
+///
+/// * If the http client cannot be created
+/// * If the balance cannot be retrieved
+pub(crate) async fn get_nonce(args: &BasicAccountArgs) -> eyre::Result<()> {
+    let address = &args.address;
+    let sequencer_client = HttpClient::new(args.sequencer_url.as_str())
+        .wrap_err("failed constructing http sequencer client")?;
+
+    let res = sequencer_client
+        .get_latest_nonce(address.0)
+        .await
+        .wrap_err("failed to get nonce")?;
+
+    println!("Nonce for address {}:", address.0);
+    println!("    {} at height {}", res.nonce, res.height);
 
     Ok(())
 }
@@ -99,6 +131,57 @@ pub(crate) async fn get_block_height(args: &BlockHeightGetArgs) -> eyre::Result<
 
     println!("Block Height:");
     println!("    {}", res.header().height);
+
+    Ok(())
+}
+
+/// Gets the latest block height of a Sequencer node
+///
+/// # Arguments
+///
+/// * `args` - The arguments passed to the command
+///
+/// # Errors
+///
+/// * If the http client cannot be created
+/// * If the latest block height cannot be retrieved
+pub(crate) async fn send_amount(args: &TransferArgs) -> eyre::Result<()> {
+     // Build the signing_key
+     let private_key_bytes: [u8; 32] = hex::decode(args.private_key.as_str())
+     .wrap_err("failed to decode private key bytes from hex string")?
+     .try_into()
+     .map_err(|_| eyre!("invalid private key length; must be 32 bytes"))?;
+    let sequencer_key =
+        SigningKey::try_from(private_key_bytes).wrap_err("failed to parse sequencer key")?;
+
+    // To and from addresses
+    let from_address = Address::from_verification_key(sequencer_key.verification_key());
+    let to_address = args.to_address.0;
+
+    let sequencer_client = HttpClient::new(args.sequencer_url.as_str())
+        .wrap_err("failed constructing http sequencer client")?;
+
+    // Fetch the nonce for the action
+    let nonce_res = sequencer_client
+        .get_latest_nonce(from_address)
+        .await
+        .wrap_err("failed to get nonce")?;
+    
+    // Build and submit tx
+    let tx = UnsignedTransaction {
+        nonce: nonce_res.nonce,
+        actions: vec![Action::Transfer(TransferAction {
+            to: to_address, 
+            amount: args.amount,
+        })],
+    }.into_signed(&sequencer_key);
+    let res = sequencer_client
+        .submit_transaction_commit(tx)
+        .await
+        .wrap_err("failed to submit transfer transaction")?;
+
+    ensure!(res.tx_result.code.is_ok(), "error with transfer");
+    println!("Transfer completed!");
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
Adds a couple commands (transfer, nonce), provides default sequencer rpc for all, and streamlines the ways to access balance.

## Background
Had to interact with the sequencer and needed more commands, found incongruence with defaults provided for rollups and found the balance `get` command to be counter intuitive.

Note that specifically did not remove the balance get command for backwards compatibility, docs.

## Changes
- provide default sequencer rpc url
- provide `sequencer account balance` command as alternative to `sequencer balance get`
- adds `sequencer account nonce` command
- adds `sequencer transfer` command

## Testing
Manually tested
