### PR TITLE
feat!: add pretty-printing to stdout

### DIFF
--- a/crates/astria-composer/local.env.example
+++ b/crates/astria-composer/local.env.example
@@ -10,6 +10,17 @@ ASTRIA_COMPOSER_NO_OTEL=false
 # If false span data is written to stdout only if it is connected to a tty.
 ASTRIA_COMPOSER_FORCE_STDOUT=false
 
+# If true uses an exceedingly pretty human readable format to write to stdout.
+# If false uses JSON formatted OTEL traces.
+# This does nothing unless stdout is connected to a tty or
+# `ASTRIA_COMPOSER_FORCE_STDOUT` is set to `true`.
+ASTRIA_COMPOSER_PRETTY_PRINT=false
+
+# If set to any non-empty value removes ANSI escape characters from the pretty
+# printed output. Note that this does nothing unless `ASTRIA_COMPOSER_PRETTY_PRINT`
+# is set to `true`.
+NO_COLOR=
+
 # Address of the API server
 ASTRIA_COMPOSER_API_LISTEN_ADDR="0.0.0.0:0"
 
@@ -50,7 +61,7 @@ OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317"
 # Sets the OTLP endpoint for trace data. This takes precedence over `OTEL_EXPORTER_OTLP_ENDPOINT` if set.
 OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="http://localhost:4317/v1/traces"
 # The duration in seconds that the OTEL exporter will wait for each batch export.
-OTEL_EXPORTER_OTLP_TRACES_TIMEOUT=10,
+OTEL_EXPORTER_OTLP_TRACES_TIMEOUT=10
 # The compression format to use for exporting. Only `"gzip"` is supported.
 # Don't set the env var if no compression is required.
 OTEL_EXPORTER_OTLP_TRACES_COMPRESSION="gzip"

