### PR TITLE
chore: bump rust version in ci to 1.73.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     if: needs.run_checker.outputs.run_tests == 'true'
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@1.72.0
+      - uses: dtolnay/rust-toolchain@1.73.0
       - uses: taiki-e/install-action@v2.15.2
         with:
           tool: cargo-hack@0.5.29
@@ -39,7 +39,7 @@ jobs:
     if: needs.run_checker.outputs.run_tests == 'true'
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@1.72.0
+      - uses: dtolnay/rust-toolchain@1.73.0
       - uses: Swatinem/rust-cache@v2.6.1
         with:
           cache-provider: "github"
@@ -52,7 +52,7 @@ jobs:
     if: needs.run_checker.outputs.run_tests == 'true'
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@1.72.0
+      - uses: dtolnay/rust-toolchain@1.73.0
       - uses: Swatinem/rust-cache@v2.6.1
         with:
           cache-provider: "buildjet"
@@ -83,7 +83,7 @@ jobs:
     if: needs.run_checker.outputs.run_tests == 'true'
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@1.72.0
+      - uses: dtolnay/rust-toolchain@1.73.0
       - uses: Swatinem/rust-cache@v2.6.1
         with:
           cache-provider: "buildjet"
@@ -100,7 +100,7 @@ jobs:
     if: needs.run_checker.outputs.run_tests == 'true' && needs.run_checker.outputs.run_lint_rust == 'true'
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@1.72.0
+      - uses: dtolnay/rust-toolchain@1.73.0
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2.6.1

--- a/containerfiles/Dockerfile
+++ b/containerfiles/Dockerfile
@@ -1,5 +1,5 @@
 # build stage
-FROM --platform=$BUILDPLATFORM lukemathwalker/cargo-chef:0.1.62-rust-1.72.0-bookworm AS chef
+FROM --platform=$BUILDPLATFORM lukemathwalker/cargo-chef:0.1.62-rust-1.73.0-bookworm AS chef
 
 WORKDIR /build/
 

--- a/crates/astria-sequencer/src/service/mempool.rs
+++ b/crates/astria-sequencer/src/service/mempool.rs
@@ -121,7 +121,7 @@ async fn handle_check_tx<S: StateReadExt + 'static>(
     };
 
     match transaction::check_stateless(&signed_tx) {
-        Ok(_) => response::CheckTx::default(),
+        Ok(()) => response::CheckTx::default(),
         Err(e) => response::CheckTx {
             code: AbciCode::INVALID_PARAMETER.into(),
             info: "transaction failed stateless check".into(),

--- a/crates/astria-test-utils/src/mock/geth.rs
+++ b/crates/astria-test-utils/src/mock/geth.rs
@@ -171,7 +171,7 @@ impl GethServer for GethImpl {
                             break Err("mock received abort command".into());
                         }
                         SubscriptionCommand::Send(tx) => {
-                            let _ = sink.send(SubscriptionMessage::from_json(&tx)?).await?;
+                            let () = sink.send(SubscriptionMessage::from_json(&tx)?).await?;
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
bump rust version in ci to 1.73.0

## Background
required for #579; had to bump penumbra deps, which bumped libp2p, which requires rust >=1.73.0

## Changes
- bump rust version in ci to 1.73.0


