### PR TITLE
fix(docker-build): build images with special Cargo.toml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2.6.1
         with:
           cache-provider: "buildjet"
-      - name: Install `just` command runner
+      - name: Install just
         uses:  taiki-e/install-action@just
       - name: Check if protobuf specs compile to commited Rust sources
         run: |
@@ -37,11 +37,42 @@ jobs:
           modified=$(git status --porcelain)
           if [[ -n "$modified" ]]; then
             echo "ERROR: protobuf specs are out of sync with the commited Rust sources"
-            echo "Recompile locally with `just compile-protos` and commit to the repository."            exit 1
+            echo "Recompile locally with \`just compile-protos\` and commit to the repository."
             echo "Files that reported differences:"
             echo "$modified"
             exit 1
           fi
+
+  cargo-toml-synced-with-containerfiles:
+    runs-on: ubuntu-22.04
+    needs: run_checker
+    if: needs.run_checker.outputs.run_tests == 'true'
+    steps:
+      - uses: actions/checkout@v3
+      - name: Download and install dasel
+        run: |
+          curl -fsSL \
+            https://github.com/TomWright/dasel/releases/download/v2.5.0/dasel_linux_amd64.gz |
+            | gzip -d - \
+            | install -m 755 /dev/stdin /usr/local/bin/dasel
+      - name: Download and install taplo
+        run: |
+          curl -fsSL \
+          https://github.com/tamasfe/taplo/releases/download/0.8.1/taplo-full-linux-x86_64.gz \
+          | gzip -d - \
+          | install -m 755 /dev/stdin /usr/local/bin/taplo
+      - name: Install just
+        uses: taiki-e/install-action@just
+      - name: Check if containerfiles/Cargo.toml is in sync with Cargo.toml
+        run: |
+          just update-containerfiles-cargo-toml
+          modified=$(git status --porcelain)
+          if [[ -n $modified ]]; then
+            echo "ERROR: containerfiles/Cargo.toml is out of sync with workspcae Cargo.toml"
+            echo "Run locally with \`just update-container-files-cargo-toml\` and commit to the repository."
+            exit 1
+          fi
+
 
   compiles:
     runs-on: buildjet-4vcpu-ubuntu-2204
@@ -198,7 +229,7 @@ jobs:
 
   test:
     if: ${{ always() && !cancelled() }}
-    needs: [compiles, protos-compiled, rust, doctest, clippy, lockfile, custom-lints]
+    needs: [compiles, protos-compiled, rust, doctest, clippy, lockfile, custom-lints, cargo-toml-synced-with-containerfiles]
     uses: ./.github/workflows/reusable-success.yml
     with:
       success: ${{ !contains(needs.*.result, 'failure') }}

