### PR TITLE
feat(conductor, proto)!: essential rollup info from genesis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -648,6 +648,7 @@ dependencies = [
  "rand 0.8.5",
  "sha2 0.10.8",
  "tempfile",
+ "tendermint 0.32.0",
  "tendermint 0.34.0",
  "tendermint-proto 0.34.0",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,3 +92,8 @@ tracing = "0.1"
 tryhard = "0.5.1"
 which = "4.4.0"
 wiremock = "0.5"
+
+[workspace.dependencies.celestia-tendermint]
+package = "tendermint"
+git = "https://github.com/eigerco/celestia-tendermint-rs"
+rev = "bbe7de8"

--- a/crates/astria-celestia-client/Cargo.toml
+++ b/crates/astria-celestia-client/Cargo.toml
@@ -29,6 +29,7 @@ merkle = { package = "astria-merkle", path = "../astria-merkle" }
 # when updating.
 jsonrpsee = { version = "0.20", features = ["client-core", "macros"] }
 prost = { workspace = true }
+celestia-tendermint = { workspace = true }
 
 [dependencies.celestia-rpc]
 git = "https://github.com/eigerco/celestia-node-rs"
@@ -37,8 +38,3 @@ rev = "4862eec"
 [dependencies.celestia-types]
 git = "https://github.com/eigerco/celestia-node-rs"
 rev = "4862eec"
-
-[dependencies.celestia-tendermint]
-package = "tendermint"
-git = "https://github.com/eigerco/celestia-tendermint-rs"
-rev = "bbe7de8"

--- a/crates/astria-conductor/local.env.example
+++ b/crates/astria-conductor/local.env.example
@@ -10,10 +10,6 @@ ASTRIA_CONDUCTOR_CELESTIA_BEARER_TOKEN="<JWT Bearer token>"
 # This url is used to read astria blocks from the Data Availability layer
 ASTRIA_CONDUCTOR_CELESTIA_NODE_URL="http://127.0.0.1:26659"
 
-# The chain id of the chain that is being read from the astria-sequencer or the
-# Data Availability layer
-ASTRIA_CONDUCTOR_CHAIN_ID="astriachain"
-
 # Execution RPC URL
 ASTRIA_CONDUCTOR_EXECUTION_RPC_URL="http://127.0.0.1:50051"
 
@@ -29,9 +25,6 @@ ASTRIA_CONDUCTOR_EXECUTION_COMMIT_LEVEL="SoftAndFirm"
 # retrieving validators.
 # 127.0.0.1:26657 is the default socket address in comebft's `rpc.laddr` setting.
 ASTRIA_CONDUCTOR_SEQUENCER_URL="ws://127.0.0.1:26657/websocket"
-
-# the sequencer block height that the rollup's first block was in
-ASTRIA_CONDUCTOR_INITIAL_SEQUENCER_BLOCK_HEIGHT=1
 
 # set to true to enable op-stack deposit derivations
 ASTRIA_CONDUCTOR_ENABLE_OPTIMISM=false

--- a/crates/astria-conductor/src/conductor.rs
+++ b/crates/astria-conductor/src/conductor.rs
@@ -112,7 +112,7 @@ impl Conductor {
                 .build()
                 .await
                 .wrap_err("failed to construct executor")?;
-            let genesis = executor.get_genesis();
+            let genesis = executor.genesis();
             let executable_sequencer_block_height = executor
                 .calculate_executable_block_height()
                 .wrap_err("failed calculating the next executable block height")?;

--- a/crates/astria-conductor/src/config.rs
+++ b/crates/astria-conductor/src/config.rs
@@ -33,17 +33,11 @@ pub struct Config {
     /// URL of the sequencer cometbft websocket
     pub sequencer_url: String,
 
-    /// Chain ID that we want to work in
-    pub chain_id: String,
-
     /// Address of the RPC server for execution
     pub execution_rpc_url: String,
 
     /// log directive to use for telemetry.
     pub log: String,
-
-    /// The Sequencer block height that the rollup genesis block was in
-    pub initial_sequencer_block_height: u32,
 
     /// The execution commit level used for controlling how blocks are sent to
     /// the execution layer.

--- a/crates/astria-conductor/src/executor/client.rs
+++ b/crates/astria-conductor/src/executor/client.rs
@@ -2,6 +2,7 @@ use astria_core::{
     execution::v1alpha2::{
         Block,
         CommitmentState,
+        GenesisInfo,
     },
     generated::execution::{
         v1alpha2 as raw,
@@ -28,6 +29,20 @@ impl Client {
         Self {
             inner,
         }
+    }
+
+    /// Calls remote procedure `astria.execution.v1alpha2.GetGenesisInfo`
+    pub(super) async fn get_genesis_info(&mut self) -> eyre::Result<GenesisInfo> {
+        let request = raw::GetGenesisInfoRequest {};
+        let response = self
+            .inner
+            .get_genesis_info(request)
+            .await
+            .wrap_err("failed to get genesis_info")?
+            .into_inner();
+        let genesis_info = GenesisInfo::try_from_raw(response)
+            .wrap_err("failed converting raw response to validated genesis info")?;
+        Ok(genesis_info)
     }
 
     /// Calls remote procedure `astria.execution.v1alpha2.ExecuteBlock`

--- a/crates/astria-conductor/src/executor/mod.rs
+++ b/crates/astria-conductor/src/executor/mod.rs
@@ -446,13 +446,13 @@ impl Executor {
         &self,
     ) -> eyre::Result<tendermint::block::Height> {
         let Some(executable_block_height) = calculate_sequencer_block_height(
-            self.genesis.sequencer_genesis_block_number(),
+            self.genesis.sequencer_genesis_block_height(),
             self.commitment_state.soft().number(),
         ) else {
             bail!(
                 "encountered overflow when calculating executable block height; sequencer height \
                  with first rollup block: {}, height recorded in soft commitment state: {}",
-                self.genesis.sequencer_genesis_block_number(),
+                self.genesis.sequencer_genesis_block_height(),
                 self.commitment_state.soft().number(),
             );
         };
@@ -469,13 +469,13 @@ impl Executor {
         &self,
     ) -> eyre::Result<tendermint::block::Height> {
         let Some(finalizable_block_height) = calculate_sequencer_block_height(
-            self.genesis.sequencer_genesis_block_number(),
+            self.genesis.sequencer_genesis_block_height(),
             self.commitment_state.firm().number(),
         ) else {
             bail!(
                 "encountered overflow when calculating finalizable block height; sequencer height \
                  with first rollup block: {}, height recorded in firm commitment state: {}",
-                self.genesis.sequencer_genesis_block_number(),
+                self.genesis.sequencer_genesis_block_height(),
                 self.commitment_state.firm().number(),
             );
         };

--- a/crates/astria-conductor/src/executor/mod.rs
+++ b/crates/astria-conductor/src/executor/mod.rs
@@ -460,8 +460,8 @@ impl Executor {
         Ok(executable_block_height.into())
     }
 
-    pub(crate) fn get_genesis(&self) -> GenesisInfo {
-        self.genesis.clone()
+    pub(crate) fn genesis(&self) -> GenesisInfo {
+        self.genesis
     }
 
     // Returns the lowest sequencer block height which can finalized on the rollup.
@@ -517,10 +517,14 @@ impl Executor {
 /// `initial_sequencer_height + rollup_height` the corresponding sequencer
 /// height.
 fn calculate_sequencer_block_height(
-    initial_sequencer_height: u32,
+    initial_sequencer_height: tendermint::block::Height,
     rollup_height: u32,
 ) -> Option<u32> {
-    initial_sequencer_height.checked_add(rollup_height)
+    let sequencer_height = initial_sequencer_height.value().try_into().expect(
+        "initial sequencer height is too large to be represented as a u32, this should not happen \
+         since it is derived from a i64 number",
+    );
+    rollup_height.checked_add(sequencer_height)
 }
 
 enum Update {

--- a/crates/astria-conductor/src/executor/tests.rs
+++ b/crates/astria-conductor/src/executor/tests.rs
@@ -15,8 +15,10 @@ use astria_core::{
         Block,
         CommitmentState,
         ExecuteBlockRequest,
+        GenesisInfo,
         GetBlockRequest,
         GetCommitmentStateRequest,
+        GetGenesisInfoRequest,
         UpdateCommitmentStateRequest,
     },
     sequencer::v1alpha1::test_utils::make_cometbft_block,
@@ -111,6 +113,21 @@ impl ExecutionService for ExecutionServiceImpl {
         }))
     }
 
+    async fn get_genesis_info(
+        &self,
+        _request: tonic::Request<GetGenesisInfoRequest>,
+    ) -> std::result::Result<tonic::Response<GenesisInfo>, tonic::Status> {
+        let bytes = [42u8; 32];
+        let rollup_id = RollupId::new(bytes).to_vec();
+
+        Ok(tonic::Response::new(GenesisInfo {
+            rollup_id,
+            sequencer_genesis_block_number: 1,
+            celestia_base_block_number: 1,
+            celestia_block_variance: 1,
+        }))
+    }
+
     async fn get_commitment_state(
         &self,
         _request: tonic::Request<GetCommitmentStateRequest>,
@@ -165,8 +182,6 @@ async fn start_mock(pre_execution_hook: Option<optimism::Handler>) -> MockEnviro
 
     let executor = Executor::builder()
         .rollup_address(&server_url)
-        .rollup_id(RollupId::from_unhashed_bytes(b"test"))
-        .sequencer_height_with_first_rollup_block(1)
         .block_channel(block_rx)
         .shutdown(shutdown_rx)
         .set_optimism_hook(pre_execution_hook)

--- a/crates/astria-conductor/src/executor/tests.rs
+++ b/crates/astria-conductor/src/executor/tests.rs
@@ -22,8 +22,8 @@ use astria_core::{
         UpdateCommitmentStateRequest,
     },
     sequencer::v1alpha1::{
-        RollupId,
         test_utils::make_cometbft_block,
+        RollupId,
     },
 };
 use ethers::{

--- a/crates/astria-conductor/src/executor/tests.rs
+++ b/crates/astria-conductor/src/executor/tests.rs
@@ -21,7 +21,10 @@ use astria_core::{
         GetGenesisInfoRequest,
         UpdateCommitmentStateRequest,
     },
-    sequencer::v1alpha1::test_utils::make_cometbft_block,
+    sequencer::v1alpha1::{
+        RollupId,
+        test_utils::make_cometbft_block,
+    },
 };
 use ethers::{
     prelude::*,

--- a/crates/astria-core/Cargo.toml
+++ b/crates/astria-core/Cargo.toml
@@ -17,6 +17,7 @@ keywords = ["astria", "grpc", "rpc", "blockchain", "execution", "protobuf"]
 [dependencies]
 merkle = { package = "astria-merkle", path = "../astria-merkle" }
 
+celestia-tendermint = { workspace = true }
 ed25519-consensus = { workspace = true }
 hex = { workspace = true }
 ibc-types = { workspace = true }

--- a/crates/astria-core/src/execution/v1alpha2/mod.rs
+++ b/crates/astria-core/src/execution/v1alpha2/mod.rs
@@ -5,7 +5,6 @@ use crate::{
     sequencer::v1alpha1::{
         IncorrectRollupIdLength,
         RollupId,
-        ROLLUP_ID_LEN,
     },
     Protobuf,
 };

--- a/crates/astria-core/src/execution/v1alpha2/mod.rs
+++ b/crates/astria-core/src/execution/v1alpha2/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     Protobuf,
 };
 
-// An error when transforming a [`raw::Block`] into a [`Block`].
+// An error when transforming a [`raw::GenesisInfo`] into a [`GenesisInfo`].
 #[derive(Debug, thiserror::Error)]
 #[error(transparent)]
 pub struct GenesisInfoError(GenesisInfoErrorKind);
@@ -26,20 +26,21 @@ enum GenesisInfoErrorKind {
     IncorrectRollupIdLength(IncorrectRollupIdLength),
 }
 
-/// An Astria execution block on a rollup.
+/// Genesis Info required from a rollup to start a an execution client.
 ///
-/// Contains information about the block number, its hash,
-/// its parent block's hash, and timestamp.
+/// Contains information about the rollup id, and base heights for both sequencer & celestia. 
 ///
 /// Usually constructed its [`Protobuf`] implementation from a
-/// [`raw::Block`].
-#[derive(Clone, Debug)]
+/// [`raw::GenesisInfo`].
+#[derive(Clone, Copy, Debug)]
 pub struct GenesisInfo {
-    /// The block number
+    /// The rollup id which is used to identify the rollup txs.
     rollup_id: RollupId,
-    /// The hash of the block
-    sequencer_genesis_block_number: u32,
-    celestia_base_block_number: u32,
+    /// The first height of sequencer which is used to identify the first block of the rollup.
+    sequencer_genesis_block_height: u32,
+    /// The first height of celestia which to look for sequencer blocks.
+    celestia_base_block_height: u32,
+    /// The allowed variance in the block height of celestia when looking for sequencer blocks.
     celestia_block_variance: u32,
 }
 
@@ -50,13 +51,13 @@ impl GenesisInfo {
     }
 
     #[must_use]
-    pub fn sequencer_genesis_block_number(&self) -> u32 {
-        self.sequencer_genesis_block_number
+    pub fn sequencer_genesis_block_height(&self) -> u32 {
+        self.sequencer_genesis_block_height
     }
 
     #[must_use]
-    pub fn celestia_base_block_number(&self) -> u32 {
-        self.celestia_base_block_number
+    pub fn celestia_base_block_height(&self) -> u32 {
+        self.celestia_base_block_height
     }
 
     #[must_use]
@@ -72,8 +73,8 @@ impl Protobuf for GenesisInfo {
     fn try_from_raw_ref(raw: &Self::Raw) -> Result<Self, Self::Error> {
         let raw::GenesisInfo {
             rollup_id,
-            sequencer_genesis_block_number,
-            celestia_base_block_number,
+            sequencer_genesis_block_height,
+            celestia_base_block_height,
             celestia_block_variance,
         } = raw;
         let rollup_id =
@@ -81,8 +82,8 @@ impl Protobuf for GenesisInfo {
 
         Ok(Self {
             rollup_id,
-            sequencer_genesis_block_number: *sequencer_genesis_block_number,
-            celestia_base_block_number: *celestia_base_block_number,
+            sequencer_genesis_block_height: *sequencer_genesis_block_height,
+            celestia_base_block_height: *celestia_base_block_height,
             celestia_block_variance: *celestia_block_variance,
         })
     }
@@ -90,14 +91,14 @@ impl Protobuf for GenesisInfo {
     fn to_raw(&self) -> Self::Raw {
         let Self {
             rollup_id,
-            sequencer_genesis_block_number,
-            celestia_base_block_number,
+            sequencer_genesis_block_height,
+            celestia_base_block_height,
             celestia_block_variance,
         } = self;
         Self::Raw {
             rollup_id: rollup_id.to_vec(),
-            sequencer_genesis_block_number: *sequencer_genesis_block_number,
-            celestia_base_block_number: *celestia_base_block_number,
+            sequencer_genesis_block_height: *sequencer_genesis_block_height,
+            celestia_base_block_height: *celestia_base_block_height,
             celestia_block_variance: *celestia_block_variance,
         }
     }

--- a/crates/astria-core/src/generated/astria.execution.v1alpha2.rs
+++ b/crates/astria-core/src/generated/astria.execution.v1alpha2.rs
@@ -1,3 +1,19 @@
+/// GenesisInfo contains the information needed to start a rollup chain.
+///
+/// This information is used to determine which sequencer & celestia data to
+/// use from the Astria & Celestia networks.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GenesisInfo {
+    #[prost(bytes = "vec", tag = "1")]
+    pub rollup_id: ::prost::alloc::vec::Vec<u8>,
+    #[prost(uint32, tag = "2")]
+    pub sequencer_genesis_block_number: u32,
+    #[prost(uint32, tag = "3")]
+    pub celestia_base_block_number: u32,
+    #[prost(uint32, tag = "4")]
+    pub celestia_block_variance: u32,
+}
 /// The set of information which deterministic driver of block production
 /// must know about a given rollup Block
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -34,6 +50,9 @@ pub mod block_identifier {
         BlockHash(::prost::alloc::vec::Vec<u8>),
     }
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetGenesisInfoRequest {}
 /// Used in GetBlock to find a single block.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -193,6 +212,34 @@ pub mod execution_service_client {
         pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
             self.inner = self.inner.max_encoding_message_size(limit);
             self
+        }
+        /// GetGenesisInfo returns the necessary genesis information for rollup chain.
+        pub async fn get_genesis_info(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetGenesisInfoRequest>,
+        ) -> std::result::Result<tonic::Response<super::GenesisInfo>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/astria.execution.v1alpha2.ExecutionService/GetGenesisInfo",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "astria.execution.v1alpha2.ExecutionService",
+                        "GetGenesisInfo",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// GetBlock will return a block given an identifier.
         pub async fn get_block(
@@ -356,6 +403,11 @@ pub mod execution_service_server {
     /// Generated trait containing gRPC methods that should be implemented for use with ExecutionServiceServer.
     #[async_trait]
     pub trait ExecutionService: Send + Sync + 'static {
+        /// GetGenesisInfo returns the necessary genesis information for rollup chain.
+        async fn get_genesis_info(
+            &self,
+            request: tonic::Request<super::GetGenesisInfoRequest>,
+        ) -> std::result::Result<tonic::Response<super::GenesisInfo>, tonic::Status>;
         /// GetBlock will return a block given an identifier.
         async fn get_block(
             &self,
@@ -472,6 +524,53 @@ pub mod execution_service_server {
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
             let inner = self.inner.clone();
             match req.uri().path() {
+                "/astria.execution.v1alpha2.ExecutionService/GetGenesisInfo" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetGenesisInfoSvc<T: ExecutionService>(pub Arc<T>);
+                    impl<
+                        T: ExecutionService,
+                    > tonic::server::UnaryService<super::GetGenesisInfoRequest>
+                    for GetGenesisInfoSvc<T> {
+                        type Response = super::GenesisInfo;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::GetGenesisInfoRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as ExecutionService>::get_genesis_info(&inner, request)
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = GetGenesisInfoSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
                 "/astria.execution.v1alpha2.ExecutionService/GetBlock" => {
                     #[allow(non_camel_case_types)]
                     struct GetBlockSvc<T: ExecutionService>(pub Arc<T>);

--- a/crates/astria-core/src/generated/astria.execution.v1alpha2.rs
+++ b/crates/astria-core/src/generated/astria.execution.v1alpha2.rs
@@ -5,12 +5,16 @@
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GenesisInfo {
+    /// The rollup_id is the unique identifier for the rollup chain.
     #[prost(bytes = "vec", tag = "1")]
     pub rollup_id: ::prost::alloc::vec::Vec<u8>,
+    /// The first block height of sequencer chain to use for rollup transactions.
     #[prost(uint32, tag = "2")]
-    pub sequencer_genesis_block_number: u32,
+    pub sequencer_genesis_block_height: u32,
+    /// The first block height of celestia chain to use for rollup transactions.
     #[prost(uint32, tag = "3")]
-    pub celestia_base_block_number: u32,
+    pub celestia_base_block_height: u32,
+    /// The allowed variance in celestia for sequencer blocks to have been posted.
     #[prost(uint32, tag = "4")]
     pub celestia_block_variance: u32,
 }

--- a/proto/astria/execution/v1alpha2/execution.proto
+++ b/proto/astria/execution/v1alpha2/execution.proto
@@ -9,9 +9,13 @@ import "google/protobuf/timestamp.proto";
 // This information is used to determine which sequencer & celestia data to
 // use from the Astria & Celestia networks.
 message GenesisInfo {
+  // The rollup_id is the unique identifier for the rollup chain.
   bytes rollup_id = 1;
-  uint32 sequencer_genesis_block_number = 2;
-  uint32 celestia_base_block_number = 3;
+  // The first block height of sequencer chain to use for rollup transactions.
+  uint32 sequencer_genesis_block_height = 2;
+  // The first block height of celestia chain to use for rollup transactions.
+  uint32 celestia_base_block_height = 3;
+  // The allowed variance in celestia for sequencer blocks to have been posted.
   uint32 celestia_block_variance = 4;
 }
 

--- a/proto/astria/execution/v1alpha2/execution.proto
+++ b/proto/astria/execution/v1alpha2/execution.proto
@@ -4,6 +4,17 @@ package astria.execution.v1alpha2;
 
 import "google/protobuf/timestamp.proto";
 
+// GenesisInfo contains the information needed to start a rollup chain.
+//
+// This information is used to determine which sequencer & celestia data to
+// use from the Astria & Celestia networks.
+message GenesisInfo {
+  bytes rollup_id = 1;
+  uint32 sequencer_genesis_block_number = 2;
+  uint32 celestia_base_block_number = 3;
+  uint32 celestia_block_variance = 4;
+}
+
 // The set of information which deterministic driver of block production
 // must know about a given rollup Block
 message Block {
@@ -24,6 +35,8 @@ message BlockIdentifier {
     bytes block_hash = 2;
   }
 }
+
+message GetGenesisInfoRequest {}
 
 // Used in GetBlock to find a single block.
 message GetBlockRequest {
@@ -84,6 +97,9 @@ message UpdateCommitmentStateRequest {
 // Astria Shared Sequencer, and will have block production driven via the Astria
 // "Conductor".
 service ExecutionService {
+  // GetGenesisInfo returns the necessary genesis information for rollup chain.
+  rpc GetGenesisInfo(GetGenesisInfoRequest) returns (GenesisInfo);
+
   // GetBlock will return a block given an identifier.
   rpc GetBlock(GetBlockRequest) returns (Block);
 

--- a/specs/execution-api.md
+++ b/specs/execution-api.md
@@ -9,10 +9,6 @@ intended to be very simple to implement. It is a gRPC API which any state
 machine can implement and use conductor with to drive their block creation to
 integrate with the Astria Sequencer.
 
-> Note: this documentation is for the v1alpha2 API which is currently being
-> implemented, and some of the documentation is on how it should be implemented,
-> not how it is currently.
-
 ## Basic Design Principles
 
 The Execution API is a resource based API with two resources: `Block` and
@@ -25,12 +21,13 @@ to generate client libraries and server implementations.
 
 ### Startup
 
-Upon startup, conductor needs to know the state of commitments in the state
-machine and calls `GetCommitmentState`. If started on a fresh rollup these will
-all be the same block. If running against a state machine with previous block
-data, Conductor must also track the block hash of any blocks between
-commitments, it will call `BatchGetBlock` to get block information between
-commitments.
+Upon startup, conductor first grabs the basic genesis information via
+`GetGenesisInfo`. After this succeeds, it  fetches the initial commitments in
+the state machine via `GetCommitmentState`. If started on a fresh rollup
+these will all be the same block. If running against a state machine with
+previous block data, Conductor must also track the block hash of any blocks
+between commitments, it will call `BatchGetBlock` to get block information
+between commitments.
 
 ### Execution & Commitments
 
@@ -73,6 +70,13 @@ Note: For our EVM rollup, we map the `CommitmentState` to the `ForkchoiceRule`:
 - `FIRM` Commitment -> `FINAL` Forkchoice
 
 ## Rollup Implementation Details
+
+### GetGenesisInfo
+
+`GetGenesisInfo` returns information which is definitional to the rollup with
+regards to how it derves data from the sequencer & celestia networks. This RPC
+should ALWAYS succeed. The API is agnostic as to how the information is defined
+in a rollups genesis, and used by the conductor as configuration on startup.
 
 ### ExecuteBlock
 


### PR DESCRIPTION
## Summary
Adds a `GenesisInfo` rpc to the execution API to pass definitional rollup information through rollup genesis instead of conductor config, as well as implementing conductor to implement this.

## Background
Certain information about the rollup should be considered a core part of the rollup definition, but was done through environmental variable configuration making it harder to spin up nodes that follow the same rules.

## Changes
- Create `GenesisInfo` protos
- Added types to astria-core
- Replaced information from config. 

## Testing
Added basic CI tests. Manual testing TBD

## Breaking Changelist
- Changes conductor config and requires `GenesisInfo` be implemented on rollup.
