### PR TITLE
chore(conductor, relayer, sequencer): release 0.10.0 conductor, 0.8.0 relayer, and 0.6.0 sequencer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,7 +483,7 @@ dependencies = [
 
 [[package]]
 name = "astria-sequencer"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "astria-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,7 +395,7 @@ dependencies = [
 
 [[package]]
 name = "astria-conductor"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "astria-celestia-client",
  "astria-config",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "astria-sequencer-relayer"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "astria-celestia-client",
  "astria-celestia-mock",

--- a/crates/astria-conductor/Cargo.toml
+++ b/crates/astria-conductor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astria-conductor"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 rust-version = "1.70.0"
 

--- a/crates/astria-sequencer-relayer/Cargo.toml
+++ b/crates/astria-sequencer-relayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astria-sequencer-relayer"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 rust-version = "1.70"

--- a/crates/astria-sequencer/Cargo.toml
+++ b/crates/astria-sequencer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astria-sequencer"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.70.0"
 


### PR DESCRIPTION
Release cuts, major releases due to fundamental change to the merkle tree shape.