--- a/containerfiles/Cargo.toml
+++ b/containerfiles/Cargo.toml
@@ -1,0 +1,88 @@
+[workspace]
+exclude = ['tools/protobuf-compiler']
+members = [
+  'crates/astria-celestia-client',
+  'crates/astria-celestia-mock',
+  'crates/astria-cli',
+  'crates/astria-composer',
+  'crates/astria-conductor',
+  'crates/astria-config',
+  'crates/astria-core',
+  'crates/astria-merkle',
+  'crates/astria-optimism',
+  'crates/astria-sequencer',
+  'crates/astria-sequencer-client',
+  'crates/astria-sequencer-relayer',
+  'crates/astria-sequencer-utils',
+  'crates/astria-telemetry',
+  'crates/astria-test-utils',
+  'lint/*',
+]
+resolver = '2'
+
+[workspace.dependencies]
+async-trait = '0.1.52'
+axum = '0.6.16'
+backon = '0.4.1'
+base64 = '0.21'
+base64-serde = '0.7.0'
+bytes = '1.4'
+clap = '4'
+color-eyre = '0.6'
+ed25519-consensus = '2.1.0'
+ethers = '2.0.11'
+eyre = '0.6'
+futures = '0.3'
+hex = '0.4'
+hex-literal = '0.4.1'
+humantime = '2.1.0'
+hyper = '0.14'
+ibc-types = '0.10.0'
+once_cell = '1.17.1'
+prost = '0.12'
+prost-types = '0.12'
+rand = '0.8.5'
+regex = '1.9'
+serde = '1'
+serde_json = '1'
+sha2 = '0.10'
+tempfile = '3.6.0'
+tendermint = '0.34.0'
+tendermint-config = '0.34.0'
+tendermint-proto = '0.34.0'
+tendermint-rpc = '0.34.0'
+thiserror = '1'
+tokio = '1.28'
+tokio-test = '0.4.2'
+tokio-util = '0.7.9'
+tonic = '0.10'
+tracing = '0.1'
+tryhard = '0.5.1'
+which = '4.4.0'
+wiremock = '0.5'
+
+[workspace.dependencies.jsonrpsee]
+version = '0.20'
+
+[workspace.dependencies.penumbra-ibc]
+default-features = false
+git = 'https://github.com/penumbra-zone/penumbra.git'
+tag = 'v0.64.1'
+
+[workspace.dependencies.penumbra-proto]
+git = 'https://github.com/penumbra-zone/penumbra.git'
+tag = 'v0.64.1'
+
+[workspace.dependencies.penumbra-tower-trace]
+git = 'https://github.com/penumbra-zone/penumbra.git'
+tag = 'v0.64.1'
+
+[workspace.dependencies.reqwest]
+default-features = false
+features = ['rustls-tls']
+version = '0.11'
+
+[workspace.metadata]
+[workspace.metadata.dylint]
+[[workspace.metadata.dylint.libraries]]
+path = 'lint/tracing_debug_field'

--- a/containerfiles/Dockerfile
+++ b/containerfiles/Dockerfile
@@ -44,6 +44,10 @@ RUN \
 FROM chef AS planner
 ARG TARGETBINARY
 COPY . .
+# XXX: override Cargo.toml in the root with containerfiles/Cargo.toml, which
+#      does not contain the `default-members` entry. It currently throws off
+#      cargo chef.
+COPY containerfiles/Cargo.toml Cargo.toml
 RUN cargo chef prepare --bin crates/$TARGETBINARY --recipe-path recipe.json
 
 FROM chef as builder

--- a/justfile
+++ b/justfile
@@ -14,6 +14,11 @@ install-cli:
 compile-protos:
   cargo run --manifest-path tools/protobuf-compiler/Cargo.toml
 
+update-containerfiles-cargo-toml:
+  dasel delete -r toml -f Cargo.toml -o - 'workspace.default-members' \
+  | taplo fmt - --stdin-filepath Cargo.toml \
+  > containerfiles/Cargo.toml
+
 ## Scripts related to formatting code
 default_lang := 'all'
 


### PR DESCRIPTION
## Summary
Build images using a Cargo.toml without a default-members entry.

## Background
We use cargo-chef to prepare recipes for each individual binary so that only its dependencies are built and cached. PR https://github.com/astriaorg/astria/pull/664 introduced the `default-members` entry so that cargo invocations by default don't target the lints (as they require a nightly compiler). But this breaks cargo-chef because it leaves default-members intact, leading to cargo compilation issues.

## Changes
- Create a special `containerfiles/Cargo.toml` file that is derived from the root `Cargo.toml` but with its `default-members` entry removed
- Update `containerfiles/Dockerfile` to run `cargo chef prepare` against `containerfiles/Cargo.toml`
- Add a just entry to remove `workspace.default-members` from `Cargo.toml`, format it with `taplo`, and write it to `containerfiles/Cargo.toml`
- Add a github job that ensures that `containerfiles/Cargo.toml` is in sync with `Cargo.toml`

## Testing
- Docker builds were broken and now work again (verified by building locally and in CI)
- Commited a modified `containerfiles/Cargo.toml` and observed the github action trigger

## Related Issues
PR causing the build to break: https://github.com/astriaorg/astria/pull/664
