### PR TITLE
fix(sequencer): cap tx size at 250kb

### DIFF
--- a/crates/astria-sequencer-types/src/abci_code.rs
+++ b/crates/astria-sequencer-types/src/abci_code.rs
@@ -8,6 +8,7 @@ impl AbciCode {
     pub const INVALID_PARAMETER: Self = Self(2);
     pub const INTERNAL_ERROR: Self = Self(3);
     pub const INVALID_NONCE: Self = Self(4);
+    pub const INVALID_SIZE: Self = Self(5);
 }
 
 impl AbciCode {
@@ -19,6 +20,7 @@ impl AbciCode {
             2 => Some("one or more path parameters were invalid"),
             3 => Some("an internal server error occured"),
             4 => Some("the provided nonce was invalid"),
+            5 => Some("the provided transaction was too large"),
             _ => None,
         }
     }
@@ -31,6 +33,7 @@ impl AbciCode {
             2 => Some(Self::INVALID_PARAMETER),
             3 => Some(Self::INTERNAL_ERROR),
             4 => Some(Self::INVALID_NONCE),
+            5 => Some(Self::INVALID_SIZE),
             _ => None,
         }
     }

--- a/crates/astria-sequencer/src/service/mempool.rs
+++ b/crates/astria-sequencer/src/service/mempool.rs
@@ -86,8 +86,12 @@ async fn handle_check_tx<S: StateReadExt + 'static>(
     } = req;
     if tx.len() > MAX_TX_SIZE {
         return response::CheckTx {
-            code: AbciCode::INVALID_PARAMETER.into(),
-            log: format!("transaction size exceeds maximum allowed size of {MAX_TX_SIZE} bytes"),
+            code: AbciCode::INVALID_SIZE.into(),
+            log: format!(
+                "transaction size too large; received: {}, allowed: {MAX_TX_SIZE}",
+                tx.len()
+            ),
+            info: AbciCode::INVALID_SIZE.to_string(),
             ..response::CheckTx::default()
         };
     }

--- a/crates/astria-sequencer/src/service/mempool.rs
+++ b/crates/astria-sequencer/src/service/mempool.rs
@@ -87,7 +87,7 @@ async fn handle_check_tx<S: StateReadExt + 'static>(
     if tx.len() > MAX_TX_SIZE {
         return response::CheckTx {
             code: AbciCode::INVALID_PARAMETER.into(),
-            log: format!("transaction size exceeds maximum allowed size of {MAX_TX_SIZE} bytes",),
+            log: format!("transaction size exceeds maximum allowed size of {MAX_TX_SIZE} bytes"),
             ..response::CheckTx::default()
         };
     }


### PR DESCRIPTION
## Summary
we saw that on devnet, submitting a tx that exceeds the `max_tx_bytes` per block (~22mb) will result in it hanging around the mempool forever, as it cannot end up in a block, and causes all txs to remain pending. this is bad, and we need to ensure txs that are too large don't end up in the mempool to begin with.

## Background
the size chosen (250kb) was based on @jbowen93 's comment:
> Celestia has 2MB blocks and I believe we batch up to 5 Astria blocks to Celestia. So if we wanted to be conservative like 250KB, but we could go as high as 400KB.

we can change this later if needed, but this is a good starting point.

## Changes
- add a check in `CheckTx` that rejects the tx if it's larger than 250kb

## Testing
devnet (after)

## Breaking Changelist
- txs >250kb will be rejected

