### PR TITLE
ci(proto): add proto formatting, cleanup justfile

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,11 +33,12 @@ jobs:
       - uses: bufbuild/buf-lint-action@v1
         with:
           input: "proto/"
+      - run: buf format proto -d --exit-code
       - uses: bufbuild/buf-breaking-action@v1
         with:
           # The 'main' branch of the GitHub repository that defines the module.
           input: "proto"
-          against: "https://github.com/astriaorg/astria.git#branch=main,ref=HEAD,subdir=proto"
+          against: "buf.build/astria/astria"
 
   rust:
     runs-on: ubuntu-22.04

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ markdown.
 # Install rustfmt
 rustup +nightly-2023-08-18 component add rustfmt
 # Run rustfmt
-just fmt-rust
+just fmt rust
 ```
 
 ### Toml
@@ -101,7 +101,7 @@ brew install taplo
 sudo pacman -S taplo
 
 # Run
-just fmt-toml
+just fmt toml
 ```
 
 ### Markdown
@@ -115,7 +115,7 @@ sudo pacman -S markdownlint-cli2
 npm install markdownlint-cli2 --global
 
 # Run
-markdownlint-cli2 "**/*.md" "#target" "#.github"
+just lint md
 
 # Run with docker
 docker run -v $PWD:/workdir davidanson/markdownlint-cli2:v0.8.1 "**/*.md" "#.github"

--- a/justfile
+++ b/justfile
@@ -1,46 +1,67 @@
 default:
   @just --list
 
-create-cluster:
-  kind create cluster --config ./crates/astria-celestia-jsonrpc-client/k8s/cluster-config.yml
-
-deploy-ingress-controller:
-  kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
-
-wait-for-ingress-controller:
-  kubectl wait --namespace ingress-nginx --for=condition=ready pod --selector=app.kubernetes.io/component=controller --timeout=600s
-
-start-celestia-jsonrpc-test-deployment:
-  kubectl apply -k crates/astria-celestia-jsonrpc-client/k8s/
-
-wait-for-celestia-jsonrpc-test-deployment:
-  kubectl wait --namespace astria-celestia-jsonrpc-client-test deployment --for=condition=Available --selector=app.kubernetes.io/name=astria-celestia-jsonrpc-client-test --timeout=600s
-
-delete-cluster:
-  kind delete cluster --name astria-celestia-jsonrpc-client-test
-
 default_docker_tag := 'local'
 
+# Builds docker image for the crate. Defaults to 'local' tag.
 docker-build crate tag=default_docker_tag:
   docker buildx build --load --build-arg TARGETBINARY={{crate}} -f containerfiles/Dockerfile -t {{crate}}:{{tag}} .
-
-fmt-rust:
-  cargo +nightly-2023-08-18 fmt --all 
-
-lint-rust:
-  cargo +nightly-2023-08-18 fmt --all -- --check
-
-fmt-toml:
-  taplo format
-
-lint-toml:
-  taplo format --check
-
-lint-md:
-  markdownlint-cli2 "**/*.md" "#target" "#.github"
 
 install-cli:
   cargo install --path ./crates/astria-cli --locked
 
+# Compiles the generated rust code from protos which are used in crates.
 compile-protos:
   cargo run --manifest-path tools/protobuf-compiler/Cargo.toml
