### PR TITLE
fix(ci): adjust input to proto breaking change linter after refactor

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           # The 'main' branch of the GitHub repository that defines the module.
           input: "proto"
-          against: "https://github.com/astriaorg/astria.git#branch=main,ref=HEAD,subdir=crates/proto"
+          against: "https://github.com/astriaorg/astria.git#branch=main,ref=HEAD,subdir=proto"
 
   rust:
     runs-on: ubuntu-22.04

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           # The 'main' branch of the GitHub repository that defines the module.
           input: "proto"
-          against: "https://github.com/astriaorg/astria.git#branch=main,ref=HEAD,subdir=crates/astria-proto/proto"
+          against: "https://github.com/astriaorg/astria.git#branch=main,ref=HEAD,subdir=crates/proto"
 
   rust:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Summary
Adjusts the proto breaking change linter to use the new `proto/` root level directory.

## Background
Moving the protobuf spec out of `astria-proto` to `proto` broke the CI job checking for breaking changes. This breakage of CI was expected and this fixes it.

## Changes
- Change the input to the breaking change proto linter to check against `main:proto/`

## Related Issues
Follow-up to https://github.com/astriaorg/astria/pull/629