### PR TITLE
feat(conductor): fetch objects for verifying blocks concurrently

### DIFF
--- a/crates/astria-conductor/src/celestia/block_verifier.rs
+++ b/crates/astria-conductor/src/celestia/block_verifier.rs
@@ -82,13 +82,13 @@ impl Verify {
         )?;
         let block_hash = block.block_id.hash;
         let commit_header = commit.signed_header;
-        Self::new(block_hash, commit_header, validator_set)
+        Self::new(block_hash, commit_header, &validator_set)
     }
 
     fn new(
         block_hash: tendermint::Hash,
         commit_header: tendermint::block::signed_header::SignedHeader,
-        validator_set: tendermint_rpc::endpoint::validators::Response,
+        validator_set: &tendermint_rpc::endpoint::validators::Response,
     ) -> eyre::Result<Self> {
         ensure!(
             block_hash == commit_header.header.hash(),
@@ -96,7 +96,7 @@ impl Verify {
         );
         ensure_commit_has_quorum(
             &commit_header.commit,
-            &validator_set,
+            validator_set,
             &commit_header.header.chain_id,
         )
         .wrap_err("unable to verify that commit had quorum")?;

--- a/crates/astria-conductor/src/celestia/mod.rs
+++ b/crates/astria-conductor/src/celestia/mod.rs
@@ -443,8 +443,8 @@ async fn process_sequencer_blob(
     rollup_namespace: Namespace,
     sequencer_blob: CelestiaSequencerBlob,
 ) -> eyre::Result<ReconstructedBlock> {
-    let sequencer_blob = verifier
-        .validate_celestia_blob_against_sequencer(sequencer_blob)
+    verifier
+        .verify_blob(&sequencer_blob)
         .await
         .wrap_err("failed validating sequencer blob retrieved from celestia")?;
     let mut rollup_blobs = client

--- a/crates/astria-conductor/src/celestia/mod.rs
+++ b/crates/astria-conductor/src/celestia/mod.rs
@@ -444,7 +444,7 @@ async fn process_sequencer_blob(
     sequencer_blob: CelestiaSequencerBlob,
 ) -> eyre::Result<ReconstructedBlock> {
     let sequencer_blob = verifier
-        .validate_sequencer_blob(sequencer_blob)
+        .validate_celestia_blob_against_sequencer(sequencer_blob)
         .await
         .wrap_err("failed validating sequencer blob retrieved from celestia")?;
     let mut rollup_blobs = client


### PR DESCRIPTION
## Summary
Concurrently fetch objects (block hash, validator set, commit) to verify sequencer blocks reconstructed from celestia.

## Background
Block verifier used to sequentially query sequencer for the necessary objects to verify a block derived from celestia blobs. While this saves network IO, it takes 3 times as long to wait for the objects.

## Changes
- Start 3 concurrent futures to fetch the necessary objects from sequencer to validate blocks derived from celestia blobs.

## Testing
No substantial changes. Instead of fetching one after the other 3 futures are ran concurrently.

## Related Issues[
Part of https://github.com/astriaorg/astria/pull/691