### PR TITLE
refactor(core)!: move fee asset from `UnsignedTransaction` to `SequenceAction` and `TransferAction` 

### DIFF
--- a/crates/astria-cli/src/commands/sequencer.rs
+++ b/crates/astria-cli/src/commands/sequencer.rs
@@ -156,6 +156,8 @@ pub(crate) async fn get_block_height(args: &BlockHeightGetArgs) -> eyre::Result<
 /// * If the http client cannot be created
 /// * If the latest block height cannot be retrieved
 pub(crate) async fn send_transfer(args: &TransferArgs) -> eyre::Result<()> {
+    use astria_core::sequencer::v1alpha1::asset::default_native_asset_id;
+
     // Build the signing_key
     let private_key_bytes: [u8; 32] = hex::decode(args.private_key.as_str())
         .wrap_err("failed to decode private key bytes from hex string")?
@@ -183,9 +185,9 @@ pub(crate) async fn send_transfer(args: &TransferArgs) -> eyre::Result<()> {
         actions: vec![Action::Transfer(TransferAction {
             to: to_address,
             amount: args.amount,
-            asset_id: astria_core::sequencer::v1alpha1::asset::default_native_asset_id(),
+            asset_id: default_native_asset_id(),
+            fee_asset_id: default_native_asset_id(),
         })],
-        fee_asset_id: astria_core::sequencer::v1alpha1::asset::default_native_asset_id(),
     }
     .into_signed(&sequencer_key);
     let res = sequencer_client

--- a/crates/astria-composer/src/searcher/collector.rs
+++ b/crates/astria-composer/src/searcher/collector.rs
@@ -1,4 +1,5 @@
 use astria_core::sequencer::v1alpha1::{
+    asset::default_native_asset_id,
     transaction::action::SequenceAction,
     RollupId,
 };
@@ -147,6 +148,7 @@ impl Collector {
             let seq_action = SequenceAction {
                 rollup_id,
                 data,
+                fee_asset_id: default_native_asset_id(),
             };
 
             match new_bundles

--- a/crates/astria-composer/src/searcher/executor/bundle_factory/tests.rs
+++ b/crates/astria-composer/src/searcher/executor/bundle_factory/tests.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 mod sized_bundle_tests {
     use astria_core::sequencer::v1alpha1::{
+        asset::default_native_asset_id,
         transaction::action::SequenceAction,
         RollupId,
         ROLLUP_ID_LEN,
@@ -21,6 +22,7 @@ mod sized_bundle_tests {
         let seq_action = SequenceAction {
             rollup_id: RollupId::new([0; ROLLUP_ID_LEN]),
             data: vec![0; 100 - ROLLUP_ID_LEN],
+            fee_asset_id: default_native_asset_id(),
         };
 
         assert_eq!(estimate_size_of_sequence_action(&seq_action), 100);
@@ -36,6 +38,7 @@ mod sized_bundle_tests {
         let seq_action = SequenceAction {
             rollup_id: RollupId::new([0; ROLLUP_ID_LEN]),
             data: vec![0; 100 - ROLLUP_ID_LEN + 1],
+            fee_asset_id: default_native_asset_id(),
         };
 
         assert!(estimate_size_of_sequence_action(&seq_action) > 100);
@@ -54,6 +57,7 @@ mod sized_bundle_tests {
         let initial_seq_action = SequenceAction {
             rollup_id: RollupId::new([0; ROLLUP_ID_LEN]),
             data: vec![0; 100 - ROLLUP_ID_LEN],
+            fee_asset_id: default_native_asset_id(),
         };
         bundle.push(initial_seq_action).unwrap();
 
@@ -62,6 +66,7 @@ mod sized_bundle_tests {
         let seq_action = SequenceAction {
             rollup_id: RollupId::new([0; ROLLUP_ID_LEN]),
             data: vec![0; 1],
+            fee_asset_id: default_native_asset_id(),
         };
 
         assert!(estimate_size_of_sequence_action(&seq_action) < 100);
@@ -81,6 +86,7 @@ mod sized_bundle_tests {
         let seq_action = SequenceAction {
             rollup_id: RollupId::new([0; ROLLUP_ID_LEN]),
             data: vec![1; 100 - ROLLUP_ID_LEN],
+            fee_asset_id: default_native_asset_id(),
         };
         bundle.push(seq_action.clone()).unwrap();
 
@@ -102,6 +108,7 @@ mod sized_bundle_tests {
 #[cfg(test)]
 mod bundle_factory_tests {
     use astria_core::sequencer::v1alpha1::{
+        asset::default_native_asset_id,
         transaction::action::SequenceAction,
         RollupId,
         ROLLUP_ID_LEN,
@@ -122,6 +129,7 @@ mod bundle_factory_tests {
         let seq_action = SequenceAction {
             rollup_id: RollupId::new([0; ROLLUP_ID_LEN]),
             data: vec![0; 100 - ROLLUP_ID_LEN],
+            fee_asset_id: default_native_asset_id(),
         };
         bundle_factory.try_push(seq_action).unwrap();
 
@@ -138,6 +146,7 @@ mod bundle_factory_tests {
         let seq_action = SequenceAction {
             rollup_id: RollupId::new([0; ROLLUP_ID_LEN]),
             data: vec![0; 100 - ROLLUP_ID_LEN + 1],
+            fee_asset_id: default_native_asset_id(),
         };
         let actual_size = estimate_size_of_sequence_action(&seq_action);
 
@@ -159,6 +168,7 @@ mod bundle_factory_tests {
         let seq_action0 = SequenceAction {
             rollup_id: RollupId::new([0; ROLLUP_ID_LEN]),
             data: vec![0; 100 - ROLLUP_ID_LEN],
+            fee_asset_id: default_native_asset_id(),
         };
         bundle_factory.try_push(seq_action0.clone()).unwrap();
 
@@ -167,6 +177,7 @@ mod bundle_factory_tests {
         let seq_action1 = SequenceAction {
             rollup_id: RollupId::new([1; ROLLUP_ID_LEN]),
             data: vec![1; 100 - ROLLUP_ID_LEN],
+            fee_asset_id: default_native_asset_id(),
         };
         bundle_factory.try_push(seq_action1).unwrap();
 
@@ -189,6 +200,7 @@ mod bundle_factory_tests {
         let seq_action = SequenceAction {
             rollup_id: RollupId::new([0; ROLLUP_ID_LEN]),
             data: vec![0; 100 - ROLLUP_ID_LEN],
+            fee_asset_id: default_native_asset_id(),
         };
         bundle_factory.try_push(seq_action.clone()).unwrap();
 
@@ -208,6 +220,7 @@ mod bundle_factory_tests {
         let seq_action = SequenceAction {
             rollup_id: RollupId::new([0; ROLLUP_ID_LEN]),
             data: vec![0; 100 - ROLLUP_ID_LEN],
+            fee_asset_id: default_native_asset_id(),
         };
         bundle_factory.try_push(seq_action.clone()).unwrap();
 
@@ -229,6 +242,7 @@ mod bundle_factory_tests {
         let seq_action0 = SequenceAction {
             rollup_id: RollupId::new([0; ROLLUP_ID_LEN]),
             data: vec![0; 100 - ROLLUP_ID_LEN],
+            fee_asset_id: default_native_asset_id(),
         };
         bundle_factory.try_push(seq_action0.clone()).unwrap();
 
@@ -237,6 +251,7 @@ mod bundle_factory_tests {
         let seq_action1 = SequenceAction {
             rollup_id: RollupId::new([1; ROLLUP_ID_LEN]),
             data: vec![1; 100 - ROLLUP_ID_LEN],
+            fee_asset_id: default_native_asset_id(),
         };
         bundle_factory.try_push(seq_action1).unwrap();
 
@@ -270,6 +285,7 @@ mod bundle_factory_tests {
         let seq_action0 = SequenceAction {
             rollup_id: RollupId::new([0; ROLLUP_ID_LEN]),
             data: vec![0; 100 - ROLLUP_ID_LEN],
+            fee_asset_id: default_native_asset_id(),
         };
         bundle_factory.try_push(seq_action0.clone()).unwrap();
 
@@ -278,6 +294,7 @@ mod bundle_factory_tests {
         let seq_action1 = SequenceAction {
             rollup_id: RollupId::new([1; ROLLUP_ID_LEN]),
             data: vec![1; 100 - ROLLUP_ID_LEN],
+            fee_asset_id: default_native_asset_id(),
         };
         bundle_factory.try_push(seq_action1.clone()).unwrap();
 

--- a/crates/astria-composer/src/searcher/executor/mod.rs
+++ b/crates/astria-composer/src/searcher/executor/mod.rs
@@ -10,7 +10,6 @@ use std::{
 };
 
 use astria_core::sequencer::v1alpha1::{
-    asset::default_native_asset_id,
     transaction::{
         action::SequenceAction,
         Action,
@@ -390,7 +389,6 @@ impl Future for SubmitFut {
                     let tx = UnsignedTransaction {
                         nonce: *this.nonce,
                         actions: this.bundle.clone(),
-                        fee_asset_id: default_native_asset_id(),
                     }
                     .into_signed(this.signing_key);
                     SubmitState::WaitingForSend {
@@ -444,7 +442,6 @@ impl Future for SubmitFut {
                         let tx = UnsignedTransaction {
                             nonce: *this.nonce,
                             actions: this.bundle.clone(),
-                            fee_asset_id: default_native_asset_id(),
                         }
                         .into_signed(this.signing_key);
                         SubmitState::WaitingForSend {

--- a/crates/astria-composer/src/searcher/executor/tests.rs
+++ b/crates/astria-composer/src/searcher/executor/tests.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use astria_core::sequencer::v1alpha1::{
+    asset::default_native_asset_id,
     transaction::action::SequenceAction,
     RollupId,
     ROLLUP_ID_LEN,
@@ -205,11 +206,13 @@ async fn full_bundle() {
     let seq0 = SequenceAction {
         rollup_id: RollupId::new([0; ROLLUP_ID_LEN]),
         data: vec![0u8; cfg.max_bytes_per_bundle - ROLLUP_ID_LEN],
+        fee_asset_id: default_native_asset_id(),
     };
 
     let seq1 = SequenceAction {
         rollup_id: RollupId::new([1; ROLLUP_ID_LEN]),
         data: vec![1u8; 1],
+        fee_asset_id: default_native_asset_id(),
     };
 
     // push both sequence actions to the executor in order to force the full bundle to be sent
@@ -283,6 +286,7 @@ async fn bundle_triggered_by_block_timer() {
     let seq0 = SequenceAction {
         rollup_id: RollupId::new([0; ROLLUP_ID_LEN]),
         data: vec![0u8; cfg.max_bytes_per_bundle / 4],
+        fee_asset_id: default_native_asset_id(),
     };
 
     // make sure at least one block has passed so that the executor will submit the bundle
@@ -358,11 +362,13 @@ async fn two_seq_actions_single_bundle() {
     let seq0 = SequenceAction {
         rollup_id: RollupId::new([0; ROLLUP_ID_LEN]),
         data: vec![0u8; cfg.max_bytes_per_bundle / 4],
+        fee_asset_id: default_native_asset_id(),
     };
 
     let seq1 = SequenceAction {
         rollup_id: RollupId::new([1; ROLLUP_ID_LEN]),
         data: vec![1u8; cfg.max_bytes_per_bundle / 4],
+        fee_asset_id: default_native_asset_id(),
     };
 
     // make sure at least one block has passed so that the executor will submit the bundle

--- a/crates/astria-composer/src/searcher/mod.rs
+++ b/crates/astria-composer/src/searcher/mod.rs
@@ -311,6 +311,7 @@ mod tests {
     use std::collections::HashMap;
 
     use astria_core::sequencer::v1alpha1::{
+        asset::default_native_asset_id,
         transaction::action::SequenceAction,
         RollupId,
     };
@@ -344,6 +345,7 @@ mod tests {
         let expected_seq_action = SequenceAction {
             rollup_id: RollupId::from_unhashed_bytes(&rollup_name),
             data: Transaction::default().rlp().to_vec(),
+            fee_asset_id: default_native_asset_id(),
         };
         let _ = mock_geth.push_tx(rollup_tx.clone()).unwrap();
         let collector_tx = rx.recv().await.unwrap();

--- a/crates/astria-core/src/generated/astria.sequencer.v1alpha1.rs
+++ b/crates/astria-core/src/generated/astria.sequencer.v1alpha1.rs
@@ -254,9 +254,6 @@ pub struct UnsignedTransaction {
     pub nonce: u32,
     #[prost(message, repeated, tag = "2")]
     pub actions: ::prost::alloc::vec::Vec<Action>,
-    /// the asset used to pay the transaction fee
-    #[prost(bytes = "vec", tag = "3")]
-    pub fee_asset_id: ::prost::alloc::vec::Vec<u8>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -299,6 +296,9 @@ pub struct TransferAction {
     /// the asset to be transferred
     #[prost(bytes = "vec", tag = "3")]
     pub asset_id: ::prost::alloc::vec::Vec<u8>,
+    /// the asset used to pay the transaction fee
+    #[prost(bytes = "vec", tag = "4")]
+    pub fee_asset_id: ::prost::alloc::vec::Vec<u8>,
 }
 /// `SequenceAction` represents a transaction destined for another
 /// chain, ordered by the sequencer.
@@ -312,6 +312,9 @@ pub struct SequenceAction {
     pub rollup_id: ::prost::alloc::vec::Vec<u8>,
     #[prost(bytes = "vec", tag = "2")]
     pub data: ::prost::alloc::vec::Vec<u8>,
+    /// the asset used to pay the transaction fee
+    #[prost(bytes = "vec", tag = "3")]
+    pub fee_asset_id: ::prost::alloc::vec::Vec<u8>,
 }
 /// / `SudoAddressChangeAction` represents a transaction that changes
 /// / the sudo address of the chain, which is the address authorized to

--- a/crates/astria-core/src/sequencer/v1alpha1/block.rs
+++ b/crates/astria-core/src/sequencer/v1alpha1/block.rs
@@ -415,6 +415,7 @@ impl SequencerBlock {
                 if let action::Action::Sequence(action::SequenceAction {
                     rollup_id,
                     data,
+                    fee_asset_id: _,
                 }) = action
                 {
                     let elem = rollup_transactions.entry(rollup_id).or_insert(vec![]);

--- a/crates/astria-core/src/sequencer/v1alpha1/mod.rs
+++ b/crates/astria-core/src/sequencer/v1alpha1/mod.rs
@@ -6,7 +6,6 @@ use sha2::{
 
 use crate::{
     generated::sequencer::v1alpha1 as raw,
-    sequencer::v1alpha1::asset::IncorrectAssetIdLength,
     Protobuf,
 };
 

--- a/crates/astria-core/src/sequencer/v1alpha1/test_utils.rs
+++ b/crates/astria-core/src/sequencer/v1alpha1/test_utils.rs
@@ -73,10 +73,10 @@ impl ConfigureCometBftBlock {
                 SequenceAction {
                     rollup_id,
                     data: [b"hello_world_id_", &*suffix].concat(),
+                    fee_asset_id: default_native_asset_id(),
                 }
                 .into(),
             ],
-            fee_asset_id: default_native_asset_id(),
         };
 
         let signed_transaction = unsigned_transaction.into_signed(&signing_key);

--- a/crates/astria-sequencer-client/src/tests/http.rs
+++ b/crates/astria-sequencer-client/src/tests/http.rs
@@ -128,13 +128,13 @@ fn create_signed_transaction() -> SignedTransaction {
             to: BOB_ADDRESS,
             amount: 333_333,
             asset_id: default_native_asset_id(),
+            fee_asset_id: default_native_asset_id(),
         }
         .into(),
     ];
     UnsignedTransaction {
         nonce: 1,
         actions,
-        fee_asset_id: default_native_asset_id(),
     }
     .into_signed(&alice_key)
 }

--- a/crates/astria-sequencer/src/accounts/action.rs
+++ b/crates/astria-sequencer/src/accounts/action.rs
@@ -5,7 +5,6 @@ use anyhow::{
     Result,
 };
 use astria_core::sequencer::v1alpha1::{
-    asset,
     transaction::action::TransferAction,
     Address,
 };
@@ -29,18 +28,17 @@ impl ActionHandler for TransferAction {
         &self,
         state: &S,
         from: Address,
-        fee_asset_id: asset::Id,
     ) -> Result<()> {
         let transfer_asset_id = self.asset_id;
 
         let from_fee_balance = state
-            .get_account_balance(from, fee_asset_id)
+            .get_account_balance(from, self.fee_asset_id)
             .await
             .context("failed getting `from` account balance for fee payment")?;
 
         // if fee asset is same as transfer asset, ensure accounts has enough funds
         // to cover both the fee and the amount transferred
-        if fee_asset_id == transfer_asset_id {
+        if self.fee_asset_id == transfer_asset_id {
             let payment_amount = self
                 .amount
                 .checked_add(TRANSFER_FEE)
@@ -82,10 +80,9 @@ impl ActionHandler for TransferAction {
         &self,
         state: &mut S,
         from: Address,
-        fee_asset_id: asset::Id,
     ) -> Result<()> {
         state
-            .get_and_increase_block_fees(fee_asset_id, TRANSFER_FEE)
+            .get_and_increase_block_fees(self.fee_asset_id, TRANSFER_FEE)
             .await
             .context("failed to add to block fees")?;
 
@@ -102,7 +99,7 @@ impl ActionHandler for TransferAction {
 
         // if fee payment asset is same asset as transfer asset, deduct fee
         // from same balance as asset transferred
-        if transfer_asset_id == fee_asset_id {
+        if transfer_asset_id == self.fee_asset_id {
             // check_stateful should have already checked this arithmetic
             let payment_amount = self
                 .amount
@@ -151,13 +148,13 @@ impl ActionHandler for TransferAction {
 
             // deduct fee from fee asset balance
             let from_fee_balance = state
-                .get_account_balance(from, fee_asset_id)
+                .get_account_balance(from, self.fee_asset_id)
                 .await
                 .context("failed getting `from` account balance for fee payment")?;
             state
                 .put_account_balance(
                     from,
-                    fee_asset_id,
+                    self.fee_asset_id,
                     from_fee_balance
                         .checked_sub(TRANSFER_FEE)
                         .ok_or(anyhow!("insufficient funds for fee payment"))?,

--- a/crates/astria-sequencer/src/accounts/action.rs
+++ b/crates/astria-sequencer/src/accounts/action.rs
@@ -76,11 +76,7 @@ impl ActionHandler for TransferAction {
             amount = self.amount,
         )
     )]
-    async fn execute<S: StateWriteExt>(
-        &self,
-        state: &mut S,
-        from: Address,
-    ) -> Result<()> {
+    async fn execute<S: StateWriteExt>(&self, state: &mut S, from: Address) -> Result<()> {
         state
             .get_and_increase_block_fees(self.fee_asset_id, TRANSFER_FEE)
             .await

--- a/crates/astria-sequencer/src/accounts/ics20_withdrawal.rs
+++ b/crates/astria-sequencer/src/accounts/ics20_withdrawal.rs
@@ -81,11 +81,7 @@ impl ActionHandler for action::Ics20Withdrawal {
     }
 
     #[instrument(skip(self, state))]
-    async fn execute<S: StateWriteExt>(
-        &self,
-        state: &mut S,
-        from: Address,
-    ) -> Result<()> {
+    async fn execute<S: StateWriteExt>(&self, state: &mut S, from: Address) -> Result<()> {
         let checked_packet = withdrawal_to_unchecked_ibc_packet(self).assume_checked();
 
         let from_transfer_balance = state

--- a/crates/astria-sequencer/src/accounts/ics20_withdrawal.rs
+++ b/crates/astria-sequencer/src/accounts/ics20_withdrawal.rs
@@ -4,7 +4,6 @@ use anyhow::{
     Result,
 };
 use astria_core::sequencer::v1alpha1::{
-    asset,
     asset::Denom,
     transaction::action,
     Address,
@@ -62,7 +61,6 @@ impl ActionHandler for action::Ics20Withdrawal {
         &self,
         state: &S,
         from: Address,
-        _fee_asset_id: asset::Id,
     ) -> Result<()> {
         let packet: IBCPacket<Unchecked> = withdrawal_to_unchecked_ibc_packet(self);
         state
@@ -87,7 +85,6 @@ impl ActionHandler for action::Ics20Withdrawal {
         &self,
         state: &mut S,
         from: Address,
-        _fee_asset_id: asset::Id,
     ) -> Result<()> {
         let checked_packet = withdrawal_to_unchecked_ibc_packet(self).assume_checked();
 

--- a/crates/astria-sequencer/src/app.rs
+++ b/crates/astria-sequencer/src/app.rs
@@ -927,10 +927,10 @@ mod test {
                     to: bob_address,
                     amount: value,
                     asset_id: get_native_asset().id(),
+                    fee_asset_id: get_native_asset().id(),
                 }
                 .into(),
             ],
-            fee_asset_id: get_native_asset().id(),
         };
 
         let signed_tx = tx.into_signed(&alice_signing_key);
@@ -980,10 +980,10 @@ mod test {
                     to: bob_address,
                     amount: value,
                     asset_id: asset,
+                    fee_asset_id: get_native_asset().id(),
                 }
                 .into(),
             ],
-            fee_asset_id: get_native_asset().id(),
         };
 
         let signed_tx = tx.into_signed(&alice_signing_key);
@@ -1042,11 +1042,12 @@ mod test {
                     to: bob,
                     amount: 0,
                     asset_id: get_native_asset().id(),
+                    fee_asset_id: get_native_asset().id(),
                 }
                 .into(),
             ],
-            fee_asset_id: get_native_asset().id(),
         };
+
         let signed_tx = tx.into_signed(&keypair);
         let res = app
             .deliver_tx(signed_tx)
@@ -1071,10 +1072,10 @@ mod test {
                 SequenceAction {
                     rollup_id: RollupId::from_unhashed_bytes(b"testchainid"),
                     data,
+                    fee_asset_id: get_native_asset().id(),
                 }
                 .into(),
             ],
-            fee_asset_id: get_native_asset().id(),
         };
 
         let signed_tx = tx.into_signed(&alice_signing_key);
@@ -1110,7 +1111,6 @@ mod test {
         let tx = UnsignedTransaction {
             nonce: 0,
             actions: vec![Action::ValidatorUpdate(update.clone())],
-            fee_asset_id: get_native_asset().id(),
         };
 
         let signed_tx = tx.into_signed(&alice_signing_key);
@@ -1140,7 +1140,6 @@ mod test {
             actions: vec![Action::SudoAddressChange(SudoAddressChangeAction {
                 new_address,
             })],
-            fee_asset_id: get_native_asset().id(),
         };
 
         let signed_tx = tx.into_signed(&alice_signing_key);
@@ -1168,7 +1167,6 @@ mod test {
             actions: vec![Action::SudoAddressChange(SudoAddressChangeAction {
                 new_address: alice_address,
             })],
-            fee_asset_id: get_native_asset().id(),
         };
 
         let signed_tx = tx.into_signed(&alice_signing_key);
@@ -1204,7 +1202,6 @@ mod test {
                 }
                 .into(),
             ],
-            fee_asset_id: get_native_asset().id(),
         };
 
         let signed_tx = tx.into_signed(&alice_signing_key);
@@ -1302,10 +1299,10 @@ mod test {
                 SequenceAction {
                     rollup_id: RollupId::from_unhashed_bytes(b"testchainid"),
                     data,
+                    fee_asset_id: get_native_asset().id(),
                 }
                 .into(),
             ],
-            fee_asset_id: get_native_asset().id(),
         };
 
         let signed_tx = tx.into_signed(&alice_signing_key);
@@ -1417,10 +1414,10 @@ mod test {
                     to: bob_address,
                     amount,
                     asset_id: native_asset,
+                    fee_asset_id: get_native_asset().id(),
                 }
                 .into(),
             ],
-            fee_asset_id: native_asset,
         };
 
         let signed_tx = tx.into_signed(&alice_signing_key);

--- a/crates/astria-sequencer/src/authority/action.rs
+++ b/crates/astria-sequencer/src/authority/action.rs
@@ -34,11 +34,7 @@ impl ActionHandler for tendermint::validator::Update {
     }
 
     #[instrument(skip_all)]
-    async fn execute<S: StateWriteExt>(
-        &self,
-        state: &mut S,
-        _: Address,
-    ) -> Result<()> {
+    async fn execute<S: StateWriteExt>(&self, state: &mut S, _: Address) -> Result<()> {
         // add validator update in non-consensus state to be used in end_block
         let mut validator_updates = state
             .get_validator_updates()
@@ -71,11 +67,7 @@ impl ActionHandler for SudoAddressChangeAction {
     }
 
     #[instrument(skip_all)]
-    async fn execute<S: StateWriteExt>(
-        &self,
-        state: &mut S,
-        _: Address,
-    ) -> Result<()> {
+    async fn execute<S: StateWriteExt>(&self, state: &mut S, _: Address) -> Result<()> {
         state
             .put_sudo_address(self.new_address)
             .context("failed to put sudo address in state")?;

--- a/crates/astria-sequencer/src/authority/action.rs
+++ b/crates/astria-sequencer/src/authority/action.rs
@@ -4,7 +4,6 @@ use anyhow::{
     Result,
 };
 use astria_core::sequencer::v1alpha1::{
-    asset,
     transaction::action::SudoAddressChangeAction,
     Address,
 };
@@ -24,7 +23,6 @@ impl ActionHandler for tendermint::validator::Update {
         &self,
         state: &S,
         from: Address,
-        _fee_asset_id: asset::Id,
     ) -> Result<()> {
         // ensure signer is the valid `sudo` key in state
         let sudo_address = state
@@ -40,7 +38,6 @@ impl ActionHandler for tendermint::validator::Update {
         &self,
         state: &mut S,
         _: Address,
-        _: asset::Id,
     ) -> Result<()> {
         // add validator update in non-consensus state to be used in end_block
         let mut validator_updates = state
@@ -63,7 +60,6 @@ impl ActionHandler for SudoAddressChangeAction {
         &self,
         state: &S,
         from: Address,
-        _fee_asset_id: asset::Id,
     ) -> Result<()> {
         // ensure signer is the valid `sudo` key in state
         let sudo_address = state
@@ -79,7 +75,6 @@ impl ActionHandler for SudoAddressChangeAction {
         &self,
         state: &mut S,
         _: Address,
-        _: asset::Id,
     ) -> Result<()> {
         state
             .put_sudo_address(self.new_address)

--- a/crates/astria-sequencer/src/mint/action.rs
+++ b/crates/astria-sequencer/src/mint/action.rs
@@ -4,7 +4,6 @@ use anyhow::{
     Result,
 };
 use astria_core::sequencer::v1alpha1::{
-    asset,
     transaction::action::MintAction,
     Address,
 };
@@ -26,7 +25,6 @@ impl ActionHandler for MintAction {
         &self,
         state: &S,
         from: Address,
-        _fee_asset_id: asset::Id,
     ) -> Result<()> {
         // ensure signer is the valid `sudo` key in state
         let sudo_address = state
@@ -42,7 +40,6 @@ impl ActionHandler for MintAction {
         &self,
         state: &mut S,
         _: Address,
-        _: asset::Id,
     ) -> Result<()> {
         let native_asset = get_native_asset().id();
 

--- a/crates/astria-sequencer/src/proposal/commitment.rs
+++ b/crates/astria-sequencer/src/proposal/commitment.rs
@@ -86,18 +86,19 @@ mod test {
         let sequence_action = SequenceAction {
             rollup_id: RollupId::from_unhashed_bytes(b"testchainid"),
             data: b"helloworld".to_vec(),
+            fee_asset_id: get_native_asset().id(),
         };
         let transfer_action = TransferAction {
             to: Address([0u8; 20]),
             amount: 1,
             asset_id: get_native_asset().id(),
+            fee_asset_id: get_native_asset().id(),
         };
 
         let signing_key = SigningKey::new(OsRng);
         let tx = UnsignedTransaction {
             nonce: 0,
             actions: vec![sequence_action.clone().into(), transfer_action.into()],
-            fee_asset_id: get_native_asset().id(),
         };
 
         let signed_tx = tx.into_signed(&signing_key);
@@ -111,7 +112,6 @@ mod test {
         let tx = UnsignedTransaction {
             nonce: 0,
             actions: vec![sequence_action.into()],
-            fee_asset_id: get_native_asset().id(),
         };
 
         let signed_tx = tx.into_signed(&signing_key);
@@ -135,18 +135,19 @@ mod test {
         let sequence_action = SequenceAction {
             rollup_id: RollupId::from_unhashed_bytes(b"testchainid"),
             data: b"helloworld".to_vec(),
+            fee_asset_id: get_native_asset().id(),
         };
         let transfer_action = TransferAction {
             to: Address([0u8; 20]),
             amount: 1,
             asset_id: get_native_asset().id(),
+            fee_asset_id: get_native_asset().id(),
         };
 
         let signing_key = SigningKey::new(OsRng);
         let tx = UnsignedTransaction {
             nonce: 0,
             actions: vec![sequence_action.into(), transfer_action.into()],
-            fee_asset_id: get_native_asset().id(),
         };
 
         let signed_tx = tx.into_signed(&signing_key);

--- a/crates/astria-sequencer/src/sequence.rs
+++ b/crates/astria-sequencer/src/sequence.rs
@@ -53,11 +53,7 @@ impl ActionHandler for SequenceAction {
             from = from.to_string(),
         )
     )]
-    async fn execute<S: StateWriteExt>(
-        &self,
-        state: &mut S,
-        from: Address,
-    ) -> Result<()> {
+    async fn execute<S: StateWriteExt>(&self, state: &mut S, from: Address) -> Result<()> {
         let fee = calculate_fee(&self.data).context("failed to calculate fee")?;
         state
             .get_and_increase_block_fees(self.fee_asset_id, fee)

--- a/crates/astria-sequencer/src/sequence.rs
+++ b/crates/astria-sequencer/src/sequence.rs
@@ -4,7 +4,6 @@ use anyhow::{
     Result,
 };
 use astria_core::sequencer::v1alpha1::{
-    asset,
     transaction::action::SequenceAction,
     Address,
 };
@@ -28,10 +27,9 @@ impl ActionHandler for SequenceAction {
         &self,
         state: &S,
         from: Address,
-        fee_asset_id: asset::Id,
     ) -> Result<()> {
         let curr_balance = state
-            .get_account_balance(from, fee_asset_id)
+            .get_account_balance(from, self.fee_asset_id)
             .await
             .context("failed getting `from` account balance for fee payment")?;
         let fee = calculate_fee(&self.data).context("calculated fee overflows u128")?;
@@ -59,20 +57,19 @@ impl ActionHandler for SequenceAction {
         &self,
         state: &mut S,
         from: Address,
-        fee_asset_id: asset::Id,
     ) -> Result<()> {
         let fee = calculate_fee(&self.data).context("failed to calculate fee")?;
         state
-            .get_and_increase_block_fees(fee_asset_id, fee)
+            .get_and_increase_block_fees(self.fee_asset_id, fee)
             .await
             .context("failed to add to block fees")?;
 
         let from_balance = state
-            .get_account_balance(from, fee_asset_id)
+            .get_account_balance(from, self.fee_asset_id)
             .await
             .context("failed getting `from` account balance")?;
         state
-            .put_account_balance(from, fee_asset_id, from_balance - fee)
+            .put_account_balance(from, self.fee_asset_id, from_balance - fee)
             .context("failed updating `from` account balance")?;
         Ok(())
     }

--- a/crates/astria-sequencer/src/service/consensus.rs
+++ b/crates/astria-sequencer/src/service/consensus.rs
@@ -305,10 +305,10 @@ mod test {
                 SequenceAction {
                     rollup_id: RollupId::from_unhashed_bytes(b"testchainid"),
                     data: b"helloworld".to_vec(),
+                    fee_asset_id: get_native_asset().id(),
                 }
                 .into(),
             ],
-            fee_asset_id: get_native_asset().id(),
         }
     }
 

--- a/crates/astria-sequencer/src/transaction/action_handler.rs
+++ b/crates/astria-sequencer/src/transaction/action_handler.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 use astria_core::sequencer::v1alpha1::{
-    asset,
     Address,
 };
 use async_trait::async_trait;
@@ -18,7 +17,6 @@ pub(crate) trait ActionHandler {
         &self,
         _state: &S,
         _from: Address,
-        _fee_asset_id: asset::Id,
     ) -> Result<()> {
         Ok(())
     }
@@ -26,7 +24,6 @@ pub(crate) trait ActionHandler {
         &self,
         _state: &mut S,
         _from: Address,
-        _fee_asset_id: asset::Id,
     ) -> Result<()> {
         Ok(())
     }

--- a/crates/astria-sequencer/src/transaction/action_handler.rs
+++ b/crates/astria-sequencer/src/transaction/action_handler.rs
@@ -1,7 +1,5 @@
 use anyhow::Result;
-use astria_core::sequencer::v1alpha1::{
-    Address,
-};
+use astria_core::sequencer::v1alpha1::Address;
 use async_trait::async_trait;
 use cnidarium::{
     StateRead,
@@ -20,11 +18,7 @@ pub(crate) trait ActionHandler {
     ) -> Result<()> {
         Ok(())
     }
-    async fn execute<S: StateWrite>(
-        &self,
-        _state: &mut S,
-        _from: Address,
-    ) -> Result<()> {
+    async fn execute<S: StateWrite>(&self, _state: &mut S, _from: Address) -> Result<()> {
         Ok(())
     }
 }

--- a/crates/astria-sequencer/src/transaction/mod.rs
+++ b/crates/astria-sequencer/src/transaction/mod.rs
@@ -187,11 +187,7 @@ impl ActionHandler for UnsignedTransaction {
             from = from.to_string(),
         )
     )]
-    async fn execute<S: StateWriteExt>(
-        &self,
-        state: &mut S,
-        from: Address,
-    ) -> anyhow::Result<()> {
+    async fn execute<S: StateWriteExt>(&self, state: &mut S, from: Address) -> anyhow::Result<()> {
         let from_nonce = state
             .get_account_nonce(from)
             .await

--- a/proto/astria/sequencer/v1alpha1/transaction.proto
+++ b/proto/astria/sequencer/v1alpha1/transaction.proto
@@ -22,8 +22,6 @@ message SignedTransaction {
 message UnsignedTransaction {
   uint32 nonce = 1;
   repeated Action actions = 2;
-  // the asset used to pay the transaction fee
-  bytes fee_asset_id = 3;
 }
 
 message Action {
@@ -47,6 +45,8 @@ message TransferAction {
   astria.primitive.v1.Uint128 amount = 2;
   // the asset to be transferred
   bytes asset_id = 3;
+  // the asset used to pay the transaction fee
+  bytes fee_asset_id = 4;
 }
 
 // `SequenceAction` represents a transaction destined for another
@@ -57,6 +57,8 @@ message TransferAction {
 message SequenceAction {
   bytes rollup_id = 1;
   bytes data = 2;
+  // the asset used to pay the transaction fee
+  bytes fee_asset_id = 3;
 }
 
 /// `SudoAddressChangeAction` represents a transaction that changes


### PR DESCRIPTION
## Summary
as title says. this is so fees can be set per-action instead of per-transaction. 

## Changes
- move fee asset from `UnsignedTransaction` to `SequenceAction` and `TransferAction` 
- fee asset was only moved to `SequenceAction` and `TransferAction` as other actions don't have any fee payment, so it's unneeded.

## Testing
unit tests

## Breaking Changelist
- `UnsignedTransaction`, `SequenceAction`, and `TransferAction` types are changed.

## Related Issues

closes #714
