### PR TITLE
refactor(conductor): adapt executor to sequential firm, soft blocks

### DIFF
--- a/crates/astria-conductor/src/executor/builder.rs
+++ b/crates/astria-conductor/src/executor/builder.rs
@@ -1,0 +1,176 @@
+use std::collections::HashMap;
+
+use astria_core::{
+    generated::execution::v1alpha2::execution_service_client::ExecutionServiceClient,
+    sequencer::v1alpha1::RollupId,
+};
+use color_eyre::eyre::{
+    self,
+    WrapErr as _,
+};
+use tokio::sync::{
+    mpsc,
+    oneshot,
+};
+use tracing::info;
+
+use super::Executor;
+use crate::executor::{
+    client,
+    optimism,
+};
+
+pub(crate) struct NoRollupAddress;
+pub(crate) struct WithRollupAddress(String);
+pub(crate) struct NoRollupId;
+pub(crate) struct WithRollupId(RollupId);
+pub(crate) struct NoShutdown;
+pub(crate) struct WithShutdown(oneshot::Receiver<()>);
+
+pub(crate) struct ExecutorBuilder<
+    TRollupAddress = NoRollupAddress,
+    TRollupId = NoRollupId,
+    TShutdown = NoShutdown,
+> {
+    optimism_hook: Option<optimism::Handler>,
+    rollup_address: TRollupAddress,
+    rollup_id: TRollupId,
+    sequencer_height_with_first_rollup_block: u32,
+    shutdown: TShutdown,
+}
+
+impl ExecutorBuilder {
+    pub(super) fn new() -> Self {
+        Self {
+            optimism_hook: None,
+            rollup_address: NoRollupAddress,
+            rollup_id: NoRollupId,
+            sequencer_height_with_first_rollup_block: 0,
+            shutdown: NoShutdown,
+        }
+    }
+}
+
+impl ExecutorBuilder<WithRollupAddress, WithRollupId, WithShutdown> {
+    pub(crate) async fn build(self) -> eyre::Result<Executor> {
+        let Self {
+            rollup_id,
+            optimism_hook: pre_execution_hook,
+            rollup_address,
+            sequencer_height_with_first_rollup_block,
+            shutdown,
+        } = self;
+        let WithRollupAddress(rollup_address) = rollup_address;
+        let WithRollupId(rollup_id) = rollup_id;
+        let WithShutdown(shutdown) = shutdown;
+
+        let mut client = client::Client::from_execution_service_client(
+            ExecutionServiceClient::connect(rollup_address)
+                .await
+                .wrap_err("failed to create execution rpc client")?,
+        );
+        let commitment_state = client
+            .get_commitment_state()
+            .await
+            .wrap_err("to get initial commitment state")?;
+
+        info!(
+            soft_block_hash = %telemetry::display::hex(&commitment_state.soft().hash()),
+            firm_block_hash = %telemetry::display::hex(&commitment_state.firm().hash()),
+            "initial execution commitment state",
+        );
+
+        let (celestia_tx, celestia_rx) = mpsc::unbounded_channel();
+        let (sequencer_tx, sequencer_rx) = mpsc::unbounded_channel();
+
+        Ok(Executor {
+            celestia_rx,
+            celestia_tx: celestia_tx.downgrade(),
+            sequencer_rx,
+            sequencer_tx: sequencer_tx.downgrade(),
+
+            shutdown,
+            client,
+            rollup_id,
+            commitment_state,
+            sequencer_height_with_first_rollup_block,
+            sequencer_hash_to_execution_block: HashMap::new(),
+            pre_execution_hook,
+        })
+    }
+}
+
+impl<TRollupAddress, TRollupId, TShutdown> ExecutorBuilder<TRollupAddress, TRollupId, TShutdown> {
+    pub(crate) fn rollup_id(
+        self,
+        rollup_id: RollupId,
+    ) -> ExecutorBuilder<TRollupAddress, WithRollupId, TShutdown> {
+        let Self {
+            optimism_hook,
+            rollup_address,
+            sequencer_height_with_first_rollup_block,
+            shutdown,
+            ..
+        } = self;
+        ExecutorBuilder {
+            optimism_hook,
+            rollup_address,
+            rollup_id: WithRollupId(rollup_id),
+            sequencer_height_with_first_rollup_block,
+            shutdown,
+        }
+    }
+
+    pub(crate) fn sequencer_height_with_first_rollup_block(
+        mut self,
+        sequencer_height_with_first_rollup_block: u32,
+    ) -> Self {
+        self.sequencer_height_with_first_rollup_block = sequencer_height_with_first_rollup_block;
+        self
+    }
+
+    pub(crate) fn set_optimism_hook(mut self, handler: Option<optimism::Handler>) -> Self {
+        self.optimism_hook = handler;
+        self
+    }
+
+    pub(crate) fn rollup_address(
+        self,
+        rollup_address: &str,
+    ) -> ExecutorBuilder<WithRollupAddress, TRollupId, TShutdown> {
+        let Self {
+            rollup_id,
+            optimism_hook,
+            sequencer_height_with_first_rollup_block,
+            shutdown,
+            ..
+        } = self;
+        ExecutorBuilder {
+            optimism_hook,
+            rollup_address: WithRollupAddress(rollup_address.to_string()),
+            rollup_id,
+            sequencer_height_with_first_rollup_block,
+            shutdown,
+        }
+    }
+
+    pub(crate) fn shutdown(
+        self,
+        shutdown: oneshot::Receiver<()>,
+    ) -> ExecutorBuilder<TRollupAddress, TRollupId, WithShutdown> {
+        let Self {
+            optimism_hook,
+            sequencer_height_with_first_rollup_block,
+            rollup_address,
+            rollup_id,
+            ..
+        } = self;
+        ExecutorBuilder {
+            optimism_hook,
+            sequencer_height_with_first_rollup_block,
+            rollup_address,
+            rollup_id,
+            shutdown: WithShutdown(shutdown),
+        }
+    }
+}

