### PR TITLE
chore: update penumbra-ibc features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ sha2 = "0.10"
 serde = "1"
 serde_json = "1"
 penumbra-component = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "11d3b524da750c16c376759b03e4bbb3474562d9" }
-penumbra-ibc = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "11d3b524da750c16c376759b03e4bbb3474562d9" }
+penumbra-ibc = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "11d3b524da750c16c376759b03e4bbb3474562d9", default-features = false }
 penumbra-proto = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "11d3b524da750c16c376759b03e4bbb3474562d9" }
 penumbra-storage = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "11d3b524da750c16c376759b03e4bbb3474562d9" }
 penumbra-tower-trace = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "11d3b524da750c16c376759b03e4bbb3474562d9" }

--- a/crates/astria-sequencer/Cargo.toml
+++ b/crates/astria-sequencer/Cargo.toml
@@ -25,7 +25,7 @@ ed25519-consensus = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true, features = ["serde"] }
 penumbra-component = { workspace = true }
-penumbra-ibc = { workspace = true, features = [ "component" ] }
+penumbra-ibc = { workspace = true, features = ["component"] }
 penumbra-proto = { workspace = true }
 penumbra-storage = { workspace = true }
 penumbra-tower-trace = { workspace = true }

--- a/crates/astria-sequencer/Cargo.toml
+++ b/crates/astria-sequencer/Cargo.toml
@@ -25,7 +25,7 @@ ed25519-consensus = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true, features = ["serde"] }
 penumbra-component = { workspace = true }
-penumbra-ibc = { workspace = true }
+penumbra-ibc = { workspace = true, features = [ "component" ] }
 penumbra-proto = { workspace = true }
 penumbra-storage = { workspace = true }
 penumbra-tower-trace = { workspace = true }


### PR DESCRIPTION
## Summary
astria-proto doesn't require the penumbra-ibc `component` feature (on by default). 

## Changes
- turn the `component` feature off by default for penumbra-ibc, enable it for sequencer only
