### PR TITLE
build(sequencer, conductor, composer, relayer): cut releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "astria-sequencer-relayer"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "astria-celestia-client",
  "astria-celestia-mock",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -544,7 +544,7 @@ dependencies = [
 
 [[package]]
 name = "astria-composer"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "astria-config",
  "astria-core",
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "astria-conductor"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "astria-celestia-client",
  "astria-config",
@@ -680,7 +680,7 @@ dependencies = [
 
 [[package]]
 name = "astria-sequencer"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "astria-config",

--- a/crates/astria-composer/Cargo.toml
+++ b/crates/astria-composer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astria-composer"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 rust-version = "1.70.0"
 

--- a/crates/astria-conductor/Cargo.toml
+++ b/crates/astria-conductor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astria-conductor"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 rust-version = "1.73"
 

--- a/crates/astria-sequencer-relayer/Cargo.toml
+++ b/crates/astria-sequencer-relayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astria-sequencer-relayer"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 rust-version = "1.73"

--- a/crates/astria-sequencer/Cargo.toml
+++ b/crates/astria-sequencer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astria-sequencer"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 rust-version = "1.73.0"
 


### PR DESCRIPTION
## Summary
Cut new releases for use in new dusk release.

sequencer v0.8.0, conductor v0.11.1, composer v0.3.1, sequencer-relayer v0.9.1

