### PR TITLE
fix(sequencer): handle abci events properly + improve tx logging

### DIFF
--- a/crates/astria-core/src/sequencer/v1alpha1/transaction/mod.rs
+++ b/crates/astria-core/src/sequencer/v1alpha1/transaction/mod.rs
@@ -4,6 +4,7 @@ use ed25519_consensus::{
     VerificationKey,
 };
 use prost::Message as _;
+use sha2::Sha256;
 
 use super::raw;
 
@@ -63,6 +64,13 @@ pub struct SignedTransaction {
 }
 
 impl SignedTransaction {
+    #[must_use]
+    pub fn hash(&self) -> [u8; 32] {
+        use sha2::Digest as _;
+        let bytes = self.to_raw().encode_to_vec();
+        Sha256::digest(bytes).into()
+    }
+
     #[must_use]
     pub fn into_raw(self) -> raw::SignedTransaction {
         let Self {

--- a/crates/astria-sequencer/src/service/consensus.rs
+++ b/crates/astria-sequencer/src/service/consensus.rs
@@ -187,7 +187,10 @@ impl Consensus {
             .deliver_tx_after_execution(&tx_hash)
             .expect("all transactions in the block must have already been executed")
         {
-            Ok(_events) => response::DeliverTx::default(),
+            Ok(events) => response::DeliverTx {
+                events,
+                ..Default::default()
+            },
             Err(e) => {
                 // we don't want to panic on failing to deliver_tx as that would crash the entire
                 // node


### PR DESCRIPTION
## Summary
we were ignoring ABCI events (bad). needed to fix this for hermes testing

## Changes
- return ABCI events emitted in `deliver_tx`
- also minor logging improvements, the full tx in `deliver_tx` was getting logged twice but the tx hash wasn't logged anywhere, this was extremely annoying for testing, so i implemented the `SignedTransaction::hash()` and logged that

## Testing
i ran it with hermes, also cometbft gets the same tx hashes.

## Related Issues

closes #476