+
+## Scripts related to formatting code
+default_lang := 'all'
+
+# Can format 'rust', 'toml', 'proto', or 'all'. Defaults to all
+fmt lang=default_lang:
+  @just _fmt-{{lang}}
+
+# Can lint 'rust', 'toml', 'proto', 'md' or 'all'. Defaults to all.
+lint lang=default_lang:
+  @just _lint-{{lang}}
+
+_fmt-all: 
+  @just _fmt-rust 
+  @just _fmt-toml
+  @just _fmt-proto
+
+@_lint-all: 
+  -just _lint-rust 
+  -just _lint-toml 
+  -just _lint-proto
+  -just _lint-md
+
+[no-exit-message]
+_fmt-rust:
+  cargo +nightly-2023-08-18 fmt --all 
+
+[no-exit-message]
+_lint-rust:
+  cargo +nightly-2023-08-18 fmt --all -- --check
+
+[no-exit-message]
+_fmt-toml:
+  taplo format
+
+[no-exit-message]
+_lint-toml:
+  taplo format --check
+
+[no-exit-message]
+_lint-md:
+  markdownlint-cli2 "**/*.md" "#target" "#.github"
+
+[no-exit-message]
+_fmt-proto:
+  buf format proto -w
+
+[no-exit-message]
+_lint-proto:
+  buf lint proto
+  buf format proto -d --exit-code
+  buf breaking proto --against 'buf.build/astria/astria'

