### PR TITLE
feat(sequencer)!: add `ibc_sudo_address` to genesis, only allow `IbcRelay` actions from this address

### DIFF
--- a/crates/astria-sequencer/src/accounts/component.rs
+++ b/crates/astria-sequencer/src/accounts/component.rs
@@ -32,6 +32,9 @@ impl Component for AccountsComponent {
                 .put_account_balance(account.address, native_asset.id(), account.balance)
                 .context("failed writing account balance to state")?;
         }
+        state
+            .put_ibc_sudo_address(app_state.ibc_sudo_address)
+            .context("failed to set IBC sudo key")?;
         Ok(())
     }
 

--- a/crates/astria-sequencer/src/app.rs
+++ b/crates/astria-sequencer/src/app.rs
@@ -178,7 +178,7 @@ impl App {
         AuthorityComponent::init_chain(
             &mut state_tx,
             &AuthorityComponentAppState {
-                authority_sudo_key: genesis_state.authority_sudo_key,
+                authority_sudo_address: genesis_state.authority_sudo_address,
                 genesis_validators,
             },
         )
@@ -772,7 +772,8 @@ mod test {
 
         let genesis_state = genesis_state.unwrap_or_else(|| GenesisState {
             accounts: default_genesis_accounts(),
-            authority_sudo_key: Address::from([0; 20]),
+            authority_sudo_address: Address::from([0; 20]),
+            ibc_sudo_address: Address::from([0; 20]),
             native_asset_base_denomination: DEFAULT_NATIVE_ASSET_DENOM.to_string(),
         });
 
@@ -1096,7 +1097,8 @@ mod test {
 
         let genesis_state = GenesisState {
             accounts: default_genesis_accounts(),
-            authority_sudo_key: alice_address,
+            authority_sudo_address: alice_address,
+            ibc_sudo_address: alice_address,
             native_asset_base_denomination: DEFAULT_NATIVE_ASSET_DENOM.to_string(),
         };
         let mut app = initialize_app(Some(genesis_state), vec![]).await;
@@ -1128,7 +1130,8 @@ mod test {
 
         let genesis_state = GenesisState {
             accounts: default_genesis_accounts(),
-            authority_sudo_key: alice_address,
+            authority_sudo_address: alice_address,
+            ibc_sudo_address: alice_address,
             native_asset_base_denomination: DEFAULT_NATIVE_ASSET_DENOM.to_string(),
         };
         let mut app = initialize_app(Some(genesis_state), vec![]).await;
@@ -1158,7 +1161,8 @@ mod test {
 
         let genesis_state = GenesisState {
             accounts: default_genesis_accounts(),
-            authority_sudo_key: sudo_address,
+            authority_sudo_address: sudo_address,
+            ibc_sudo_address: [0u8; 20].into(),
             native_asset_base_denomination: DEFAULT_NATIVE_ASSET_DENOM.to_string(),
         };
         let mut app = initialize_app(Some(genesis_state), vec![]).await;
@@ -1188,7 +1192,8 @@ mod test {
 
         let genesis_state = GenesisState {
             accounts: default_genesis_accounts(),
-            authority_sudo_key: alice_address,
+            authority_sudo_address: alice_address,
+            ibc_sudo_address: [0u8; 20].into(),
             native_asset_base_denomination: DEFAULT_NATIVE_ASSET_DENOM.to_string(),
         };
         let mut app = initialize_app(Some(genesis_state), vec![]).await;
@@ -1335,7 +1340,8 @@ mod test {
     async fn app_commit() {
         let genesis_state = GenesisState {
             accounts: default_genesis_accounts(),
-            authority_sudo_key: Address::from([0; 20]),
+            authority_sudo_address: Address::from([0; 20]),
+            ibc_sudo_address: Address::from([0; 20]),
             native_asset_base_denomination: DEFAULT_NATIVE_ASSET_DENOM.to_string(),
         };
 

--- a/crates/astria-sequencer/src/authority/component.rs
+++ b/crates/astria-sequencer/src/authority/component.rs
@@ -26,7 +26,7 @@ pub(crate) struct AuthorityComponent;
 
 #[derive(Debug)]
 pub(crate) struct AuthorityComponentAppState {
-    pub(crate) authority_sudo_key: Address,
+    pub(crate) authority_sudo_address: Address,
     pub(crate) genesis_validators: Vec<validator::Update>,
 }
 
@@ -38,7 +38,7 @@ impl Component for AuthorityComponent {
     async fn init_chain<S: StateWriteExt>(mut state: S, app_state: &Self::AppState) -> Result<()> {
         // set sudo key and initial validator set
         state
-            .put_sudo_address(app_state.authority_sudo_key)
+            .put_sudo_address(app_state.authority_sudo_address)
             .context("failed to set sudo key")?;
         state
             .put_validator_set(ValidatorSet::new_from_updates(

--- a/crates/astria-sequencer/src/genesis.rs
+++ b/crates/astria-sequencer/src/genesis.rs
@@ -9,7 +9,9 @@ use serde::{
 pub(crate) struct GenesisState {
     pub(crate) accounts: Vec<Account>,
     #[serde(deserialize_with = "deserialize_address")]
-    pub(crate) authority_sudo_key: Address,
+    pub(crate) authority_sudo_address: Address,
+    #[serde(deserialize_with = "deserialize_address")]
+    pub(crate) ibc_sudo_address: Address,
     pub(crate) native_asset_base_denomination: String,
 }
 

--- a/crates/astria-sequencer/src/service/consensus.rs
+++ b/crates/astria-sequencer/src/service/consensus.rs
@@ -502,7 +502,8 @@ mod test {
         fn default() -> Self {
             Self {
                 accounts: vec![],
-                authority_sudo_key: Address::from([0; 20]),
+                authority_sudo_address: Address::from([0; 20]),
+                ibc_sudo_address: Address::from([0; 20]),
                 native_asset_base_denomination: DEFAULT_NATIVE_ASSET_DENOM.to_string(),
             }
         }

--- a/crates/astria-sequencer/src/transaction/mod.rs
+++ b/crates/astria-sequencer/src/transaction/mod.rs
@@ -165,7 +165,14 @@ impl ActionHandler for UnsignedTransaction {
                     .await
                     .context("stateful check failed for SudoAddressChangeAction")?,
                 Action::Ibc(_) => {
-                    // no-op; IBC actions merge check_stateful and execute.
+                    let ibc_sudo_address = state
+                        .get_ibc_sudo_address()
+                        .await
+                        .context("failed to get IBC sudo address")?;
+                    ensure!(
+                        from == ibc_sudo_address,
+                        "only IBC sudo address can execute IBC actions"
+                    );
                 }
                 Action::Ics20Withdrawal(act) => act
                     .check_stateful(state, from, fee_asset_id)

--- a/crates/astria-sequencer/test-genesis-app-state.json
+++ b/crates/astria-sequencer/test-genesis-app-state.json
@@ -13,6 +13,7 @@
       "balance": 1000000000000000000
     }
   ],
-  "authority_sudo_key": "1c0c490f1b5528d8173c5de46d131160e4b2c0c3",
+  "authority_sudo_address": "1c0c490f1b5528d8173c5de46d131160e4b2c0c3",
+  "ibc_sudo_address": "1c0c490f1b5528d8173c5de46d131160e4b2c0c3",
   "native_asset_base_denomination": "nria"
 }


### PR DESCRIPTION
## Summary
as title says, make modifying IBC clients/connections/channels permissioned. this allows only a specific key (should be the key used by hermes) to send `IbcRelay` actions.

## Background
we probably don't want IBC channels being arbitrarily opened at this time.

## Changes
- add `ibc_sudo_address` to genesis
- store this in state
- only allow `IbcRelay` actions from this address

## Testing
unit tests

## Breaking Changelist
- updates state by adding `ibc_sudo_address`

## Related Issues
Link any issues that are related, prefer full github links.

closes #720
