### PR TITLE
chore(conductor, relayer): release conductor 0.9.0, sequencer-relayer 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,7 +395,7 @@ dependencies = [
 
 [[package]]
 name = "astria-conductor"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "astria-celestia-client",
  "astria-config",
@@ -517,7 +517,7 @@ dependencies = [
 
 [[package]]
 name = "astria-sequencer-relayer"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "astria-celestia-client",
  "astria-celestia-mock",

--- a/crates/astria-conductor/Cargo.toml
+++ b/crates/astria-conductor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astria-conductor"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 rust-version = "1.70.0"
 

--- a/crates/astria-sequencer-relayer/Cargo.toml
+++ b/crates/astria-sequencer-relayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astria-sequencer-relayer"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 rust-version = "1.70"


### PR DESCRIPTION
Cut new releases of conductor + relayer after updating celestia namespace logic.