### PR TITLE
refactor(conductor): use idiomatic types, streamline some executor code

### DIFF
--- a/crates/astria-conductor/src/executor/client.rs
+++ b/crates/astria-conductor/src/executor/client.rs
@@ -1,71 +1,32 @@
-use astria_core::generated::execution::v1alpha2::{
-    execution_service_client::ExecutionServiceClient,
-    BatchGetBlocksRequest,
-    BatchGetBlocksResponse,
-    Block,
-    BlockIdentifier,
-    CommitmentState,
-    ExecuteBlockRequest,
-    GetBlockRequest,
-    GetCommitmentStateRequest,
-    UpdateCommitmentStateRequest,
+use astria_core::{
+    execution::v1alpha2::{
+        Block,
+        CommitmentState,
+    },
+    generated::execution::{
+        v1alpha2 as raw,
+        v1alpha2::execution_service_client::ExecutionServiceClient,
+    },
+    Protobuf as _,
 };
 use color_eyre::eyre::{
-    Result,
-    WrapErr,
+    self,
+    WrapErr as _,
 };
 use prost_types::Timestamp;
 use tonic::transport::Channel;
 
-use super::ExecutorCommitmentState;
-
-/// Extension trait for the ExecutionServiceClient that makes it easier to interact with the
-/// execution client.
-#[async_trait::async_trait]
-pub(super) trait ExecutionClientExt {
-    async fn call_batch_get_blocks(
-        &mut self,
-        identifiers: Vec<BlockIdentifier>,
-    ) -> Result<BatchGetBlocksResponse>;
-
-    async fn call_execute_block(
-        &mut self,
-        prev_block_hash: Vec<u8>,
-        transactions: Vec<Vec<u8>>,
-        timestamp: Timestamp,
-    ) -> Result<Block>;
-
-    async fn call_get_block(&mut self, identifier: BlockIdentifier) -> Result<Block>;
-
-    async fn call_get_commitment_state(&mut self) -> Result<ExecutorCommitmentState>;
-
-    async fn call_update_commitment_state(
-        &mut self,
-        firm: Block,
-        soft: Block,
-    ) -> Result<ExecutorCommitmentState>;
+/// A newtype wrapper around [`ExecutionServiceClient`] to work with
+/// idiomatic types.
+pub(super) struct Client {
+    inner: ExecutionServiceClient<Channel>,
 }
 
-#[async_trait::async_trait]
-impl ExecutionClientExt for ExecutionServiceClient<Channel> {
-    /// Calls remote procedure BatchGetBlocks
-    ///
-    /// # Arguments
-    ///
-    /// * `identifiers` - List of block identifiers describes which blocks we want to get
-    async fn call_batch_get_blocks(
-        &mut self,
-        identifiers: Vec<BlockIdentifier>,
-    ) -> Result<BatchGetBlocksResponse> {
-        let request = BatchGetBlocksRequest {
-            identifiers,
-        };
-        let response = self
-            .batch_get_blocks(request)
-            .await
-            .wrap_err("failed to batch get blocks")?
-            .into_inner();
-        Ok(response)
+impl Client {
+    pub(super) fn from_execution_service_client(inner: ExecutionServiceClient<Channel>) -> Self {
+        Self {
+            inner,
+        }
     }
 
     /// Calls remote procedure ExecuteBlock
@@ -75,52 +36,39 @@ impl ExecutionClientExt for ExecutionServiceClient<Channel> {
     /// * `prev_block_hash` - Block hash of the parent block
     /// * `transactions` - List of transactions extracted from the sequencer block
     /// * `timestamp` - Optional timestamp of the sequencer block
-    async fn call_execute_block(
+    pub(super) async fn execute_block(
         &mut self,
-        prev_block_hash: Vec<u8>,
+        prev_block_hash: [u8; 32],
         transactions: Vec<Vec<u8>>,
         timestamp: Timestamp,
-    ) -> Result<Block> {
-        let request = ExecuteBlockRequest {
-            prev_block_hash,
+    ) -> eyre::Result<Block> {
+        let request = raw::ExecuteBlockRequest {
+            prev_block_hash: prev_block_hash.to_vec(),
             transactions,
             timestamp: Some(timestamp),
         };
         let response = self
+            .inner
             .execute_block(request)
             .await
             .wrap_err("failed to execute block")?
             .into_inner();
-        Ok(response)
-    }
-
-    /// Calls remote procedure GetBlock
-    ///
-    /// # Arguments
-    ///
-    /// * `identifier` - The identifier describes the block we want to get
-    async fn call_get_block(&mut self, identifier: BlockIdentifier) -> Result<Block> {
-        let request = GetBlockRequest {
-            identifier: Some(identifier),
-        };
-        let response = self
-            .get_block(request)
-            .await
-            .wrap_err("failed to get block")?
-            .into_inner();
-        Ok(response)
+        let block = Block::try_from_raw(response)
+            .wrap_err("failed converting raw response to validated block")?;
+        Ok(block)
     }
 
     /// Calls remote procedure GetCommitmentState
-    async fn call_get_commitment_state(&mut self) -> Result<ExecutorCommitmentState> {
-        let request = GetCommitmentStateRequest {};
+    pub(super) async fn get_commitment_state(&mut self) -> eyre::Result<CommitmentState> {
+        let request = raw::GetCommitmentStateRequest {};
         let response = self
+            .inner
             .get_commitment_state(request)
             .await
             .wrap_err("failed to get commitment state")?
             .into_inner();
-        let commitment_state =
-            ExecutorCommitmentState::from_execution_client_commitment_state(response);
+        let commitment_state = CommitmentState::try_from_raw(response)
+            .wrap_err("failed converting raw response to validated commitment state")?;
         Ok(commitment_state)
     }
 
@@ -130,25 +78,21 @@ impl ExecutionClientExt for ExecutionServiceClient<Channel> {
     ///
     /// * `firm` - The firm block
     /// * `soft` - The soft block
-    async fn call_update_commitment_state(
+    pub(super) async fn update_commitment_state(
         &mut self,
-        firm: Block,
-        soft: Block,
-    ) -> Result<ExecutorCommitmentState> {
-        let commitment_state = CommitmentState {
-            firm: Some(firm),
-            soft: Some(soft),
-        };
-        let request = UpdateCommitmentStateRequest {
-            commitment_state: Some(commitment_state),
+        commitment_state: CommitmentState,
+    ) -> eyre::Result<CommitmentState> {
+        let request = raw::UpdateCommitmentStateRequest {
+            commitment_state: Some(commitment_state.into_raw()),
         };
         let response = self
+            .inner
             .update_commitment_state(request)
             .await
             .wrap_err("failed to update commitment state")?
             .into_inner();
-        let commitment_state =
-            ExecutorCommitmentState::from_execution_client_commitment_state(response);
+        let commitment_state = CommitmentState::try_from_raw(response)
+            .wrap_err("failed converting raw response to validated commitment state")?;
         Ok(commitment_state)
     }
 }

--- a/crates/astria-conductor/src/executor/client.rs
+++ b/crates/astria-conductor/src/executor/client.rs
@@ -18,6 +18,7 @@ use tonic::transport::Channel;
 
 /// A newtype wrapper around [`ExecutionServiceClient`] to work with
 /// idiomatic types.
+#[derive(Clone)]
 pub(super) struct Client {
     inner: ExecutionServiceClient<Channel>,
 }

--- a/crates/astria-conductor/src/executor/client.rs
+++ b/crates/astria-conductor/src/executor/client.rs
@@ -29,7 +29,7 @@ impl Client {
         }
     }
 
-    /// Calls remote procedure ExecuteBlock
+    /// Calls remote procedure `astria.execution.v1alpha2.ExecuteBlock`
     ///
     /// # Arguments
     ///
@@ -58,7 +58,7 @@ impl Client {
         Ok(block)
     }
 
-    /// Calls remote procedure GetCommitmentState
+    /// Calls remote procedure `astria.execution.v1alpha2.GetCommitmentState`
     pub(super) async fn get_commitment_state(&mut self) -> eyre::Result<CommitmentState> {
         let request = raw::GetCommitmentStateRequest {};
         let response = self
@@ -72,7 +72,7 @@ impl Client {
         Ok(commitment_state)
     }
 
-    /// Calls remote procedure UpdateCommitmentState
+    /// Calls remote procedure `astria.execution.v1alpha2.UpdateCommitmentState`
     ///
     /// # Arguments
     ///

--- a/crates/astria-conductor/src/executor/mod.rs
+++ b/crates/astria-conductor/src/executor/mod.rs
@@ -535,7 +535,11 @@ impl Executor {
     }
 
     async fn update_commitment_state(&mut self, update: Update) -> eyre::Result<()> {
-        use Update::*;
+        use Update::{
+            OnlyFirm,
+            OnlySoft,
+            ToSame,
+        };
         let (firm, soft) = match update {
             OnlyFirm(firm) => (firm, self.commitment_state.soft().clone()),
             OnlySoft(soft) => (self.commitment_state.firm().clone(), soft),

--- a/crates/astria-core/src/execution/mod.rs
+++ b/crates/astria-core/src/execution/mod.rs
@@ -1,0 +1,1 @@
+pub mod v1alpha2;

--- a/crates/astria-core/src/execution/v1alpha2/mod.rs
+++ b/crates/astria-core/src/execution/v1alpha2/mod.rs
@@ -242,7 +242,6 @@ impl CommitmentStateBuilder<WithFirm, WithSoft> {
 /// - Block numbers are such that soft >= firm (upheld by this type).
 /// - No blocks ever decrease in block number.
 /// - The chain defined by soft is the head of the canonical chain the firm block must belong to.
-// NOTE: The type's fields are public because no invariants are upheld.
 #[derive(Clone, Debug)]
 pub struct CommitmentState {
     /// Soft commitment is the rollup block matching latest sequencer block.

--- a/crates/astria-core/src/execution/v1alpha2/mod.rs
+++ b/crates/astria-core/src/execution/v1alpha2/mod.rs
@@ -1,0 +1,219 @@
+use prost_types::Timestamp;
+
+use crate::{
+    generated::execution::v1alpha2 as raw,
+    Protobuf,
+};
+
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub struct BlockError(BlockErrorKind);
+
+impl BlockError {
+    fn field_not_set(field: &'static str) -> Self {
+        Self(BlockErrorKind::FieldNotSet(field))
+    }
+
+    fn incorrect_block_hash_length(wrong_hash: &[u8]) -> Self {
+        Self(BlockErrorKind::IncorrectBlockHashLength(wrong_hash.len()))
+    }
+
+    fn incorrect_parent_block_hash_length(wrong_hash: &[u8]) -> Self {
+        Self(BlockErrorKind::IncorrectParentBlockHashLength(
+            wrong_hash.len(),
+        ))
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum BlockErrorKind {
+    #[error("{0} field not set")]
+    FieldNotSet(&'static str),
+    #[error(".hash field contained wrong number of bytes; expected 32, got {0}")]
+    IncorrectBlockHashLength(usize),
+    #[error(".parent_block_hash field contained wrong number of bytes; expected 32, got {0}")]
+    IncorrectParentBlockHashLength(usize),
+}
+
+#[derive(Clone, Debug)]
+pub struct Block {
+    /// The block number
+    number: u32,
+    /// The hash of the block
+    hash: [u8; 32],
+    /// The hash from the parent block
+    parent_block_hash: [u8; 32],
+    /// Timestamp on the block, standardized to google protobuf standard.
+    timestamp: Timestamp,
+}
+
+impl Block {
+    #[must_use]
+    pub fn number(&self) -> u32 {
+        self.number
+    }
+
+    #[must_use]
+    pub fn hash(&self) -> [u8; 32] {
+        self.hash
+    }
+
+    #[must_use]
+    pub fn parent_block_hash(&self) -> [u8; 32] {
+        self.parent_block_hash
+    }
+
+    #[must_use]
+    pub fn timestamp(&self) -> Timestamp {
+        // prost_types::Timestamp is a (i64, i32) tuple, so this is
+        // effectively just a copy
+        self.timestamp.clone()
+    }
+}
+
+impl Protobuf for Block {
+    type Error = BlockError;
+    type Raw = raw::Block;
+
+    fn try_from_raw_ref(raw: &Self::Raw) -> Result<Self, Self::Error> {
+        let raw::Block {
+            number,
+            hash,
+            parent_block_hash,
+            timestamp,
+        } = raw;
+        let hash = hash
+            .as_slice()
+            .try_into()
+            .map_err(|_| Self::Error::incorrect_block_hash_length(hash))?;
+        let parent_block_hash = parent_block_hash
+            .as_slice()
+            .try_into()
+            .map_err(|_| Self::Error::incorrect_parent_block_hash_length(parent_block_hash))?;
+
+        // Clone'ing timestamp is effectively a copy because timestamp is just a (i32, i64) tuple
+        let timestamp = timestamp
+            .clone()
+            .ok_or(Self::Error::field_not_set(".timestamp"))?;
+
+        Ok(Self {
+            number: *number,
+            hash,
+            parent_block_hash,
+            timestamp,
+        })
+    }
+
+    fn to_raw(&self) -> Self::Raw {
+        let Self {
+            number,
+            hash,
+            parent_block_hash,
+            timestamp,
+        } = self;
+        Self::Raw {
+            number: *number,
+            hash: hash.to_vec(),
+            parent_block_hash: parent_block_hash.to_vec(),
+            // Clone'ing timestamp is effectively a copy because timestamp is just a (i32, i64)
+            // tuple
+            timestamp: Some(timestamp.clone()),
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub struct CommitmentStateError(CommitmentStateErrorKind);
+
+impl CommitmentStateError {
+    fn field_not_set(field: &'static str) -> Self {
+        Self(CommitmentStateErrorKind::FieldNotSet(field))
+    }
+
+    fn firm(source: BlockError) -> Self {
+        Self(CommitmentStateErrorKind::Firm(source))
+    }
+
+    fn soft(source: BlockError) -> Self {
+        Self(CommitmentStateErrorKind::Soft(source))
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum CommitmentStateErrorKind {
+    #[error("{0} field not set")]
+    FieldNotSet(&'static str),
+    #[error(".firm field did not contain a valid block")]
+    Firm(#[source] BlockError),
+    #[error(".soft field did not contain a valid block")]
+    Soft(#[source] BlockError),
+}
+
+/// The CommitmentState holds the block at each stage of sequencer commitment
+/// level
+///
+/// A Valid CommitmentState:
+/// - Block numbers are such that soft >= firm.
+/// - No blocks ever decrease in block number.
+/// - The chain defined by soft is the head of the canonical chain the firm block must belong to.
+#[derive(Clone, Debug)]
+pub struct CommitmentState {
+    /// Soft commitment is the rollup block matching latest sequencer block.
+    pub soft: Block,
+    /// Firm commitment is achieved when data has been seen in DA.
+    pub firm: Block,
+}
+
+impl CommitmentState {
+    #[must_use]
+    pub fn firm(&self) -> &Block {
+        &self.firm
+    }
+
+    #[must_use]
+    pub fn soft(&self) -> &Block {
+        &self.soft
+    }
+}
+
+impl Protobuf for CommitmentState {
+    type Error = CommitmentStateError;
+    type Raw = raw::CommitmentState;
+
+    fn try_from_raw_ref(raw: &Self::Raw) -> Result<Self, Self::Error> {
+        let Self::Raw {
+            soft,
+            firm,
+        } = raw;
+        let soft = 'soft: {
+            let Some(soft) = soft else {
+                break 'soft Err(Self::Error::field_not_set(".soft"));
+            };
+            Block::try_from_raw_ref(soft).map_err(Self::Error::soft)
+        }?;
+        let firm = 'firm: {
+            let Some(firm) = firm else {
+                break 'firm Err(Self::Error::field_not_set(".firm"));
+            };
+            Block::try_from_raw_ref(firm).map_err(Self::Error::firm)
+        }?;
+        Ok(Self {
+            soft,
+            firm,
+        })
+    }
+
+    fn to_raw(&self) -> Self::Raw {
+        let Self {
+            soft,
+            firm,
+        } = self;
+        let soft = soft.to_raw();
+        let firm = firm.to_raw();
+        Self::Raw {
+            soft: Some(soft),
+            firm: Some(firm),
+        }
+    }
+}

--- a/crates/astria-core/src/lib.rs
+++ b/crates/astria-core/src/lib.rs
@@ -6,6 +6,7 @@ compile_error!(
 #[rustfmt::skip]
 pub mod generated;
 
+pub mod execution;
 pub mod primitive;
 pub mod sequencer;
 


### PR DESCRIPTION
## Summary
Defined idiomatic execution types in `astria-core`, refactored and streamlined executor code.

## Background
The conversion method for commitment states would panic, it returns an error now and the conversion happens in `astria-core`, similar to the sequencer types.

There was also a lot of unused code in the execution service extension trait, and unnecessary redirection when updating commitment states (single-use functions that make reading the code opaque). All of that has been removed. 

## Changes
- Defined `Block` and `CommitmentState` in `astria-core` with conversion methods from the raw generated prost types.
- Changed the exection service extension crate to a newtype wrapper on `ExecutionServiceClient<Channel>` (it used to be that, but the newtype wrapper fits better in this instance)
- Removed a few methods by inlining their logic at the call site.

## Testing
Executor tests still run, only refactoring.