--- a/crates/astria-conductor/src/executor/builder.rs
+++ b/crates/astria-conductor/src/executor/builder.rs
@@ -83,7 +83,7 @@ impl ExecutorBuilder<WithRollupAddress, WithRollupId, WithShutdown> {
         let (celestia_tx, celestia_rx) = mpsc::unbounded_channel();
         let (sequencer_tx, sequencer_rx) = mpsc::unbounded_channel();
 
-        let mut commitment_state = super::TrackCommitmentState::with_state(commitment_state);
+        let mut commitment_state = super::TrackState::with_state(commitment_state);
         commitment_state
             .set_sequencer_height_with_first_rollup_block(sequencer_height_with_first_rollup_block);
 

--- a/crates/astria-conductor/src/executor/builder.rs
+++ b/crates/astria-conductor/src/executor/builder.rs
@@ -83,6 +83,10 @@ impl ExecutorBuilder<WithRollupAddress, WithRollupId, WithShutdown> {
         let (celestia_tx, celestia_rx) = mpsc::unbounded_channel();
         let (sequencer_tx, sequencer_rx) = mpsc::unbounded_channel();
 
+        let mut commitment_state = super::TrackCommitmentState::with_state(commitment_state);
+        commitment_state
+            .set_sequencer_height_with_first_rollup_block(sequencer_height_with_first_rollup_block);
+
         Ok(Executor {
             celestia_rx,
             celestia_tx: celestia_tx.downgrade(),
@@ -93,8 +97,7 @@ impl ExecutorBuilder<WithRollupAddress, WithRollupId, WithShutdown> {
             client,
             rollup_id,
             commitment_state,
-            sequencer_height_with_first_rollup_block,
-            sequencer_hash_to_execution_block: HashMap::new(),
+            blocks_pending_finalization: HashMap::new(),
             pre_execution_hook,
         })
     }

--- a/crates/astria-conductor/src/executor/mod.rs
+++ b/crates/astria-conductor/src/executor/mod.rs
@@ -76,7 +76,9 @@ impl Executor {
 
     /// Returns the next sequencer height expected by the executor.
     pub(super) fn next_soft_sequencer_height(&self) -> Height {
-        self.commitment_state.next_soft_sequencer_height()
+        self.commitment_state
+            .next_soft_sequencer_height()
+            .increment()
     }
 
     pub(super) fn celestia_channel(&self) -> mpsc::UnboundedSender<ReconstructedBlock> {
@@ -178,7 +180,9 @@ impl Executor {
         let executable_block = ExecutableBlock::from_reconstructed(block);
         ensure!(
             executable_block.height == self.commitment_state.next_firm_sequencer_height(),
-            "block was not at the expected height",
+            "expected block at sequencer height {}, but got {}",
+            self.commitment_state.next_firm_sequencer_height(),
+            executable_block.height,
         );
 
         match self

--- a/crates/astria-conductor/src/executor/mod.rs
+++ b/crates/astria-conductor/src/executor/mod.rs
@@ -9,12 +9,13 @@ use astria_core::{
 };
 use color_eyre::eyre::{
     self,
-    bail,
     ensure,
     WrapErr as _,
 };
-use prost_types::Timestamp as ProstTimestamp;
-use sequencer_client::SequencerBlock;
+use sequencer_client::{
+    tendermint::block::Height,
+    SequencerBlock,
+};
 use tokio::{
     select,
     sync::{
@@ -37,25 +38,14 @@ pub(crate) mod optimism;
 mod client;
 #[cfg(test)]
 mod tests;
-
-// Given `Time`, convert to protobuf timestamp
-fn convert_tendermint_to_prost_timestamp(value: tendermint::Time) -> ProstTimestamp {
-    use tendermint_proto::google::protobuf::Timestamp as TendermintTimestamp;
-    let TendermintTimestamp {
-        seconds,
-        nanos,
-    } = value.into();
-    ProstTimestamp {
-        seconds,
-        nanos,
-    }
-}
+mod track_state;
+use track_state::TrackCommitmentState;
 
 pub(crate) struct Executor {
     celestia_rx: mpsc::UnboundedReceiver<ReconstructedBlock>,
     celestia_tx: mpsc::WeakUnboundedSender<ReconstructedBlock>,
-    sequencer_rx: mpsc::UnboundedReceiver<Box<SequencerBlock>>,
-    sequencer_tx: mpsc::WeakUnboundedSender<Box<SequencerBlock>>,
+    sequencer_rx: mpsc::UnboundedReceiver<SequencerBlock>,
+    sequencer_tx: mpsc::WeakUnboundedSender<SequencerBlock>,
 
     shutdown: oneshot::Receiver<()>,
 
@@ -66,23 +56,13 @@ pub(crate) struct Executor {
     rollup_id: RollupId,
 
     /// Tracks SOFT and FIRM on the execution chain
-    commitment_state: CommitmentState,
+    commitment_state: TrackCommitmentState,
 
-    /// The first block height from sequencer used for a rollup block,
-    /// executable block height & finalizable block height can be calcuated from
-    /// this plus the commitment_state
-    sequencer_height_with_first_rollup_block: u32,
-
-    /// map of sequencer block hash to execution block
+    /// Tracks executed blocks as soft commitments.
     ///
-    /// this is required because when we receive sequencer blocks (from network or DA),
-    /// we only know the sequencer block hash, but not the execution block hash,
-    /// as the execution block hash is created by executing the block.
-    /// as well, the execution layer is not aware of the sequencer block hash.
-    /// we need to track the mapping of sequencer block hash -> execution block
-    /// so that we can mark the block as final on the execution layer when
-    /// we receive a finalized sequencer block.
-    sequencer_hash_to_execution_block: HashMap<[u8; 32], Block>,
+    /// Required to mark firm blocks received from celestia as executed
+    /// without re-executing on top of the rollup node on top of the rollup node..
+    blocks_pending_finalization: HashMap<[u8; 32], Block>,
 
     /// optional hook which is called to modify the rollup transaction list
     /// right before it's sent to the execution layer via `ExecuteBlock`.
@@ -94,13 +74,18 @@ impl Executor {
         builder::ExecutorBuilder::new()
     }
 
+    /// Returns the next sequencer height expected by the executor.
+    pub(super) fn next_soft_sequencer_height(&self) -> Height {
+        self.commitment_state.next_soft_sequencer_height()
+    }
+
     pub(super) fn celestia_channel(&self) -> mpsc::UnboundedSender<ReconstructedBlock> {
         self.celestia_tx.upgrade().expect(
             "should work because the channel is held by self, is open, and other senders exist",
         )
     }
 
-    pub(super) fn sequencer_channel(&self) -> mpsc::UnboundedSender<Box<SequencerBlock>> {
+    pub(super) fn sequencer_channel(&self) -> mpsc::UnboundedSender<SequencerBlock> {
         self.sequencer_tx.upgrade().expect(
             "should work because the channel is held by self, is open, and other senders exist",
         )
@@ -130,7 +115,7 @@ impl Executor {
                         block.hash = %telemetry::display::hex(&block.block_hash),
                         "received block from celestia reader",
                     );
-                    if let Err(e) = self.execute_firm_block(block).await {
+                    if let Err(e) = self.execute_firm(block).await {
                         let reason = "failed executing firm block";
                         error!(
                             error = AsRef::<dyn std::error::Error>::as_ref(&e),
@@ -147,7 +132,7 @@ impl Executor {
                         block.hash = %telemetry::display::hex(&block.block_hash()),
                         "received block from sequencer reader",
                     );
-                    if let Err(e) = self.execute_soft_block(block).await {
+                    if let Err(e) = self.execute_soft(block).await {
                         let reason = "failed executing soft block";
                         error!(
                             error = AsRef::<dyn std::error::Error>::as_ref(&e),
@@ -162,180 +147,104 @@ impl Executor {
         // XXX: shut down the channels here and attempt to drain them before returning.
     }
 
-    async fn execute_soft_block(&mut self, block: Box<SequencerBlock>) -> eyre::Result<()> {
+    async fn execute_soft(&mut self, block: SequencerBlock) -> eyre::Result<()> {
         // TODO(https://github.com/astriaorg/astria/issues/624): add retry logic before failing hard.
-        // XXX: this will be replaced.
-        let block_hash = block.block_hash();
-        let mut block = (*block).into_unchecked();
-        let reconstructed_block = ReconstructedBlock {
-            block_hash,
-            header: block.header,
-            transactions: block
-                .rollup_transactions
-                .remove(&self.rollup_id)
-                .unwrap_or_default(),
-        };
+        let executable_block = ExecutableBlock::from_sequencer(block, self.rollup_id);
 
+        ensure!(
+            executable_block.height == self.commitment_state.next_soft_sequencer_height(),
+            "block was not at the expected height",
+        );
+
+        let block_hash = executable_block.hash;
+
+        let parent_block_hash = self.commitment_state.soft_parent_hash();
         let executed_block = self
-            .execute_block(reconstructed_block)
+            .execute_block(parent_block_hash, executable_block)
             .await
             .wrap_err("failed to execute block")?;
-        self.update_commitment_state(Update::OnlySoft(executed_block))
+
+        self.update_commitment_state(Update::OnlySoft(executed_block.clone()))
             .await
             .wrap_err("failed to update soft commitment state")?;
+
+        self.blocks_pending_finalization
+            .insert(block_hash, executed_block);
+
         Ok(())
     }
 
-    /// Execute the sequencer block on the execution layer, returning the
-    /// resulting execution block. If the block has already been executed, it
-    /// returns the previously-computed execution block hash.
-    #[instrument(skip(self), fields(sequencer_block_hash = ?block.block_hash, sequencer_block_height = block.header.height.value()))]
-    async fn execute_block(&mut self, block: ReconstructedBlock) -> eyre::Result<Block> {
-        let executable_block_height = self
-            .calculate_executable_block_height()
-            .wrap_err("failed calculating the next executable block height")?;
-        let actual_block_height = block.header.height;
+    async fn execute_firm(&mut self, block: ReconstructedBlock) -> eyre::Result<()> {
+        let executable_block = ExecutableBlock::from_reconstructed(block);
         ensure!(
-            executable_block_height == actual_block_height,
-            "received out-of-order block; expected `{executable_block_height}`, got \
-             `{actual_block_height}`",
+            executable_block.height == self.commitment_state.next_firm_sequencer_height(),
+            "block was not at the expected height",
         );
 
-        if let Some(execution_block) = self
-            .sequencer_hash_to_execution_block
-            .get(&block.block_hash)
+        match self
+            .blocks_pending_finalization
+            .remove(&executable_block.hash)
         {
-            debug!(
-                sequencer_block_height = block.header.height.value(),
-                execution_hash = hex::encode(execution_block.hash()),
-                "block already executed"
-            );
-            return Ok(execution_block.clone());
+            Some(block) => self
+                .update_commitment_state(Update::OnlyFirm(block))
+                .await
+                .wrap_err("failed to update firm commitment state")?,
+
+            None => {
+                let parent_block_hash = self.commitment_state.firm_parent_hash();
+                let executed_block = self
+                    .execute_block(parent_block_hash, executable_block)
+                    .await
+                    .wrap_err("failed to execute block")?;
+
+                self.update_commitment_state(Update::ToSame(executed_block))
+                    .await
+                    .wrap_err("failed to setting both commitment states to executed block")?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Executes `block` on top of its `parent_block_hash`.
+    ///
+    /// This function is called via [`Executor::execute_firm`] or [`Executor::execute_soft`],
+    /// and should not be called directly.
+    #[instrument(skip_all, fields(
+        hash.sequencer_block = %telemetry::display::hex(&block.hash),
+        height.sequencer_block = %block.height,
+        hash.parent_block = %telemetry::display::hex(&parent_block_hash),
+    ))]
+    async fn execute_block(
+        &mut self,
+        parent_block_hash: [u8; 32],
+        block: ExecutableBlock,
+    ) -> eyre::Result<Block> {
+        let ExecutableBlock {
+            mut transactions,
+            timestamp,
+            ..
+        } = block;
+
+        if let Some(hook) = self.pre_execution_hook.as_mut() {
+            transactions = hook
+                .populate_rollup_transactions(transactions)
+                .await
+                .wrap_err("failed to populate rollup transactions with pre execution hook")?;
         }
 
-        let prev_block_hash = self.commitment_state.soft().hash();
-        info!(
-            sequencer_block_height = block.header.height.value(),
-            parent_block_hash = hex::encode(prev_block_hash),
-            "executing block with given parent block",
-        );
-
-        let timestamp = convert_tendermint_to_prost_timestamp(block.header.time);
-
-        let rollup_transactions = if let Some(hook) = self.pre_execution_hook.as_mut() {
-            hook.populate_rollup_transactions(block.transactions)
-                .await
-                .wrap_err("failed to populate rollup transactions before execution")?
-        } else {
-            block.transactions
-        };
-
-        let tx_count = rollup_transactions.len();
         let executed_block = self
             .client
-            .execute_block(prev_block_hash, rollup_transactions, timestamp)
+            .execute_block(parent_block_hash, transactions, timestamp)
             .await
-            .wrap_err("failed to call execute_block")?;
+            .wrap_err("failed to run execute_block RPC")?;
 
-        // store block hash returned by execution client, as we need it to finalize the block later
-        info!(
-            execution_block_hash = %telemetry::display::hex(&executed_block.hash()),
-            tx_count,
-            "executed sequencer block",
+        debug!(
+            hash.executed_block = %telemetry::display::hex(&executed_block.hash()),
+            height.executed_block = executed_block.number(),
+            "executed block",
         );
 
-        // store block returned by execution client, as we need it to finalize the block later
-        self.sequencer_hash_to_execution_block
-            .insert(block.block_hash, executed_block.clone());
-
         Ok(executed_block)
-    }
-
-    async fn execute_firm_block(&mut self, block: ReconstructedBlock) -> eyre::Result<()> {
-        let finalizable_block_height = self
-            .calculate_finalizable_block_height()
-            .wrap_err("failed calculating next finalizable block height")?;
-        if block.header.height < finalizable_block_height {
-            info!(
-                sequencer_block_height = %block.header.height,
-                finalized_block_height = %finalizable_block_height,
-                "received block which is already finalized; skipping finalization"
-            );
-            return Ok(());
-        }
-
-        let sequencer_block_hash = block.block_hash;
-        let maybe_executed_block = self
-            .sequencer_hash_to_execution_block
-            .get(&sequencer_block_hash)
-            .cloned();
-        if let Some(block) = maybe_executed_block {
-            // this case means block has already been executed.
-            self.update_commitment_state(Update::OnlyFirm(block))
-                .await
-                .wrap_err("failed to update firm commitment state")?;
-            // remove the sequencer block hash from the map, as it's been firmly committed
-            self.sequencer_hash_to_execution_block
-                .remove(&sequencer_block_hash);
-        } else {
-            // this means either we didn't receive the block from the sequencer stream
-
-            // try executing the block as it hasn't been executed before
-            // execute_block will check if our namespace has txs; if so, it'll return the
-            // resulting execution block hash, otherwise None
-            let executed_block = self
-                .execute_block(block)
-                .await
-                .wrap_err("failed to execute block")?;
-
-            // when we execute a block received from da, nothing else has been executed on
-            // top of it, so we set FIRM and SOFT to this executed block
-            self.update_commitment_state(Update::ToSame(executed_block))
-                .await
-                .wrap_err("failed to setting both commitment states to executed block")?;
-            // remove the sequencer block hash from the map, as it's been firmly committed
-            self.sequencer_hash_to_execution_block
-                .remove(&sequencer_block_hash);
-        };
-        Ok(())
-    }
-
-    // Returns the next sequencer block height which can be executed on the rollup
-    pub(crate) fn calculate_executable_block_height(
-        &self,
-    ) -> eyre::Result<tendermint::block::Height> {
-        let Some(executable_block_height) = calculate_sequencer_block_height(
-            self.sequencer_height_with_first_rollup_block,
-            self.commitment_state.soft().number(),
-        ) else {
-            bail!(
-                "encountered overflow when calculating executable block height; sequencer height \
-                 with first rollup block: {}, height recorded in soft commitment state: {}",
-                self.sequencer_height_with_first_rollup_block,
-                self.commitment_state.soft().number(),
-            );
-        };
-
-        Ok(executable_block_height.into())
-    }
-
-    // Returns the lowest sequencer block height which can finalized on the rollup.
-    pub(crate) fn calculate_finalizable_block_height(
-        &self,
-    ) -> eyre::Result<tendermint::block::Height> {
-        let Some(finalizable_block_height) = calculate_sequencer_block_height(
-            self.sequencer_height_with_first_rollup_block,
-            self.commitment_state.firm().number(),
-        ) else {
-            bail!(
-                "encountered overflow when calculating finalizable block height; sequencer height \
-                 with first rollup block: {}, height recorded in firm commitment state: {}",
-                self.sequencer_height_with_first_rollup_block,
-                self.commitment_state.firm().number(),
-            );
-        };
-
-        Ok(finalizable_block_height.into())
     }
 
     async fn update_commitment_state(&mut self, update: Update) -> eyre::Result<()> {
@@ -359,27 +268,66 @@ impl Executor {
             .update_commitment_state(commitment_state)
             .await
             .wrap_err("failed updating remote commitment state")?;
-        self.commitment_state = new_state;
+        self.commitment_state.set_state(new_state);
         Ok(())
     }
-}
-
-/// Calculates the sequencer block height for a given rollup height.
-///
-/// This function assumes that sequencer heights and rollup heights increment in
-/// lockstep. `initial_sequencer_height` contains the first rollup height, while
-/// `rollup_height` is the height of a rollup block. That makes
-/// `initial_sequencer_height + rollup_height` the corresponding sequencer
-/// height.
-fn calculate_sequencer_block_height(
-    initial_sequencer_height: u32,
-    rollup_height: u32,
-) -> Option<u32> {
-    initial_sequencer_height.checked_add(rollup_height)
 }
 
 enum Update {
     OnlyFirm(Block),
     OnlySoft(Block),
     ToSame(Block),
+}
+
+#[derive(Debug)]
+struct ExecutableBlock {
+    hash: [u8; 32],
+    height: Height,
+    transactions: Vec<Vec<u8>>,
+    timestamp: prost_types::Timestamp,
+}
+
+impl ExecutableBlock {
+    fn from_reconstructed(block: ReconstructedBlock) -> Self {
+        let ReconstructedBlock {
+            block_hash,
+            header,
+            transactions,
+        } = block;
+        let timestamp = convert_tendermint_to_prost_timestamp(header.time);
+        Self {
+            hash: block_hash,
+            height: header.height,
+            timestamp,
+            transactions,
+        }
+    }
+
+    fn from_sequencer(block: SequencerBlock, id: RollupId) -> Self {
+        let hash = block.block_hash();
+        let height = block.height();
+        let timestamp = convert_tendermint_to_prost_timestamp(block.header().time);
+        let transactions = block
+            .into_rollup_transactions()
+            .remove(&id)
+            .unwrap_or_default();
+        Self {
+            hash,
+            height,
+            timestamp,
+            transactions,
+        }
+    }
+}
+
+/// Converts a [`tendermint::Time`] to a [`prost_types::Timestamp`].
+fn convert_tendermint_to_prost_timestamp(value: tendermint::Time) -> prost_types::Timestamp {
+    let tendermint_proto::google::protobuf::Timestamp {
+        seconds,
+        nanos,
+    } = value.into();
+    prost_types::Timestamp {
+        seconds,
+        nanos,
+    }
 }

--- a/crates/astria-conductor/src/executor/mod.rs
+++ b/crates/astria-conductor/src/executor/mod.rs
@@ -5,7 +5,6 @@ use astria_core::{
         Block,
         CommitmentState,
     },
-    generated::execution::v1alpha2::execution_service_client::ExecutionServiceClient,
     sequencer::v1alpha1::RollupId,
 };
 use color_eyre::eyre::{
@@ -32,6 +31,7 @@ use tracing::{
 
 use crate::celestia::ReconstructedBlock;
 
+mod builder;
 pub(crate) mod optimism;
 
 mod client;
@@ -48,161 +48,6 @@ fn convert_tendermint_to_prost_timestamp(value: tendermint::Time) -> ProstTimest
     ProstTimestamp {
         seconds,
         nanos,
-    }
-}
-
-pub(crate) struct NoRollupAddress;
-pub(crate) struct WithRollupAddress(String);
-pub(crate) struct NoRollupId;
-pub(crate) struct WithRollupId(RollupId);
-pub(crate) struct NoShutdown;
-pub(crate) struct WithShutdown(oneshot::Receiver<()>);
-
-pub(crate) struct ExecutorBuilder<
-    TRollupAddress = NoRollupAddress,
-    TRollupId = NoRollupId,
-    TShutdown = NoShutdown,
-> {
-    optimism_hook: Option<optimism::Handler>,
-    rollup_address: TRollupAddress,
-    rollup_id: TRollupId,
-    sequencer_height_with_first_rollup_block: u32,
-    shutdown: TShutdown,
-}
-
-impl ExecutorBuilder {
-    fn new() -> Self {
-        Self {
-            optimism_hook: None,
-            rollup_address: NoRollupAddress,
-            rollup_id: NoRollupId,
-            sequencer_height_with_first_rollup_block: 0,
-            shutdown: NoShutdown,
-        }
-    }
-}
-
-impl ExecutorBuilder<WithRollupAddress, WithRollupId, WithShutdown> {
-    pub(crate) async fn build(self) -> eyre::Result<Executor> {
-        let Self {
-            rollup_id,
-            optimism_hook: pre_execution_hook,
-            rollup_address,
-            sequencer_height_with_first_rollup_block,
-            shutdown,
-        } = self;
-        let WithRollupAddress(rollup_address) = rollup_address;
-        let WithRollupId(rollup_id) = rollup_id;
-        let WithShutdown(shutdown) = shutdown;
-
-        let mut client = client::Client::from_execution_service_client(
-            ExecutionServiceClient::connect(rollup_address)
-                .await
-                .wrap_err("failed to create execution rpc client")?,
-        );
-        let commitment_state = client
-            .get_commitment_state()
-            .await
-            .wrap_err("to get initial commitment state")?;
-
-        info!(
-            soft_block_hash = %telemetry::display::hex(&commitment_state.soft().hash()),
-            firm_block_hash = %telemetry::display::hex(&commitment_state.firm().hash()),
-            "initial execution commitment state",
-        );
-
-        let (celestia_tx, celestia_rx) = mpsc::unbounded_channel();
-        let (sequencer_tx, sequencer_rx) = mpsc::unbounded_channel();
-
-        Ok(Executor {
-            celestia_rx,
-            celestia_tx: celestia_tx.downgrade(),
-            sequencer_rx,
-            sequencer_tx: sequencer_tx.downgrade(),
-
-            shutdown,
-            client,
-            rollup_id,
-            commitment_state,
-            sequencer_height_with_first_rollup_block,
-            sequencer_hash_to_execution_block: HashMap::new(),
-            pre_execution_hook,
-        })
-    }
-}
-
-impl<TRollupAddress, TRollupId, TShutdown> ExecutorBuilder<TRollupAddress, TRollupId, TShutdown> {
-    pub(crate) fn rollup_id(
-        self,
-        rollup_id: RollupId,
-    ) -> ExecutorBuilder<TRollupAddress, WithRollupId, TShutdown> {
-        let Self {
-            optimism_hook,
-            rollup_address,
-            sequencer_height_with_first_rollup_block,
-            shutdown,
-            ..
-        } = self;
-        ExecutorBuilder {
-            optimism_hook,
-            rollup_address,
-            rollup_id: WithRollupId(rollup_id),
-            sequencer_height_with_first_rollup_block,
-            shutdown,
-        }
-    }
-
-    pub(crate) fn sequencer_height_with_first_rollup_block(
-        mut self,
-        sequencer_height_with_first_rollup_block: u32,
-    ) -> Self {
-        self.sequencer_height_with_first_rollup_block = sequencer_height_with_first_rollup_block;
-        self
-    }
-
-    pub(crate) fn set_optimism_hook(mut self, handler: Option<optimism::Handler>) -> Self {
-        self.optimism_hook = handler;
-        self
-    }
-
-    pub(crate) fn rollup_address(
-        self,
-        rollup_address: &str,
-    ) -> ExecutorBuilder<WithRollupAddress, TRollupId, TShutdown> {
-        let Self {
-            rollup_id,
-            optimism_hook,
-            sequencer_height_with_first_rollup_block,
-            shutdown,
-            ..
-        } = self;
-        ExecutorBuilder {
-            optimism_hook,
-            rollup_address: WithRollupAddress(rollup_address.to_string()),
-            rollup_id,
-            sequencer_height_with_first_rollup_block,
-            shutdown,
-        }
-    }
-
-    pub(crate) fn shutdown(
-        self,
-        shutdown: oneshot::Receiver<()>,
-    ) -> ExecutorBuilder<TRollupAddress, TRollupId, WithShutdown> {
-        let Self {
-            optimism_hook,
-            sequencer_height_with_first_rollup_block,
-            rollup_address,
-            rollup_id,
-            ..
-        } = self;
-        ExecutorBuilder {
-            optimism_hook,
-            sequencer_height_with_first_rollup_block,
-            rollup_address,
-            rollup_id,
-            shutdown: WithShutdown(shutdown),
-        }
     }
 }
 
@@ -245,8 +90,8 @@ pub(crate) struct Executor {
 }
 
 impl Executor {
-    pub(super) fn builder() -> ExecutorBuilder {
-        ExecutorBuilder::new()
+    pub(super) fn builder() -> builder::ExecutorBuilder {
+        builder::ExecutorBuilder::new()
     }
 
     pub(super) fn celestia_channel(&self) -> mpsc::UnboundedSender<ReconstructedBlock> {

--- a/crates/astria-conductor/src/executor/track_state.rs
+++ b/crates/astria-conductor/src/executor/track_state.rs
@@ -98,7 +98,7 @@ mod tests {
             hash: vec![42u8; 32],
             parent_block_hash: vec![41u8; 32],
             timestamp: Some(Timestamp {
-                seconds: 123456,
+                seconds: 123_456,
                 nanos: 789,
             }),
         })
@@ -108,7 +108,7 @@ mod tests {
             hash: vec![43u8; 32],
             parent_block_hash: vec![42u8; 32],
             timestamp: Some(Timestamp {
-                seconds: 123456,
+                seconds: 123_456,
                 nanos: 789,
             }),
         })

--- a/crates/astria-conductor/src/executor/track_state.rs
+++ b/crates/astria-conductor/src/executor/track_state.rs
@@ -24,14 +24,15 @@ fn map_rollup_height_to_sequencer_height(
         .into()
 }
 
-pub(super) struct TrackCommitmentState {
+#[derive(Debug)]
+pub(super) struct TrackState {
     // The sequencer height that contains the first block of the executed-upon rollup.
     sequencer_height_with_first_rollup_block: u32,
 
     state: CommitmentState,
 }
 
-impl TrackCommitmentState {
+impl TrackState {
     pub(super) fn with_state(state: CommitmentState) -> Self {
         Self {
             sequencer_height_with_first_rollup_block: 0,
@@ -122,7 +123,7 @@ mod tests {
     #[test]
     fn next_firm_sequencer_height_is_correct() {
         let commitment_state = make_commitment_state();
-        let mut tracker = TrackCommitmentState::with_state(commitment_state);
+        let mut tracker = TrackState::with_state(commitment_state);
         tracker.set_sequencer_height_with_first_rollup_block(10);
         assert_eq!(Height::from(11u32), tracker.next_firm_sequencer_height(),);
     }
@@ -130,7 +131,7 @@ mod tests {
     #[test]
     fn next_soft_sequencer_height_is_correct() {
         let commitment_state = make_commitment_state();
-        let mut tracker = TrackCommitmentState::with_state(commitment_state);
+        let mut tracker = TrackState::with_state(commitment_state);
         tracker.set_sequencer_height_with_first_rollup_block(10);
         assert_eq!(Height::from(12u32), tracker.next_soft_sequencer_height(),);
     }

--- a/crates/astria-conductor/src/executor/track_state.rs
+++ b/crates/astria-conductor/src/executor/track_state.rs
@@ -1,0 +1,162 @@
+use astria_core::execution::v1alpha2::{
+    Block,
+    CommitmentState,
+};
+use sequencer_client::tendermint::block::Height;
+
+// Maps a rollup height to a sequencer heights.
+/// # Panics
+///
+/// Panics if adding the integers overflows. Comet BFT has hopefully migrated
+/// to `uint64` heights by the times this becomes an issue.
+fn map_rollup_height_to_sequencer_height(
+    first_sequencer_height: u32,
+    current_rollup_height: u32,
+) -> u32 {
+    first_sequencer_height
+        .checked_add(current_rollup_height)
+        .expect(
+            "should not overflow; if this overflows either the first sequencer height or current \
+             rollup height have been incorrectly set incorrectly set, are in the future, or the \
+             rollup/sequencer have been running for several decades without cometbft ever \
+             receiving an update to uin64 heights",
+        )
+}
+
+pub(super) struct TrackCommitmentState {
+    // The sequencer height that contains the first block of the executed-upon rollup.
+    sequencer_height_with_first_rollup_block: u32,
+
+    state: CommitmentState,
+}
+
+impl TrackCommitmentState {
+    pub(super) fn with_state(state: CommitmentState) -> Self {
+        Self {
+            sequencer_height_with_first_rollup_block: 0,
+            state,
+        }
+    }
+
+    pub(super) fn set_state(&mut self, state: CommitmentState) {
+        self.state = state;
+    }
+
+    pub(super) fn set_sequencer_height_with_first_rollup_block(
+        &mut self,
+        sequencer_height_with_first_rollup_block: u32,
+    ) {
+        self.sequencer_height_with_first_rollup_block = sequencer_height_with_first_rollup_block;
+    }
+
+    pub(super) fn firm(&self) -> &Block {
+        self.state.firm()
+    }
+
+    pub(super) fn soft(&self) -> &Block {
+        self.state.soft()
+    }
+
+    pub(super) fn firm_parent_hash(&self) -> [u8; 32] {
+        self.firm().hash()
+    }
+
+    pub(super) fn soft_parent_hash(&self) -> [u8; 32] {
+        self.soft().hash()
+    }
+
+    pub(super) fn next_firm_sequencer_height(&self) -> Height {
+        map_rollup_height_to_sequencer_height(
+            self.sequencer_height_with_first_rollup_block,
+            self.state.firm().number(),
+        )
+        .into()
+    }
+
+    pub(super) fn next_soft_sequencer_height(&self) -> Height {
+        map_rollup_height_to_sequencer_height(
+            self.sequencer_height_with_first_rollup_block,
+            self.state.soft().number(),
+        )
+        .into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use astria_core::{
+        generated::execution::v1alpha2::Block as RawBlock,
+        Protobuf as _,
+    };
+    use prost_types::Timestamp;
+
+    use super::*;
+
+    fn make_commitment_state() -> CommitmentState {
+        let firm = Block::try_from_raw(RawBlock {
+            number: 1,
+            hash: vec![42u8; 32],
+            parent_block_hash: vec![41u8; 32],
+            timestamp: Some(Timestamp {
+                seconds: 123456,
+                nanos: 789,
+            }),
+        })
+        .unwrap();
+        let soft = Block::try_from_raw(RawBlock {
+            number: 2,
+            hash: vec![43u8; 32],
+            parent_block_hash: vec![42u8; 32],
+            timestamp: Some(Timestamp {
+                seconds: 123456,
+                nanos: 789,
+            }),
+        })
+        .unwrap();
+        CommitmentState::builder()
+            .firm(firm)
+            .soft(soft)
+            .build()
+            .unwrap()
+    }
+
+    #[test]
+    fn next_firm_sequencer_height_is_correct() {
+        let commitment_state = make_commitment_state();
+        let mut tracker = TrackCommitmentState::with_state(commitment_state);
+        tracker.set_sequencer_height_with_first_rollup_block(10);
+        assert_eq!(
+            Height::from(1u32 + 10),
+            tracker.next_soft_sequencer_height(),
+        );
+    }
+
+    #[test]
+    fn next_soft_sequencer_height_is_correct() {
+        let commitment_state = make_commitment_state();
+        let mut tracker = TrackCommitmentState::with_state(commitment_state);
+        tracker.set_sequencer_height_with_first_rollup_block(10);
+        assert_eq!(
+            Height::from(2u32 + 10),
+            tracker.next_soft_sequencer_height(),
+        );
+    }
+
+    #[track_caller]
+    fn assert_height_is_correct(left: u32, right: u32, expected: u32) {
+        assert_eq!(expected, map_rollup_height_to_sequencer_height(left, right),);
+    }
+
+    #[test]
+    fn mapping_rollup_height_to_sequencer_height_works() {
+        assert_height_is_correct(0, 0, 0);
+        assert_height_is_correct(0, 1, 1);
+        assert_height_is_correct(1, 0, 1);
+    }
+
+    #[test]
+    #[should_panic]
+    fn too_large_heights_panic() {
+        map_rollup_height_to_sequencer_height(2u32.pow(31), 2u32.pow(31));
+    }
+}

--- a/crates/astria-conductor/src/sequencer.rs
+++ b/crates/astria-conductor/src/sequencer.rs
@@ -30,7 +30,6 @@ use pin_project_lite::pin_project;
 use sequencer_client::{
     extension_trait::NewBlocksStream,
     tendermint::block::Height,
-    // NewBlockStreamError,
     SequencerBlock,
 };
 use tokio::{
@@ -57,7 +56,7 @@ use crate::{
 
 pub(crate) struct Reader {
     /// The channel used to send messages to the executor task.
-    executor_channel: mpsc::UnboundedSender<Box<SequencerBlock>>,
+    executor_channel: mpsc::UnboundedSender<SequencerBlock>,
 
     /// The object pool providing clients to the sequencer.
     pool: Pool<ClientProvider>,
@@ -74,7 +73,7 @@ impl Reader {
         start_height: Height,
         pool: Pool<ClientProvider>,
         shutdown: oneshot::Receiver<()>,
-        executor_channel: mpsc::UnboundedSender<Box<SequencerBlock>>,
+        executor_channel: mpsc::UnboundedSender<SequencerBlock>,
     ) -> Self {
         Self {
             executor_channel,

--- a/crates/astria-conductor/src/sequencer.rs
+++ b/crates/astria-conductor/src/sequencer.rs
@@ -147,7 +147,7 @@ impl Reader {
 
 
                 Some(block) = sequential_blocks.next_block() => {
-                    if let Err(e) = executor_channel.send(block.into()) {
+                    if let Err(e) = executor_channel.send(block) {
                         let reason = "failed sending next sequencer block to executor";
                         error!(
                             error = &e as &dyn std::error::Error,

--- a/crates/astria-core/src/execution/v1alpha2/mod.rs
+++ b/crates/astria-core/src/execution/v1alpha2/mod.rs
@@ -43,7 +43,7 @@ enum BlockErrorKind {
 ///
 /// Usually constructed its [`Protobuf`] implementation from a
 /// [`raw::Block`].
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Block {
     /// The block number
     number: u32,
@@ -242,7 +242,7 @@ impl CommitmentStateBuilder<WithFirm, WithSoft> {
 /// - Block numbers are such that soft >= firm (upheld by this type).
 /// - No blocks ever decrease in block number.
 /// - The chain defined by soft is the head of the canonical chain the firm block must belong to.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CommitmentState {
     /// Soft commitment is the rollup block matching latest sequencer block.
     soft: Block,

--- a/crates/astria-core/src/sequencer/v1alpha1/block.rs
+++ b/crates/astria-core/src/sequencer/v1alpha1/block.rs
@@ -314,6 +314,12 @@ impl SequencerBlock {
         &self.rollup_transactions
     }
 
+    /// Returns the map of rollup transactions, consuming `self`.
+    #[must_use]
+    pub fn into_rollup_transactions(self) -> IndexMap<RollupId, Vec<Vec<u8>>> {
+        self.rollup_transactions
+    }
+
     #[must_use]
     pub fn into_raw(self) -> raw::SequencerBlock {
         fn tuple_to_rollup_txs(

--- a/crates/astria-core/src/sequencer/v1alpha1/test_utils.rs
+++ b/crates/astria-core/src/sequencer/v1alpha1/test_utils.rs
@@ -17,13 +17,13 @@ use super::{
 /// If you don't really care what's in the block, you just need it to be a valid block.
 #[must_use]
 pub fn make_cometbft_block() -> tendermint::Block {
-    use rand::rngs::OsRng;
     let height = 1;
-    let signing_key = ed25519_consensus::SigningKey::new(OsRng);
+    let rollup_id = RollupId::from_unhashed_bytes(b"test_chain_id_1");
+    let data = b"hello_world_id_1".to_vec();
     ConfigureCometBftBlock {
         height,
-        signing_key,
-        proposer_address: None,
+        rollup_transactions: vec![(rollup_id, data)],
+        ..Default::default()
     }
     .make()
 }
@@ -32,10 +32,12 @@ pub fn make_cometbft_block() -> tendermint::Block {
 /// proposer address.
 ///
 /// If the proposer address is not set it will be generated from the signing key.
+#[derive(Default)]
 pub struct ConfigureCometBftBlock {
     pub height: u32,
     pub proposer_address: Option<tendermint::account::Id>,
-    pub signing_key: ed25519_consensus::SigningKey,
+    pub signing_key: Option<ed25519_consensus::SigningKey>,
+    pub rollup_transactions: Vec<(RollupId, Vec<u8>)>,
 }
 
 impl ConfigureCometBftBlock {
@@ -57,7 +59,11 @@ impl ConfigureCometBftBlock {
             height,
             signing_key,
             proposer_address,
+            rollup_transactions,
         } = self;
+
+        let signing_key =
+            signing_key.unwrap_or_else(|| ed25519_consensus::SigningKey::new(rand::rngs::OsRng));
 
         let proposer_address = proposer_address.unwrap_or_else(|| {
             let public_key: tendermint::crypto::ed25519::VerificationKey =
@@ -65,17 +71,27 @@ impl ConfigureCometBftBlock {
             tendermint::account::Id::from(public_key)
         });
 
-        let suffix = height.to_string().into_bytes();
-        let rollup_id = RollupId::from_unhashed_bytes([b"test_chain_id_", &*suffix].concat());
-        let unsigned_transaction = UnsignedTransaction {
-            nonce: 1,
-            actions: vec![
+        let actions = rollup_transactions
+            .into_iter()
+            .map(|(rollup_id, data)| {
                 SequenceAction {
                     rollup_id,
-                    data: [b"hello_world_id_", &*suffix].concat(),
+                    data,
                 }
-                .into(),
-            ],
+                .into()
+            })
+            .collect();
+        // let rollup_id = RollupId::from_unhashed_bytes([b"test_chain_id_", &*suffix].concat());
+        let unsigned_transaction = UnsignedTransaction {
+            nonce: 1,
+            // actions: vec![
+            //     SequenceAction {
+            //         rollup_id,
+            //         data: [b"hello_world_id_", &*suffix].concat(),
+            //     }
+            //     .into(),
+            // ],
+            actions,
             fee_asset_id: default_native_asset_id(),
         };
 
@@ -86,7 +102,15 @@ impl ConfigureCometBftBlock {
             ]);
         let rollup_transactions_tree = derive_merkle_tree_from_rollup_txs(&rollup_transactions);
 
-        let rollup_ids_root = merkle::Tree::from_leaves(std::iter::once(rollup_id)).root();
+        let rollup_ids_root = merkle::Tree::from_leaves(
+            signed_transaction
+                .unsigned_transaction()
+                .actions
+                .iter()
+                .filter_map(|act| act.as_sequence())
+                .map(|seq| seq.rollup_id),
+        )
+        .root();
         let data = vec![
             rollup_transactions_tree.root().to_vec(),
             rollup_ids_root.to_vec(),

--- a/crates/astria-sequencer-relayer/tests/blackbox/helper.rs
+++ b/crates/astria-sequencer-relayer/tests/blackbox/helper.rs
@@ -3,7 +3,10 @@ use std::{
     time::Duration,
 };
 
-use astria_core::sequencer::v1alpha1::test_utils::ConfigureCometBftBlock;
+use astria_core::sequencer::v1alpha1::{
+    test_utils::ConfigureCometBftBlock,
+    RollupId,
+};
 use astria_sequencer_relayer::{
     config::Config,
     telemetry,
@@ -335,10 +338,13 @@ fn create_block_response(
         block,
         Hash,
     };
+    let rollup_id = RollupId::from_unhashed_bytes(b"test_chain_id_1");
+    let data = b"hello_world_id_1".to_vec();
     let block = ConfigureCometBftBlock {
         height,
-        signing_key: signing_key.clone(),
+        signing_key: Some(signing_key.clone()),
         proposer_address: Some(proposer_address),
+        rollup_transactions: vec![(rollup_id, data)],
     }
     .make();
 


### PR DESCRIPTION
## Summary
Refactor executor to the stricter contract, expecting firm (from celestia) and soft (from sequencer) blocks to be in strict sequential order.

## Background
Enforcing a contract that the celestia and sequencer readers only forward blocks in strict sequential order of heights makes the executor implementation much simpler.

## Changes
- executor expects to receive firm/soft blocks in strict sequential order
- soft blocks are dropped if they are too old
- old firm blocks, or soft/firm blocks that lie in the future violate the contract between the executor and {celestia, sequencer}-readers and lead to conductor aborting
- move storage of blocks pending finalization into the `execute_soft` handler

## Testing
The executor tests have been updated to support various scenarios of receiving old blocks, out of order blocks, new blocks etc.

## Related Issues
Part of https://github.com/astriaorg/astria/pull/691
