### PR TITLE
feat(core): add `SignedTransaction::sha256_of_proto_encoding()` method

### DIFF
--- a/crates/astria-conductor/src/executor/tests.rs
+++ b/crates/astria-conductor/src/executor/tests.rs
@@ -136,7 +136,7 @@ fn get_expected_execution_hash(parent_block_hash: &[u8], transactions: &[Vec<u8>
 }
 
 fn hash(s: &[u8]) -> Vec<u8> {
-    let mut hasher = sha2::Sha256::new();
+    let mut hasher = sha2::new();
     hasher.update(s);
     hasher.finalize().to_vec()
 }

--- a/crates/astria-conductor/src/executor/tests.rs
+++ b/crates/astria-conductor/src/executor/tests.rs
@@ -136,7 +136,7 @@ fn get_expected_execution_hash(parent_block_hash: &[u8], transactions: &[Vec<u8>
 }
 
 fn hash(s: &[u8]) -> Vec<u8> {
-    let mut hasher = sha2::new();
+    let mut hasher = sha2::Sha256::new();
     hasher.update(s);
     hasher.finalize().to_vec()
 }

--- a/crates/astria-core/src/sequencer/v1alpha1/transaction/mod.rs
+++ b/crates/astria-core/src/sequencer/v1alpha1/transaction/mod.rs
@@ -4,6 +4,7 @@ use ed25519_consensus::{
     VerificationKey,
 };
 use prost::Message as _;
+use sha2::Sha256;
 
 use super::raw;
 
@@ -63,6 +64,17 @@ pub struct SignedTransaction {
 }
 
 impl SignedTransaction {
+    /// Returns the transaction hash.
+    ///
+    /// The transaction hash is calculated by protobuf-encoding the transaction
+    /// and hashing the resulting bytes with sha256.
+    #[must_use]
+    pub fn hash(&self) -> [u8; 32] {
+        use sha2::Digest as _;
+        let bytes = self.to_raw().encode_to_vec();
+        Sha256::digest(bytes).into()
+    }
+
     #[must_use]
     pub fn into_raw(self) -> raw::SignedTransaction {
         let Self {

--- a/crates/astria-core/src/sequencer/v1alpha1/transaction/mod.rs
+++ b/crates/astria-core/src/sequencer/v1alpha1/transaction/mod.rs
@@ -69,7 +69,7 @@ impl SignedTransaction {
     /// The transaction hash is calculated by protobuf-encoding the transaction
     /// and hashing the resulting bytes with sha256.
     #[must_use]
-    pub fn hash(&self) -> [u8; 32] {
+    pub fn sha256_of_proto_encoding(&self) -> [u8; 32] {
         use sha2::Digest as _;
         let bytes = self.to_raw().encode_to_vec();
         Sha256::digest(bytes).into()

--- a/crates/astria-core/src/sequencer/v1alpha1/transaction/mod.rs
+++ b/crates/astria-core/src/sequencer/v1alpha1/transaction/mod.rs
@@ -4,7 +4,6 @@ use ed25519_consensus::{
     VerificationKey,
 };
 use prost::Message as _;
-use sha2::Sha256;
 
 use super::raw;
 
@@ -70,7 +69,10 @@ impl SignedTransaction {
     /// and hashing the resulting bytes with sha256.
     #[must_use]
     pub fn sha256_of_proto_encoding(&self) -> [u8; 32] {
-        use sha2::Digest as _;
+        use sha2::{
+            Digest as _,
+            Sha256,
+        };
         let bytes = self.to_raw().encode_to_vec();
         Sha256::digest(bytes).into()
     }
@@ -279,10 +281,7 @@ mod test {
     use super::*;
     use crate::sequencer::v1alpha1::{
         asset::default_native_asset_id,
-        transaction::action::{
-            Action::Transfer,
-            TransferAction,
-        },
+        transaction::action::TransferAction,
         Address,
     };
 
@@ -313,7 +312,7 @@ mod test {
 
         let unsigned = UnsignedTransaction {
             nonce: 0,
-            actions: vec![Transfer(transfer)],
+            actions: vec![transfer.into()],
             fee_asset_id: default_native_asset_id(),
         };
 

--- a/crates/astria-core/src/sequencer/v1alpha1/transaction/mod.rs
+++ b/crates/astria-core/src/sequencer/v1alpha1/transaction/mod.rs
@@ -278,10 +278,7 @@ enum UnsignedTransactionErrorKind {
 mod test {
     use super::*;
     use crate::sequencer::v1alpha1::{
-        asset::{
-            default_native_asset_id,
-            Id,
-        },
+        asset::default_native_asset_id,
         transaction::action::{
             Action::Transfer,
             TransferAction,
@@ -326,6 +323,6 @@ mod test {
             transaction: unsigned,
         };
 
-        assert_eq!(tx.hash(), expected_hash);
+        assert_eq!(tx.sha256_of_proto_encoding(), expected_hash);
     }
 }

--- a/crates/astria-sequencer/src/app.rs
+++ b/crates/astria-sequencer/src/app.rs
@@ -464,7 +464,7 @@ impl App {
     ///
     /// Note that `begin_block` is now called *after* transaction execution.
     #[instrument(name = "App::deliver_tx", skip_all, fields(
-        signed_transaction_hash = %telemetry::display::hex(&signed_tx.hash()),
+        signed_transaction_hash = %telemetry::display::hex(&signed_tx.sha256_of_proto_encoding()),
         sender = %Address::from_verification_key(signed_tx.verification_key()),
     ))]
     pub(crate) async fn deliver_tx(

--- a/crates/astria-sequencer/src/app.rs
+++ b/crates/astria-sequencer/src/app.rs
@@ -464,7 +464,7 @@ impl App {
     ///
     /// Note that `begin_block` is now called *after* transaction execution.
     #[instrument(name = "App::deliver_tx", skip_all, fields(
-        signed_transaction_hash = %telemetry::display::hex(&Sha256::digest(signed_tx.to_raw().encode_to_vec())),
+        signed_transaction_hash = %telemetry::display::hex(&signed_tx.hash()),
         sender = %Address::from_verification_key(signed_tx.verification_key()),
     ))]
     pub(crate) async fn deliver_tx(


### PR DESCRIPTION
## Summary

add transaction hashes to match what cometbft/hermes are logging/use internally.

## Changes
- add `SignedTransaction::sha256_of_proto_encoding()` method

## Testing

unit test + I ran it and cometbft/hermes get the same tx hashes.

## Related Issues

closes https://github.com/astriaorg/astria/issues/476