### PR TITLE
fix(ci): only run title lint on pull requests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,7 @@ jobs:
 
   pr_title:
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v2
       - uses: CondeNast/conventional-pull-request-action@v0.2.0


### PR DESCRIPTION
Lint would break on main everytime otherwise.
