### PR TITLE
fix(conductor): remove the bearer token from conductor

### DIFF
--- a/crates/astria-conductor/local.env.example
+++ b/crates/astria-conductor/local.env.example
@@ -1,11 +1,6 @@
 # Log Level
 ASTRIA_CONDUCTOR_LOG="astria_conductor=info"
 
-# The bearer token to retrieve sequencer blocks as blobs from Celestia.
-# The token is obtained by running `celestia bridge auth <permissions>`
-# on the host running the celestia node.
-ASTRIA_CONDUCTOR_CELESTIA_BEARER_TOKEN="<JWT Bearer token>"
-
 # Data Availability service url (Celestia node in this case)
 # This url is used to read astria blocks from the Data Availability layer
 ASTRIA_CONDUCTOR_CELESTIA_NODE_URL="http://127.0.0.1:26659"

--- a/crates/astria-conductor/src/conductor.rs
+++ b/crates/astria-conductor/src/conductor.rs
@@ -150,7 +150,6 @@ impl Conductor {
             // TODO ghi(https://github.com/astriaorg/astria/issues/470): add sync functionality to data availability reader
             let reader = data_availability::Reader::new(
                 &cfg.celestia_node_url,
-                &cfg.celestia_bearer_token,
                 std::time::Duration::from_secs(3),
                 executor_tx.clone(),
                 block_verifier,

--- a/crates/astria-conductor/src/config.rs
+++ b/crates/astria-conductor/src/config.rs
@@ -28,9 +28,6 @@ pub struct Config {
     /// URL of the Celestia Node
     pub celestia_node_url: String,
 
-    /// The JWT bearer token supplied with each jsonrpc call
-    pub celestia_bearer_token: String,
-
     /// URL of the sequencer cometbft websocket
     pub sequencer_url: String,
 

--- a/crates/astria-conductor/src/data_availability.rs
+++ b/crates/astria-conductor/src/data_availability.rs
@@ -80,7 +80,6 @@ impl Reader {
     /// Creates a new Reader instance and returns a command sender.
     pub(crate) async fn new(
         celestia_node_url: &str,
-        celestia_bearer_token: &str,
         celestia_poll_interval: Duration,
         executor_tx: executor::Sender,
         block_verifier: BlockVerifier,
@@ -91,7 +90,7 @@ impl Reader {
 
         let celestia_client = celestia_client::celestia_rpc::client::new_http(
             celestia_node_url,
-            Some(celestia_bearer_token),
+            None,
         )
         .wrap_err("failed constructing celestia http client")?;
 


### PR DESCRIPTION
## Summary
Removing the celestia bearer token from conductor

## Background
New versions of celestia node don't require a bearer token to read data, and we are only reading data. This cleans up the flow of using a light client quite a lot. 

## Changes
- remove bearer token from light client. 

## Testing
CI + testing as a part of astriaorg/dev-cluster#124

## Breaking Changelist
- Removes a configuration setting
