### PR TITLE
ci: require conventional commit naming for PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,16 @@ jobs:
   run_checker:
     uses: ./.github/workflows/reusable-run-checker.yml
 
+  pr_title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: CondeNast/conventional-pull-request-action@v0.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          ignoreCommits: "true"
+
   proto:
     runs-on: ubuntu-latest
     needs: run_checker
@@ -70,6 +80,6 @@ jobs:
             #.github
 
   lint:
-    needs: [proto, rust, toml, markdown]
+    needs: [proto, rust, toml, markdown, pr_title]
     if: ${{ always() && !cancelled() }}
     uses: ./.github/workflows/reusable-success.yml


### PR DESCRIPTION
Adds a ci linting rule which requires PR be named according to [conventional commit standards ](https://www.conventionalcommits.org/en/v1.0.0/#specification)

