### PR TITLE
chore(cli): bump for dusk-3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -523,7 +523,7 @@ dependencies = [
 
 [[package]]
 name = "astria-cli"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "assert_cmd",
  "astria-core",

--- a/crates/astria-cli/Cargo.toml
+++ b/crates/astria-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astria-cli"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 rust-version = "1.73"
 

--- a/crates/astria-cli/src/cli/mod.rs
+++ b/crates/astria-cli/src/cli/mod.rs
@@ -12,7 +12,7 @@ use crate::cli::{
     sequencer::Command as SequencerCommand,
 };
 
-const DEFAULT_SEQUENCER_RPC: &str = "https://rpc.sequencer.dusk-2.devnet.astria.org";
+const DEFAULT_SEQUENCER_RPC: &str = "https://rpc.sequencer.dusk-3.devnet.astria.org";
 
 /// A CLI for deploying and managing Astria services and related infrastructure.
 #[derive(Debug, Parser)]


### PR DESCRIPTION
## Summary
release new cli version which points to dusk-3

## Background
We are launching a new devnet, and cli should point to the correct rpc by default
