### PR TITLE
fix(constructor): add error context, simplify type conversions

### DIFF
--- a/crates/astria-conductor/src/conductor.rs
+++ b/crates/astria-conductor/src/conductor.rs
@@ -117,7 +117,9 @@ impl Conductor {
                 .build()
                 .await
                 .wrap_err("failed to construct executor")?;
-            let executable_sequencer_block_height = executor.get_executable_block_height()?;
+            let executable_sequencer_block_height = executor
+                .calculate_executable_block_height()
+                .wrap_err("failed calculating the next executable block height")?;
 
             tasks.spawn(Self::EXECUTOR, executor.run_until_stopped());
             shutdown_channels.insert(Self::EXECUTOR, shutdown_tx);

--- a/crates/astria-conductor/src/executor/mod.rs
+++ b/crates/astria-conductor/src/executor/mod.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use color_eyre::eyre::{
     self,
     bail,
-    eyre,
+    ensure,
     Result,
     WrapErr as _,
 };
@@ -417,15 +417,15 @@ impl Executor {
     /// returns the previously-computed execution block hash.
     #[instrument(skip(self), fields(sequencer_block_hash = ?block.block_hash, sequencer_block_height = block.header.height.value()))]
     async fn execute_block(&mut self, block: SequencerBlockSubset) -> Result<Block> {
-        let executable_block_height = self.get_executable_block_height()?;
-        if u64::from(executable_block_height) != block.header.height.value() {
-            error!(
-                sequencer_block_height = block.header.height.value(),
-                executable_block_height = executable_block_height,
-                "block received out of order;"
-            );
-            return Err(eyre!("block received out of order"));
-        }
+        let executable_block_height = self
+            .calculate_executable_block_height()
+            .wrap_err("failed calculating the next executable block height")?;
+        let actual_block_height = block.header.height;
+        ensure!(
+            executable_block_height == actual_block_height,
+            "received out-of-order block; expected `{executable_block_height}`, got \
+             `{actual_block_height}`",
+        );
 
         if let Some(execution_block) = self
             .sequencer_hash_to_execution_block
@@ -521,11 +521,13 @@ impl Executor {
             return Ok(());
         }
         for block in blocks {
-            let finalizable_block_height = self.get_finalizable_block_height()?;
-            if block.header.height.value() < u64::from(finalizable_block_height) {
+            let finalizable_block_height = self
+                .calculate_finalizable_block_height()
+                .wrap_err("failed calculating next finalizable block height")?;
+            if block.header.height < finalizable_block_height {
                 info!(
-                    sequencer_block_height = block.header.height.value(),
-                    finalized_block_height = finalizable_block_height,
+                    sequencer_block_height = %block.header.height,
+                    finalized_block_height = %finalizable_block_height,
                     "received block which is already finalized; skipping finalization"
                 );
                 continue;
@@ -569,7 +571,7 @@ impl Executor {
     }
 
     // Returns the next sequencer block height which can be executed on the rollup
-    pub(crate) fn get_executable_block_height(&self) -> Result<u32> {
+    pub(crate) fn calculate_executable_block_height(&self) -> Result<tendermint::block::Height> {
         let Some(executable_block_height) = calculate_sequencer_block_height(
             self.sequencer_height_with_first_rollup_block,
             self.commitment_state.soft.number,
@@ -582,11 +584,11 @@ impl Executor {
             );
         };
 
-        Ok(executable_block_height)
+        Ok(executable_block_height.into())
     }
 
     // Returns the lowest sequencer block height which can finalized on the rollup.
-    pub(crate) fn get_finalizable_block_height(&self) -> Result<u32> {
+    pub(crate) fn calculate_finalizable_block_height(&self) -> Result<tendermint::block::Height> {
         let Some(finalizable_block_height) = calculate_sequencer_block_height(
             self.sequencer_height_with_first_rollup_block,
             self.commitment_state.firm.number,
@@ -599,7 +601,7 @@ impl Executor {
             );
         };
 
-        Ok(finalizable_block_height)
+        Ok(finalizable_block_height.into())
     }
 }
 

--- a/crates/astria-conductor/src/sequencer/mod.rs
+++ b/crates/astria-conductor/src/sequencer/mod.rs
@@ -60,7 +60,7 @@ pub(crate) struct Reader {
     shutdown: oneshot::Receiver<()>,
 
     /// The start height from which to start syncing sequencer blocks.
-    start_sync_height: u32,
+    start_sync_height: Height,
 
     /// The sync-done channel to notify `Conductor` that `Reader` has finished syncing.
     sync_done: oneshot::Sender<()>,
@@ -68,7 +68,7 @@ pub(crate) struct Reader {
 
 impl Reader {
     pub(crate) fn new(
-        start_sync_height: u32,
+        start_sync_height: Height,
         pool: Pool<ClientProvider>,
         shutdown: oneshot::Receiver<()>,
         executor_tx: executor::Sender,
@@ -126,7 +126,7 @@ impl Reader {
         );
 
         let mut sync = sync::run(
-            start_sync_height.into(),
+            start_sync_height,
             next_height,
             pool.clone(),
             executor_tx.clone(),


### PR DESCRIPTION
## Summary
This patch adds missing error context to fallible operations.

## Background
Errors should not be returned with context.

## Changes
- Add error context with `wrap_err` where missing
- Rename `get_*` to `calculate_*` methods because that's what they do
- Let `calculate_*`methods returned a tendermint `Height` to avoid moving in and out of types.

## Testing
No logic changes, tests still pass.

## Related Issues
Follow-up to https://github.com/astriaorg/astria/pull/617