### PR TITLE
feat(conductor): sync executor commitment state with sequencer reader

### DIFF
--- a/crates/astria-conductor/src/conductor.rs
+++ b/crates/astria-conductor/src/conductor.rs
@@ -116,10 +116,11 @@ impl Conductor {
             // sequencer block that can be executed on top of the rollup state.
             // This value is derived by the Executor.
             let sequencer_reader = sequencer::Reader::new(
-                executor.next_soft_sequencer_height(),
                 sequencer_client_pool.clone(),
                 shutdown_rx,
                 executor.sequencer_channel(),
+                executor.subscribe_to_state(),
+                0,
             );
             tasks.spawn(Self::SEQUENCER, sequencer_reader.run_until_stopped());
             shutdown_channels.insert(Self::SEQUENCER, shutdown_tx);


### PR DESCRIPTION
## Summary
Sync the executor commitment state and sequencer reader so that it only fetches and forwards blocks at the current level.

## Background
Soft blocks should only be read from the sequencer and forwarded to the executor if the executor expects them. This patch ensures that obsolete heights are not fetched from sequencer (heights that have already been firmly confirmed).

This also lays the groundwork for allowing sequencer syncing and block forwarding to start at a later height than the firm block sync (although not implemented in this patch).

## Changes
- wrap the executor commitment state in a watch channel
- monitor the executor state in the sequencer reader
- drop obsolete heights from both the block cache and the height reader

## Testing
This interaction should be tested end to end.


## Related Issues
Part of https://github.com/astriaorg/astria/pull/691