--- a/proto/README.md
+++ b/proto/README.md
@@ -25,6 +25,19 @@ $ cargo run --manifest-path tools/protobuf-compiler/Cargo.toml
 # Will emit warnings or errors raised by buf
 ```
 
+There are also just commands which can be run from anywhere in repo:
+
+```sh
+# Compiles protos as above
+$ just compile-protos
+
+# Will apply formatting to proto files
+$ just fmt proto
+
+# checks for breaking changes, buf lint errors, and logs any formatting changes
+$ just lint proto
+```
+
 When creating a new package, follow the following convention:
 
 * Create a new folder `proto/astria/<pkg-name>/<version>`.
@@ -39,9 +52,3 @@ When creating a new package, follow the following convention:
   * [other ways to install](https://docs.buf.build/installation)
 * `$ buf registry login` - [must first create an API
   token](https://docs.buf.build/tutorials/getting-started-with-bsr#create-an-api-token)
-
-### Building and pushing after making changes in `proto`
-
-* `$ buf build` - [builds the proto files into a single binary
-  file](https://docs.buf.build/build/explanation#what-are-buf-images)
-* `$ buf push` - pushes a module to the registry

--- a/proto/astria/execution/v1alpha1/execution.proto
+++ b/proto/astria/execution/v1alpha1/execution.proto
@@ -20,7 +20,7 @@ message FinalizeBlockRequest {
 
 message FinalizeBlockResponse {}
 
-message InitStateRequest{}
+message InitStateRequest {}
 
 message InitStateResponse {
   bytes block_hash = 1;

--- a/proto/astria/execution/v1alpha2/execution.proto
+++ b/proto/astria/execution/v1alpha2/execution.proto
@@ -35,11 +35,11 @@ message GetBlockRequest {
 message BatchGetBlocksRequest {
   repeated BlockIdentifier identifiers = 1;
 }
+
 // The list of blocks in response to BatchGetBlocks.
 message BatchGetBlocksResponse {
   repeated Block blocks = 1;
 }
-
 
 // ExecuteBlockRequest contains all the information needed to create a new rollup
 // block.
@@ -71,7 +71,7 @@ message CommitmentState {
 }
 
 // There is only one CommitmentState object, so the request is empty.
-message GetCommitmentStateRequest{}
+message GetCommitmentStateRequest {}
 
 // The CommitmentState to set, must include complete state.
 message UpdateCommitmentStateRequest {
@@ -79,7 +79,7 @@ message UpdateCommitmentStateRequest {
 }
 
 // ExecutionService is used to drive deterministic production of blocks.
-// 
+//
 // The service can be implemented by any blockchain which wants to utilize the
 // Astria Shared Sequencer, and will have block production driven via the Astria
 // "Conductor".

--- a/proto/astria/sequencer/v1alpha1/asset.proto
+++ b/proto/astria/sequencer/v1alpha1/asset.proto
@@ -5,6 +5,6 @@ package astria.sequencer.v1alpha1;
 /// Represents a denomination of some asset used within the sequencer.
 /// The `id` is used to identify the asset and for balance accounting.
 message Denom {
-    bytes id = 1;
-    string base_denom = 2;
+  bytes id = 1;
+  string base_denom = 2;
 }

--- a/proto/astria/sequencer/v1alpha1/block.proto
+++ b/proto/astria/sequencer/v1alpha1/block.proto
@@ -2,8 +2,8 @@ syntax = "proto3";
 
 package astria.sequencer.v1alpha1;
 
-import "tendermint/types/types.proto";
 import "astria/sequencer/v1alpha1/merkle.proto";
+import "tendermint/types/types.proto";
 
 // `RollupTransactions` are a sequence of opaque bytes together with a 32 byte
 // identifier of that rollup.
@@ -11,33 +11,33 @@ import "astria/sequencer/v1alpha1/merkle.proto";
 // The binary encoding is understood as an implementation detail of the
 // services sending and receiving the transactions.
 message RollupTransactions {
-    // The 32 bytes identifying a rollup. Usually the sha256 hash of a plain rollup name.
-    bytes id = 1;
-    // The serialized opaque bytes of the rollup transactions.
-    repeated bytes transactions = 2;
+  // The 32 bytes identifying a rollup. Usually the sha256 hash of a plain rollup name.
+  bytes id = 1;
+  // The serialized opaque bytes of the rollup transactions.
+  repeated bytes transactions = 2;
 }
 
 // `SequencerBlock` is constructed from a tendermint/cometbft block by
 // converting its opaque `data` bytes into sequencer specific types.
 message SequencerBlock {
-    // The original CometBFT header that was the input to this sequencer block.
-    tendermint.types.Header header = 1;
-    // The collection of rollup transactions that were included in this block.
-    repeated RollupTransactions rollup_transactions = 2;
-    // The proof that the rollup transactions are included in the CometBFT block this
-    // sequencer block is derived form. This proof together with
-    // `Sha256(MTH(rollup_transactions))` must match `header.data_hash`.
-    // `MTH(rollup_transactions)` is the Merkle Tree Hash derived from the
-    // rollup transactions.
-    astria.sequencer.v1alpha1.Proof rollup_transactions_proof = 3;
-    // The proof that the rollup IDs listed in `rollup_transactions` are included
-    // in the CometBFT block this sequencer block is derived form.
-    //
-    // This proof is used to verify that the relayer that posts to celestia
-    // includes all rollup IDs and does not censor any.
-    //
-    // This proof together with `Sha256(MTH(rollup_ids))` must match `header.data_hash`.
-    // `MTH(rollup_ids)` is the Merkle Tree Hash derived from the rollup IDs listed in
-    // the rollup transactions.
-    astria.sequencer.v1alpha1.Proof rollup_ids_proof = 4;
+  // The original CometBFT header that was the input to this sequencer block.
+  tendermint.types.Header header = 1;
+  // The collection of rollup transactions that were included in this block.
+  repeated RollupTransactions rollup_transactions = 2;
+  // The proof that the rollup transactions are included in the CometBFT block this
+  // sequencer block is derived form. This proof together with
+  // `Sha256(MTH(rollup_transactions))` must match `header.data_hash`.
+  // `MTH(rollup_transactions)` is the Merkle Tree Hash derived from the
+  // rollup transactions.
+  astria.sequencer.v1alpha1.Proof rollup_transactions_proof = 3;
+  // The proof that the rollup IDs listed in `rollup_transactions` are included
+  // in the CometBFT block this sequencer block is derived form.
+  //
+  // This proof is used to verify that the relayer that posts to celestia
+  // includes all rollup IDs and does not censor any.
+  //
+  // This proof together with `Sha256(MTH(rollup_ids))` must match `header.data_hash`.
+  // `MTH(rollup_ids)` is the Merkle Tree Hash derived from the rollup IDs listed in
+  // the rollup transactions.
+  astria.sequencer.v1alpha1.Proof rollup_ids_proof = 4;
 }

--- a/proto/astria/sequencer/v1alpha1/celestia.proto
+++ b/proto/astria/sequencer/v1alpha1/celestia.proto
@@ -2,8 +2,8 @@ syntax = "proto3";
 
 package astria.sequencer.v1alpha1;
 
-import "tendermint/types/types.proto";
 import "astria/sequencer/v1alpha1/merkle.proto";
+import "tendermint/types/types.proto";
 
 // A collection of transactions belonging to a specific rollup that are submitted to celestia.
 //
@@ -11,16 +11,16 @@ import "astria/sequencer/v1alpha1/merkle.proto";
 // by `rollup_id`, and were included in the sequencer block identified
 // by `sequencer_block_hash`.
 message CelestiaRollupBlob {
-    // The hash of the sequencer block. Must be 32 bytes.
-    bytes sequencer_block_hash = 1;
-    // The 32 bytes identifying the rollup this blob belongs to. Matches
-    // `astria.sequencer.v1alpha1.RollupTransactions.rollup_id`
-    bytes rollup_id = 2;
-    // A list of opaque bytes that are serialized rollup transactions.
-    repeated bytes transactions = 3;
-    // The proof that these rollup transactions are included in sequencer block.
-    // `astria.sequencer.v1alpha.SequencerBlock.rollup_transactions_proof`.
-    astria.sequencer.v1alpha1.Proof proof = 4;
+  // The hash of the sequencer block. Must be 32 bytes.
+  bytes sequencer_block_hash = 1;
+  // The 32 bytes identifying the rollup this blob belongs to. Matches
+  // `astria.sequencer.v1alpha1.RollupTransactions.rollup_id`
+  bytes rollup_id = 2;
+  // A list of opaque bytes that are serialized rollup transactions.
+  repeated bytes transactions = 3;
+  // The proof that these rollup transactions are included in sequencer block.
+  // `astria.sequencer.v1alpha.SequencerBlock.rollup_transactions_proof`.
+  astria.sequencer.v1alpha1.Proof proof = 4;
 }
 
 // The metadata of a sequencer block that is submitted to celestia.
@@ -32,22 +32,22 @@ message CelestiaRollupBlob {
 // The original sequencer block (and in turn CometBFT block) can be identified by the
 // block hash calculated from `header`.
 message CelestiaSequencerBlob {
-    // The original CometBFT header that is the input to this blob's original sequencer block.
-    // Corresponds to `astria.sequencer.v1alpha.SequencerBlock.header`.
-    tendermint.types.Header header = 1;
-    // The rollup IDs for which `CelestiaRollupBlob`s were submitted to celestia.
-    // Corresponds to the `astria.sequencer.v1alpha1.RollupTransactions.rollup_id` field
-    // and is extracted from `astria.sequencer.v1alpha.SequencerBlock.rollup_transactions`.
-    repeated bytes rollup_ids = 2;
-    // The Merkle Tree Hash of the rollup transactions. Corresponds to
-    // `MHT(astria.sequencer.v1alpha.SequencerBlock.rollup_transactions)`, the Merkle
-    // Tree Hash deriveed from the rollup transactions.
-    // Always 32 bytes.
-    bytes rollup_transactions_root = 3;
-    // The proof that the rollup transactions are included in sequencer block.
-    // Corresponds to `astria.sequencer.v1alpha.SequencerBlock.rollup_transactions_proof`.
-    astria.sequencer.v1alpha1.Proof rollup_transactions_proof = 4;
-    // The proof that the rollup IDs are included in sequencer block.
-    // Corresponds to `astria.sequencer.v1alpha.SequencerBlock.rollup_ids_proof`.
-    astria.sequencer.v1alpha1.Proof rollup_ids_proof = 5;
+  // The original CometBFT header that is the input to this blob's original sequencer block.
+  // Corresponds to `astria.sequencer.v1alpha.SequencerBlock.header`.
+  tendermint.types.Header header = 1;
+  // The rollup IDs for which `CelestiaRollupBlob`s were submitted to celestia.
+  // Corresponds to the `astria.sequencer.v1alpha1.RollupTransactions.rollup_id` field
+  // and is extracted from `astria.sequencer.v1alpha.SequencerBlock.rollup_transactions`.
+  repeated bytes rollup_ids = 2;
+  // The Merkle Tree Hash of the rollup transactions. Corresponds to
+  // `MHT(astria.sequencer.v1alpha.SequencerBlock.rollup_transactions)`, the Merkle
+  // Tree Hash deriveed from the rollup transactions.
+  // Always 32 bytes.
+  bytes rollup_transactions_root = 3;
+  // The proof that the rollup transactions are included in sequencer block.
+  // Corresponds to `astria.sequencer.v1alpha.SequencerBlock.rollup_transactions_proof`.
+  astria.sequencer.v1alpha1.Proof rollup_transactions_proof = 4;
+  // The proof that the rollup IDs are included in sequencer block.
+  // Corresponds to `astria.sequencer.v1alpha.SequencerBlock.rollup_ids_proof`.
+  astria.sequencer.v1alpha1.Proof rollup_ids_proof = 5;
 }

--- a/proto/astria/sequencer/v1alpha1/data.proto
+++ b/proto/astria/sequencer/v1alpha1/data.proto
@@ -7,25 +7,25 @@ import "tendermint/types/types.proto";
 // `IndexedTransaction` represents a sequencer transaction along with the index
 // it was originally in the sequencer block.
 message IndexedTransaction {
-    uint64 block_index = 1; // TODO: this is usize - how to define for variable size?
-    bytes transaction = 2;
+  uint64 block_index = 1; // TODO: this is usize - how to define for variable size?
+  bytes transaction = 2;
 }
 
 message RollupNamespace {
-    uint64 block_height = 1;
-    bytes namespace = 2;
+  uint64 block_height = 1;
+  bytes namespace = 2;
 }
 
 // `RollupNamespaceData`
 message RollupNamespaceData {
-    bytes block_hash = 1;
-    repeated IndexedTransaction rollup_txs = 2;
+  bytes block_hash = 1;
+  repeated IndexedTransaction rollup_txs = 2;
 }
 
 // `SequencerNamespaceData`
 message SequencerNamespaceData {
-    bytes block_hash = 1;
-    tendermint.types.Header header = 2;
-    repeated IndexedTransaction sequencer_txs = 3;
-    repeated RollupNamespace rollup_namespaces = 4;
+  bytes block_hash = 1;
+  tendermint.types.Header header = 2;
+  repeated IndexedTransaction sequencer_txs = 3;
+  repeated RollupNamespace rollup_namespaces = 4;
 }

--- a/proto/astria/sequencer/v1alpha1/merkle.proto
+++ b/proto/astria/sequencer/v1alpha1/merkle.proto
@@ -4,10 +4,10 @@ package astria.sequencer.v1alpha1;
 
 // A proof for a tree of the given size containing the audit path from a leaf to the root.
 message Proof {
-    // A sequence of 32 byte hashes used to reconstruct a Merkle Tree Hash.
-    bytes audit_path = 1;
-    // The index of the leaf this proof applies to.
-    uint64 leaf_index = 2;
-    // The total size of the tree this proof was derived from.
-    uint64 tree_size = 3;
+  // A sequence of 32 byte hashes used to reconstruct a Merkle Tree Hash.
+  bytes audit_path = 1;
+  // The index of the leaf this proof applies to.
+  uint64 leaf_index = 2;
+  // The total size of the tree this proof was derived from.
+  uint64 tree_size = 3;
 }

--- a/proto/astria/sequencer/v1alpha1/transaction.proto
+++ b/proto/astria/sequencer/v1alpha1/transaction.proto
@@ -3,38 +3,38 @@ syntax = "proto3";
 package astria.sequencer.v1alpha1;
 
 import "astria/primitive/v1/types.proto";
-import "tendermint/abci/types.proto";
 import "penumbra/core/component/ibc/v1alpha1/ibc.proto";
+import "tendermint/abci/types.proto";
 
 // `SignedTransaction` is a transaction that has
 // been signed by the given public key.
-// It wraps an `UnsignedTransaction` with a 
+// It wraps an `UnsignedTransaction` with a
 // signature and public key.
 message SignedTransaction {
-    bytes signature = 1;
-    bytes public_key = 2;
-    UnsignedTransaction transaction = 3;
+  bytes signature = 1;
+  bytes public_key = 2;
+  UnsignedTransaction transaction = 3;
 }
 
-// `UnsignedTransaction` is a transaction that does 
+// `UnsignedTransaction` is a transaction that does
 // not have an attached signature.
 // Note: `value` must be set, it cannot be `None`.
 message UnsignedTransaction {
-    uint32 nonce = 1;
-    repeated Action actions = 2;
-    // the asset used to pay the transaction fee
-    bytes fee_asset_id = 3;
+  uint32 nonce = 1;
+  repeated Action actions = 2;
+  // the asset used to pay the transaction fee
+  bytes fee_asset_id = 3;
 }
 
 message Action {
-    oneof value {
-        TransferAction transfer_action = 1;
-        SequenceAction sequence_action = 2;
-        tendermint.abci.ValidatorUpdate validator_update_action = 3;
-        SudoAddressChangeAction sudo_address_change_action = 4;
-        MintAction mint_action = 5;
-        penumbra.core.component.ibc.v1alpha1.IbcRelay ibc_action = 6;
-    }   
+  oneof value {
+    TransferAction transfer_action = 1;
+    SequenceAction sequence_action = 2;
+    tendermint.abci.ValidatorUpdate validator_update_action = 3;
+    SudoAddressChangeAction sudo_address_change_action = 4;
+    MintAction mint_action = 5;
+    penumbra.core.component.ibc.v1alpha1.IbcRelay ibc_action = 6;
+  }
 }
 
 // `TransferAction` represents a value transfer transaction.
@@ -42,10 +42,10 @@ message Action {
 // Note: all values must be set (ie. not `None`), otherwise it will
 // be considered invalid by the sequencer.
 message TransferAction {
-    bytes to = 1;
-    astria.primitive.v1.Uint128 amount = 2;
-    // the asset to be transferred
-    bytes asset_id = 3;
+  bytes to = 1;
+  astria.primitive.v1.Uint128 amount = 2;
+  // the asset to be transferred
+  bytes asset_id = 3;
 }
 
 // `SequenceAction` represents a transaction destined for another
@@ -54,17 +54,17 @@ message TransferAction {
 // It contains the rollup ID of the destination chain, and the
 // opaque transaction data.
 message SequenceAction {
-    bytes rollup_id = 1;
-    bytes data = 2;
+  bytes rollup_id = 1;
+  bytes data = 2;
 }
 
 /// `SudoAddressChangeAction` represents a transaction that changes
-/// the sudo address of the chain, which is the address authorized to 
+/// the sudo address of the chain, which is the address authorized to
 /// make validator update actions.
 ///
 /// It contains the new sudo address.
 message SudoAddressChangeAction {
-    bytes new_address = 1;
+  bytes new_address = 1;
 }
 
 // `MintAction` represents a minting transaction.
@@ -72,6 +72,6 @@ message SudoAddressChangeAction {
 //
 // It contains the address to mint to, and the amount to mint.
 message MintAction {
-    bytes to = 1;
-    astria.primitive.v1.Uint128 amount = 2;
+  bytes to = 1;
+  astria.primitive.v1.Uint128 amount = 2;
 }


### PR DESCRIPTION
## Summary
Cleans up some justfile, updates to check protos against buf, updates readmes,  and adds default formatting of proto files. 

## Background
We moved protos, this caused an issue with breaking changes. Additionally we had non consistent proto formatting.

## Changes
- remove no longer needed just commands
- restructure fmt & lint to take args, add an `all` which is default
- add buf format, run against the repo
- use the buf posted files for breaking changes checks.
- update readmes

## Testing
CI/CD tests, manual testing commands
