### PR TITLE
fix(cli)!: refactor yaml serialization to match format in rollup's values.yaml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -523,7 +523,7 @@ dependencies = [
 
 [[package]]
 name = "astria-cli"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "assert_cmd",
  "astria-core",

--- a/crates/astria-cli/Cargo.toml
+++ b/crates/astria-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astria-cli"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.73"
 

--- a/crates/astria-cli/README.md
+++ b/crates/astria-cli/README.md
@@ -38,7 +38,6 @@ cargo build --release
     --log-level DEBUG \
     --rollup.name steezechain \
     --rollup.network-id 42 \
-    --rollup.skip-empty-blocks \
     --rollup.genesis-accounts 0xaC21B97d35Bf75A7dAb16f35b111a50e78A72F30:100000000000000000000
   
 # edit config

--- a/crates/astria-cli/src/cli/rollup.rs
+++ b/crates/astria-cli/src/cli/rollup.rs
@@ -8,7 +8,7 @@ use color_eyre::eyre;
 use serde::Serialize;
 
 const DEFAULT_ROLLUP_CHART_PATH: &str =
-    "https://astriaorg.github.io/dev-cluster/astria-evm-rollup-0.7.4.tgz";
+    "https://github.com/astriaorg/dev-cluster/releases/download/astria-evm-rollup-0.8.6/astria-evm-rollup-0.8.6.tgz";
 const DEFAULT_SEQUENCER_WS: &str = "wss://rpc.sequencer.dusk-2.devnet.astria.org/websocket";
 const DEFAULT_LOG_LEVEL: &str = "debug";
 const DEFAULT_NETWORK_ID: u64 = 1337;

--- a/crates/astria-cli/src/types.rs
+++ b/crates/astria-cli/src/types.rs
@@ -182,7 +182,9 @@ impl TryFrom<&ConfigCreateArgs> for RollupDeploymentConfig {
                 name: args.name.clone(),
                 chain_id,
                 network_id: args.network_id.to_string(),
-                genesis_accounts,
+                genesis: GenesisConfig {
+                    alloc: genesis_accounts,
+                },
             },
             sequencer: SequencerConfig {
                 initial_block_height: sequencer_initial_block_height.to_string(),
@@ -200,13 +202,25 @@ pub struct RollupConfig {
     chain_id: String,
     // NOTE - String here because yaml will serialize large ints w/ scientific notation
     network_id: String,
-    genesis_accounts: Vec<GenesisAccount>,
+    genesis: GenesisConfig,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GenesisConfig {
+    alloc: Vec<GenesisAccount>,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct GenesisAccount {
     address: String,
+    value: GenesisAccountValue,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GenesisAccountValue {
     // NOTE - string because yaml will serialize large ints w/ scientific notation
     balance: String,
 }
@@ -215,7 +229,9 @@ impl From<GenesisAccountArg> for GenesisAccount {
     fn from(arg: GenesisAccountArg) -> Self {
         Self {
             address: arg.address,
-            balance: arg.balance.to_string(),
+            value: GenesisAccountValue {
+                balance: arg.balance.to_string(),
+            },
         }
     }
 }
@@ -274,16 +290,22 @@ mod tests {
                     name: "rollup1".to_string(),
                     chain_id: "chain1".to_string(),
                     network_id: "1".to_string(),
-                    genesis_accounts: vec![
-                        GenesisAccount {
-                            address: "0xA5TR14".to_string(),
-                            balance: "1000000000000000000".to_string(),
-                        },
-                        GenesisAccount {
-                            address: "0x420XYZ69".to_string(),
-                            balance: "420".to_string(),
-                        },
-                    ],
+                    genesis: GenesisConfig {
+                        alloc: vec![
+                            GenesisAccount {
+                                address: "0xA5TR14".to_string(),
+                                value: GenesisAccountValue {
+                                    balance: "1000000000000000000".to_string(),
+                                },
+                            },
+                            GenesisAccount {
+                                address: "0x420XYZ69".to_string(),
+                                value: GenesisAccountValue {
+                                    balance: "420".to_string(),
+                                },
+                            },
+                        ],
+                    },
                 },
                 sequencer: SequencerConfig {
                     initial_block_height: "127689000000".to_string(),
@@ -341,10 +363,14 @@ mod tests {
                     name: "rollup2".to_string(),
                     chain_id: "rollup2-chain".to_string(), // Derived from name
                     network_id: "2211011801".to_string(),
-                    genesis_accounts: vec![GenesisAccount {
-                        address: "0xA5TR14".to_string(),
-                        balance: "10000".to_string(),
-                    }],
+                    genesis: GenesisConfig {
+                        alloc: vec![GenesisAccount {
+                            address: "0xA5TR14".to_string(),
+                            value: GenesisAccountValue {
+                                balance: "10000".to_string(),
+                            },
+                        }],
+                    },
                 },
                 sequencer: SequencerConfig {
                     initial_block_height: "1".to_string(), // Default value


### PR DESCRIPTION
## Summary
Refactors the cli to serialize the rollup config as yaml to match what is expected in the rollup chart's values.yaml.

## Background
Genesis accounts weren't getting funded in RaaS because the shape of values.yaml changed.

## Changes
- changed generated yaml shape

## Testing
- updated unit and integration tests

## Breaking Changelist
The api of the cli did not change

