### PR TITLE
chore(relayer): implement clippy pedantic suggestions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,7 +120,6 @@ jobs:
           --all-targets \
           --all-features \
           --exclude astria-conductor \
-          --exclude astria-sequencer-relayer \
           -- --warn clippy::pedantic \
              --deny warnings
       - name: run default clippy

--- a/crates/astria-sequencer-relayer/src/api.rs
+++ b/crates/astria-sequencer-relayer/src/api.rs
@@ -51,10 +51,12 @@ pub(crate) fn start(port: u16, relayer_state: RelayerState) -> ApiServer {
     axum::Server::bind(&socket_addr).serve(app.into_make_service())
 }
 
+#[allow(clippy::unused_async)] // Permit because axum handlers must be async
 async fn get_healthz(State(relayer_status): State<RelayerState>) -> Healthz {
-    match relayer_status.borrow().is_ready() {
-        true => Healthz::Ok,
-        false => Healthz::Degraded,
+    if relayer_status.borrow().is_ready() {
+        Healthz::Ok
+    } else {
+        Healthz::Degraded
     }
 }
 
@@ -64,6 +66,7 @@ async fn get_healthz(State(relayer_status): State<RelayerState>) -> Healthz {
 ///
 /// + there is a current sequencer height (implying a block from sequencer was received)
 /// + there is a current data availability height (implying a height was received from the DA)
+#[allow(clippy::unused_async)] // Permit because axum handlers must be async
 async fn get_readyz(State(relayer_status): State<RelayerState>) -> Readyz {
     let is_relayer_online = relayer_status.borrow().is_ready();
     if is_relayer_online {
@@ -73,6 +76,7 @@ async fn get_readyz(State(relayer_status): State<RelayerState>) -> Readyz {
     }
 }
 
+#[allow(clippy::unused_async)] // Permit because axum handlers must be async
 async fn get_status(State(relayer_status): State<RelayerState>) -> Json<serde_json::Value> {
     let relayer::State {
         data_availability_connected,

--- a/crates/astria-sequencer-relayer/src/main.rs
+++ b/crates/astria-sequencer-relayer/src/main.rs
@@ -14,7 +14,7 @@ async fn main() {
         "initializing sequencer relayer"
     );
 
-    SequencerRelayer::new(cfg)
+    SequencerRelayer::new(&cfg)
         .expect("could not initialize sequencer relayer")
         .run()
         .await;

--- a/crates/astria-sequencer-relayer/src/relayer.rs
+++ b/crates/astria-sequencer-relayer/src/relayer.rs
@@ -150,7 +150,7 @@ impl Relayer {
                 .await
                 .wrap_err("timed out getting latest block from sequencer")??;
             Ok(block)
-        }))
+        }));
     }
 
     #[instrument(skip_all)]
