### PR TITLE
fix(ci): pin foundry to different version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: "nightly-89f74f26926b552e0fbfca0858f0a129dec79881"
+          version: "nightly-94518c20bf42c23e7b5d557190998abcfc05b7a7"
       - name: Build tests
         run: |
           cargo test --no-run --release --workspace \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: "nightly-94518c20bf42c23e7b5d557190998abcfc05b7a7"
+          version: "nightly-60ec00296f00754bc21ed68fd05ab6b54b50e024"
       - name: Build tests
         run: |
           cargo test --no-run --release --workspace \


### PR DESCRIPTION
## Summary
previous version appeared to have been pulled, causing a 404?? https://github.com/foundry-rs/foundry/tags 
see https://github.com/foundry-rs/foundry-toolchain/issues/35

this updates it to an older version that doesn't look like it will get pulled.