### PR TITLE
chore(ci): bump all checkout actions to v3

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: CondeNast/conventional-pull-request-action@v0.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable-cargo-version.yml
+++ b/.github/workflows/reusable-cargo-version.yml
@@ -14,7 +14,7 @@ jobs:
   rust-version-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: git fetch --all --tags
       - name: Check Release Version
         id: release_version


### PR DESCRIPTION
## Summary
Bump all git `actions/checkout` to `v3`.

## Background
Checkouts v2 used node12 which causes the github jobs to emit warnings because node 12 was deprecated by github: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

## Changes
- Update our github workflows to use actions/checkout@v3 everywhere.
