### PR TITLE
fix(conductor): fail hard when executing blocks fails

### DIFF
--- a/crates/astria-conductor/src/executor/mod.rs
+++ b/crates/astria-conductor/src/executor/mod.rs
@@ -37,7 +37,6 @@ use tracing::{
     error,
     info,
     instrument,
-    warn,
 };
 
 use crate::data_availability::SequencerBlockSubset;


### PR DESCRIPTION
## Summary
Return an error when executing blocks fails because this means the block chain state is no longer reconcilable.

## Changes
- Return errors rather than just logging them when encountering errors during block execution.
- Refactor shutdown reporting in executor.

## Testing
No testable changes