### PR TITLE
chore(sequencer): update instrumentation for all consensus & app functions

### DIFF
--- a/crates/astria-sequencer/src/app.rs
+++ b/crates/astria-sequencer/src/app.rs
@@ -120,7 +120,7 @@ impl App {
         }
     }
 
-    #[instrument(name = "App:init_chain", skip(self))]
+    #[instrument(name = "App:init_chain", skip_all)]
     pub(crate) async fn init_chain(
         &mut self,
         genesis_state: GenesisState,
@@ -161,7 +161,7 @@ impl App {
     /// It puts this special "commitment" as the first transaction in a block.
     /// When other validators receive the block, they know the first transaction is
     /// supposed to be the commitment, and verifies that is it correct.
-    #[instrument(name = "App::prepare_proposal", skip(self, prepare_proposal))]
+    #[instrument(name = "App::prepare_proposal", skip_all)]
     pub(crate) async fn prepare_proposal(
         &mut self,
         prepare_proposal: abci::request::PrepareProposal,
@@ -185,7 +185,7 @@ impl App {
     /// Generates a commitment to the `sequence::Actions` in the block's transactions
     /// and ensures it matches the commitment created by the proposer, which
     /// should be the first transaction in the block.
-    #[instrument(name = "App::process_proposal", skip(self, process_proposal))]
+    #[instrument(name = "App::process_proposal", skip_all)]
     pub(crate) async fn process_proposal(
         &mut self,
         process_proposal: abci::request::ProcessProposal,
@@ -259,7 +259,9 @@ impl App {
     ///
     /// Returns the transactions which were successfully decoded and executed
     /// in both their [`SignedTransaction`] and raw bytes form.
-    #[instrument(name = "App::execute_block_data", skip(self, txs))]
+    #[instrument(name = "App::execute_block_data", skip_all, fields(
+        tx_count = txs.len()
+    ))]
     async fn execute_block_data(
         &mut self,
         txs: Vec<bytes::Bytes>,
@@ -315,7 +317,7 @@ impl App {
         (signed_txs, validated_txs)
     }
 
-    #[instrument(name = "App::begin_block", skip(self))]
+    #[instrument(name = "App::begin_block", skip_all)]
     pub(crate) async fn begin_block(
         &mut self,
         begin_block: &abci::request::BeginBlock,
@@ -353,7 +355,9 @@ impl App {
     ///
     /// Note that the first two "transactions" in the block, which are the proposer-generated
     /// commitments, are ignored.
-    #[instrument(name = "App::deliver_tx_after_execution", skip(self))]
+    #[instrument(name = "App::deliver_tx_after_execution", skip_all, fields(
+        tx_hash =  %telemetry::display::hex(tx_hash),
+    ))]
     pub(crate) fn deliver_tx_after_execution(
         &mut self,
         tx_hash: &[u8; 32],
@@ -430,7 +434,7 @@ impl App {
         Ok(events)
     }
 
-    #[instrument(name = "App::end_block", skip(self))]
+    #[instrument(name = "App::end_block", skip_all)]
     pub(crate) async fn end_block(
         &mut self,
         end_block: &abci::request::EndBlock,
@@ -468,7 +472,7 @@ impl App {
         })
     }
 
-    #[instrument(name = "App::commit", skip(self, storage))]
+    #[instrument(name = "App::commit", skip_all)]
     pub(crate) async fn commit(&mut self, storage: Storage) -> RootHash {
         // We need to extract the State we've built up to commit it.  Fill in a dummy state.
         let dummy_state = StateDelta::new(storage.latest_snapshot());

--- a/crates/astria-sequencer/src/service/consensus.rs
+++ b/crates/astria-sequencer/src/service/consensus.rs
@@ -177,7 +177,7 @@ impl Consensus {
         tx_count = process_proposal.txs.len(),
         proposer = %process_proposal.proposer_address,
         hash = %telemetry::display::hex(&process_proposal.hash),
-        next_validators_hash = %process_proposal.next_validators_hash,
+        next_validators_hash = %telemetry::display::hex(&process_proposal.next_validators_hash),
     ))]
     async fn handle_process_proposal(
         &mut self,

--- a/crates/astria-sequencer/src/service/consensus.rs
+++ b/crates/astria-sequencer/src/service/consensus.rs
@@ -4,6 +4,10 @@ use anyhow::{
 };
 use astria_core::sequencer::v1alpha1::AbciErrorCode;
 use cnidarium::Storage;
+use sha2::{
+    Digest as _,
+    Sha256,
+};
 use tendermint::v0_37::abci::{
     request,
     response,
@@ -72,7 +76,7 @@ impl Consensus {
         Ok(())
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip_all)]
     async fn handle_request(
         &mut self,
         req: ConsensusRequest,
@@ -121,7 +125,7 @@ impl Consensus {
         })
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip_all, fields(chain_id = init_chain.chain_id, time = %init_chain.time, init_height = %init_chain.initial_height))]
     async fn init_chain(
         &mut self,
         init_chain: request::InitChain,
@@ -151,7 +155,11 @@ impl Consensus {
         })
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip_all, fields(
+        height = %prepare_proposal.height,
+        tx_count = prepare_proposal.txs.len(),
+        time = %prepare_proposal.time
+    ))]
     async fn handle_prepare_proposal(
         &mut self,
         prepare_proposal: request::PrepareProposal,
@@ -159,7 +167,14 @@ impl Consensus {
         self.app.prepare_proposal(prepare_proposal).await
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip_all, fields(
+        height = %process_proposal.height,
+        time = %process_proposal.time,
+        tx_count = process_proposal.txs.len(),
+        proposer = %process_proposal.proposer_address,
+        hash = %telemetry::display::hex(&process_proposal.hash),
+        next_validators_hash = %process_proposal.next_validators_hash,
+    ))]
     async fn handle_process_proposal(
         &mut self,
         process_proposal: request::ProcessProposal,
@@ -167,7 +182,12 @@ impl Consensus {
         self.app.process_proposal(process_proposal).await
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip_all, fields(
+        hash = %begin_block.hash,
+        height = %begin_block.header.height,
+        time = %begin_block.header.time,
+        proposer = %begin_block.header.proposer_address
+    ))]
     async fn begin_block(
         &mut self,
         begin_block: request::BeginBlock,
@@ -182,7 +202,9 @@ impl Consensus {
         })
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip_all, fields(
+        tx_hash = %telemetry::display::hex(&Sha256::digest(&deliver_tx.tx))
+    ))]
     async fn deliver_tx(&mut self, deliver_tx: request::DeliverTx) -> response::DeliverTx {
         use sha2::Digest as _;
 
@@ -218,7 +240,7 @@ impl Consensus {
         }
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip_all, fields(height = %end_block.height))]
     async fn end_block(
         &mut self,
         end_block: request::EndBlock,
@@ -226,7 +248,7 @@ impl Consensus {
         self.app.end_block(&end_block).await
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip_all)]
     async fn commit(&mut self) -> anyhow::Result<response::Commit> {
         let app_hash = self.app.commit(self.storage.clone()).await;
         Ok(response::Commit {

--- a/crates/astria-sequencer/src/service/consensus.rs
+++ b/crates/astria-sequencer/src/service/consensus.rs
@@ -125,7 +125,11 @@ impl Consensus {
         })
     }
 
-    #[instrument(skip_all, fields(chain_id = init_chain.chain_id, time = %init_chain.time, init_height = %init_chain.initial_height))]
+    #[instrument(skip_all, fields(
+        chain_id = init_chain.chain_id,
+        time = %init_chain.time,
+        init_height = %init_chain.initial_height
+    ))]
     async fn init_chain(
         &mut self,
         init_chain: request::InitChain,


### PR DESCRIPTION
## Summary
Updates all consensus API calls to have specifically chosen data in the spans, and omits anything but context of function from children (ie handle has context, the funciton it calls doesn't need it)

## Background
Debugging sequencer is hard, spans from handle request on process proposal were unreadable. Similar changes made in sequencer for debugging fix. 

## Changes
- Update all functions to skip_all with specific fields logged
