### PR TITLE
wip(cli)!: update cli to not take cli + basic validation

### DIFF
--- a/crates/astria-cli/src/cli/rollup.rs
+++ b/crates/astria-cli/src/cli/rollup.rs
@@ -58,12 +58,9 @@ pub struct ConfigCreateArgs {
     pub log_level: String,
 
     // rollup config
-    /// The name of the rollup
+    /// The name of the rollup, lowercase alphanumeric and '-' allowed. Max 240 charachters.
     #[clap(long = "rollup.name", env = "ROLLUP_NAME")]
     pub name: String,
-    /// Optional. Will be derived from the rollup name if not provided
-    #[clap(long = "rollup.chain-id", env = "ROLLUP_CHAIN_ID", required = false)]
-    pub chain_id: Option<String>,
     /// The Network ID for the EVM chain
     #[clap(long = "rollup.network-id", env = "ROLLUP_NETWORK_ID", default_value_t = DEFAULT_NETWORK_ID)]
     pub network_id: u64,

--- a/crates/astria-cli/src/commands/rollup.rs
+++ b/crates/astria-cli/src/commands/rollup.rs
@@ -18,7 +18,7 @@ use astria_sequencer_client::{
 };
 use color_eyre::{
     eyre,
-    eyre::Context,
+    eyre::{Context, ensure},
 };
 
 use crate::{
@@ -106,6 +106,11 @@ fn update_yaml_value(
 pub(crate) async fn create_config(args: &ConfigCreateArgs) -> eyre::Result<()> {
     // create rollup from args
     let mut conf = args.clone();
+
+    ensure!(
+        conf.name.len() <= 240 && conf.name.chars().all(|c| c.is_ascii_lowercase() || c.is_numeric() || c == '-'),
+        "rollup name must be alphanumeric or '-' and less than 240 characters"
+    );
 
     // Fetch the latest block from sequencer if none specified.
     if conf.sequencer_initial_block_height.is_none() {
@@ -326,7 +331,6 @@ mod test {
         ConfigCreateArgs {
             use_tty: false,
             name: "test".to_string(),
-            chain_id: None,
             network_id: 0,
             skip_empty_blocks: false,
             genesis_accounts: vec![],

--- a/crates/astria-cli/src/types.rs
+++ b/crates/astria-cli/src/types.rs
@@ -162,11 +162,6 @@ impl TryFrom<&ConfigCreateArgs> for RollupDeploymentConfig {
     type Error = eyre::Report;
 
     fn try_from(args: &ConfigCreateArgs) -> eyre::Result<Self> {
-        let chain_id = args
-            .chain_id
-            .clone()
-            .unwrap_or(format!("{}-chain", args.name));
-
         // Set to block 1 if nothing set.
         let sequencer_initial_block_height = args.sequencer_initial_block_height.unwrap_or(1);
 
@@ -180,7 +175,6 @@ impl TryFrom<&ConfigCreateArgs> for RollupDeploymentConfig {
         Ok(Self {
             rollup: RollupConfig {
                 name: args.name.clone(),
-                chain_id,
                 network_id: args.network_id.to_string(),
                 skip_empty_blocks: args.skip_empty_blocks,
                 genesis_accounts,
@@ -198,7 +192,6 @@ impl TryFrom<&ConfigCreateArgs> for RollupDeploymentConfig {
 #[serde(rename_all = "camelCase")]
 pub struct RollupConfig {
     name: String,
-    chain_id: String,
     // NOTE - String here because yaml will serialize large ints w/ scientific notation
     network_id: String,
     skip_empty_blocks: bool,
@@ -246,7 +239,6 @@ mod tests {
             use_tty: true,
             log_level: "debug".to_string(),
             name: "rollup1".to_string(),
-            chain_id: Some("chain1".to_string()),
             network_id: 1,
             skip_empty_blocks: true,
             genesis_accounts: vec![
@@ -275,7 +267,6 @@ mod tests {
             deployment_config: RollupDeploymentConfig {
                 rollup: RollupConfig {
                     name: "rollup1".to_string(),
-                    chain_id: "chain1".to_string(),
                     network_id: "1".to_string(),
                     skip_empty_blocks: true,
                     genesis_accounts: vec![
@@ -321,7 +312,6 @@ mod tests {
             use_tty: false,
             log_level: "info".to_string(),
             name: "rollup2".to_string(),
-            chain_id: None,
             network_id: 2_211_011_801,
             skip_empty_blocks: false,
             genesis_accounts: vec![GenesisAccountArg {
@@ -344,7 +334,6 @@ mod tests {
             deployment_config: RollupDeploymentConfig {
                 rollup: RollupConfig {
                     name: "rollup2".to_string(),
-                    chain_id: "rollup2-chain".to_string(), // Derived from name
                     network_id: "2211011801".to_string(),
                     skip_empty_blocks: false,
                     genesis_accounts: vec![GenesisAccount {


### PR DESCRIPTION
## Summary
Removes the concept of rollup chain id, replaces with always using rollup chain id. Adds some validation of that name

## Background
Chain ID is overloaded, #633 removes the concept from main surfaces of conductor and composer. Also removing from helm charts. This PR will rely on the helm chart updates. 

## Changes
- List changes which were made.

## Testing
How are these changes tested?

## Breaking Changelist
- Bulleted list of breaking changes, any notes on migration. Delete section if none.

## Related Issues
Link any issues that are related, prefer full github links.

closes <!-- list any issues closed here -->
