### PR TITLE
fix(sequencer): fix ABCI event handling

### DIFF
--- a/crates/astria-sequencer/src/app.rs
+++ b/crates/astria-sequencer/src/app.rs
@@ -392,7 +392,7 @@ impl App {
         transaction::execute(&signed_tx, &mut state_tx)
             .await
             .context("failed executing transaction")?;
-        state_tx.apply();
+        let (_, events) = state_tx.apply();
 
         // note: deliver_tx is now called (internally) before begin_block,
         // so increment the logged height by 1.
@@ -403,9 +403,10 @@ impl App {
             ?signed_tx,
             height = height + 1,
             sender = %Address::from_verification_key(signed_tx.verification_key()),
+            event_count = events.len(),
             "executed transaction"
         );
-        Ok(vec![])
+        Ok(events)
     }
 
     #[instrument(name = "App::end_block", skip(self))]

--- a/crates/astria-sequencer/src/service/consensus.rs
+++ b/crates/astria-sequencer/src/service/consensus.rs
@@ -187,7 +187,10 @@ impl Consensus {
             .deliver_tx_after_execution(&tx_hash)
             .expect("all transactions in the block must have already been executed")
         {
-            Ok(_events) => response::DeliverTx::default(),
+            Ok(events) => response::DeliverTx {
+                events,
+                ..Default::default()
+            },
             Err(e) => {
                 // we don't want to panic on failing to deliver_tx as that would crash the entire
                 // node


### PR DESCRIPTION
## Summary
we were ignoring ABCI events (bad). needed to fix this for hermes testing

## Changes
- return ABCI events emitted in `deliver_tx`

## Testing
i ran it with hermes, this fixes errors due to no events
