### PR TITLE
feat(conductor): added commitment grab to better set sync start height

### DIFF
--- a/crates/astria-conductor/src/conductor.rs
+++ b/crates/astria-conductor/src/conductor.rs
@@ -90,7 +90,8 @@ impl Conductor {
                 ChainId::new(cfg.chain_id.as_bytes().to_vec())
                     .wrap_err("failed to create chain ID")?,
                 cfg.disable_empty_block_execution,
-                cfg.initial_sequencer_block_height, // the sequencer block the rollup was start on
+                // the sequencer block that contains the first rollup block
+                cfg.initial_sequencer_block_height,
                 block_rx,
                 shutdown_rx,
             )

--- a/crates/astria-conductor/src/conductor.rs
+++ b/crates/astria-conductor/src/conductor.rs
@@ -96,7 +96,7 @@ impl Conductor {
             )
             .await
             .wrap_err("failed to construct executor")?;
-            let executable_sequencer_block_height = executor.executable_block_height;
+            let executable_sequencer_block_height = executor.get_executable_block_height();
 
             tasks.spawn(Self::EXECUTOR, executor.run_until_stopped());
             shutdown_channels.insert(Self::EXECUTOR, shutdown_tx);

--- a/crates/astria-conductor/src/conductor.rs
+++ b/crates/astria-conductor/src/conductor.rs
@@ -125,13 +125,9 @@ impl Conductor {
             let (shutdown_tx, shutdown_rx) = oneshot::channel();
             let (sync_done_tx, sync_done_rx) = oneshot::channel();
 
-            // the `sync_start_block_height` below is the height at which the sync
-            // of Conductor will start. This value is a combination of the
-            // initial sequencer block height, which is set in the config when
-            // the rollup is first created, plus the height of the most recently
-            // executed block on the rollup.
-            // sync_start_block_height =
-            //   initial sequencer block height + most recently executed block height
+            // The `sync_start_block_height` represents the height of the next
+            // sequencer block that can be executed on top of the rollup state.
+            // This value is derived by the Executor.
             let sequencer_reader = sequencer::Reader::new(
                 sync_start_block_height,
                 sequencer_client_pool.clone(),

--- a/crates/astria-conductor/src/conductor.rs
+++ b/crates/astria-conductor/src/conductor.rs
@@ -43,7 +43,6 @@ use crate::{
     data_availability,
     executor::Executor,
     sequencer,
-    types::ExecutorCommitmentState,
     Config,
 };
 
@@ -97,7 +96,7 @@ impl Conductor {
             )
             .await
             .wrap_err("failed to construct executor")?;
-            let init_sequencer_height = executor.executable_block_height.clone();
+            let init_sequencer_height = executor.executable_block_height;
 
             tasks.spawn(Self::EXECUTOR, executor.run_until_stopped());
             shutdown_channels.insert(Self::EXECUTOR, shutdown_tx);
@@ -124,7 +123,7 @@ impl Conductor {
 
         if !cfg.execution_commit_level.is_firm_only() {
             let (shutdown_tx, shutdown_rx) = oneshot::channel();
-            let (sync_done_tx, sync_done_rx) = oneshot::channel();    
+            let (sync_done_tx, sync_done_rx) = oneshot::channel();
 
             let sequencer_reader = sequencer::Reader::new(
                 init_sequencer_height,

--- a/crates/astria-conductor/src/conductor.rs
+++ b/crates/astria-conductor/src/conductor.rs
@@ -90,7 +90,7 @@ impl Conductor {
                 ChainId::new(cfg.chain_id.as_bytes().to_vec())
                     .wrap_err("failed to create chain ID")?,
                 cfg.disable_empty_block_execution,
-                cfg.initial_sequencer_block_height,
+                cfg.initial_sequencer_block_height, // the sequencer block the rollup was start on
                 block_rx,
                 shutdown_rx,
             )
@@ -125,6 +125,13 @@ impl Conductor {
             let (shutdown_tx, shutdown_rx) = oneshot::channel();
             let (sync_done_tx, sync_done_rx) = oneshot::channel();
 
+            // the `sync_start_block_height` below is the height at which the sync
+            // of Conductor will start. This value is a combination of the
+            // initial sequencer block height, which is set in the config when
+            // the rollup is first created, plus the height of the most recently
+            // executed block on the rollup.
+            // sync_start_block_height =
+            //   initial sequencer block height + most recently executed block height
             let sequencer_reader = sequencer::Reader::new(
                 sync_start_block_height,
                 sequencer_client_pool.clone(),

--- a/crates/astria-conductor/src/executor/mod.rs
+++ b/crates/astria-conductor/src/executor/mod.rs
@@ -6,6 +6,7 @@ use astria_sequencer_types::{
 };
 use color_eyre::eyre::{
     self,
+    eyre,
     Result,
     WrapErr as _,
 };
@@ -228,6 +229,29 @@ impl Executor {
     /// execution block hash.
     #[instrument(skip(self), fields(sequencer_block_hash = ?block.block_hash, sequencer_block_height = block.header.height.value()))]
     async fn execute_block(&mut self, block: SequencerBlockSubset) -> Result<Block> {
+        match self
+            .executable_block_height
+            .cmp(&(block.header.height.value() as u32))
+        {
+            std::cmp::Ordering::Less => {
+                return Err(eyre!(
+                    "incoming sequencer block at height {} is above executable block height of \
+                     {}, skipping execution of future block",
+                    block.header.height.value(),
+                    self.executable_block_height
+                ));
+            }
+            std::cmp::Ordering::Greater => {
+                return Err(eyre!(
+                    "incoming sequencer block at height {} is below executable block height of \
+                     {}, skipping execution of stale block",
+                    block.header.height.value(),
+                    self.executable_block_height
+                ));
+            }
+            _ => {}
+        }
+
         if let Some(execution_block) = self
             .sequencer_hash_to_execution_block
             .get(&block.block_hash)

--- a/crates/astria-conductor/src/executor/mod.rs
+++ b/crates/astria-conductor/src/executor/mod.rs
@@ -133,10 +133,10 @@ impl Executor {
             .await
             .wrap_err("executor failed to get commitment state")?;
 
-        // The `executable_block_height` is the height of the fist sequencer block
+        // The `executable_block_height` is the height of the next sequencer block
         // that can be executed on top of the rollup state. The `init_sequencer_height`
-        // is set when the rollup is first created and let's us know that this
-        // rollup's genesis block is in block K of the sequencer chain.
+        // is set when the rollup is first created and lets us know that this
+        // rollup's first block is in block K of the sequencer chain.
         // The `commitment_state.soft.number` is the block height of the most
         // recently executed block on the rollup and is pulled from the rollup
         // the Conductor is associated with on startup of the Conductor (N

--- a/crates/astria-conductor/src/executor/mod.rs
+++ b/crates/astria-conductor/src/executor/mod.rs
@@ -133,8 +133,8 @@ impl Executor {
             .await
             .wrap_err("executor failed to get commitment state")?;
 
-        // The `executable_block_height` is the height of the sequencer block
-        // where the Conductor sync will be started. The `init_sequencer_height`
+        // The `executable_block_height` is the height of the fist sequencer block
+        // that can be executed on top of the rollup state. The `init_sequencer_height`
         // is set when the rollup is first created and let's us know that this
         // rollup's genesis block is in block K of the sequencer chain.
         // The `commitment_state.soft.number` is the block height of the most

--- a/crates/astria-conductor/src/executor/mod.rs
+++ b/crates/astria-conductor/src/executor/mod.rs
@@ -133,6 +133,20 @@ impl Executor {
             .await
             .wrap_err("executor failed to get commitment state")?;
 
+        // The `executable_block_height` is the height of the sequencer block
+        // where the Conductor sync will be started. The `init_sequencer_height`
+        // is set when the rollup is first created and let's us know that this
+        // rollup's genesis block is in block K of the sequencer chain.
+        // The `commitment_state.soft.number` is the block height of the most
+        // recently executed block on the rollup and is pulled from the rollup
+        // the Conductor is associated with on startup of the Conductor (N
+        // blocks have already been executed on the rollup).
+        // `executable_block_height` represents where the Condutor sync should
+        // start:
+        // `executable_block_height` = sequencer block K + executed block N
+        // By setting this value we prevent the reexecution of blocks on the
+        // rollup. If block M is the most recent sequencer block, we then know
+        // that we need to sync blocks from `executable_block_height` to M.
         let executable_block_height = commitment_state.soft.number + init_sequencer_height;
 
         Ok(Self {

--- a/crates/astria-conductor/src/executor/mod.rs
+++ b/crates/astria-conductor/src/executor/mod.rs
@@ -229,20 +229,27 @@ impl Executor {
             return Ok(None);
         }
 
-        if self.executable_block_height > block.header.height.value() as u32 {
-            debug!(
-                sequencer_block_height = block.header.height.value(),
-                executable_block_height = self.executable_block_height,
-                "skipping execution of stale block"
-            );
-            return Ok(None);
-        } else if self.executable_block_height < block.header.height.value() as u32 {
-            debug!(
-                sequencer_block_height = block.header.height.value(),
-                executable_block_height = self.executable_block_height,
-                "skipping execution of future block"
-            );
-            return Ok(None);
+        match self
+            .executable_block_height
+            .cmp(&(block.header.height.value() as u32))
+        {
+            std::cmp::Ordering::Less => {
+                debug!(
+                    sequencer_block_height = block.header.height.value(),
+                    executable_block_height = self.executable_block_height,
+                    "skipping execution of future block"
+                );
+                return Ok(None);
+            }
+            std::cmp::Ordering::Greater => {
+                debug!(
+                    sequencer_block_height = block.header.height.value(),
+                    executable_block_height = self.executable_block_height,
+                    "skipping execution of stale block"
+                );
+                return Ok(None);
+            }
+            _ => {}
         }
 
         if let Some(execution_block) = self

--- a/crates/astria-conductor/src/executor/mod.rs
+++ b/crates/astria-conductor/src/executor/mod.rs
@@ -214,13 +214,14 @@ impl Executor {
         Ok(())
     }
 
-    /// checks for relevant transactions in the SequencerBlock and attempts
-    /// to execute them via the execution service function DoBlock.
-    /// if there are relevant transactions that successfully execute,
+    /// Checks for relevant transactions in the SequencerBlock and attempts
+    /// to execute them via the execution service function ExecuteBlock.
+    /// If there are relevant transactions that successfully execute,
     /// it returns the resulting execution block hash.
-    /// if the block has already been executed, it returns the previously-computed
+    /// If the block has already been executed, it returns the previously-computed
     /// execution block hash.
     /// if there are no relevant transactions in the SequencerBlock, it returns None.
+    /// If the block is out of order, it returns an error.
     async fn execute_block(&mut self, block: SequencerBlockSubset) -> Result<Option<Block>> {
         if self.disable_empty_block_execution && block.rollup_transactions.is_empty() {
             debug!(

--- a/crates/astria-conductor/src/executor/mod.rs
+++ b/crates/astria-conductor/src/executor/mod.rs
@@ -6,7 +6,6 @@ use astria_sequencer_types::{
 };
 use color_eyre::eyre::{
     self,
-    eyre,
     Result,
     WrapErr as _,
 };

--- a/crates/astria-conductor/src/executor/mod.rs
+++ b/crates/astria-conductor/src/executor/mod.rs
@@ -98,7 +98,7 @@ pub(crate) struct Executor {
     commitment_state: ExecutorCommitmentState,
 
     /// Tracks the height of the next sequencer block that can be executed
-    pub(crate) executable_block_height: u32,
+    executable_block_height: u32,
 
     /// map of sequencer block hash to execution block
     ///
@@ -386,5 +386,9 @@ impl Executor {
             }
         };
         Ok(())
+    }
+
+    pub(crate) fn get_executable_block_height(&self) -> u32 {
+        self.executable_block_height
     }
 }

--- a/crates/astria-conductor/src/executor/tests.rs
+++ b/crates/astria-conductor/src/executor/tests.rs
@@ -283,13 +283,13 @@ async fn try_execute_out_of_order_block_from_sequencer() {
     let mut block = get_test_block_subset();
 
     // 0 is always the genesis block, so this should fail
-    block.header.height = (0 as u32).into();
+    block.header.height = 0_u32.into();
     let execution_result = mock.executor.execute_block(block.clone()).await;
     assert!(execution_result.is_err());
 
     // the first block to execute should always be 1, this should fail as it is
     // in the future
-    block.header.height = (2 as u32).into();
+    block.header.height = 2_u32.into();
     let execution_result = mock.executor.execute_block(block).await;
     assert!(execution_result.is_err());
 }
@@ -300,7 +300,7 @@ async fn try_execute_out_of_order_block_from_celestia() {
     let mut block = get_test_block_subset();
 
     // 0 is always the genesis block, so this should fail
-    block.header.height = (0 as u32).into();
+    block.header.height = 0_u32.into();
     let execution_result = mock
         .executor
         .execute_and_finalize_blocks_from_celestia(vec![block.clone()])
@@ -309,7 +309,7 @@ async fn try_execute_out_of_order_block_from_celestia() {
 
     // the first block to execute should always be 1, this should fail as it is
     // in the future
-    block.header.height = (2 as u32).into();
+    block.header.height = 2_u32.into();
     let execution_result = mock
         .executor
         .execute_and_finalize_blocks_from_celestia(vec![block])

--- a/crates/astria-conductor/src/executor/tests.rs
+++ b/crates/astria-conductor/src/executor/tests.rs
@@ -256,7 +256,7 @@ async fn empty_message_from_data_availability_is_dropped() {
 
 #[tokio::test]
 async fn try_execute_out_of_order_block_from_sequencer() {
-    let mut mock = start_mock(false).await;
+    let mut mock = start_mock().await;
     let mut block = get_test_block_subset();
 
     // 0 is always the genesis block, so this should fail
@@ -273,7 +273,7 @@ async fn try_execute_out_of_order_block_from_sequencer() {
 
 #[tokio::test]
 async fn try_execute_out_of_order_block_from_celestia() {
-    let mut mock = start_mock(false).await;
+    let mut mock = start_mock().await;
     let mut block = get_test_block_subset();
 
     // 0 is always the genesis block, so this should fail

--- a/crates/astria-conductor/src/executor/tests.rs
+++ b/crates/astria-conductor/src/executor/tests.rs
@@ -151,6 +151,7 @@ async fn start_mock(disable_empty_block_execution: bool) -> MockEnvironment {
         &server_url,
         chain_id,
         disable_empty_block_execution,
+        1,
         block_rx,
         shutdown_rx,
     )


### PR DESCRIPTION
## Summary
Conductor now uses the initial commitment state that is pulled when Conductor starts to set the initial sequencer block height more accurately so that sync at startup runs faster.

Basic checks were also put in place to prevent out of order blocks from executing when getting passed to `execute_block`.

## Background
When starting up, Conductor was syncing from it's block 1 even if blocks have already been executed on the rollup. This is inefficient. With the implementation of the execution api v1alpha2, the latest executed block from the rollup can now be pulled and the sync can start where normal execution left off.

## Changes
- Added checks to `execute_block` to prevent out of order execution
- Hight of latest soft block is now pulled from rollup and used to set the block height that sync starts at.

## Testing
Manually tested using dev-cluster

closes https://github.com/astriaorg/astria/issues/530
