### PR TITLE
refactor(conductor): use separate channels for celestia, sequencer blocks

### DIFF
--- a/crates/astria-conductor/src/data_availability/builder.rs
+++ b/crates/astria-conductor/src/data_availability/builder.rs
@@ -9,14 +9,19 @@ use color_eyre::eyre::{
     WrapErr as _,
 };
 use deadpool::managed::Pool;
-use tokio::sync::oneshot;
+use tokio::sync::{
+    mpsc,
+    oneshot,
+};
 use tokio_util::task::JoinMap;
 
-use super::Reader;
+use super::{
+    Reader,
+    SequencerBlockSubset,
+};
 use crate::{
     client_provider::ClientProvider,
     data_availability::block_verifier::BlockVerifier,
-    executor,
 };
 
 pub(crate) struct ReaderBuilder<
@@ -383,7 +388,7 @@ impl<
 
     pub(crate) fn executor_channel(
         self,
-        executor_channel: executor::Sender,
+        executor_channel: mpsc::UnboundedSender<Vec<SequencerBlockSubset>>,
     ) -> ReaderBuilder<
         TCelestiaEndpoint,
         TCelestiaPollInterval,
@@ -424,7 +429,7 @@ pub(crate) struct WithCelestiaPollInterval(Duration);
 pub(crate) struct NoCelestiaToken;
 pub(crate) struct WithCelestiaToken(String);
 pub(crate) struct NoExecutorChannel;
-pub(crate) struct WithExecutorChannel(executor::Sender);
+pub(crate) struct WithExecutorChannel(mpsc::UnboundedSender<Vec<SequencerBlockSubset>>);
 pub(crate) struct NoRollupNamespace;
 pub(crate) struct WithRollupNamespace(Namespace);
 pub(crate) struct NoSequencerClientPool;

--- a/crates/astria-conductor/src/data_availability/mod.rs
+++ b/crates/astria-conductor/src/data_availability/mod.rs
@@ -41,8 +41,6 @@ use tracing::{
     Instrument,
 };
 
-use crate::executor;
-
 mod block_verifier;
 use block_verifier::BlockVerifier;
 mod builder;
@@ -76,7 +74,7 @@ impl SequencerBlockSubset {
 
 pub(crate) struct Reader {
     /// The channel used to send messages to the executor task.
-    executor_channel: executor::Sender,
+    executor_channel: mpsc::UnboundedSender<Vec<SequencerBlockSubset>>,
 
     /// The client used to communicate with Celestia.
     celestia_client: HttpClient,
@@ -305,7 +303,7 @@ impl Reader {
             Ok(Ok(subsets)) => subsets,
         };
         self.executor_channel
-            .send(executor::ExecutorCommand::FromCelestia(subsets))
+            .send(subsets)
             .wrap_err("failed sending processed sequencer subsets: executor channel is closed")
     }
 }


### PR DESCRIPTION
## Summary
Splits the legacy "executor command" channel into separate channels for the celestia and sequencer reader sending their blocks to the executor.

## Background
This allows for a cleaner implementation with the celestia/sequencer readers being completely agnostic to each other where before they had to be wrapped in a common enum.

Furthermore it allows separate back pressure on both channels so that frequent sequencer blocks don't flood out celestia blocks (although this is not currently implemented).

## Changes
- Removed the common "executor command" mpsc channel, replace by two separate mpsc channels.

## Testing
No functional changes other than using two different channels.

## Related Issues
Part of https://github.com/astriaorg/astria/pull/691