### PR TITLE
fix(conductor, relayer): use sequencer chain id for sequencer blobs

### DIFF
--- a/crates/astria-celestia-client/src/client.rs
+++ b/crates/astria-celestia-client/src/client.rs
@@ -164,13 +164,12 @@ pub trait CelestiaClientExt: BlobClient {
 
         let mut all_blobs = Vec::with_capacity(num_expected_blobs);
         for (i, block) in blocks.into_iter().enumerate() {
-            let mut blobs =
-                assemble_blobs_from_sequencer_block_data(block).map_err(|source| {
-                    SubmitSequencerBlocksError::AssembleBlobs {
-                        source,
-                        index: i,
-                    }
-                })?;
+            let mut blobs = assemble_blobs_from_sequencer_block_data(block).map_err(|source| {
+                SubmitSequencerBlocksError::AssembleBlobs {
+                    source,
+                    index: i,
+                }
+            })?;
             all_blobs.append(&mut blobs);
         }
 
@@ -258,7 +257,8 @@ fn assemble_blobs_from_sequencer_block_data(
         chain_ids.push(chain_id);
     }
 
-    let sequencer_namespace = celestia_namespace_v0_from_hashed_bytes(header.chain_id.clone().as_bytes());
+    let sequencer_namespace =
+        celestia_namespace_v0_from_hashed_bytes(header.chain_id.clone().as_bytes());
     let sequencer_namespace_data = SequencerNamespaceData {
         block_hash,
         header,
@@ -275,7 +275,8 @@ fn assemble_blobs_from_sequencer_block_data(
     );
 
     blobs.push(
-        Blob::new(sequencer_namespace, data).map_err(BlobAssemblyError::ConstructBlobFromSequencerData)?,
+        Blob::new(sequencer_namespace, data)
+            .map_err(BlobAssemblyError::ConstructBlobFromSequencerData)?,
     );
     Ok(blobs)
 }

--- a/crates/astria-celestia-client/src/client.rs
+++ b/crates/astria-celestia-client/src/client.rs
@@ -146,7 +146,8 @@ pub trait CelestiaClientExt: BlobClient {
     }
 
     /// Submits sequencer `blocks` to celestia after converting and signing them, returning the
-    /// height at which they were included.
+    /// height at which they were included. Sequencer data for each block will be posted to a
+    /// namespace derived from the block's chain ID.
     ///
     /// This calls the `blob.Submit` celestia-node RPC.
     async fn submit_sequencer_blocks(

--- a/crates/astria-celestia-client/src/client.rs
+++ b/crates/astria-celestia-client/src/client.rs
@@ -145,11 +145,20 @@ pub trait CelestiaClientExt: BlobClient {
         Ok(rollup_datas)
     }
 
-    /// Submits sequencer `blocks` to celestia after converting and signing them, returning the
-    /// height at which they were included. Sequencer data for each block will be posted to a
-    /// namespace derived from the block's chain ID.
+    /// Submits sequencer `blocks` to celestia
+    ///
+    /// `Blocks` after converted into celestia blobs and then posted. Rollup
+    /// data is posted to a namespace derived from the rollup chain id.
+    /// Sequencer data for each is posted to a namespace derived from the
+    /// sequencer block's chain ID.
     ///
     /// This calls the `blob.Submit` celestia-node RPC.
+    ///
+    /// Returns Result:
+    /// - Ok: the celestia block height blobs were included in.
+    /// - Errors:
+    ///     - SubmitSequencerBlocksError::AssembleBlobs when failed to assemble blob
+    ///     - SubmitSequencerBlocksError::JsonRpc when Celestia `blob.Submit` fails
     async fn submit_sequencer_blocks(
         &self,
         blocks: Vec<SequencerBlockData>,

--- a/crates/astria-celestia-client/src/client.rs
+++ b/crates/astria-celestia-client/src/client.rs
@@ -258,8 +258,7 @@ fn assemble_blobs_from_sequencer_block_data(
         chain_ids.push(chain_id);
     }
 
-    let sequencer_namespace =
-        celestia_namespace_v0_from_hashed_bytes(header.chain_id.as_bytes());
+    let sequencer_namespace = celestia_namespace_v0_from_hashed_bytes(header.chain_id.as_bytes());
     let sequencer_namespace_data = SequencerNamespaceData {
         block_hash,
         header,

--- a/crates/astria-celestia-client/src/client.rs
+++ b/crates/astria-celestia-client/src/client.rs
@@ -259,7 +259,7 @@ fn assemble_blobs_from_sequencer_block_data(
     }
 
     let sequencer_namespace =
-        celestia_namespace_v0_from_hashed_bytes(header.chain_id.clone().as_bytes());
+        celestia_namespace_v0_from_hashed_bytes(header.chain_id.as_bytes());
     let sequencer_namespace_data = SequencerNamespaceData {
         block_hash,
         header,

--- a/crates/astria-celestia-client/src/lib.rs
+++ b/crates/astria-celestia-client/src/lib.rs
@@ -8,8 +8,5 @@ pub use blob_space::{
 pub use celestia_rpc;
 pub use celestia_tendermint;
 pub use celestia_types;
-use celestia_types::nmt::Namespace;
 pub use client::CelestiaClientExt;
 pub use jsonrpsee;
-
-pub const SEQUENCER_NAMESPACE: Namespace = Namespace::const_v0(*b"astriasequ");

--- a/crates/astria-conductor/src/conductor.rs
+++ b/crates/astria-conductor/src/conductor.rs
@@ -40,7 +40,10 @@ use crate::{
         self,
         ClientProvider,
     },
-    data_availability::{self, CelestiaReaderConfig},
+    data_availability::{
+        self,
+        CelestiaReaderConfig,
+    },
     executor::Executor,
     sequencer,
     Config,

--- a/crates/astria-conductor/src/conductor.rs
+++ b/crates/astria-conductor/src/conductor.rs
@@ -154,10 +154,17 @@ impl Conductor {
             let block_verifier = BlockVerifier::new(sequencer_client_pool.clone());
             let sequencer_namespace = {
                 use sequencer_client::SequencerClientExt as _;
-    
+
                 let client = sequencer_client_pool.get().await?;
-                let chain_id = client.latest_sequencer_block().await?.header().chain_id.clone();
-                celestia_client::blob_space::celestia_namespace_v0_from_hashed_bytes(chain_id.as_bytes())
+                let chain_id = client
+                    .latest_sequencer_block()
+                    .await?
+                    .header()
+                    .chain_id
+                    .clone();
+                celestia_client::blob_space::celestia_namespace_v0_from_hashed_bytes(
+                    chain_id.as_bytes(),
+                )
             };
             // TODO ghi(https://github.com/astriaorg/astria/issues/470): add sync functionality to data availability reader
             let reader = data_availability::Reader::new(

--- a/crates/astria-conductor/src/conductor.rs
+++ b/crates/astria-conductor/src/conductor.rs
@@ -5,6 +5,10 @@ use std::{
 };
 
 use astria_sequencer_types::ChainId;
+use base64::{
+    display::Base64Display,
+    engine::general_purpose::STANDARD,
+};
 use color_eyre::eyre::{
     self,
     WrapErr as _,
@@ -169,6 +173,11 @@ impl Conductor {
                     chain_id.as_bytes(),
                 )
             };
+            info!(
+                celestia_namespace = %Base64Display::new(sequencer_namespace.as_bytes(), &STANDARD),
+                sequencer_chain_id = %cfg.chain_id,
+                "celestia namespace derived from sequencer chain id",
+            );
             let celestia_config = CelestiaReaderConfig {
                 node_url: cfg.celestia_node_url,
                 bearer_token: Some(cfg.celestia_bearer_token),

--- a/crates/astria-conductor/src/conductor.rs
+++ b/crates/astria-conductor/src/conductor.rs
@@ -162,13 +162,19 @@ impl Conductor {
             let sequencer_namespace = {
                 use sequencer_client::SequencerClientExt as _;
 
-                let client = sequencer_client_pool.get().await?;
+                let client = sequencer_client_pool
+                    .get()
+                    .await
+                    .wrap_err(
+                        "failed to get a sequencer client from the pool"
+                    )?;
                 let chain_id = client
                     .latest_sequencer_block()
-                    .await?
-                    .header()
-                    .chain_id
-                    .clone();
+                    .await
+                    .wrap_err("failed to get a block from sequencer")?
+                    .into_raw()
+                    .header
+                    .chain_id;
                 celestia_client::blob_space::celestia_namespace_v0_from_hashed_bytes(
                     chain_id.as_bytes(),
                 )

--- a/crates/astria-conductor/src/conductor.rs
+++ b/crates/astria-conductor/src/conductor.rs
@@ -171,8 +171,10 @@ impl Conductor {
                     .wrap_err("failed to get a sequencer client from the pool")?;
                 let block = tryhard::retry_fn(|| client.latest_sequencer_block())
                     .retries(10)
+                    .exponential_backoff(Duration::from_millis(100))
+                    .max_delay(Duration::from_secs(10))
                     .await
-                    .wrap_err("failed to get block from sequencer")?;
+                    .wrap_err("failed to get block from sequencer after 10 attempts")?;
                 let chain_id = block.into_raw().header.chain_id;
                 celestia_client::blob_space::celestia_namespace_v0_from_hashed_bytes(
                     chain_id.as_bytes(),

--- a/crates/astria-conductor/src/conductor.rs
+++ b/crates/astria-conductor/src/conductor.rs
@@ -40,7 +40,7 @@ use crate::{
         self,
         ClientProvider,
     },
-    data_availability,
+    data_availability::{self, CelestiaReaderConfig},
     executor::Executor,
     sequencer,
     Config,
@@ -166,11 +166,14 @@ impl Conductor {
                     chain_id.as_bytes(),
                 )
             };
+            let celestia_config = CelestiaReaderConfig {
+                node_url: cfg.celestia_node_url,
+                bearer_token: Some(cfg.celestia_bearer_token),
+                poll_interval: std::time::Duration::from_secs(3),
+            };
             // TODO ghi(https://github.com/astriaorg/astria/issues/470): add sync functionality to data availability reader
             let reader = data_availability::Reader::new(
-                &cfg.celestia_node_url,
-                &cfg.celestia_bearer_token,
-                std::time::Duration::from_secs(3),
+                celestia_config,
                 executor_tx.clone(),
                 block_verifier,
                 sequencer_namespace,

--- a/crates/astria-conductor/src/data_availability.rs
+++ b/crates/astria-conductor/src/data_availability.rs
@@ -117,7 +117,7 @@ pub(crate) struct Reader {
     shutdown: oneshot::Receiver<()>,
 }
 
-pub (crate) struct CelestiaReaderConfig {
+pub(crate) struct CelestiaReaderConfig {
     pub(crate) node_url: String,
     pub(crate) bearer_token: Option<String>,
     pub(crate) poll_interval: Duration,

--- a/crates/astria-conductor/src/data_availability.rs
+++ b/crates/astria-conductor/src/data_availability.rs
@@ -12,7 +12,7 @@ use celestia_client::{
     },
     jsonrpsee::http_client::HttpClient,
     CelestiaClientExt as _,
-    SequencerNamespaceData
+    SequencerNamespaceData,
 };
 use color_eyre::eyre::{
     self,

--- a/crates/astria-sequencer-relayer/src/relayer.rs
+++ b/crates/astria-sequencer-relayer/src/relayer.rs
@@ -1,6 +1,5 @@
 use std::time::Duration;
 
-use celestia_client::SEQUENCER_NAMESPACE;
 use eyre::WrapErr as _;
 use humantime::format_duration;
 use sequencer_types::SequencerBlockData;
@@ -479,9 +478,9 @@ async fn submit_blocks_to_celestia(
         num_blocks = sequencer_block_data.len(),
         "submitting collected sequencer blocks to data availability layer",
     );
+
     let height = client
         .submit_sequencer_blocks(
-            SEQUENCER_NAMESPACE,
             sequencer_block_data,
             SubmitOptions {
                 fee: Some(fee),


### PR DESCRIPTION
## Summary
Updates `sequencer-relayer` and `conductor` to use the attached sequencer nodes `chain-id` for  blob namespace.

## Background
We were using a constant for the namespace, which would mean when reading from a production network that sequencer blobs might need to be filtered further based on chain-id, accessing and filtering data without any savings for cost to submit (still would be seperate relayers). This makes it such that our various chains through regenesis and all won't have to do this filtering

## Changes
- Sequencer-relayer sequencer blob namespace derived from sequencer block chain ID on header
- Conductor grabs chain id at startup from a block on rpc sequencer.
- Removed the default namespace

## Testing
CI/CD + manual testing in dev-cluster

## Breaking Changelist
- Posted data blobs to celestia will not match from previous releases.
