### PR TITLE
feat(conductor): use http client to fetch celestia blobs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,6 +601,7 @@ dependencies = [
  "ethers",
  "futures",
  "hex",
+ "http 1.0.0",
  "humantime",
  "jsonrpsee",
  "pin-project-lite",
@@ -761,7 +762,7 @@ dependencies = [
  "eyre",
  "futures",
  "hex",
- "http",
+ "http 0.2.11",
  "humantime",
  "hyper",
  "jsonrpsee",
@@ -954,7 +955,7 @@ dependencies = [
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "http",
+ "http 0.2.11",
  "http-body",
  "hyper",
  "itoa",
@@ -984,7 +985,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
+ "http 0.2.11",
  "http-body",
  "mime",
  "rustversion",
@@ -1413,7 +1414,7 @@ source = "git+https://github.com/eigerco/celestia-node-rs?rev=4862eec#4862eec404
 dependencies = [
  "async-trait",
  "celestia-types",
- "http",
+ "http 0.2.11",
  "jsonrpsee",
  "serde",
  "thiserror",
@@ -2684,7 +2685,7 @@ dependencies = [
  "futures-timer",
  "futures-util",
  "hashers",
- "http",
+ "http 0.2.11",
  "instant",
  "jsonwebtoken",
  "once_cell",
@@ -3168,7 +3169,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.11",
  "indexmap 2.1.0",
  "slab",
  "tokio",
@@ -3292,13 +3293,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b32afd38673a8016f7c9ae69e5af41a58f81b1d31689040f2f1959594ce194ea"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.11",
  "pin-project-lite",
 ]
 
@@ -3318,7 +3330,7 @@ dependencies = [
  "async-channel",
  "base64 0.13.1",
  "futures-lite",
- "http",
+ "http 0.2.11",
  "infer",
  "pin-project-lite",
  "rand 0.7.3",
@@ -3358,7 +3370,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.11",
  "http-body",
  "httparse",
  "httpdate",
@@ -3378,7 +3390,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
- "http",
+ "http 0.2.11",
  "hyper",
  "log",
  "rustls",
@@ -3962,7 +3974,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b005c793122d03217da09af68ba9383363caa950b90d3436106df8cabce935"
 dependencies = [
  "futures-util",
- "http",
+ "http 0.2.11",
  "jsonrpsee-core",
  "pin-project",
  "rustls-native-certs",
@@ -4040,7 +4052,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82c39a00449c9ef3f50b84fc00fc4acba20ef8f559f07902244abf4c15c5ab9c"
 dependencies = [
  "futures-util",
- "http",
+ "http 0.2.11",
  "hyper",
  "jsonrpsee-core",
  "jsonrpsee-types",
@@ -4076,7 +4088,7 @@ version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bca9cb3933ccae417eb6b08c3448eb1cb46e39834e5b503e395e5e5bd08546c0"
 dependencies = [
- "http",
+ "http 0.2.11",
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
  "jsonrpsee-types",
@@ -5209,7 +5221,7 @@ source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.64.1#5b57c7b9
 dependencies = [
  "futures",
  "hex",
- "http",
+ "http 0.2.11",
  "pin-project",
  "pin-project-lite",
  "sha2 0.9.9",
@@ -5868,7 +5880,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.11",
  "http-body",
  "hyper",
  "hyper-rustls",
@@ -6676,7 +6688,7 @@ dependencies = [
  "base64 0.13.1",
  "bytes",
  "futures",
- "http",
+ "http 0.2.11",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -7355,7 +7367,7 @@ dependencies = [
  "base64 0.21.5",
  "bytes",
  "h2",
- "http",
+ "http 0.2.11",
  "http-body",
  "hyper",
  "hyper-timeout",
@@ -7448,7 +7460,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
+ "http 0.2.11",
  "http-body",
  "http-range-header",
  "pin-project-lite",
@@ -7633,7 +7645,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http",
+ "http 0.2.11",
  "httparse",
  "log",
  "rand 0.8.5",

--- a/crates/astria-conductor/Cargo.toml
+++ b/crates/astria-conductor/Cargo.toml
@@ -45,6 +45,7 @@ sequencer-client = { package = "astria-sequencer-client", path = "../astria-sequ
 telemetry = { package = "astria-telemetry", path = "../astria-telemetry", features = [
   "display",
 ] }
+http = "1.0.0"
 
 [dev-dependencies]
 jsonrpsee = { workspace = true, features = ["server"] }

--- a/crates/astria-conductor/local.env.example
+++ b/crates/astria-conductor/local.env.example
@@ -6,9 +6,16 @@ ASTRIA_CONDUCTOR_LOG="astria_conductor=info"
 # on the host running the celestia node.
 ASTRIA_CONDUCTOR_CELESTIA_BEARER_TOKEN="<JWT Bearer token>"
 
-# Data Availability service url (Celestia node in this case)
-# This url is used to read astria blocks from the Data Availability layer
-ASTRIA_CONDUCTOR_CELESTIA_NODE_URL="ws://127.0.0.1:26658"
+# The URL of the celestia node used to subscribe to new headers and fetch
+# blocks from. Note that this string need not be a fully qualified URL and
+# can miss the scheme part. The scheme part, if present, will be replaced by
+# `ws:` or `http:` for websocket subscriptions and http GET requests,
+# respectively. The following are examples of accepted strings (26658 is
+# the default port of a celestia node to listen for RPCs).
+# - 127.0.0.1:26658
+# - ws://127.0.0.1:26658
+# - http://127.0.0.1:26658
+ASTRIA_CONDUCTOR_CELESTIA_NODE_URL="127.0.0.1:26658"
 
 # The chain id of the chain that is being read from the astria-sequencer or the
 # Data Availability layer

--- a/crates/astria-conductor/src/celestia/builder.rs
+++ b/crates/astria-conductor/src/celestia/builder.rs
@@ -422,6 +422,6 @@ mod tests {
     }
     #[test]
     fn wss_scheme_utility_works() {
-        assert_eq!(&super::ws_scheme(), "wss");
+        assert_eq!(&super::wss_scheme(), "wss");
     }
 }

--- a/crates/astria-conductor/src/celestia/builder.rs
+++ b/crates/astria-conductor/src/celestia/builder.rs
@@ -118,10 +118,10 @@ impl
             .height;
 
         Ok(Reader {
+            executor_channel,
             celestia_http_client,
             celestia_ws_client,
             celestia_start_height,
-            executor_channel,
             block_verifier,
             sequencer_namespace,
             rollup_namespace,


### PR DESCRIPTION
## Summary
This patch changed blob-fetching to use a http client. The websocket subscription is still used for fetch the latest celestia header (and hence height).

## Background
Reusing the same websocket client for jsonrpsee subscriptions and simple methods requires some complex client pool + resetting logic. Using the websocket client for the subscription only and http clients for fetching blocks allows to simplify this significantly.

## Changes
- Add a http client to the `celestia::Reader`
- fetch celestia blobs using the http client instead of the websocket client
- update the URI scheme of the celestia node API depending on whether the websocket or http clients are to be constructed
 
## Related Issues
Part of https://github.com/astriaorg/astria/pull/691