@@ -430,7 +430,7 @@ impl Relayer {
         {
             self.conversion_workers.abort_all();
             if let Some(task) = self.submission_task.as_mut() {
-                task.abort()
+                task.abort();
             }
             Ok(())
         }

--- a/crates/astria-sequencer-relayer/src/sequencer_relayer.rs
+++ b/crates/astria-sequencer-relayer/src/sequencer_relayer.rs
@@ -20,8 +20,8 @@ impl SequencerRelayer {
     /// # Errors
     ///
     /// Returns an error if constructing the inner relayer type failed.
-    pub fn new(cfg: Config) -> eyre::Result<Self> {
-        let relayer = Relayer::new(&cfg).wrap_err("failed to create relayer")?;
+    pub fn new(cfg: &Config) -> eyre::Result<Self> {
+        let relayer = Relayer::new(cfg).wrap_err("failed to create relayer")?;
         let state_rx = relayer.subscribe_to_state();
         let api_server = api::start(cfg.rpc_port, state_rx);
         Ok(Self {

--- a/crates/astria-sequencer-relayer/tests/blackbox/helper.rs
+++ b/crates/astria-sequencer-relayer/tests/blackbox/helper.rs
@@ -89,7 +89,7 @@ pub struct TestSequencerRelayer {
     pub signing_key: SigningKey,
     pub account: tendermint::account::Id,
 
-    pub _keyfile: NamedTempFile,
+    pub keyfile: NamedTempFile,
 }
 
 impl TestSequencerRelayer {
@@ -155,7 +155,7 @@ pub async fn spawn_sequencer_relayer(
     let mut celestia = MockCelestia::start(block_time, celestia_mode).await;
     let celestia_addr = (&mut celestia.addr_rx).await.unwrap();
 
-    let _keyfile = tokio::task::spawn_blocking(|| {
+    let keyfile = tokio::task::spawn_blocking(|| {
         use std::io::Write as _;
 
         let keyfile = NamedTempFile::new().unwrap();
@@ -183,21 +183,22 @@ pub async fn spawn_sequencer_relayer(
     let config = Config {
         sequencer_endpoint: sequencer.uri(),
         celestia_endpoint: format!("http://{celestia_addr}"),
-        celestia_bearer_token: "".into(),
-        gas_limit: 100000,
+        celestia_bearer_token: String::new(),
+        gas_limit: 100_000,
         block_time: 1000,
         relay_only_validator_key_blocks,
-        validator_key_file: Some(_keyfile.path().to_string_lossy().to_string()),
+        validator_key_file: Some(keyfile.path().to_string_lossy().to_string()),
         rpc_port: 0,
-        log: "".into(),
+        log: String::new(),
     };
 
     info!(config = serde_json::to_string(&config).unwrap());
     let config_clone = config.clone();
-    let sequencer_relayer = tokio::task::spawn_blocking(|| SequencerRelayer::new(config_clone))
-        .await
-        .unwrap()
-        .unwrap();
+    let sequencer_relayer =
+        tokio::task::spawn_blocking(move || SequencerRelayer::new(&config_clone))
+            .await
+            .unwrap()
+            .unwrap();
     let api_address = sequencer_relayer.local_addr();
     let sequencer_relayer = tokio::task::spawn(sequencer_relayer.run());
 
@@ -211,7 +212,7 @@ pub async fn spawn_sequencer_relayer(
         sequencer_relayer,
         signing_key,
         account: address,
-        _keyfile,
+        keyfile,
     }
 }
 
@@ -246,7 +247,7 @@ use jsonrpsee::{
 pub struct MockCelestia {
     pub addr_rx: oneshot::Receiver<SocketAddr>,
     pub state_rpc_confirmed_rx: mpsc::UnboundedReceiver<Vec<Blob>>,
-    pub _server_handle: ServerHandle,
+    pub server_handle: ServerHandle,
 }
 
 impl MockCelestia {
@@ -265,11 +266,11 @@ impl MockCelestia {
         let header_celestia = HeaderServerImpl;
         let mut merged_celestia = state_celestia.into_rpc();
         merged_celestia.merge(header_celestia.into_rpc()).unwrap();
-        let _server_handle = server.start(merged_celestia);
+        let server_handle = server.start(merged_celestia);
         Self {
             addr_rx,
             state_rpc_confirmed_rx,
-            _server_handle,
+            server_handle,
         }
     }
 }

--- a/crates/astria-sequencer-relayer/tests/blackbox/main.rs
+++ b/crates/astria-sequencer-relayer/tests/blackbox/main.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::missing_panics_doc)]
+
 pub mod helper;
 
 use std::time::Duration;


### PR DESCRIPTION
## Summary
Implement all clippy pedantic suggestions for relayer, activate in CI.

## Background
These changes were made for consistency. All repositories should be checked with clippy pedantic.

## Changes
- Run `cargo clippy -- -W clippy::pedantic`, fix all nags
- Remove `astria-sequencer-relayer` from the `--exclude` list in the clippy CI.

## Testing
All tests still pass. No extra tests are necessary because no structural refactoring took place.

## Related Issues
Closes https://github.com/astriaorg/astria/issues/571