--- a/crates/astria-composer/src/config.rs
+++ b/crates/astria-composer/src/config.rs
@@ -39,6 +39,7 @@ pub struct Config {
     /// Max bytes to encode into a single sequencer `SignedTransaction`, not including signature,
     /// public key, nonce. This is the sum of the sizes of all the `SequenceAction`s
     pub max_bytes_per_bundle: usize,
+
     /// Forces writing trace data to stdout no matter if connected to a tty or not.
     pub force_stdout: bool,
 
@@ -50,6 +51,9 @@ pub struct Config {
 
     /// The endpoint which will be listened on for serving prometheus metrics
     pub metrics_http_listener_addr: String,
+
+    /// Writes a human readable format to stdout instead of JSON formatted OTEL trace data.
+    pub pretty_print: bool,
 }
 
 impl config::Config for Config {

--- a/crates/astria-composer/src/main.rs
+++ b/crates/astria-composer/src/main.rs
@@ -21,6 +21,7 @@ async fn main() -> ExitCode {
     let mut telemetry_conf = telemetry::configure()
         .set_no_otel(cfg.no_otel)
         .set_force_stdout(cfg.force_stdout)
+        .set_pretty_print(cfg.pretty_print)
         .filter_directives(&cfg.log);
 
     if !cfg.no_metrics {

--- a/crates/astria-composer/src/searcher/executor/tests.rs
+++ b/crates/astria-composer/src/searcher/executor/tests.rs
@@ -92,6 +92,7 @@ async fn setup() -> (MockServer, MockGuard, Config) {
         force_stdout: false,
         no_metrics: false,
         metrics_http_listener_addr: String::new(),
+        pretty_print: true,
     };
     (server, startup_guard, cfg)
 }

--- a/crates/astria-composer/tests/blackbox/helper/mod.rs
+++ b/crates/astria-composer/tests/blackbox/helper/mod.rs
@@ -80,6 +80,7 @@ pub async fn spawn_composer(rollup_ids: &[&str]) -> TestComposer {
         force_stdout: false,
         no_metrics: true,
         metrics_http_listener_addr: String::new(),
+        pretty_print: true,
     };
     let (composer_addr, composer) = {
         let composer = Composer::from_config(&config).unwrap();

--- a/crates/astria-conductor/local.env.example
+++ b/crates/astria-conductor/local.env.example
@@ -38,6 +38,17 @@ ASTRIA_CONDUCTOR_NO_OTEL=false
 # If false span data is written to stdout only if it is connected to a tty.
 ASTRIA_CONDUCTOR_FORCE_STDOUT=false
 
+# If true uses an exceedingly pretty human readable format to write to stdout.
+# If false uses JSON formatted OTEL traces.
+# This does nothing unless stdout is connected to a tty or
+# `ASTRIA_CONDUCTOR_FORCE_STDOUT` is set to `true`.
+ASTRIA_CONDUCTOR_PRETTY_PRINT=false
+
+# If set to any non-empty value removes ANSI escape characters from the pretty
+# printed output. Note that this does nothing unless `ASTRIA_CONDUCTOR_PRETTY_PRINT`
+# is set to `true`.
+NO_COLOR=
+
 # The URL to a fully trusted CometBFT/Sequencer to issue cometbft RPCs. Example
 # RPCs are subscribing to new blocks, fetching blocks at a given level, or
 # retrieving validators.
@@ -71,7 +82,7 @@ OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317"
 # Sets the OTLP endpoint for trace data. This takes precedence over `OTEL_EXPORTER_OTLP_ENDPOINT` if set.
 OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="http://localhost:4317/v1/traces"
 # The duration in seconds that the OTEL exporter will wait for each batch export.
-OTEL_EXPORTER_OTLP_TRACES_TIMEOUT=10,
+OTEL_EXPORTER_OTLP_TRACES_TIMEOUT=10
 # The compression format to use for exporting. Only `"gzip"` is supported.
 # Don't set the env var if no compression is required.
 OTEL_EXPORTER_OTLP_TRACES_COMPRESSION="gzip"

--- a/crates/astria-conductor/src/config.rs
+++ b/crates/astria-conductor/src/config.rs
@@ -63,6 +63,7 @@ pub struct Config {
 
     /// Forces writing trace data to stdout no matter if connected to a tty or not.
     pub force_stdout: bool,
+
     /// Disables writing trace data to an opentelemetry endpoint.
     pub no_otel: bool,
 
@@ -71,6 +72,9 @@ pub struct Config {
 
     /// The endpoint which will be listened on for serving prometheus metrics
     pub metrics_http_listener_addr: String,
+
+    /// Writes a human readable format to stdout instead of JSON formatted OTEL trace data.
+    pub pretty_print: bool,
 }
 
 impl config::Config for Config {

--- a/crates/astria-conductor/src/config.rs
+++ b/crates/astria-conductor/src/config.rs
@@ -22,7 +22,8 @@ impl CommitLevel {
     }
 }
 
-// this is a config, may have many boolean values
+// Allowed `struct_excessive_bools` because this is used as a container
+// for deserialization. Making this a builder-pattern is not actionable.
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Config {

--- a/crates/astria-conductor/src/main.rs
+++ b/crates/astria-conductor/src/main.rs
@@ -32,6 +32,7 @@ async fn main() -> ExitCode {
     let mut telemetry_conf = telemetry::configure()
         .set_no_otel(cfg.no_otel)
         .set_force_stdout(cfg.force_stdout)
+        .set_pretty_print(cfg.pretty_print)
         .filter_directives(&cfg.log);
 
     if !cfg.no_metrics {

--- a/crates/astria-sequencer-relayer/local.env.example
+++ b/crates/astria-sequencer-relayer/local.env.example
@@ -8,6 +8,17 @@ ASTRIA_SEQUENCER_RELAYER_NO_OTEL=false
 # If false span data is written to stdout only if it is connected to a tty.
 ASTRIA_SEQUENCER_RELAYER_FORCE_STDOUT=false
 
+# If true uses an exceedingly pretty human readable format to write to stdout.
+# If false uses JSON formatted OTEL traces.
+# This does nothing unless stdout is connected to a tty or
+# `ASTRIA_SEQUENCER_RELAYER_FORCE_STDOUT` is set to `true`.
+ASTRIA_SEQUENCER_RELAYER_PRETTY_PRINT=false
+
+# If set to any non-empty value removes ANSI escape characters from the pretty
+# printed output. Note that this does nothing unless
+# `ASTRIA_SEQUENCER_RELAYER_PRETTY_PRINT` is set to `true`.
+NO_COLOR=
+
 # Address of sequencer/cometbft/tendermint to request new blocks.
 # 127.0.0.1:26657 is the default socket address at which cometbft
 # serves RPCs.
@@ -52,7 +63,7 @@ OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317"
 # Sets the OTLP endpoint for trace data. This takes precedence over `OTEL_EXPORTER_OTLP_ENDPOINT` if set.
 OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="http://localhost:4317/v1/traces"
 # The duration in seconds that the OTEL exporter will wait for each batch export.
-OTEL_EXPORTER_OTLP_TRACES_TIMEOUT=10,
+OTEL_EXPORTER_OTLP_TRACES_TIMEOUT=10
 # The compression format to use for exporting. Only `"gzip"` is supported.
 # Don't set the env var if no compression is required.
 OTEL_EXPORTER_OTLP_TRACES_COMPRESSION="gzip"

--- a/crates/astria-sequencer-relayer/src/config.rs
+++ b/crates/astria-sequencer-relayer/src/config.rs
@@ -3,7 +3,8 @@ use serde::{
     Serialize,
 };
 
-// this is a config, may have many boolean values
+// Allowed `struct_excessive_bools` because this is used as a container
+// for deserialization. Making this a builder-pattern is not actionable.
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 /// The single config for creating an astria-sequencer-relayer service.

--- a/crates/astria-sequencer-relayer/src/config.rs
+++ b/crates/astria-sequencer-relayer/src/config.rs
@@ -24,6 +24,8 @@ pub struct Config {
     pub no_metrics: bool,
     /// The endpoint which will be listened on for serving prometheus metrics
     pub metrics_http_listener_addr: String,
+    /// Writes a human readable format to stdout instead of JSON formatted OTEL trace data.
+    pub pretty_print: bool,
 }
 
 impl config::Config for Config {

--- a/crates/astria-sequencer-relayer/src/main.rs
+++ b/crates/astria-sequencer-relayer/src/main.rs
@@ -16,6 +16,7 @@ async fn main() -> ExitCode {
     let mut telemetry_conf = telemetry::configure()
         .set_no_otel(cfg.no_otel)
         .set_force_stdout(cfg.force_stdout)
+        .set_pretty_print(cfg.pretty_print)
         .filter_directives(&cfg.log);
 
     if !cfg.no_metrics {

--- a/crates/astria-sequencer-relayer/tests/blackbox/helper.rs
+++ b/crates/astria-sequencer-relayer/tests/blackbox/helper.rs
@@ -201,6 +201,7 @@ pub async fn spawn_sequencer_relayer(
         no_otel: false,
         no_metrics: false,
         metrics_http_listener_addr: String::new(),
+        pretty_print: true,
     };
 
     info!(config = serde_json::to_string(&config).unwrap());

--- a/crates/astria-sequencer/local.env.example
+++ b/crates/astria-sequencer/local.env.example
@@ -28,6 +28,17 @@ ASTRIA_SEQUENCER_NO_METRICS=true
 # The address at which the prometheus HTTP listener will bind if enabled.
 ASTRIA_SEQUENCER_METRICS_HTTP_LISTENER_ADDR="127.0.0.1:9000"
 
+# If true uses an exceedingly pretty human readable format to write to stdout.
+# If false uses JSON formatted OTEL traces.
+# This does nothing unless stdout is connected to a tty or
+# `ASTRIA_SEQUENCER_FORCE_STDOUT` is set to `true`.
+ASTRIA_SEQUENCER_PRETTY_PRINT=false
+
+# If set to any non-empty value removes ANSI escape characters from the pretty
+# printed output. Note that this does nothing unless `ASTRIA_SEQUENCER_PRETTY_PRINT`
+# is set to `true`.
+NO_COLOR=
+
 # The OTEL specific config options follow the OpenTelemetry Protocol Exporter v1
 # specification as defined here:
 # https://github.com/open-telemetry/opentelemetry-specification/blob/e94af89e3d0c01de30127a0f423e912f6cda7bed/specification/protocol/exporter.md
@@ -37,7 +48,7 @@ OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317"
 # Sets the OTLP endpoint for trace data. This takes precedence over `OTEL_EXPORTER_OTLP_ENDPOINT` if set.
 OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="http://localhost:4317/v1/traces"
 # The duration in seconds that the OTEL exporter will wait for each batch export.
-OTEL_EXPORTER_OTLP_TRACES_TIMEOUT=10,
+OTEL_EXPORTER_OTLP_TRACES_TIMEOUT=10
 # The compression format to use for exporting. Only `"gzip"` is supported.
 # Don't set the env var if no compression is required.
 OTEL_EXPORTER_OTLP_TRACES_COMPRESSION="gzip"

--- a/crates/astria-sequencer/src/config.rs
+++ b/crates/astria-sequencer/src/config.rs
@@ -28,6 +28,8 @@ pub struct Config {
     pub no_metrics: bool,
     /// The endpoint which will be listened on for serving prometheus metrics
     pub metrics_http_listener_addr: String,
+    /// Writes a human readable format to stdout instead of JSON formatted OTEL trace data.
+    pub pretty_print: bool,
 }
 
 impl config::Config for Config {

--- a/crates/astria-sequencer/src/config.rs
+++ b/crates/astria-sequencer/src/config.rs
@@ -5,7 +5,8 @@ use serde::{
     Serialize,
 };
 
-// this is a config, may have many boolean values
+// Allowed `struct_excessive_bools` because this is used as a container
+// for deserialization. Making this a builder-pattern is not actionable.
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Config {

--- a/crates/astria-sequencer/src/main.rs
+++ b/crates/astria-sequencer/src/main.rs
@@ -23,6 +23,7 @@ async fn main() -> ExitCode {
     let mut telemetry_conf = telemetry::configure()
         .set_no_otel(cfg.no_otel)
         .set_force_stdout(cfg.force_stdout)
+        .set_pretty_print(cfg.pretty_print)
         .filter_directives(&cfg.log);
     if !cfg.no_metrics {
         telemetry_conf = telemetry_conf

--- a/crates/astria-telemetry/src/lib.rs
+++ b/crates/astria-telemetry/src/lib.rs
@@ -281,7 +281,7 @@ impl Config {
         let mut pretty_printer = None;
         if force_stdout || std::io::stdout().is_terminal() {
             if pretty_print {
-                pretty_printer = Some(tracing_subscriber::fmt::layer().pretty());
+                pretty_printer = Some(tracing_subscriber::fmt::layer().compact());
             } else {
                 tracer_provider = tracer_provider.with_simple_exporter(
                     SpanExporter::builder()


### PR DESCRIPTION
## Summary
Adds pretty printing to stdout to all services.

## Background
The move to OTEL in https://github.com/astriaorg/astria/pull/727 lead to excessively noisy stdout. While useful as a backup mechanism in deployments, it makes it difficult for humans to read.

## Changes
- add the `pretty_print` and `set_pretty_print` methods to the telemetry builder; if enabled, trace data will be written in a human readable format instead of JSON formatted OTEL traces.
- add the `<service>_PRETTY_PRINT` env var and config to all services taking the values `true` or `false` to enable/disable pretty printing.
- document the new env var and the `NO_COLOR` env var which disables ANSI escape characters from being emitted (makes sharing logs easier)

## Testing
All services were started with the new env var set. The services were emitting pretty-printed formatting.

## Breaking Changelist
- The following env vars must be added to dev cluster as the services will not start without these env vars being present:
    - `ASTRIA_COMPOSER_PRETTY_PRINT`
    - `ASTRIA_CONDUCTOR_PRETTY_PRINT`
    - `ASTRIA_SEQUENCER_PRETTY_PRINT`
    - `ASTRIA_SEQUENCER_RELAYER_PRETTY_PRINT`