### PR TITLE
feat(sequencer)!: max sequencer bytes per block limit

### DIFF
--- a/crates/astria-sequencer/src/app.rs
+++ b/crates/astria-sequencer/src/app.rs
@@ -350,7 +350,7 @@ impl App {
                 excluded_tx_count = excluded_tx_count,
                 included_tx_count = validated_txs.len(),
                 "excluded transactions from block"
-            )
+            );
         }
 
         (signed_txs, validated_txs)


### PR DESCRIPTION
## Summary
Adds a limit to the amount of sequenced data which is allowed into a single block, important to avoid overflowing celestia + ensuring that we can propogate full blocks successfully.

## Background
We had a limit on transaction sizes but not on aggregate of transactions, this adds a basic limit of 256kb for total sequenced data. This size was chosen based on Celestia block size with max of ~5-6 blocks per celestia block completely filled blocks would use up ~60% of 2mb Celestia block size.

## Changes
- Adds a limitation to execute block transactions to limit the number of bytes that make it into full block.

## Breaking Changes
- This a network upgrade, all future proposals will be rejected if they have too many txs. However, old blocks will still be successfully executed through blocksync.

## Issues
closes https://github.com/astriaorg/astria/issues/524 

