### PR TITLE
feat(conductor, proto): add genesis info RPC, initialize in terms of it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,6 +650,7 @@ dependencies = [
  "rand 0.8.5",
  "sha2 0.10.8",
  "tempfile",
+ "tendermint 0.32.0",
  "tendermint 0.34.0",
  "tendermint-proto 0.34.0",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,3 +92,8 @@ tracing = "0.1"
 tryhard = "0.5.1"
 which = "4.4.0"
 wiremock = "0.5"
+
+[workspace.dependencies.celestia-tendermint]
+package = "tendermint"
+git = "https://github.com/eigerco/celestia-tendermint-rs"
+rev = "bbe7de8"

--- a/containerfiles/Cargo.toml
+++ b/containerfiles/Cargo.toml
@@ -61,6 +61,11 @@ tryhard = '0.5.1'
 which = '4.4.0'
 wiremock = '0.5'
 
+[workspace.dependencies.celestia-tendermint]
+git = 'https://github.com/eigerco/celestia-tendermint-rs'
+package = 'tendermint'
+rev = 'bbe7de8'
+
 [workspace.dependencies.jsonrpsee]
 version = '0.20'
 

--- a/crates/astria-celestia-client/Cargo.toml
+++ b/crates/astria-celestia-client/Cargo.toml
@@ -29,6 +29,7 @@ merkle = { package = "astria-merkle", path = "../astria-merkle" }
 # when updating.
 jsonrpsee = { version = "0.20", features = ["client-core", "macros"] }
 prost = { workspace = true }
+celestia-tendermint = { workspace = true }
 
 [dependencies.celestia-rpc]
 git = "https://github.com/eigerco/celestia-node-rs"
@@ -37,8 +38,3 @@ rev = "4862eec"
 [dependencies.celestia-types]
 git = "https://github.com/eigerco/celestia-node-rs"
 rev = "4862eec"
-
-[dependencies.celestia-tendermint]
-package = "tendermint"
-git = "https://github.com/eigerco/celestia-tendermint-rs"
-rev = "bbe7de8"

--- a/crates/astria-conductor/local.env.example
+++ b/crates/astria-conductor/local.env.example
@@ -17,10 +17,6 @@ ASTRIA_CONDUCTOR_CELESTIA_BEARER_TOKEN="<JWT Bearer token>"
 # - http://127.0.0.1:26658
 ASTRIA_CONDUCTOR_CELESTIA_NODE_URL="127.0.0.1:26658"
 
-# The chain id of the chain that is being read from the astria-sequencer or the
-# Data Availability layer
-ASTRIA_CONDUCTOR_CHAIN_ID="astriachain"
-
 # Execution RPC URL
 ASTRIA_CONDUCTOR_EXECUTION_RPC_URL="http://127.0.0.1:50051"
 
@@ -36,9 +32,6 @@ ASTRIA_CONDUCTOR_EXECUTION_COMMIT_LEVEL="SoftAndFirm"
 # retrieving validators.
 # 127.0.0.1:26657 is the default socket address in comebft's `rpc.laddr` setting.
 ASTRIA_CONDUCTOR_SEQUENCER_URL="ws://127.0.0.1:26657/websocket"
-
-# the sequencer block height that the rollup's first block was in
-ASTRIA_CONDUCTOR_INITIAL_SEQUENCER_BLOCK_HEIGHT=1
 
 # set to true to enable op-stack deposit derivations
 ASTRIA_CONDUCTOR_ENABLE_OPTIMISM=false

--- a/crates/astria-conductor/src/config.rs
+++ b/crates/astria-conductor/src/config.rs
@@ -33,17 +33,11 @@ pub struct Config {
     /// URL of the sequencer cometbft websocket
     pub sequencer_url: String,
 
-    /// Chain ID that we want to work in
-    pub chain_id: String,
-
     /// Address of the RPC server for execution
     pub execution_rpc_url: String,
 
     /// log directive to use for telemetry.
     pub log: String,
-
-    /// The Sequencer block height that the rollup genesis block was in
-    pub initial_sequencer_block_height: u32,
 
     /// The execution commit level used for controlling how blocks are sent to
     /// the execution layer.

--- a/crates/astria-conductor/src/executor/builder.rs
+++ b/crates/astria-conductor/src/executor/builder.rs
@@ -1,9 +1,5 @@
 use std::collections::HashMap;
 
-use astria_core::{
-    generated::execution::v1alpha2::execution_service_client::ExecutionServiceClient,
-    sequencer::v1alpha1::RollupId,
-};
 use color_eyre::eyre::{
     self,
     WrapErr as _,
@@ -13,30 +9,18 @@ use tokio::sync::{
     oneshot,
     watch,
 };
-use tracing::info;
 
 use super::Executor;
-use crate::executor::{
-    client,
-    optimism,
-};
+use crate::executor::optimism;
 
 pub(crate) struct NoRollupAddress;
-pub(crate) struct WithRollupAddress(String);
-pub(crate) struct NoRollupId;
-pub(crate) struct WithRollupId(RollupId);
+pub(crate) struct WithRollupAddress(tonic::transport::Uri);
 pub(crate) struct NoShutdown;
 pub(crate) struct WithShutdown(oneshot::Receiver<()>);
 
-pub(crate) struct ExecutorBuilder<
-    TRollupAddress = NoRollupAddress,
-    TRollupId = NoRollupId,
-    TShutdown = NoShutdown,
-> {
+pub(crate) struct ExecutorBuilder<TRollupAddress = NoRollupAddress, TShutdown = NoShutdown> {
     optimism_hook: Option<optimism::Handler>,
     rollup_address: TRollupAddress,
-    rollup_id: TRollupId,
-    sequencer_height_with_first_rollup_block: u32,
     shutdown: TShutdown,
 }
 
@@ -45,96 +29,43 @@ impl ExecutorBuilder {
         Self {
             optimism_hook: None,
             rollup_address: NoRollupAddress,
-            rollup_id: NoRollupId,
-            sequencer_height_with_first_rollup_block: 0,
             shutdown: NoShutdown,
         }
     }
 }
 
-impl ExecutorBuilder<WithRollupAddress, WithRollupId, WithShutdown> {
-    pub(crate) async fn build(self) -> eyre::Result<Executor> {
+impl ExecutorBuilder<WithRollupAddress, WithShutdown> {
+    pub(crate) fn build(self) -> Executor {
         let Self {
-            rollup_id,
             optimism_hook: pre_execution_hook,
             rollup_address,
-            sequencer_height_with_first_rollup_block,
             shutdown,
         } = self;
         let WithRollupAddress(rollup_address) = rollup_address;
-        let WithRollupId(rollup_id) = rollup_id;
         let WithShutdown(shutdown) = shutdown;
-
-        let mut client = client::Client::from_execution_service_client(
-            ExecutionServiceClient::connect(rollup_address)
-                .await
-                .wrap_err("failed to create execution rpc client")?,
-        );
-        let commitment_state = client
-            .get_commitment_state()
-            .await
-            .wrap_err("to get initial commitment state")?;
-
-        info!(
-            soft_block_hash = %telemetry::display::hex(&commitment_state.soft().hash()),
-            firm_block_hash = %telemetry::display::hex(&commitment_state.firm().hash()),
-            "initial execution commitment state",
-        );
 
         let (celestia_tx, celestia_rx) = mpsc::unbounded_channel();
         let (sequencer_tx, sequencer_rx) = mpsc::unbounded_channel();
 
-        let state = watch::channel(super::State::new(
-            commitment_state,
-            sequencer_height_with_first_rollup_block,
-        ))
-        .0;
+        let state = watch::channel(super::State::new()).0;
 
-        Ok(Executor {
+        Executor {
             celestia_rx,
             celestia_tx: celestia_tx.downgrade(),
             sequencer_rx,
             sequencer_tx: sequencer_tx.downgrade(),
 
+            rollup_address,
+
             shutdown,
-            client,
-            rollup_id,
             state,
             blocks_pending_finalization: HashMap::new(),
             pre_execution_hook,
-        })
+        }
     }
 }
 
-impl<TRollupAddress, TRollupId, TShutdown> ExecutorBuilder<TRollupAddress, TRollupId, TShutdown> {
-    pub(crate) fn rollup_id(
-        self,
-        rollup_id: RollupId,
-    ) -> ExecutorBuilder<TRollupAddress, WithRollupId, TShutdown> {
-        let Self {
-            optimism_hook,
-            rollup_address,
-            sequencer_height_with_first_rollup_block,
-            shutdown,
-            ..
-        } = self;
-        ExecutorBuilder {
-            optimism_hook,
-            rollup_address,
-            rollup_id: WithRollupId(rollup_id),
-            sequencer_height_with_first_rollup_block,
-            shutdown,
-        }
-    }
-
-    pub(crate) fn sequencer_height_with_first_rollup_block(
-        mut self,
-        sequencer_height_with_first_rollup_block: u32,
-    ) -> Self {
-        self.sequencer_height_with_first_rollup_block = sequencer_height_with_first_rollup_block;
-        self
-    }
-
+impl<TRollupAddress, TShutdown> ExecutorBuilder<TRollupAddress, TShutdown> {
     pub(crate) fn set_optimism_hook(mut self, handler: Option<optimism::Handler>) -> Self {
         self.optimism_hook = handler;
         self
@@ -143,39 +74,36 @@ impl<TRollupAddress, TRollupId, TShutdown> ExecutorBuilder<TRollupAddress, TRoll
     pub(crate) fn rollup_address(
         self,
         rollup_address: &str,
-    ) -> ExecutorBuilder<WithRollupAddress, TRollupId, TShutdown> {
+    ) -> eyre::Result<ExecutorBuilder<WithRollupAddress, TShutdown>> {
         let Self {
-            rollup_id,
             optimism_hook,
-            sequencer_height_with_first_rollup_block,
             shutdown,
             ..
         } = self;
-        ExecutorBuilder {
+        let rollup_address = WithRollupAddress(
+            rollup_address
+                .parse()
+                .wrap_err("failed to parse rollup address as URI")?,
+        );
+        Ok(ExecutorBuilder {
             optimism_hook,
-            rollup_address: WithRollupAddress(rollup_address.to_string()),
-            rollup_id,
-            sequencer_height_with_first_rollup_block,
+            rollup_address,
             shutdown,
-        }
+        })
     }
 
     pub(crate) fn shutdown(
         self,
         shutdown: oneshot::Receiver<()>,
-    ) -> ExecutorBuilder<TRollupAddress, TRollupId, WithShutdown> {
+    ) -> ExecutorBuilder<TRollupAddress, WithShutdown> {
         let Self {
             optimism_hook,
-            sequencer_height_with_first_rollup_block,
             rollup_address,
-            rollup_id,
             ..
         } = self;
         ExecutorBuilder {
             optimism_hook,
-            sequencer_height_with_first_rollup_block,
             rollup_address,
-            rollup_id,
             shutdown: WithShutdown(shutdown),
         }
     }

--- a/crates/astria-conductor/src/executor/client.rs
+++ b/crates/astria-conductor/src/executor/client.rs
@@ -2,6 +2,7 @@ use astria_core::{
     execution::v1alpha2::{
         Block,
         CommitmentState,
+        GenesisInfo,
     },
     generated::execution::{
         v1alpha2 as raw,
@@ -28,6 +29,20 @@ impl Client {
         Self {
             inner,
         }
+    }
+
+    /// Calls remote procedure `astria.execution.v1alpha2.GetGenesisInfo`
+    pub(super) async fn get_genesis_info(&mut self) -> eyre::Result<GenesisInfo> {
+        let request = raw::GetGenesisInfoRequest {};
+        let response = self
+            .inner
+            .get_genesis_info(request)
+            .await
+            .wrap_err("failed to get genesis_info")?
+            .into_inner();
+        let genesis_info = GenesisInfo::try_from_raw(response)
+            .wrap_err("failed converting raw response to validated genesis info")?;
+        Ok(genesis_info)
     }
 
     /// Calls remote procedure `astria.execution.v1alpha2.ExecuteBlock`

--- a/crates/astria-conductor/src/executor/state.rs
+++ b/crates/astria-conductor/src/executor/state.rs
@@ -1,60 +1,95 @@
-use astria_core::execution::v1alpha2::{
-    Block,
-    CommitmentState,
+use astria_core::{
+    execution::v1alpha2::{
+        Block,
+        CommitmentState,
+        GenesisInfo,
+    },
+    sequencer::v1alpha1::RollupId,
 };
+use celestia_client::celestia_types::Height as CelestiaHeight;
 use sequencer_client::tendermint::block::Height;
-
-// Maps a rollup height to a sequencer heights.
-/// # Panics
-///
-/// Panics if adding the integers overflows. Comet BFT has hopefully migrated
-/// to `uint64` heights by the times this becomes an issue.
-fn map_rollup_height_to_sequencer_height(
-    first_sequencer_height: u32,
-    current_rollup_height: u32,
-) -> Height {
-    first_sequencer_height
-        .checked_add(current_rollup_height)
-        .expect(
-            "should not overflow; if this overflows either the first sequencer height or current \
-             rollup height have been incorrectly set incorrectly set, are in the future, or the \
-             rollup/sequencer have been running for several decades without cometbft ever \
-             receiving an update to uin64 heights",
-        )
-        .into()
-}
 
 #[derive(Debug)]
 pub(crate) struct State {
+    inner: Option<StateImpl>,
+}
+
+#[derive(Debug)]
+struct StateImpl {
+    genesis_info: GenesisInfo,
     commitment_state: CommitmentState,
 
     next_firm_sequencer_height: Height,
     next_soft_sequencer_height: Height,
-
-    // The sequencer height that contains the first block of the executed-upon rollup.
-    sequencer_height_with_first_rollup_block: u32,
 }
 
 impl State {
-    pub(super) fn new(
-        commitment_state: CommitmentState,
-        sequencer_height_with_first_rollup_block: u32,
-    ) -> Self {
+    pub(super) fn new() -> Self {
+        Self {
+            inner: None,
+        }
+    }
+
+    pub(super) fn init(&mut self, genesis_info: GenesisInfo, commitment_state: CommitmentState) {
+        self.inner
+            .replace(StateImpl::new(genesis_info, commitment_state));
+    }
+
+    pub(crate) fn is_init(&self) -> bool {
+        self.inner.is_some()
+    }
+
+    /// Updates the tracked state if `commitment_state` is different.
+    pub(super) fn update_if_modified(&mut self, commitment_state: CommitmentState) -> bool {
+        self.inner
+            .as_mut()
+            .expect("the state is initialized")
+            .update_if_modified(commitment_state)
+    }
+}
+
+macro_rules! forward_impls {
+    ($([$fn:ident -> $ret:ty]),*$(,)?) => {
+        impl State {
+            $(
+            pub(crate) fn $fn(&self) -> $ret {
+                self.inner
+                    .as_ref()
+                    .expect("the state is initialized")
+                    .$fn()
+            }
+            )*
+        }
+    }
+}
+
+forward_impls!(
+    [firm -> &Block],
+    [soft -> &Block],
+    [firm_parent_hash -> [u8; 32]],
+    [soft_parent_hash -> [u8; 32]],
+    [celestia_base_block_height -> CelestiaHeight],
+    [rollup_id -> RollupId],
+    [next_firm_sequencer_height -> Height],
+    [next_soft_sequencer_height -> Height],
+);
+
+impl StateImpl {
+    pub(super) fn new(genesis_info: GenesisInfo, commitment_state: CommitmentState) -> Self {
         let next_firm_sequencer_height = map_rollup_height_to_sequencer_height(
-            sequencer_height_with_first_rollup_block,
+            genesis_info.sequencer_genesis_block_height(),
             commitment_state.firm().number(),
         );
 
         let next_soft_sequencer_height = map_rollup_height_to_sequencer_height(
-            sequencer_height_with_first_rollup_block,
+            genesis_info.sequencer_genesis_block_height(),
             commitment_state.soft().number(),
         );
-
         Self {
+            genesis_info,
             commitment_state,
             next_firm_sequencer_height,
             next_soft_sequencer_height,
-            sequencer_height_with_first_rollup_block,
         }
     }
 
@@ -63,11 +98,11 @@ impl State {
         let changed = self.commitment_state != commitment_state;
         if changed {
             self.next_firm_sequencer_height = map_rollup_height_to_sequencer_height(
-                self.sequencer_height_with_first_rollup_block,
+                self.genesis_info.sequencer_genesis_block_height(),
                 commitment_state.firm().number(),
             );
             self.next_soft_sequencer_height = map_rollup_height_to_sequencer_height(
-                self.sequencer_height_with_first_rollup_block,
+                self.genesis_info.sequencer_genesis_block_height(),
                 commitment_state.soft().number(),
             );
             self.commitment_state = commitment_state;
@@ -91,6 +126,14 @@ impl State {
         self.soft().hash()
     }
 
+    pub(super) fn celestia_base_block_height(&self) -> CelestiaHeight {
+        self.genesis_info.celestia_base_block_height()
+    }
+
+    pub(super) fn rollup_id(&self) -> RollupId {
+        self.genesis_info.rollup_id()
+    }
+
     pub(super) fn next_firm_sequencer_height(&self) -> Height {
         self.next_firm_sequencer_height
     }
@@ -100,10 +143,34 @@ impl State {
     }
 }
 
+// Maps a rollup height to a sequencer heights.
+/// # Panics
+///
+/// Panics if adding the integers overflows. Comet BFT has hopefully migrated
+/// to `uint64` heights by the times this becomes an issue.
+fn map_rollup_height_to_sequencer_height(
+    first_sequencer_height: Height,
+    current_rollup_height: u32,
+) -> Height {
+    let first_sequencer_height: u32 = first_sequencer_height
+        .value()
+        .try_into()
+        .expect("should not fail; cometbft heights are internally represented as int64");
+    first_sequencer_height
+        .checked_add(current_rollup_height)
+        .expect(
+            "should not overflow; if this overflows either the first sequencer height or current \
+             rollup height have been incorrectly set incorrectly set, are in the future, or the \
+             rollup/sequencer have been running for several decades without cometbft ever \
+             receiving an update to uin64 heights",
+        )
+        .into()
+}
+
 #[cfg(test)]
 mod tests {
     use astria_core::{
-        generated::execution::v1alpha2::Block as RawBlock,
+        generated::execution::v1alpha2 as raw,
         Protobuf as _,
     };
     use prost_types::Timestamp;
@@ -111,7 +178,7 @@ mod tests {
     use super::*;
 
     fn make_commitment_state() -> CommitmentState {
-        let firm = Block::try_from_raw(RawBlock {
+        let firm = Block::try_from_raw(raw::Block {
             number: 1,
             hash: vec![42u8; 32],
             parent_block_hash: vec![41u8; 32],
@@ -121,7 +188,7 @@ mod tests {
             }),
         })
         .unwrap();
-        let soft = Block::try_from_raw(RawBlock {
+        let soft = Block::try_from_raw(raw::Block {
             number: 2,
             hash: vec![43u8; 32],
             parent_block_hash: vec![42u8; 32],
@@ -138,17 +205,31 @@ mod tests {
             .unwrap()
     }
 
+    fn make_genesis_info() -> GenesisInfo {
+        GenesisInfo::try_from_raw(raw::GenesisInfo {
+            rollup_id: vec![24; 32],
+            sequencer_genesis_block_height: 10,
+            celestia_base_block_height: 1,
+            celestia_block_variance: 0,
+        })
+        .unwrap()
+    }
+
+    fn make_state() -> State {
+        let mut state = State::new();
+        state.init(make_genesis_info(), make_commitment_state());
+        state
+    }
+
     #[test]
     fn next_firm_sequencer_height_is_correct() {
-        let commitment_state = make_commitment_state();
-        let state = State::new(commitment_state, 10);
+        let state = make_state();
         assert_eq!(Height::from(11u32), state.next_firm_sequencer_height(),);
     }
 
     #[test]
     fn next_soft_sequencer_height_is_correct() {
-        let commitment_state = make_commitment_state();
-        let state = State::new(commitment_state, 10);
+        let state = make_state();
         assert_eq!(Height::from(12u32), state.next_soft_sequencer_height(),);
     }
 
@@ -156,7 +237,7 @@ mod tests {
     fn assert_height_is_correct(left: u32, right: u32, expected: u32) {
         assert_eq!(
             Height::from(expected),
-            map_rollup_height_to_sequencer_height(left, right),
+            map_rollup_height_to_sequencer_height(Height::from(left), right),
         );
     }
 
@@ -165,11 +246,5 @@ mod tests {
         assert_height_is_correct(0, 0, 0);
         assert_height_is_correct(0, 1, 1);
         assert_height_is_correct(1, 0, 1);
-    }
-
-    #[test]
-    #[should_panic]
-    fn too_large_heights_panic() {
-        map_rollup_height_to_sequencer_height(2u32.pow(31), 2u32.pow(31));
     }
 }

--- a/crates/astria-core/Cargo.toml
+++ b/crates/astria-core/Cargo.toml
@@ -17,6 +17,7 @@ keywords = ["astria", "grpc", "rpc", "blockchain", "execution", "protobuf"]
 [dependencies]
 merkle = { package = "astria-merkle", path = "../astria-merkle" }
 
+celestia-tendermint = { workspace = true }
 ed25519-consensus = { workspace = true }
 hex = { workspace = true }
 ibc-types = { workspace = true }

--- a/crates/astria-core/src/generated/astria.execution.v1alpha2.rs
+++ b/crates/astria-core/src/generated/astria.execution.v1alpha2.rs
@@ -1,3 +1,23 @@
+/// GenesisInfo contains the information needed to start a rollup chain.
+///
+/// This information is used to determine which sequencer & celestia data to
+/// use from the Astria & Celestia networks.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GenesisInfo {
+    /// The rollup_id is the unique identifier for the rollup chain.
+    #[prost(bytes = "vec", tag = "1")]
+    pub rollup_id: ::prost::alloc::vec::Vec<u8>,
+    /// The first block height of sequencer chain to use for rollup transactions.
+    #[prost(uint32, tag = "2")]
+    pub sequencer_genesis_block_height: u32,
+    /// The first block height of celestia chain to use for rollup transactions.
+    #[prost(uint32, tag = "3")]
+    pub celestia_base_block_height: u32,
+    /// The allowed variance in celestia for sequencer blocks to have been posted.
+    #[prost(uint32, tag = "4")]
+    pub celestia_block_variance: u32,
+}
 /// The set of information which deterministic driver of block production
 /// must know about a given rollup Block
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -34,6 +54,9 @@ pub mod block_identifier {
         BlockHash(::prost::alloc::vec::Vec<u8>),
     }
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetGenesisInfoRequest {}
 /// Used in GetBlock to find a single block.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -193,6 +216,34 @@ pub mod execution_service_client {
         pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
             self.inner = self.inner.max_encoding_message_size(limit);
             self
+        }
+        /// GetGenesisInfo returns the necessary genesis information for rollup chain.
+        pub async fn get_genesis_info(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetGenesisInfoRequest>,
+        ) -> std::result::Result<tonic::Response<super::GenesisInfo>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/astria.execution.v1alpha2.ExecutionService/GetGenesisInfo",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "astria.execution.v1alpha2.ExecutionService",
+                        "GetGenesisInfo",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
         }
         /// GetBlock will return a block given an identifier.
         pub async fn get_block(
@@ -356,6 +407,11 @@ pub mod execution_service_server {
     /// Generated trait containing gRPC methods that should be implemented for use with ExecutionServiceServer.
     #[async_trait]
     pub trait ExecutionService: Send + Sync + 'static {
+        /// GetGenesisInfo returns the necessary genesis information for rollup chain.
+        async fn get_genesis_info(
+            &self,
+            request: tonic::Request<super::GetGenesisInfoRequest>,
+        ) -> std::result::Result<tonic::Response<super::GenesisInfo>, tonic::Status>;
         /// GetBlock will return a block given an identifier.
         async fn get_block(
             &self,
@@ -472,6 +528,53 @@ pub mod execution_service_server {
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
             let inner = self.inner.clone();
             match req.uri().path() {
+                "/astria.execution.v1alpha2.ExecutionService/GetGenesisInfo" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetGenesisInfoSvc<T: ExecutionService>(pub Arc<T>);
+                    impl<
+                        T: ExecutionService,
+                    > tonic::server::UnaryService<super::GetGenesisInfoRequest>
+                    for GetGenesisInfoSvc<T> {
+                        type Response = super::GenesisInfo;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::GetGenesisInfoRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as ExecutionService>::get_genesis_info(&inner, request)
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = GetGenesisInfoSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
                 "/astria.execution.v1alpha2.ExecutionService/GetBlock" => {
                     #[allow(non_camel_case_types)]
                     struct GetBlockSvc<T: ExecutionService>(pub Arc<T>);

--- a/proto/astria/execution/v1alpha2/execution.proto
+++ b/proto/astria/execution/v1alpha2/execution.proto
@@ -4,6 +4,21 @@ package astria.execution.v1alpha2;
 
 import "google/protobuf/timestamp.proto";
 
+// GenesisInfo contains the information needed to start a rollup chain.
+//
+// This information is used to determine which sequencer & celestia data to
+// use from the Astria & Celestia networks.
+message GenesisInfo {
+  // The rollup_id is the unique identifier for the rollup chain.
+  bytes rollup_id = 1;
+  // The first block height of sequencer chain to use for rollup transactions.
+  uint32 sequencer_genesis_block_height = 2;
+  // The first block height of celestia chain to use for rollup transactions.
+  uint32 celestia_base_block_height = 3;
+  // The allowed variance in celestia for sequencer blocks to have been posted.
+  uint32 celestia_block_variance = 4;
+}
+
 // The set of information which deterministic driver of block production
 // must know about a given rollup Block
 message Block {
@@ -24,6 +39,8 @@ message BlockIdentifier {
     bytes block_hash = 2;
   }
 }
+
+message GetGenesisInfoRequest {}
 
 // Used in GetBlock to find a single block.
 message GetBlockRequest {
@@ -84,6 +101,9 @@ message UpdateCommitmentStateRequest {
 // Astria Shared Sequencer, and will have block production driven via the Astria
 // "Conductor".
 service ExecutionService {
+  // GetGenesisInfo returns the necessary genesis information for rollup chain.
+  rpc GetGenesisInfo(GetGenesisInfoRequest) returns (GenesisInfo);
+
   // GetBlock will return a block given an identifier.
   rpc GetBlock(GetBlockRequest) returns (Block);
 

--- a/specs/execution-api.md
+++ b/specs/execution-api.md
@@ -9,10 +9,6 @@ intended to be very simple to implement. It is a gRPC API which any state
 machine can implement and use conductor with to drive their block creation to
 integrate with the Astria Sequencer.
 
-> Note: this documentation is for the v1alpha2 API which is currently being
-> implemented, and some of the documentation is on how it should be implemented,
-> not how it is currently.
-
 ## Basic Design Principles
 
 The Execution API is a resource based API with two resources: `Block` and
@@ -25,12 +21,13 @@ to generate client libraries and server implementations.
 
 ### Startup
 
-Upon startup, conductor needs to know the state of commitments in the state
-machine and calls `GetCommitmentState`. If started on a fresh rollup these will
-all be the same block. If running against a state machine with previous block
-data, Conductor must also track the block hash of any blocks between
-commitments, it will call `BatchGetBlock` to get block information between
-commitments.
+Upon startup, conductor first grabs the basic genesis information via
+`GetGenesisInfo`. After this succeeds, it  fetches the initial commitments in
+the state machine via `GetCommitmentState`. If started on a fresh rollup
+these will all be the same block. If running against a state machine with
+previous block data, Conductor must also track the block hash of any blocks
+between commitments, it will call `BatchGetBlock` to get block information
+between commitments.
 
 ### Execution & Commitments
 
@@ -73,6 +70,13 @@ Note: For our EVM rollup, we map the `CommitmentState` to the `ForkchoiceRule`:
 - `FIRM` Commitment -> `FINAL` Forkchoice
 
 ## Rollup Implementation Details
+
+### GetGenesisInfo
+
+`GetGenesisInfo` returns information which is definitional to the rollup with
+regards to how it derves data from the sequencer & celestia networks. This RPC
+should ALWAYS succeed. The API is agnostic as to how the information is defined
+in a rollups genesis, and used by the conductor as configuration on startup.
 
 ### ExecuteBlock
 


### PR DESCRIPTION
## Summary
Adds a genesis info RPC to the executor v1alpha2 API and initializes conductor using it.

## Background
Certain information about the rollup should be considered a core part of the rollup definition, but was done through environmental variable configuration making it harder to spin up nodes that follow the same rules.

## Changes
- Create `GenesisInfo` protos
- Added idiomatic types to `astria-core`
- Remove fields from config that are now derived from genesis info
- Initialize the executor actor in terms of the genesis info and propagate it to the celestia and sequencer readers

## Testing
Updated executor tests to still pass. Rest has to be tested end-to-end.

## Breaking Changelist
- Requires an updated rollup node to implement the genesis info RPCs

## Related Issues
Part of https://github.com/astriaorg/astria/pull/691