### PR TITLE
fix(sequencer): run only `prepare_proposal` if proposer

### DIFF
--- a/crates/astria-conductor/src/executor/mod.rs
+++ b/crates/astria-conductor/src/executor/mod.rs
@@ -213,6 +213,7 @@ impl Executor {
     /// if the block has already been executed, it returns the previously-computed
     /// execution block hash.
     /// if there are no relevant transactions in the SequencerBlock, it returns None.
+    #[instrument(skip(self), fields(sequencer_block_hash = ?block.block_hash, sequencer_block_height = block.header.height.value()))]
     async fn execute_block(&mut self, block: SequencerBlockSubset) -> Result<Option<Block>> {
         if self.disable_empty_block_execution && block.rollup_transactions.is_empty() {
             debug!(
@@ -252,11 +253,8 @@ impl Executor {
 
         // store block hash returned by execution client, as we need it to finalize the block later
         info!(
-            sequencer_block_hash = ?block.block_hash,
-            sequencer_block_height = block.header.height.value(),
             execution_block_hash = hex::encode(&executed_block.hash),
-            tx_count,
-            "executed sequencer block",
+            tx_count, "executed sequencer block",
         );
 
         // store block returned by execution client, as we need it to finalize the block later

--- a/crates/astria-conductor/src/executor/mod.rs
+++ b/crates/astria-conductor/src/executor/mod.rs
@@ -244,6 +244,7 @@ impl Executor {
         let timestamp = convert_tendermint_to_prost_timestamp(block.header.time)
             .wrap_err("failed parsing str as protobuf timestamp")?;
 
+        let tx_count = block.rollup_transactions.len();
         let executed_block = self
             .execution_rpc_client
             .call_execute_block(prev_block_hash, block.rollup_transactions, timestamp)
@@ -254,6 +255,7 @@ impl Executor {
             sequencer_block_hash = ?block.block_hash,
             sequencer_block_height = block.header.height.value(),
             execution_block_hash = hex::encode(&executed_block.hash),
+            tx_count,
             "executed sequencer block",
         );
 

--- a/crates/astria-sequencer/justfile
+++ b/crates/astria-sequencer/justfile
@@ -15,7 +15,7 @@ run:
 run-cometbft:
   cometbft init
   ../../target/debug/astria-sequencer-utils --genesis-app-state-file=test-genesis-app-state.json --destination-genesis-file=$HOME/.cometbft/config/genesis.json
-  sed -i'.bak' 's/timeout_commit = "0s"/timeout_commit = "15s"/g' ~/.cometbft/config/config.toml
+  sed -i'.bak' 's/timeout_commit = "1s"/timeout_commit = "15s"/g' ~/.cometbft/config/config.toml
   cometbft node
 
 run-testnet: 

--- a/crates/astria-sequencer/src/app.rs
+++ b/crates/astria-sequencer/src/app.rs
@@ -77,6 +77,11 @@ type InterBlockState = Arc<StateDelta<Snapshot>>;
 pub(crate) struct App {
     state: InterBlockState,
 
+    // set to true when `prepare_proposal` is called, indicating we are the proposer for this slot.
+    // set to false when `commit` is called, finalizing the block.
+    // when this is se to true, `process_proposal` is not executed, as we have already executed
+    // the transactions for the block during `prepare_proposal`, and re-executing them would
+    // cause failure.
     is_proposer: bool,
 
     // cache of results of executing of transactions in prepare_proposal or process_proposal.

--- a/crates/astria-sequencer/src/app.rs
+++ b/crates/astria-sequencer/src/app.rs
@@ -77,11 +77,13 @@ type InterBlockState = Arc<StateDelta<Snapshot>>;
 pub(crate) struct App {
     state: InterBlockState,
 
-    // set to true when `prepare_proposal` is called, indicating we are the proposer for this slot.
-    // set to false when `commit` is called, finalizing the block.
-    // when this is se to true, `process_proposal` is not executed, as we have already executed
-    // the transactions for the block during `prepare_proposal`, and re-executing them would
-    // cause failure.
+    // set to true when `prepare_proposal` is called, indicating we are the proposer for this
+    // block. set to false when `process_proposal` is called, as it's called during the prevote
+    // phase for that block.
+    //
+    // if true, `process_proposal` is not executed, as this means we are the proposer of that
+    // block, and we have already executed the transactions for the block during
+    // `prepare_proposal`, and re-executing them would cause failure.
     is_proposer: bool,
 
     // cache of results of executing of transactions in prepare_proposal or process_proposal.
@@ -182,9 +184,18 @@ impl App {
         &mut self,
         process_proposal: abci::request::ProcessProposal,
     ) -> anyhow::Result<()> {
+        // if we proposed this block (ie. prepare_proposal was called directly before this), then
+        // we skip execution for this `process_proposal` call.
+        //
+        // if we didn't propose this block, `self.is_proposer` will be `false`, so
+        // we will execute the block as normal.
         if self.is_proposer {
+            debug!("skipping process_proposal as we are the proposer for this block");
+            self.is_proposer = false;
             return Ok(());
         }
+
+        self.is_proposer = false;
 
         // clear the cache of transaction execution results
         self.execution_result.clear();
@@ -422,6 +433,7 @@ impl App {
         state_tx.clear_validator_updates();
 
         let events = self.apply(state_tx);
+
         Ok(abci::response::EndBlock {
             validator_updates: validator_updates.into_tendermint_validator_updates(),
             events,
@@ -461,7 +473,6 @@ impl App {
 
         // Get the latest version of the state, now that we've committed it.
         self.state = Arc::new(StateDelta::new(storage.latest_snapshot()));
-        self.is_proposer = false;
 
         app_hash
     }


### PR DESCRIPTION
## Summary
turns out both `prepare_proposal` and `process_proposal` are called for a proposer node. since we moved transaction execution to prepare/process_proposal, when the proposer called both these functions, execution would fail during `process_proposal` since the state was already updated for post-execution.

## Background
see summary.

## Changes
- track if we're the proposer during the block lifecycle in the `App` struct, and if we are, don't execute transactions during `process_proposal` 

## Testing
local testing
