### PR TITLE
feat(sequencer-utils): add `--chain-id` to sequencer genesis utils

### DIFF
--- a/crates/astria-sequencer-utils/src/config.rs
+++ b/crates/astria-sequencer-utils/src/config.rs
@@ -7,6 +7,9 @@ pub struct Config {
 
     #[clap(long)]
     pub destination_genesis_file: String,
+
+    #[clap(long)]
+    pub chain_id: String,
 }
 
 impl Config {

--- a/crates/astria-sequencer-utils/src/genesis_parser.rs
+++ b/crates/astria-sequencer-utils/src/genesis_parser.rs
@@ -48,7 +48,11 @@ impl GenesisParser {
                 .wrap_err("failed deserializing cometbft genesis state from file")?;
 
         // insert sequencer app genesis data into cometbft genesis data
-        insert_app_state(&mut destination_genesis_data, &source_genesis_data);
+        insert_app_state_and_chain_id(
+            &mut destination_genesis_data,
+            &source_genesis_data,
+            data.chain_id,
+        );
 
         // write new state
         let dest_file = File::create(Path::new(data.destination_genesis_file.as_str()))
@@ -60,11 +64,12 @@ impl GenesisParser {
     }
 }
 
-fn insert_app_state(dst: &mut Value, app_state: &Value) {
+fn insert_app_state_and_chain_id(dst: &mut Value, app_state: &Value, chain_id: String) {
     let Value::Object(dst) = dst else {
         panic!("dst is not an object");
     };
     dst.insert("app_state".to_string(), app_state.clone());
+    dst.insert("chain_id".to_string(), chain_id.into());
 }
 
 #[cfg(test)]
@@ -129,10 +134,11 @@ mod tests {
                         "balance": 1000
                     }
                 ]
-            }
+            },
+            "chain_id": "test"
         });
 
-        insert_app_state(&mut a, &b);
+        insert_app_state_and_chain_id(&mut a, &b, "test".to_string());
         assert_eq!(a, output);
     }
 }

--- a/crates/astria-sequencer/justfile
+++ b/crates/astria-sequencer/justfile
@@ -11,10 +11,9 @@ copy-env type=default_env:
 run:
   cargo run
 
-
 run-cometbft:
   cometbft init
-  ../../target/debug/astria-sequencer-utils --genesis-app-state-file=test-genesis-app-state.json --destination-genesis-file=$HOME/.cometbft/config/genesis.json
+  ../../target/debug/astria-sequencer-utils --genesis-app-state-file=test-genesis-app-state.json --destination-genesis-file=$HOME/.cometbft/config/genesis.json --chain-id=astria
   sed -i'.bak' 's/timeout_commit = "1s"/timeout_commit = "15s"/g' ~/.cometbft/config/config.toml
   cometbft node
 


### PR DESCRIPTION
## Summary
utils to set the chain ID in the cometbft genesis.json file.

## Background
need it for ibc testing (we need to set the chain id when starting hermes) this makes my life a lot easier, cause otherwise it picks a random chain ID.

## Changes
- add `--chain-id` to sequencer genesis utils which sets the `chain_id` field in the cometbft genesis file to the given string

## Testing
unit tests + i ran it (`just run-cometbft` and `cat ~/.cometbft/config/genesis.json`)

