### PR TITLE
chore: upgrade metrics to latest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,17 +49,6 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom 0.2.12",
- "once_cell",
- "version_check",
-]
-
-[[package]]
-name = "ahash"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
@@ -503,7 +492,7 @@ dependencies = [
  "celestia-types",
  "hex",
  "jsonrpsee",
- "metrics 0.19.0",
+ "metrics",
  "prost 0.12.3",
  "serde",
  "serde_json",
@@ -772,7 +761,7 @@ dependencies = [
  "humantime",
  "hyper",
  "jsonrpsee",
- "metrics 0.19.0",
+ "metrics",
  "once_cell",
  "prost 0.12.3",
  "rand_core 0.6.4",
@@ -918,15 +907,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d818003e740b63afc82337e3160717f4f63078720a810b7b903e70a5d1d2994"
 dependencies = [
  "bytemuck",
-]
-
-[[package]]
-name = "atomic-shim"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67cd4b51d303cf3501c301e8125df442128d3c6d7c69f71b27833d253de47e77"
-dependencies = [
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -1624,9 +1604,9 @@ dependencies = [
  "ibc-types",
  "ics23",
  "jmt",
- "metrics 0.22.1",
+ "metrics",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot",
  "pin-project",
  "regex",
  "rocksdb",
@@ -2898,7 +2878,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b6e5bc7bd59d60d0d45a6ccab6cf0f4ce28698fb4e81e750ddf229c9b824026"
 dependencies = [
  "atomic",
- "parking_lot 0.12.1",
+ "parking_lot",
  "pear",
  "serde",
  "tempfile",
@@ -2914,7 +2894,7 @@ checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.4.1",
+ "redox_syscall",
  "windows-sys 0.52.0",
 ]
 
@@ -2961,6 +2941,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -3264,15 +3259,6 @@ checksum = "74721d007512d0cb3338cd20f0654ac913920061a4c4d0d8708edb3f2a698c0c"
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-dependencies = [
- "ahash 0.7.8",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
@@ -3283,7 +3269,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.7",
+ "ahash",
 ]
 
 [[package]]
@@ -3292,7 +3278,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
- "ahash 0.8.7",
+ "ahash",
  "allocator-api2",
 ]
 
@@ -3497,6 +3483,19 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -4100,7 +4099,7 @@ dependencies = [
  "futures-util",
  "hyper",
  "jsonrpsee-types",
- "parking_lot 0.12.1",
+ "parking_lot",
  "rand 0.8.5",
  "rustc-hash",
  "serde",
@@ -4330,7 +4329,7 @@ checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
 dependencies = [
  "bitflags 2.4.2",
  "libc",
- "redox_syscall 0.4.1",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -4408,15 +4407,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mach"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "matchers"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4470,36 +4460,27 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142c53885123b68d94108295a09d4afe1a1388ed95b54d5dacd9a454753030f2"
-dependencies = [
- "ahash 0.7.8",
- "metrics-macros",
-]
-
-[[package]]
-name = "metrics"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd71d9db2e4287c3407fa04378b8c2ee570aebe0854431562cdd89ca091854f4"
 dependencies = [
- "ahash 0.8.7",
+ "ahash",
  "portable-atomic",
 ]
 
 [[package]]
 name = "metrics-exporter-prometheus"
-version = "0.10.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953cbbb6f9ba4b9304f4df79b98cdc9d14071ed93065a9fca11c00c5d9181b66"
+checksum = "9bf4e7146e30ad172c42c39b3246864bd2d3c6396780711a1baf749cfe423e21"
 dependencies = [
+ "base64 0.21.7",
  "hyper",
- "indexmap 1.9.3",
+ "hyper-tls",
+ "indexmap 2.2.3",
  "ipnet",
- "metrics 0.19.0",
+ "metrics",
  "metrics-util",
- "parking_lot 0.11.2",
  "quanta",
  "thiserror",
  "tokio",
@@ -4507,29 +4488,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "metrics-macros"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49e30813093f757be5cf21e50389a24dc7dbb22c49f23b7e8f51d69b508a5ffa"
-dependencies = [
- "proc-macro2 1.0.78",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "metrics-util"
-version = "0.13.0"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd1f4b69bef1e2b392b2d4a12902f2af90bb438ba4a66aa222d1023fa6561b50"
+checksum = "ece71ab046dcf45604e573329966ec1db5ff4b81cfa170a924ff4c959ab5451a"
 dependencies = [
- "atomic-shim",
  "crossbeam-epoch",
  "crossbeam-utils",
- "hashbrown 0.11.2",
- "metrics 0.19.0",
+ "hashbrown 0.14.3",
+ "metrics",
  "num_cpus",
- "parking_lot 0.11.2",
  "quanta",
  "sketches-ddsketch",
 ]
@@ -4659,6 +4627,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bddcd3bf5144b6392de80e04c347cd7fab2508f6df16a85fc496ecd5cec39bc"
 dependencies = [
  "rand 0.8.5",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -4867,6 +4853,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl"
+version = "0.10.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c9d69dd87a29568d4d017cfe8ec518706046a05184e5aea92d0af890b803c8"
+dependencies = [
+ "bitflags 2.4.2",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2 1.0.78",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5038,37 +5050,12 @@ checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.6",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.9",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall 0.2.16",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -5079,7 +5066,7 @@ checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.4.1",
+ "redox_syscall",
  "smallvec",
  "windows-targets 0.48.5",
 ]
@@ -5283,7 +5270,7 @@ dependencies = [
  "ibc-proto",
  "ibc-types",
  "ics23",
- "metrics 0.22.1",
+ "metrics",
  "num-traits",
  "once_cell",
  "pbjson-types",
@@ -5432,7 +5419,7 @@ dependencies = [
  "decaf377-rdsa",
  "hex",
  "im",
- "metrics 0.22.1",
+ "metrics",
  "once_cell",
  "penumbra-keys",
  "penumbra-proto",
@@ -5465,7 +5452,7 @@ dependencies = [
  "hex",
  "im",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot",
  "penumbra-proto",
  "poseidon377",
  "rand 0.8.5",
@@ -5983,16 +5970,15 @@ dependencies = [
 
 [[package]]
 name = "quanta"
-version = "0.9.3"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20afe714292d5e879d8b12740aa223c6a88f118af41870e8b6196e39a02238a8"
+checksum = "9ca0b7bac0b97248c40bb77288fc52029cf1459c0461ea1b05ee32ccf011de2c"
 dependencies = [
  "crossbeam-utils",
  "libc",
- "mach",
  "once_cell",
  "raw-cpuid",
- "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "web-sys",
  "winapi",
 ]
@@ -6112,11 +6098,11 @@ dependencies = [
 
 [[package]]
 name = "raw-cpuid"
-version = "10.7.0"
+version = "11.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
+checksum = "9d86a7c4638d42c44551f4791a20e687dbb4c3de1f33c43dd71e355cd429def1"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.2",
 ]
 
 [[package]]
@@ -6137,15 +6123,6 @@ checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -7018,9 +6995,9 @@ dependencies = [
 
 [[package]]
 name = "sketches-ddsketch"
-version = "0.1.3"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04d2ecae5fcf33b122e2e6bd520a57ccf152d2dde3b38c71039df1a6867264ee"
+checksum = "85636c14b73d81f541e525f585c0a2109e6744e1565b5c1668e31c70c10ed65c"
 
 [[package]]
 name = "slab"
@@ -7113,7 +7090,7 @@ checksum = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
 dependencies = [
  "new_debug_unreachable",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot",
  "phf_shared 0.10.0",
  "precomputed-hash",
 ]
@@ -7568,7 +7545,7 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
- "parking_lot 0.12.1",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -7596,6 +7573,16 @@ dependencies = [
  "proc-macro2 1.0.78",
  "quote",
  "syn 2.0.48",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -8327,12 +8314,6 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,8 +66,7 @@ once_cell = "1.17.1"
 sha2 = "0.10"
 serde = "1"
 serde_json = "1"
-# TODO (https://github.com/astriaorg/astria/issues/748): Update when dependencies don't clash
-metrics = "0.19.0"
+metrics = "0.22.1"
 # Note that when updating the penumbra versions, vendored types in `proto/sequencerapis/astria_vendored` may need to be updated as well.
 penumbra-ibc = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.66.0", default-features = false }
 penumbra-proto = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.66.0" }

--- a/crates/astria-celestia-client/src/client.rs
+++ b/crates/astria-celestia-client/src/client.rs
@@ -203,10 +203,7 @@ pub trait CelestiaClientExt: BlobClient {
         // the number of blobs should always be low enough to not cause precision loss
         #[allow(clippy::cast_precision_loss)]
         let metric_rollup_count = num_of_rollup_blobs as f64;
-        metrics::gauge!(
-            metrics_init::ROLLUP_BLOBS_PER_CELESTIA_TX,
-            metric_rollup_count
-        );
+        metrics::gauge!(metrics_init::ROLLUP_BLOBS_PER_CELESTIA_TX).set(metric_rollup_count);
 
         let mut all_blobs = Vec::with_capacity(num_expected_blobs);
         for (i, block) in blocks.into_iter().enumerate() {
@@ -257,10 +254,7 @@ fn assemble_blobs_from_sequencer_block(
     // the number of blobs should always be low enough to not cause precision loss
     #[allow(clippy::cast_precision_loss)]
     let rollup_blobs_count = rollup_blobs.len() as f64;
-    metrics::gauge!(
-        metrics_init::ROLLUP_BLOBS_PER_ASTRIA_BLOCK,
-        rollup_blobs_count
-    );
+    metrics::gauge!(metrics_init::ROLLUP_BLOBS_PER_ASTRIA_BLOCK).set(rollup_blobs_count);
 
     let mut blobs = Vec::with_capacity(rollup_blobs.len() + 1);
 

--- a/crates/astria-celestia-client/src/metrics_init.rs
+++ b/crates/astria-celestia-client/src/metrics_init.rs
@@ -4,20 +4,20 @@
 
 use metrics::{
     describe_gauge,
-    register_gauge,
+    gauge,
     Unit,
 };
 
 /// Registers all metrics used by this crate.
 pub fn register() {
-    register_gauge!(ROLLUP_BLOBS_PER_ASTRIA_BLOCK, "lib" => env!("CARGO_CRATE_NAME"));
+    gauge!(ROLLUP_BLOBS_PER_ASTRIA_BLOCK, "lib" => env!("CARGO_CRATE_NAME"));
     describe_gauge!(
         ROLLUP_BLOBS_PER_ASTRIA_BLOCK,
         Unit::Count,
         "The number of rollup blobs generated from a single astria sequencer block"
     );
 
-    register_gauge!(ROLLUP_BLOBS_PER_CELESTIA_TX, "lib" => env!("CARGO_CRATE_NAME"));
+    gauge!(ROLLUP_BLOBS_PER_CELESTIA_TX, "lib" => env!("CARGO_CRATE_NAME"));
     describe_gauge!(
         ROLLUP_BLOBS_PER_CELESTIA_TX,
         Unit::Count,

--- a/crates/astria-sequencer-relayer/src/metrics_init.rs
+++ b/crates/astria-sequencer-relayer/src/metrics_init.rs
@@ -6,9 +6,6 @@ use metrics::{
     describe_counter,
     describe_gauge,
     describe_histogram,
-    register_counter,
-    register_gauge,
-    register_histogram,
     Unit,
 };
 
@@ -16,35 +13,30 @@ use metrics::{
 pub fn register() {
     celestia_client::metrics_init::register();
 
-    register_counter!(CELESTIA_SUBMISSION_HEIGHT);
     describe_counter!(
         CELESTIA_SUBMISSION_HEIGHT,
         Unit::Count,
         "The height of the last blob submitted to Celestia"
     );
 
-    register_counter!(CELESTIA_SUBMISSION_COUNT);
     describe_counter!(
         CELESTIA_SUBMISSION_COUNT,
         Unit::Count,
         "The number of calls made to submit to celestia"
     );
 
-    register_counter!(CELESTIA_SUBMISSION_COUNT);
     describe_counter!(
         CELESTIA_SUBMISSION_COUNT,
         Unit::Count,
         "The number of calls made to submit to celestia which have failed"
     );
 
-    register_gauge!(BLOCKS_PER_CELESTIA_TX);
     describe_gauge!(
         BLOCKS_PER_CELESTIA_TX,
         Unit::Count,
         "The number of astria blocks included in the last Celestia submission"
     );
 
-    register_histogram!(CELESTIA_SUBMISSION_LATENCY);
     describe_histogram!(
         CELESTIA_SUBMISSION_LATENCY,
         Unit::Seconds,

--- a/crates/astria-sequencer-relayer/src/relayer.rs
+++ b/crates/astria-sequencer-relayer/src/relayer.rs
@@ -167,7 +167,7 @@ impl Relayer {
         // Then report update the internal state or report if submission failed
         match submission_result {
             Ok(height) => self.state_tx.send_modify(|state| {
-                metrics::absolute_counter!(metrics_init::CELESTIA_SUBMISSION_HEIGHT, height);
+                metrics::counter!(metrics_init::CELESTIA_SUBMISSION_HEIGHT).absolute(height);
                 debug!(
                     celestia_height=%height,
                     "successfully submitted blocks to data availability layer"
@@ -175,7 +175,7 @@ impl Relayer {
                 state.current_data_availability_height.replace(height);
             }),
             Err(e) => {
-                metrics::increment_counter!(metrics_init::CELESTIA_SUBMISSION_FAILURE_COUNT);
+                metrics::counter!(metrics_init::CELESTIA_SUBMISSION_FAILURE_COUNT).increment(1);
                 warn!(
                     error = AsRef::<dyn std::error::Error>::as_ref(&e),
                     "failed submitting blocks to celestia",
@@ -401,13 +401,13 @@ async fn submit_blocks_to_celestia(
     // the number of blocks should always be low enough to not cause precision loss
     #[allow(clippy::cast_precision_loss)]
     let blocks_per_celestia_tx = sequencer_blocks.len() as f64;
-    metrics::gauge!(metrics_init::BLOCKS_PER_CELESTIA_TX, blocks_per_celestia_tx);
+    metrics::gauge!(metrics_init::BLOCKS_PER_CELESTIA_TX).set(blocks_per_celestia_tx);
 
     info!(
         num_blocks = sequencer_blocks.len(),
         "submitting collected sequencer blocks to data availability layer",
     );
-    metrics::increment_counter!(metrics_init::CELESTIA_SUBMISSION_COUNT);
+    metrics::counter!(metrics_init::CELESTIA_SUBMISSION_COUNT).increment(1);
     let height = client
         .submit_sequencer_blocks(
             sequencer_blocks,
@@ -418,6 +418,6 @@ async fn submit_blocks_to_celestia(
         )
         .await
         .wrap_err("failed submitting sequencer blocks to celestia")?;
-    metrics::histogram!(metrics_init::CELESTIA_SUBMISSION_LATENCY, start.elapsed());
+    metrics::histogram!(metrics_init::CELESTIA_SUBMISSION_LATENCY).record(start.elapsed());
     Ok(height)
 }

--- a/crates/astria-telemetry/Cargo.toml
+++ b/crates/astria-telemetry/Cargo.toml
@@ -9,8 +9,7 @@ rust-version = "1.70.0"
 [dependencies]
 base64 = { workspace = true, optional = true }
 
-# TODO (https://github.com/astriaorg/astria/issues/748): Update when dependencies don't clash
-metrics-exporter-prometheus = "0.10.0"
+metrics-exporter-prometheus = "0.13.1"
 # When updating ensure that `opentelemetry-semantic-conventions` matches
 # that used by `opentelemetry-otlp`.
 opentelemetry = "0.21.0"


### PR DESCRIPTION
## Summary
Upgraded the metrics + exporter crates to latest versions.

## Background
Previous version of metrics crate had dependency restrictions which were in conflict with cnidarium. This has been fixed.

## Changes
- upgrade to metrics 0.22.1
- upgrade metrics-prometheus-exporter to 0.13.1
- update metrics usages to work with newest releases.

## Related Issues
closes https://github.com/astriaorg/astria/issues/748
