### PR TITLE
refactor(conductor): interact with executor via handle

### DIFF
--- a/crates/astria-conductor/src/celestia/mod.rs
+++ b/crates/astria-conductor/src/celestia/mod.rs
@@ -120,12 +120,8 @@ impl Reader {
             .await
             .wrap_err("handle to executor failed while waiting for it being initialized")?;
 
-        let (rollup_namespace, celestia_start_height) = {
-            let state = executor.state_mut().borrow_and_update();
-            let rollup_namespace = celestia_namespace_v0_from_rollup_id(state.rollup_id());
-            let celestia_start_height = state.celestia_base_block_height();
-            (rollup_namespace, celestia_start_height)
-        };
+        let rollup_namespace = celestia_namespace_v0_from_rollup_id(executor.rollup_id());
+        let celestia_start_height = executor.celestia_base_block_height();
 
         // XXX: Add retry
         let mut headers = self
@@ -167,7 +163,7 @@ impl Reader {
                 }
 
                 Some(block) = sequential_blocks.next_block() => {
-                    if let Err(e) = executor.firm_blocks().send(block) {
+                    if let Err(e) = executor.send_firm(block) {
                         error!(
                             error = &e as &dyn std::error::Error,
                             "failed sending block reconstructed from celestia to executor; exiting",

--- a/crates/astria-conductor/src/executor/builder.rs
+++ b/crates/astria-conductor/src/executor/builder.rs
@@ -13,6 +13,8 @@ use tokio::sync::{
 use super::{
     Executor,
     Handle,
+    State,
+    StateNotInit,
 };
 use crate::executor::optimism;
 
@@ -50,7 +52,7 @@ impl ExecutorBuilder<WithRollupAddress, WithShutdown> {
         let (firm_blocks_tx, firm_blocks_rx) = mpsc::unbounded_channel();
         let (soft_blocks_tx, soft_blocks_rx) = mpsc::unbounded_channel();
 
-        let (state_tx, state_rx) = watch::channel(super::State::new());
+        let (state_tx, state_rx) = watch::channel(State::new());
 
         let executor = Executor {
             firm_blocks: firm_blocks_rx,
@@ -67,6 +69,7 @@ impl ExecutorBuilder<WithRollupAddress, WithShutdown> {
             firm_blocks: firm_blocks_tx,
             soft_blocks: soft_blocks_tx,
             state: state_rx,
+            _state_init: StateNotInit,
         };
         (executor, handle)
     }

--- a/crates/astria-conductor/src/executor/mod.rs
+++ b/crates/astria-conductor/src/executor/mod.rs
@@ -50,6 +50,12 @@ pub(crate) struct StateNotInit;
 #[derive(Clone, Debug)]
 pub(crate) struct StateIsInit;
 
+/// A handle to the executor.
+///
+/// To be be useful, [`Handle<StateNotInit>::wait_for_init`] must be called in
+/// order to obtain a [`Handle<StateInit>`]. This is to ensure that the executor
+/// state was primed before using its other methods. See [`State`] for more
+/// information.
 #[derive(Debug, Clone)]
 pub(crate) struct Handle<TStateInit = StateNotInit> {
     firm_blocks: mpsc::UnboundedSender<ReconstructedBlock>,

--- a/crates/astria-conductor/src/executor/mod.rs
+++ b/crates/astria-conductor/src/executor/mod.rs
@@ -71,7 +71,7 @@ pub(crate) struct Handle<TStateInit = StateNotInit> {
     _state_init: TStateInit,
 }
 
-impl Handle<StateNotInit> {
+impl<T> Handle<T> {
     pub(crate) async fn wait_for_init(&mut self) -> eyre::Result<Handle<StateIsInit>> {
         self.state
             .wait_for(State::is_init)

--- a/crates/astria-conductor/src/executor/mod.rs
+++ b/crates/astria-conductor/src/executor/mod.rs
@@ -71,7 +71,7 @@ pub(crate) struct Handle<TStateInit = StateNotInit> {
     _state_init: TStateInit,
 }
 
-impl<T> Handle<T> {
+impl<T: Clone> Handle<T> {
     pub(crate) async fn wait_for_init(&mut self) -> eyre::Result<Handle<StateIsInit>> {
         self.state
             .wait_for(State::is_init)

--- a/crates/astria-conductor/src/executor/tests.rs
+++ b/crates/astria-conductor/src/executor/tests.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashMap,
     net::SocketAddr,
     sync::{
         Arc,
@@ -42,7 +43,15 @@ use tokio::{
 };
 use tonic::transport::Server;
 
-use super::*;
+use super::{
+    optimism,
+    Client,
+    Executor,
+    ReconstructedBlock,
+    RollupId,
+    SequencerBlock,
+    SequencerHeight,
+};
 
 const GENESIS_HASH: [u8; 32] = [0u8; 32];
 
@@ -198,7 +207,7 @@ fn hash(s: &[u8]) -> [u8; 32] {
 
 fn make_reconstructed_block() -> ReconstructedBlock {
     let mut block = make_cometbft_block();
-    block.header.height = Height::from(100u32);
+    block.header.height = SequencerHeight::from(100u32);
     ReconstructedBlock {
         block_hash: hash(b"block1"),
         header: block.header,
@@ -254,7 +263,7 @@ struct MockEnvironmentWithEthereum {
 async fn start_mock_with_optimism_handler() -> MockEnvironmentWithEthereum {
     let (contract_address, provider, wallet, anvil) = deploy_mock_optimism_portal().await;
 
-    let pre_execution_hook = Some(crate::executor::optimism::Handler::new(
+    let pre_execution_hook = Some(optimism::Handler::new(
         provider.clone(),
         contract_address,
         1,
@@ -312,7 +321,7 @@ async fn soft_blocks_at_expected_heights_are_executed() {
     let mut mock = start_mock(None).await;
 
     let mut block = make_cometbft_block();
-    block.header.height = Height::from(100u32);
+    block.header.height = SequencerHeight::from(100u32);
     let block = SequencerBlock::try_from_cometbft(block).unwrap();
     assert!(
         mock.executor
@@ -322,14 +331,14 @@ async fn soft_blocks_at_expected_heights_are_executed() {
     );
 
     let mut block = make_cometbft_block();
-    block.header.height = Height::from(101u32);
+    block.header.height = SequencerHeight::from(101u32);
     let block = SequencerBlock::try_from_cometbft(block).unwrap();
     mock.executor
         .execute_soft(mock.client.clone(), block)
         .await
         .unwrap();
     assert_eq!(
-        Height::from(102u32),
+        SequencerHeight::from(102u32),
         mock.executor.state.borrow().next_soft_sequencer_height()
     );
 }
@@ -438,7 +447,7 @@ async fn first_soft_then_firm_update_state_correctly() {
 async fn old_soft_blocks_are_ignored() {
     let mut mock = start_mock(None).await;
     let mut block = make_cometbft_block();
-    block.header.height = Height::from(99u32);
+    block.header.height = SequencerHeight::from(99u32);
     let sequencer_block = SequencerBlock::try_from_cometbft(block).unwrap();
 
     let firm = mock.executor.state.borrow().firm().clone();
@@ -458,7 +467,7 @@ async fn non_sequential_future_soft_blocks_give_error() {
     let mut mock = start_mock(None).await;
 
     let mut block = make_cometbft_block();
-    block.header.height = Height::from(101u32);
+    block.header.height = SequencerHeight::from(101u32);
     let sequencer_block = SequencerBlock::try_from_cometbft(block).unwrap();
     assert!(
         mock.executor
@@ -468,7 +477,7 @@ async fn non_sequential_future_soft_blocks_give_error() {
     );
 
     let mut block = make_cometbft_block();
-    block.header.height = Height::from(100u32);
+    block.header.height = SequencerHeight::from(100u32);
     let sequencer_block = SequencerBlock::try_from_cometbft(block).unwrap();
     assert!(
         mock.executor
@@ -483,7 +492,7 @@ async fn out_of_order_firm_blocks_are_rejected() {
     let mut mock = start_mock(None).await;
     let mut block = make_reconstructed_block();
 
-    block.header.height = Height::from(99u32);
+    block.header.height = SequencerHeight::from(99u32);
     assert!(
         mock.executor
             .execute_firm(mock.client.clone(), block.clone())
@@ -491,7 +500,7 @@ async fn out_of_order_firm_blocks_are_rejected() {
             .is_err()
     );
 
-    block.header.height = Height::from(101u32);
+    block.header.height = SequencerHeight::from(101u32);
     assert!(
         mock.executor
             .execute_firm(mock.client.clone(), block.clone())
@@ -499,7 +508,7 @@ async fn out_of_order_firm_blocks_are_rejected() {
             .is_err()
     );
 
-    block.header.height = Height::from(100u32);
+    block.header.height = SequencerHeight::from(100u32);
     assert!(
         mock.executor
             .execute_firm(mock.client.clone(), block.clone())

--- a/crates/astria-conductor/src/executor/tests.rs
+++ b/crates/astria-conductor/src/executor/tests.rs
@@ -219,7 +219,7 @@ async fn start_mock(pre_execution_hook: Option<optimism::Handler>) -> MockEnviro
 
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
 
-    let executor = Executor::builder()
+    let (executor, _) = Executor::builder()
         .rollup_address(&server_url)
         .unwrap()
         .shutdown(shutdown_rx)

--- a/crates/astria-conductor/src/sequencer.rs
+++ b/crates/astria-conductor/src/sequencer.rs
@@ -84,16 +84,14 @@ impl Reader {
             mut shutdown,
         } = self;
 
-        let start_height = {
-            executor
-                .state_mut()
-                .wait_for(executor::State::is_init)
-                .await
-                .wrap_err(
-                    "executor state channel terminated before initial state could be observed",
-                )?
-                .next_soft_sequencer_height()
-        };
+        let mut executor = executor
+            .wait_for_init()
+            .await
+            .wrap_err("handle to executor failed while waiting for it being initialized")?;
+        let start_height = executor
+            .state_mut()
+            .borrow_and_update()
+            .next_soft_sequencer_height();
 
         let mut subscription = resubscribe(pool.clone())
             .await


### PR DESCRIPTION
## Summary
Added an `executor::Handle` type to send blocks, read state.

## Background
The previous implementation required too much manual plumbing to set up connections to the executor. A handle to a long running task is a more elegant and idiomatic solution. It also allows to ensure at the type-level that a `Handle::wait_for_init -> Handle<StateIsInit>` is called prior to reading its state and sending data to it because all methods to do so are only implemented on `Handle<StateIsInit>`.

## Changes
- Introduce an `executor::Handle<T>` type to interact with the `Executor`.
- Move all send channels out of the executor and into the Handle
- Introduce `StateIsInit` and `StateNotInit` marker types to ensure the executor state is initialized (which is the case when it read the genesis info and commitment state off its rollup node)

## Testing
Needs to be done end-to-end

## Related 
Part of #691.

Also removes the `WeakUnboundedSender` in favor of `UnboundedSender` because that was buggy (noticed in https://github.com/astriaorg/astria/pull/694)