### PR TITLE
feat(telemetry)!: use opentelemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,7 +504,7 @@ dependencies = [
  "celestia-types",
  "hex",
  "jsonrpsee",
- "prost",
+ "prost 0.12.3",
  "serde",
  "serde_json",
  "sha2 0.10.8",
@@ -564,7 +564,7 @@ dependencies = [
  "hyper",
  "once_cell",
  "pin-project-lite",
- "prost",
+ "prost 0.12.3",
  "rand 0.8.5",
  "regex",
  "reqwest",
@@ -608,7 +608,7 @@ dependencies = [
  "humantime",
  "jsonrpsee",
  "pin-project-lite",
- "prost",
+ "prost 0.12.3",
  "prost-types",
  "rand 0.8.5",
  "reqwest",
@@ -619,7 +619,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util 0.7.10",
- "tonic",
+ "tonic 0.10.2",
  "tracing",
  "tracing-futures",
  "tryhard",
@@ -648,7 +648,7 @@ dependencies = [
  "indexmap 2.1.0",
  "penumbra-ibc",
  "penumbra-proto",
- "prost",
+ "prost 0.12.3",
  "prost-types",
  "rand 0.8.5",
  "serde",
@@ -658,7 +658,7 @@ dependencies = [
  "tendermint 0.34.0",
  "tendermint-proto 0.34.0",
  "thiserror",
- "tonic",
+ "tonic 0.10.2",
  "tonic-build",
  "tracing",
  "walkdir",
@@ -708,7 +708,7 @@ dependencies = [
  "penumbra-ibc",
  "penumbra-proto",
  "penumbra-tower-trace",
- "prost",
+ "prost 0.12.3",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -716,7 +716,7 @@ dependencies = [
  "tendermint 0.34.0",
  "tendermint-proto 0.34.0",
  "tokio",
- "tonic",
+ "tonic 0.10.2",
  "tower",
  "tower-abci",
  "tower-actor",
@@ -734,7 +734,7 @@ dependencies = [
  "futures",
  "hex",
  "hex-literal",
- "prost",
+ "prost 0.12.3",
  "regex",
  "serde",
  "serde_json",
@@ -773,7 +773,7 @@ dependencies = [
  "hyper",
  "jsonrpsee",
  "once_cell",
- "prost",
+ "prost 0.12.3",
  "rand_core 0.6.4",
  "reqwest",
  "serde",
@@ -805,7 +805,14 @@ name = "astria-telemetry"
 version = "0.1.0"
 dependencies = [
  "base64 0.21.5",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry-stdout",
+ "opentelemetry_sdk",
+ "thiserror",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber 0.3.18",
 ]
 
@@ -1406,7 +1413,7 @@ version = "0.1.0"
 source = "git+https://github.com/eigerco/celestia-node-rs?rev=4862eec#4862eec404de6f421d7ebde3ada731445022f494"
 dependencies = [
  "anyhow",
- "prost",
+ "prost 0.12.3",
  "prost-build",
  "prost-types",
  "serde",
@@ -1848,6 +1855,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "176dc175b78f56c0f321911d9c8eb2b77a78a4860b9c19db83835fea1a46649b"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1873,12 +1889,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.16"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
-dependencies = [
- "cfg-if",
-]
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "crunchy"
@@ -3463,11 +3476,11 @@ dependencies = [
  "flex-error",
  "ics23",
  "informalsystems-pbjson 0.7.0",
- "prost",
+ "prost 0.12.3",
  "serde",
  "subtle-encoding",
  "tendermint-proto 0.34.0",
- "tonic",
+ "tonic 0.10.2",
 ]
 
 [[package]]
@@ -3508,7 +3521,7 @@ dependencies = [
  "ics23",
  "num-traits",
  "proc-macro2 0.1.10",
- "prost",
+ "prost 0.12.3",
  "safe-regex",
  "serde",
  "serde_derive",
@@ -3537,7 +3550,7 @@ dependencies = [
  "ibc-types-timestamp",
  "ics23",
  "num-traits",
- "prost",
+ "prost 0.12.3",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3568,7 +3581,7 @@ dependencies = [
  "ics23",
  "num-traits",
  "primitive-types",
- "prost",
+ "prost 0.12.3",
  "safe-regex",
  "serde",
  "serde_derive",
@@ -3601,7 +3614,7 @@ dependencies = [
  "ibc-types-timestamp",
  "ics23",
  "num-traits",
- "prost",
+ "prost 0.12.3",
  "safe-regex",
  "serde",
  "serde_derive",
@@ -3621,7 +3634,7 @@ checksum = "0ac16371dda10031cb6824352cfaf830da98acc5feacb025e6330f6eb048fd4a"
 dependencies = [
  "anyhow",
  "bytes",
- "prost",
+ "prost 0.12.3",
 ]
 
 [[package]]
@@ -3657,7 +3670,7 @@ dependencies = [
  "ics23",
  "num-traits",
  "primitive-types",
- "prost",
+ "prost 0.12.3",
  "safe-regex",
  "serde",
  "serde_derive",
@@ -3685,7 +3698,7 @@ dependencies = [
  "ibc-types-core-client",
  "ibc-types-core-connection",
  "num-traits",
- "prost",
+ "prost 0.12.3",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3704,7 +3717,7 @@ dependencies = [
  "bytes",
  "displaydoc",
  "num-traits",
- "prost",
+ "prost 0.12.3",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3747,7 +3760,7 @@ dependencies = [
  "bytes",
  "hex",
  "informalsystems-pbjson 0.6.0",
- "prost",
+ "prost 0.12.3",
  "ripemd",
  "serde",
  "sha2 0.10.8",
@@ -4765,10 +4778,112 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e32339a5dc40459130b3bd269e9892439f55b33e772d2a9d402a789baaf4e8a"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "indexmap 2.1.0",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror",
+ "urlencoding",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f24cda83b20ed2433c68241f918d0f6fdec8b1d43b7a9590ab4420c5095ca930"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "http 0.2.11",
+ "opentelemetry",
+ "opentelemetry-proto",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
+ "prost 0.11.9",
+ "thiserror",
+ "tokio",
+ "tonic 0.9.2",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2e155ce5cc812ea3d1dffbd1539aed653de4bf4882d60e6e04dcf0901d674e1"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost 0.11.9",
+ "tonic 0.9.2",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5774f1ef1f982ef2a447f6ee04ec383981a3ab99c8e77a1a7b30182e65bbc84"
+dependencies = [
+ "opentelemetry",
+]
+
+[[package]]
+name = "opentelemetry-stdout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13b2df4cd59c176099ac82806725ba340c8fa7b1a7004c0912daad30470f63e"
+dependencies = [
+ "chrono",
+ "futures-util",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "ordered-float",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f16aec8a98a457a52664d69e0091bac3a0abd18ead9b641cb00202ba4e0efe4"
+dependencies = [
+ "async-trait",
+ "crossbeam-channel",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "once_cell",
+ "opentelemetry",
+ "ordered-float",
+ "percent-encoding",
+ "rand 0.8.5",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76df7075c7d4d01fdcb46c912dd17fba5b60c78ea480b475f2b6ab6f666584e"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "overload"
@@ -4878,7 +4993,7 @@ checksum = "2580e33f2292d34be285c5bc3dba5259542b083cfad6037b6d70345f24dcb735"
 dependencies = [
  "heck",
  "itertools 0.11.0",
- "prost",
+ "prost 0.12.3",
  "prost-types",
 ]
 
@@ -4892,7 +5007,7 @@ dependencies = [
  "chrono",
  "pbjson",
  "pbjson-build",
- "prost",
+ "prost 0.12.3",
  "prost-build",
  "serde",
 ]
@@ -5056,7 +5171,7 @@ dependencies = [
  "sha2 0.9.9",
  "tendermint 0.34.0",
  "tokio",
- "tonic",
+ "tonic 0.10.2",
  "tracing",
 ]
 
@@ -5086,13 +5201,13 @@ dependencies = [
  "penumbra-num",
  "penumbra-proto",
  "penumbra-txhash",
- "prost",
+ "prost 0.12.3",
  "serde",
  "serde_json",
  "sha2 0.10.8",
  "tendermint 0.34.0",
  "tendermint-light-client-verifier",
- "tonic",
+ "tonic 0.10.2",
  "tower",
  "tracing",
 ]
@@ -5208,12 +5323,12 @@ dependencies = [
  "pbjson",
  "pbjson-types",
  "pin-project",
- "prost",
+ "prost 0.12.3",
  "serde",
  "serde_json",
  "subtle-encoding",
  "tendermint 0.34.0",
- "tonic",
+ "tonic 0.10.2",
  "tracing",
 ]
 
@@ -5261,7 +5376,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util 0.7.10",
- "tonic",
+ "tonic 0.10.2",
  "tower",
  "tower-service",
  "tracing",
@@ -5657,12 +5772,22 @@ dependencies = [
 
 [[package]]
 name = "prost"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+dependencies = [
+ "bytes",
+ "prost-derive 0.11.9",
+]
+
+[[package]]
+name = "prost"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.12.3",
 ]
 
 [[package]]
@@ -5679,12 +5804,25 @@ dependencies = [
  "once_cell",
  "petgraph",
  "prettyplease",
- "prost",
+ "prost 0.12.3",
  "prost-types",
  "regex",
  "syn 2.0.39",
  "tempfile",
  "which",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.5",
+ "proc-macro2 1.0.70",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5706,7 +5844,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "193898f59edcf43c26227dcd4c8427f00d99d61e95dcde58dabd49fa291d470e"
 dependencies = [
- "prost",
+ "prost 0.12.3",
 ]
 
 [[package]]
@@ -6956,7 +7094,7 @@ dependencies = [
  "futures",
  "num-traits",
  "once_cell",
- "prost",
+ "prost 0.12.3",
  "prost-types",
  "serde",
  "serde_bytes",
@@ -6985,7 +7123,7 @@ dependencies = [
  "futures",
  "num-traits",
  "once_cell",
- "prost",
+ "prost 0.12.3",
  "prost-types",
  "serde",
  "serde_bytes",
@@ -7036,7 +7174,7 @@ dependencies = [
  "flex-error",
  "num-derive",
  "num-traits",
- "prost",
+ "prost 0.12.3",
  "prost-types",
  "serde",
  "serde_bytes",
@@ -7054,7 +7192,7 @@ dependencies = [
  "flex-error",
  "num-derive",
  "num-traits",
- "prost",
+ "prost 0.12.3",
  "prost-types",
  "serde",
  "serde_bytes",
@@ -7401,6 +7539,35 @@ dependencies = [
 
 [[package]]
 name = "tonic"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64 0.21.5",
+ "bytes",
+ "flate2",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http 0.2.11",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.11.9",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d560933a0de61cf715926b9cac824d4c883c2c43142f787595e48280c40a1d0e"
@@ -7417,7 +7584,7 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost",
+ "prost 0.12.3",
  "tokio",
  "tokio-stream",
  "tower",
@@ -7469,7 +7636,7 @@ dependencies = [
  "bytes",
  "futures",
  "pin-project",
- "prost",
+ "prost 0.12.3",
  "tendermint 0.34.0",
  "tendermint-proto 0.34.0",
  "tokio",
@@ -7599,6 +7766,24 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c67ac25c5407e7b961fafc6f7e9aa5958fd297aada2d20fa2ae1737357e55596"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log 0.2.0",
+ "tracing-subscriber 0.3.18",
+ "web-time",
 ]
 
 [[package]]
@@ -7827,6 +8012,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7983,6 +8174,16 @@ name = "web-sys"
 version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa30049b1c872b72c89866d458eae9f20380ab280ffd1b1e18df2d3e2d98cfe0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/crates/astria-composer/Cargo.toml
+++ b/crates/astria-composer/Cargo.toml
@@ -25,6 +25,7 @@ humantime = { workspace = true }
 hyper = { workspace = true }
 hex = { workspace = true }
 once_cell = { workspace = true }
+prost = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
 rand = { workspace = true }
 regex = { workspace = true }
@@ -42,7 +43,6 @@ tokio = { workspace = true, features = [
 tokio-util = { workspace = true, features = ["rt"] }
 tracing = { workspace = true, features = ["attributes"] }
 tryhard = { workspace = true }
-prost.workspace = true
 
 [dependencies.sequencer-client]
 package = "astria-sequencer-client"

--- a/crates/astria-composer/local.env.example
+++ b/crates/astria-composer/local.env.example
@@ -1,5 +1,14 @@
+# Configuration options of Astria Composer.
+
 # Log level. One of debug, info, warn, or error
 ASTRIA_COMPOSER_LOG="astria_composer=info"
+
+# If true disables writing to the opentelemetry OTLP endpoint.
+ASTRIA_COMPOSER_NO_OTEL=false
+
+# If true disables tty detection and forces writing telemetry to stdout.
+# If false span data is written to stdout only if it is connected to a tty.
+ASTRIA_COMPOSER_FORCE_STDOUT=false
 
 # Address of the API server
 ASTRIA_COMPOSER_API_LISTEN_ADDR="0.0.0.0:0"
@@ -25,3 +34,21 @@ ASTRIA_COMPOSER_MAX_SUBMIT_INTERVAL_MS=2000
 # set below the sequencer's max block size to allow space for encoding, signature, public
 # key and nonce bytes
 ASTRIA_COMPOSER_MAX_BYTES_PER_BUNDLE=200000
+
+# The OTEL specific config options follow the OpenTelemetry Protocol Exporter v1
+# specification as defined here:
+# https://github.com/open-telemetry/opentelemetry-specification/blob/e94af89e3d0c01de30127a0f423e912f6cda7bed/specification/protocol/exporter.md
+
+# Sets the general OTLP endpoint.
+OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317"
+# Sets the OTLP endpoint for trace data. This takes precedence over `OTEL_EXPORTER_OTLP_ENDPOINT` if set.
+OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="http://localhost:4317/v1/traces"
+# The duration in seconds that the OTEL exporter will wait for each batch export.
+OTEL_EXPORTER_OTLP_TRACES_TIMEOUT=10,
+# The compression format to use for exporting. Only `"gzip"` is supported.
+# Don't set the env var if no compression is required.
+OTEL_EXPORTER_OTLP_TRACES_COMPRESSION="gzip"
+# The HTTP headers that will be set when sending gRPC requests.
+OTEL_EXPORTER_OTLP_HEADERS="key1=value1,key2=value2"
+# The HTTP headers that will be set when sending gRPC requests. This takes precedence over `OTEL_EXPORTER_OTLP_HEADERS` if set.
+OTEL_EXPORTER_OTLP_TRACE_HEADERS="key1=value1,key2=value2"

--- a/crates/astria-composer/src/config.rs
+++ b/crates/astria-composer/src/config.rs
@@ -37,6 +37,11 @@ pub struct Config {
     /// Max bytes to encode into a single sequencer `SignedTransaction`, not including signature,
     /// public key, nonce. This is the sum of the sizes of all the `SequenceAction`s
     pub max_bytes_per_bundle: usize,
+    /// Forces writing trace data to stdout no matter if connected to a tty or not.
+    pub force_stdout: bool,
+
+    /// Disables writing trace data to an opentelemetry endpoint.
+    pub no_otel: bool,
 }
 
 impl config::Config for Config {

--- a/crates/astria-composer/src/lib.rs
+++ b/crates/astria-composer/src/lib.rs
@@ -24,8 +24,10 @@
 //!     .expect("the json serializer should never fail when serializing to a string");
 //! eprintln!("config:\n{cfg_ser}");
 //!
-//! telemetry::init(std::io::stdout, &cfg.log).expect("failed to initialize tracing");
-//!
+//! telemetry::configure()
+//!     .filter_directives(&cfg.log)
+//!     .try_init()
+//!     .expect("failed to setup telemetry");
 //! info!(config = cfg_ser, "initializing composer",);
 //!
 //! let _composer = Composer::from_config(&cfg)

--- a/crates/astria-composer/src/main.rs
+++ b/crates/astria-composer/src/main.rs
@@ -1,24 +1,37 @@
+use std::process::ExitCode;
+
 use astria_composer::{
     telemetry,
     Composer,
     Config,
 };
+use color_eyre::eyre::WrapErr as _;
 use tracing::info;
 
 #[tokio::main]
-async fn main() {
+async fn main() -> ExitCode {
     let cfg: Config = match config::get() {
         Ok(cfg) => cfg,
         Err(e) => {
             eprintln!("failed to read configuration: {e}");
-            std::process::exit(2);
+            return ExitCode::FAILURE;
         }
     };
+
+    if let Err(e) = telemetry::configure()
+        .set_no_otel(cfg.no_otel)
+        .set_force_stdout(cfg.force_stdout)
+        .filter_directives(&cfg.log)
+        .try_init()
+        .wrap_err("failed to setup telemetry")
+    {
+        eprintln!("initializing composer failed:\n{e:?}");
+        return ExitCode::FAILURE;
+    }
+
     let cfg_ser = serde_json::to_string(&cfg)
         .expect("the json serializer should never fail when serializing to a string");
     eprintln!("config:\n{cfg_ser}");
-
-    telemetry::init(std::io::stdout, &cfg.log).expect("failed to initialize tracing");
 
     info!(config = cfg_ser, "initializing composer",);
 
@@ -26,4 +39,5 @@ async fn main() {
         .expect("failed creating composer")
         .run_until_stopped()
         .await;
+    ExitCode::SUCCESS
 }

--- a/crates/astria-composer/src/searcher/executor/tests.rs
+++ b/crates/astria-composer/src/searcher/executor/tests.rs
@@ -48,9 +48,18 @@ use crate::{
 static TELEMETRY: Lazy<()> = Lazy::new(|| {
     if std::env::var_os("TEST_LOG").is_some() {
         let filter_directives = std::env::var("RUST_LOG").unwrap_or_else(|_| "info".into());
-        telemetry::init(std::io::stdout, &filter_directives).unwrap();
+        telemetry::configure()
+            .no_otel()
+            .stdout_writer(std::io::stdout)
+            .filter_directives(&filter_directives)
+            .try_init()
+            .unwrap();
     } else {
-        telemetry::init(std::io::sink, "").unwrap();
+        telemetry::configure()
+            .no_otel()
+            .stdout_writer(std::io::sink)
+            .try_init()
+            .unwrap();
     }
 });
 
@@ -79,6 +88,8 @@ async fn setup() -> (MockServer, MockGuard, Config) {
             .into(),
         block_time_ms: 2000,
         max_bytes_per_bundle: 1000,
+        no_otel: false,
+        force_stdout: false,
     };
     (server, startup_guard, cfg)
 }

--- a/crates/astria-composer/tests/blackbox/helper/mod.rs
+++ b/crates/astria-composer/tests/blackbox/helper/mod.rs
@@ -20,9 +20,18 @@ pub mod mock_sequencer;
 static TELEMETRY: Lazy<()> = Lazy::new(|| {
     if std::env::var_os("TEST_LOG").is_some() {
         let filter_directives = std::env::var("RUST_LOG").unwrap_or_else(|_| "info".into());
-        telemetry::init(std::io::stdout, &filter_directives).unwrap();
+        telemetry::configure()
+            .no_otel()
+            .stdout_writer(std::io::stdout)
+            .filter_directives(&filter_directives)
+            .try_init()
+            .unwrap();
     } else {
-        telemetry::init(std::io::sink, "").unwrap();
+        telemetry::configure()
+            .no_otel()
+            .stdout_writer(std::io::sink)
+            .try_init()
+            .unwrap();
     }
 });
 
@@ -67,6 +76,8 @@ pub async fn spawn_composer(rollup_ids: &[&str]) -> TestComposer {
             .into(),
         block_time_ms: 2000,
         max_bytes_per_bundle: 200_000,
+        no_otel: false,
+        force_stdout: false,
     };
     let (composer_addr, composer) = {
         let composer = Composer::from_config(&config).unwrap();

--- a/crates/astria-conductor/local.env.example
+++ b/crates/astria-conductor/local.env.example
@@ -1,5 +1,6 @@
-# Log Level
-ASTRIA_CONDUCTOR_LOG="astria_conductor=info"
+# The OTEL specific config options follow the OpenTelemetry Protocol Exporter v1
+# specification as defined here:
+# https://github.com/open-telemetry/opentelemetry-specification/blob/e94af89e3d0c01de30127a0f423e912f6cda7bed/specification/protocol/exporter.md
 
 # The bearer token to retrieve sequencer blocks as blobs from Celestia.
 # The token is obtained by running `celestia bridge auth <permissions>`
@@ -27,6 +28,16 @@ ASTRIA_CONDUCTOR_EXECUTION_RPC_URL="http://127.0.0.1:50051"
 # - "SoftAndFirm" -> blocks are pulled from both the sequencer and DA
 ASTRIA_CONDUCTOR_EXECUTION_COMMIT_LEVEL="SoftAndFirm"
 
+# Log Level
+ASTRIA_CONDUCTOR_LOG="astria_conductor=info"
+
+# If true disables writing to the opentelemetry OTLP endpoint.
+ASTRIA_CONDUCTOR_NO_OTEL=false
+
+# If true disables tty detection and forces writing telemetry to stdout.
+# If false span data is written to stdout only if it is connected to a tty.
+ASTRIA_CONDUCTOR_FORCE_STDOUT=false
+
 # The URL to a fully trusted CometBFT/Sequencer to issue cometbft RPCs. Example
 # RPCs are subscribing to new blocks, fetching blocks at a given level, or
 # retrieving validators.
@@ -48,3 +59,17 @@ ASTRIA_CONDUCTOR_OPTIMISM_PORTAL_CONTRACT_ADDRESS=""
 # OptimismPortal contract was deployed at.
 # Only used if `ASTRIA_CONDUCTOR_ENABLE_OPTIMISM=true`.
 ASTRIA_CONDUCTOR_INITIAL_ETHEREUM_L1_BLOCK_HEIGHT=1
+
+# Sets the general OTLP endpoint.
+OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317"
+# Sets the OTLP endpoint for trace data. This takes precedence over `OTEL_EXPORTER_OTLP_ENDPOINT` if set.
+OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="http://localhost:4317/v1/traces"
+# The duration in seconds that the OTEL exporter will wait for each batch export.
+OTEL_EXPORTER_OTLP_TRACES_TIMEOUT=10,
+# The compression format to use for exporting. Only `"gzip"` is supported.
+# Don't set the env var if no compression is required.
+OTEL_EXPORTER_OTLP_TRACES_COMPRESSION="gzip"
+# The HTTP headers that will be set when sending gRPC requests.
+OTEL_EXPORTER_OTLP_HEADERS="key1=value1,key2=value2"
+# The HTTP headers that will be set when sending gRPC requests. This takes precedence over `OTEL_EXPORTER_OTLP_HEADERS` if set.
+OTEL_EXPORTER_OTLP_TRACE_HEADERS="key1=value1,key2=value2"

--- a/crates/astria-conductor/src/config.rs
+++ b/crates/astria-conductor/src/config.rs
@@ -58,6 +58,11 @@ pub struct Config {
     /// OptimismPortal contract was deployed at.
     /// Only used if `enable_optimism` is true.
     pub initial_ethereum_l1_block_height: u64,
+
+    /// Forces writing trace data to stdout no matter if connected to a tty or not.
+    pub force_stdout: bool,
+    /// Disables writing trace data to an opentelemetry endpoint.
+    pub no_otel: bool,
 }
 
 impl config::Config for Config {

--- a/crates/astria-conductor/src/main.rs
+++ b/crates/astria-conductor/src/main.rs
@@ -28,14 +28,17 @@ async fn main() -> ExitCode {
         }
         Ok(cfg) => cfg,
     };
-    if let Err(err) = telemetry::init(std::io::stdout, &cfg.log) {
-        eprintln!(
-            "failed initializing config with filter directive `{log}`\n{err:?}",
-            log = cfg.log,
-            err = err,
-        );
+
+    if let Err(e) = telemetry::configure()
+        .set_no_otel(cfg.no_otel)
+        .set_force_stdout(cfg.force_stdout)
+        .filter_directives(&cfg.log)
+        .try_init()
+        .wrap_err("failed to setup telemetry")
+    {
+        eprintln!("initializing conductor failed:\n{e:?}");
         return ExitCode::FAILURE;
-    };
+    }
 
     info!(
         config = serde_json::to_string(&cfg).expect("serializing to a string cannot fail"),

--- a/crates/astria-sequencer-client/Cargo.toml
+++ b/crates/astria-sequencer-client/Cargo.toml
@@ -9,12 +9,12 @@ astria-core = { path = "../astria-core" }
 async-trait = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }
+prost = { workspace = true }
 tendermint = { workspace = true }
 tendermint-proto = { workspace = true }
 tendermint-rpc = { workspace = true }
 tracing = { workspace = true }
 thiserror = { workspace = true }
-prost.workspace = true
 
 [features]
 http = ["tendermint-rpc/http-client"]

--- a/crates/astria-sequencer-relayer/local.env.example
+++ b/crates/astria-sequencer-relayer/local.env.example
@@ -1,3 +1,13 @@
+# A list of filter directives of the form target[span{field=value}]=level.
+ASTRIA_SEQUENCER_RELAYER_LOG=astria_sequencer_relayer=info
+
+# If true disables writing to the opentelemetry OTLP endpoint.
+ASTRIA_SEQUENCER_RELAYER_NO_OTEL=false
+
+# If true disables tty detection and forces writing telemetry to stdout.
+# If false span data is written to stdout only if it is connected to a tty.
+ASTRIA_SEQUENCER_RELAYER_FORCE_STDOUT=false
+
 # Address of sequencer/cometbft/tendermint to request new blocks.
 # 127.0.0.1:26657 is the default socket address at which cometbft
 # serves RPCs.
@@ -27,5 +37,20 @@ ASTRIA_SEQUENCER_RELAYER_VALIDATOR_KEY_FILE=.cometbft/config/priv_validator_key.
 # The port that sequencer relayer will bind on 127.0.0.1 to serve RPCs.
 ASTRIA_SEQUENCER_RELAYER_RPC_PORT=2450
 
-# A list of filter directives of the form target[span{field=value}]=level.
-ASTRIA_SEQUENCER_RELAYER_LOG=astria_sequencer_relayer=info
+# The OTEL specific config options follow the OpenTelemetry Protocol Exporter v1
+# specification as defined here:
+# https://github.com/open-telemetry/opentelemetry-specification/blob/e94af89e3d0c01de30127a0f423e912f6cda7bed/specification/protocol/exporter.md
+
+# Sets the general OTLP endpoint.
+OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317"
+# Sets the OTLP endpoint for trace data. This takes precedence over `OTEL_EXPORTER_OTLP_ENDPOINT` if set.
+OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="http://localhost:4317/v1/traces"
+# The duration in seconds that the OTEL exporter will wait for each batch export.
+OTEL_EXPORTER_OTLP_TRACES_TIMEOUT=10,
+# The compression format to use for exporting. Only `"gzip"` is supported.
+# Don't set the env var if no compression is required.
+OTEL_EXPORTER_OTLP_TRACES_COMPRESSION="gzip"
+# The HTTP headers that will be set when sending gRPC requests.
+OTEL_EXPORTER_OTLP_HEADERS="key1=value1,key2=value2"
+# The HTTP headers that will be set when sending gRPC requests. This takes precedence over `OTEL_EXPORTER_OTLP_HEADERS` if set.
+OTEL_EXPORTER_OTLP_TRACE_HEADERS="key1=value1,key2=value2"

--- a/crates/astria-sequencer-relayer/src/config.rs
+++ b/crates/astria-sequencer-relayer/src/config.rs
@@ -14,6 +14,10 @@ pub struct Config {
     pub validator_key_file: Option<String>,
     pub rpc_port: u16,
     pub log: String,
+    /// Forces writing trace data to stdout no matter if connected to a tty or not.
+    pub force_stdout: bool,
+    /// Disables writing trace data to an opentelemetry endpoint.
+    pub no_otel: bool,
 }
 
 impl config::Config for Config {

--- a/crates/astria-sequencer-relayer/src/main.rs
+++ b/crates/astria-sequencer-relayer/src/main.rs
@@ -1,14 +1,28 @@
+use std::process::ExitCode;
+
 use astria_sequencer_relayer::{
     telemetry,
     Config,
     SequencerRelayer,
 };
+use eyre::WrapErr as _;
 use tracing::info;
 
 #[tokio::main]
-async fn main() {
+async fn main() -> ExitCode {
     let cfg: Config = config::get().expect("failed to read configuration");
-    telemetry::init(std::io::stdout, &cfg.log).expect("failed to setup telemetry");
+
+    if let Err(e) = telemetry::configure()
+        .set_no_otel(cfg.no_otel)
+        .set_force_stdout(cfg.force_stdout)
+        .filter_directives(&cfg.log)
+        .try_init()
+        .wrap_err("failed to setup telemetry")
+    {
+        eprintln!("initializing sequencer-relayer failed:\n{e:?}");
+        return ExitCode::FAILURE;
+    }
+
     info!(
         config = serde_json::to_string(&cfg).expect("serializing to a string cannot fail"),
         "initializing sequencer relayer"
@@ -19,4 +33,6 @@ async fn main() {
         .expect("could not initialize sequencer relayer")
         .run()
         .await;
+
+    ExitCode::SUCCESS
 }

--- a/crates/astria-sequencer-relayer/tests/blackbox/helper.rs
+++ b/crates/astria-sequencer-relayer/tests/blackbox/helper.rs
@@ -46,9 +46,18 @@ use wiremock::{
 static TELEMETRY: Lazy<()> = Lazy::new(|| {
     if std::env::var_os("TEST_LOG").is_some() {
         let filter_directives = std::env::var("RUST_LOG").unwrap_or_else(|_| "info".into());
-        telemetry::init(std::io::stdout, &filter_directives).unwrap();
+        telemetry::configure()
+            .no_otel()
+            .stdout_writer(std::io::stdout)
+            .filter_directives(&filter_directives)
+            .try_init()
+            .unwrap();
     } else {
-        telemetry::init(std::io::sink, "").unwrap();
+        telemetry::configure()
+            .no_otel()
+            .stdout_writer(std::io::sink)
+            .try_init()
+            .unwrap();
     }
 });
 
@@ -188,6 +197,8 @@ pub async fn spawn_sequencer_relayer(
         validator_key_file: Some(keyfile.path().to_string_lossy().to_string()),
         rpc_port: 0,
         log: String::new(),
+        force_stdout: false,
+        no_otel: false,
     };
 
     info!(config = serde_json::to_string(&config).unwrap());

--- a/crates/astria-sequencer/local.env.example
+++ b/crates/astria-sequencer/local.env.example
@@ -1,6 +1,3 @@
-# Log level for the sequencer
-ASTRIA_SEQUENCER_LOG="astria_sequencer=info"
-
 # Socket address to listen for ABCI requests from cometbft.
 # This address corresponds to the `--proxy_app "tcp://<ASTRIA_SEQUENCER_LISTEN_ADDR>"`,
 # where `tcp://127.0.0.1:26658` is comebft's default.
@@ -15,3 +12,30 @@ ASTRIA_SEQUENCER_ENABLE_MINT=false
 
 # Socket address for gRPC server
 ASTRIA_SEQUENCER_GRPC_ADDR="127.0.0.1:8080"
+# Log level for the sequencer
+ASTRIA_SEQUENCER_LOG="astria_sequencer=info"
+
+# If true disables writing to the opentelemetry OTLP endpoint.
+ASTRIA_SEQUENCER_NO_OTEL=false
+
+# If true disables tty detection and forces writing telemetry to stdout.
+# If false span data is written to stdout only if it is connected to a tty.
+ASTRIA_SEQUENCER_FORCE_STDOUT=false
+
+# The OTEL specific config options follow the OpenTelemetry Protocol Exporter v1
+# specification as defined here:
+# https://github.com/open-telemetry/opentelemetry-specification/blob/e94af89e3d0c01de30127a0f423e912f6cda7bed/specification/protocol/exporter.md
+
+# Sets the general OTLP endpoint.
+OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317"
+# Sets the OTLP endpoint for trace data. This takes precedence over `OTEL_EXPORTER_OTLP_ENDPOINT` if set.
+OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="http://localhost:4317/v1/traces"
+# The duration in seconds that the OTEL exporter will wait for each batch export.
+OTEL_EXPORTER_OTLP_TRACES_TIMEOUT=10,
+# The compression format to use for exporting. Only `"gzip"` is supported.
+# Don't set the env var if no compression is required.
+OTEL_EXPORTER_OTLP_TRACES_COMPRESSION="gzip"
+# The HTTP headers that will be set when sending gRPC requests.
+OTEL_EXPORTER_OTLP_HEADERS="key1=value1,key2=value2"
+# The HTTP headers that will be set when sending gRPC requests. This takes precedence over `OTEL_EXPORTER_OTLP_HEADERS` if set.
+OTEL_EXPORTER_OTLP_TRACE_HEADERS="key1=value1,key2=value2"

--- a/crates/astria-sequencer/src/config.rs
+++ b/crates/astria-sequencer/src/config.rs
@@ -18,6 +18,10 @@ pub struct Config {
     pub enable_mint: bool,
     /// The gRPC endpoint
     pub grpc_addr: String,
+    /// Forces writing trace data to stdout no matter if connected to a tty or not.
+    pub force_stdout: bool,
+    /// Disables writing trace data to an opentelemetry endpoint.
+    pub no_otel: bool,
 }
 
 impl config::Config for Config {

--- a/crates/astria-sequencer/src/main.rs
+++ b/crates/astria-sequencer/src/main.rs
@@ -1,5 +1,6 @@
 use std::process::ExitCode;
 
+use anyhow::Context as _;
 use astria_sequencer::{
     Config,
     Sequencer,
@@ -12,21 +13,30 @@ const EX_CONFIG: u8 = 78;
 
 #[tokio::main]
 async fn main() -> ExitCode {
-    let config: Config = match config::get() {
+    let cfg: Config = match config::get() {
         Ok(cfg) => cfg,
         Err(e) => {
             eprintln!("failed to read configuration:\n{e:?}");
             return ExitCode::from(EX_CONFIG);
         }
     };
-    telemetry::init(std::io::stdout, &config.log).expect("failed to initialize telemetry");
+    if let Err(e) = telemetry::configure()
+        .set_no_otel(cfg.no_otel)
+        .set_force_stdout(cfg.force_stdout)
+        .filter_directives(&cfg.log)
+        .try_init()
+        .context("failed to setup telemetry")
+    {
+        eprintln!("initializing sequencer failed:\n{e:?}");
+        return ExitCode::FAILURE;
+    }
     info!(
-        config = serde_json::to_string(&config).expect("serializing to a string cannot fail"),
+        config = serde_json::to_string(&cfg).expect("serializing to a string cannot fail"),
         "initializing sequencer"
     );
 
     #[cfg(feature = "mint")]
-    if config.enable_mint {
+    if cfg.enable_mint {
         tokio::spawn(async {
             let duration = std::time::Duration::from_secs(5);
             loop {
@@ -39,7 +49,7 @@ async fn main() -> ExitCode {
         });
     }
 
-    Sequencer::run_until_stopped(config)
+    Sequencer::run_until_stopped(cfg)
         .await
         .expect("failed to run sequencer");
 

--- a/crates/astria-telemetry/Cargo.toml
+++ b/crates/astria-telemetry/Cargo.toml
@@ -9,6 +9,15 @@ rust-version = "1.70.0"
 [dependencies]
 base64 = { workspace = true, optional = true }
 
+# When updating ensure that `opentelemetry-semantic-conventions` matches
+# that used by `opentelemetry-otlp`.
+opentelemetry = "0.21.0"
+opentelemetry-otlp = { version = "0.14.0", features = ["gzip-tonic"] }
+opentelemetry-semantic-conventions = "0.13.0"
+opentelemetry-stdout = { version = "0.2.0", features = ["trace"] }
+opentelemetry_sdk = { version = "0.21.1", features = ["rt-tokio"] }
+thiserror = { workspace = true }
+tracing-opentelemetry = "0.22.0"
 tracing-subscriber = { version = "0.3.17", features = [
   "fmt",
   "env-filter",


### PR DESCRIPTION
## Summary
Export trace data as opentelemetry, replacing the tracing json and pretty-print formatting subscribers.

## Background
We want to export our trace data in a formalized way, targeting observability platforms that understand the opentelemetry protocol (OTLP).

If the opentelemetry-otlp has hard-coded env vars that are always read at runtime to configure it. These are (see https://github.com/open-telemetry/opentelemetry-rust/blob/4e80e3a2ebf96a166917b169f7d27e44e83cd3da/opentelemetry-otlp/src/span.rs#L30-L42):

+ `OTEL_EXPORTER_OTLP_ENDPOINT`: to set the OTLP endpoint
+ `OTEL_EXPORTER_OTLP_TRACE_ENDPOINT`: to set the trace OTLP endpoint (taking precedence over the general one)
+ `OTEL_EXPORTER_OTLP_TRACE_TIMEOUT`: to set the timeout for the backend to process span batches
+ `OTEL_EXPORTER_OTLP_TRACE_COMPRESSION`: the compression algorithm to use for compressing spans
+ `OTEL_EXPORTER_OTLP_HEADERS`: key-value pairs to set as grpc/http headers
+ `OTEL_EXPORTER_OTLP_TRACE_HEADERS`: key-value pairs to set as grpc/http headers taking precedence over the more general one.

If none of the above are set then their default values are used according to the `opentelemetry-otlp` crate.

Because these are always read and take precedence over custom per-service settings the service config do not contain extra settings.

## Changes
- Replace the tracing_subscriber fmt layer by tracing-opentelemetry
- Send tracing data to an OTLP endpoint (this is understood to replace the json-formatted output to stdout)
- Allow disabling OTLP with `ASTRIA_<SERVICE>_NO_OTLP=true`
- Optionally emit otel traces to stdout if connected to a tty (this replaces the pretty printer)
- Allow forcing writing to stdout with `ASTRIA_<SERVICE>_FORCE_STDOUT=true`

## Testing
In tests: trace data is written to stdout
In a cluster: **not yet tested**

## Breaking Changelist
- The various services got new settings with env vars `ASTRIA_<SERVICE>_NO_OTEL` and `ASTRIA_<SERVICE>_FORCE_STDOUT`, which must be set
- if `ASTRIA_<SERVICE>_NO_OTEL=false` then a GRPC-ready opentelemetry endpoint must be available at the default location `http://localhost:4317` or at a location defined via `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` or `OTEL_EXPORTER_OTLP_ENDPOINT`

## Related Issues
closes https://github.com/astriaorg/astria/issues/652
