### PR TITLE
feat(sequencer): implement ability to update fee assets using sudo key

### DIFF
--- a/crates/astria-core/src/generated/astria.sequencer.v1alpha1.rs
+++ b/crates/astria-core/src/generated/astria.sequencer.v1alpha1.rs
@@ -399,3 +399,24 @@ pub mod ibc_relayer_change_action {
         Removal(::prost::alloc::vec::Vec<u8>),
     }
 }
+/// `FeeAssetChangeAction` represents a transaction that adds
+/// or removes an asset for fee payments.
+/// The bytes contained in each variant are the 32-byte asset ID
+/// to add or remove.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FeeAssetChangeAction {
+    #[prost(oneof = "fee_asset_change_action::Value", tags = "1, 2")]
+    pub value: ::core::option::Option<fee_asset_change_action::Value>,
+}
+/// Nested message and enum types in `FeeAssetChangeAction`.
+pub mod fee_asset_change_action {
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Value {
+        #[prost(bytes, tag = "1")]
+        Addition(::prost::alloc::vec::Vec<u8>),
+        #[prost(bytes, tag = "2")]
+        Removal(::prost::alloc::vec::Vec<u8>),
+    }
+}

--- a/crates/astria-core/src/generated/astria.sequencer.v1alpha1.rs
+++ b/crates/astria-core/src/generated/astria.sequencer.v1alpha1.rs
@@ -258,7 +258,7 @@ pub struct UnsignedTransaction {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Action {
-    #[prost(oneof = "action::Value", tags = "1, 2, 3, 4, 5, 6, 7, 8")]
+    #[prost(oneof = "action::Value", tags = "1, 2, 3, 4, 5, 6, 7, 8, 9")]
     pub value: ::core::option::Option<action::Value>,
 }
 /// Nested message and enum types in `Action`.
@@ -282,6 +282,8 @@ pub mod action {
         Ics20Withdrawal(super::Ics20Withdrawal),
         #[prost(message, tag = "8")]
         IbcRelayerChangeAction(super::IbcRelayerChangeAction),
+        #[prost(message, tag = "9")]
+        FeeAssetChangeAction(super::FeeAssetChangeAction),
     }
 }
 /// `TransferAction` represents a value transfer transaction.

--- a/crates/astria-core/src/sequencer/v1alpha1/transaction/action.rs
+++ b/crates/astria-core/src/sequencer/v1alpha1/transaction/action.rs
@@ -33,6 +33,7 @@ pub enum Action {
     Ibc(IbcRelay),
     Ics20Withdrawal(Ics20Withdrawal),
     IbcRelayerChange(IbcRelayerChangeAction),
+    FeeAssetChange(FeeAssetChangeAction),
 }
 
 impl Action {
@@ -48,6 +49,7 @@ impl Action {
             Action::Ibc(act) => Value::IbcAction(act.into()),
             Action::Ics20Withdrawal(act) => Value::Ics20Withdrawal(act.into_raw()),
             Action::IbcRelayerChange(act) => Value::IbcRelayerChangeAction(act.into_raw()),
+            Action::FeeAssetChange(act) => Value::FeeAssetChangeAction(act.into_raw()),
         };
         raw::Action {
             value: Some(kind),
@@ -68,6 +70,7 @@ impl Action {
             Action::Ibc(act) => Value::IbcAction(act.clone().into()),
             Action::Ics20Withdrawal(act) => Value::Ics20Withdrawal(act.to_raw()),
             Action::IbcRelayerChange(act) => Value::IbcRelayerChangeAction(act.to_raw()),
+            Action::FeeAssetChange(act) => Value::FeeAssetChangeAction(act.to_raw()),
         };
         raw::Action {
             value: Some(kind),
@@ -114,6 +117,9 @@ impl Action {
             Value::IbcRelayerChangeAction(act) => Self::IbcRelayerChange(
                 IbcRelayerChangeAction::try_from_raw(&act)
                     .map_err(ActionError::ibc_relayer_change)?,
+            ),
+            Value::FeeAssetChangeAction(act) => Self::FeeAssetChange(
+                FeeAssetChangeAction::try_from_raw(&act).map_err(ActionError::fee_asset_change)?,
             ),
         };
         Ok(action)
@@ -178,6 +184,12 @@ impl From<IbcRelayerChangeAction> for Action {
     }
 }
 
+impl From<FeeAssetChangeAction> for Action {
+    fn from(value: FeeAssetChangeAction) -> Self {
+        Self::FeeAssetChange(value)
+    }
+}
+
 #[allow(clippy::module_name_repetitions)]
 #[derive(Debug, thiserror::Error)]
 #[error(transparent)]
@@ -219,6 +231,10 @@ impl ActionError {
     fn ibc_relayer_change(inner: IbcRelayerChangeActionError) -> Self {
         Self(ActionErrorKind::IbcRelayerChange(inner))
     }
+
+    fn fee_asset_change(inner: FeeAssetChangeActionError) -> Self {
+        Self(ActionErrorKind::FeeAssetChange(inner))
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -241,6 +257,8 @@ enum ActionErrorKind {
     Ics20Withdrawal(#[source] Ics20WithdrawalError),
     #[error("ibc relayer change action was not valid")]
     IbcRelayerChange(#[source] IbcRelayerChangeActionError),
+    #[error("fee asset change action was not valid")]
+    FeeAssetChange(#[source] FeeAssetChangeActionError),
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/astria-sequencer/src/fee_asset_change.rs
+++ b/crates/astria-sequencer/src/fee_asset_change.rs
@@ -1,4 +1,5 @@
 use anyhow::{
+    bail,
     ensure,
     Context as _,
     Result,
@@ -15,7 +16,10 @@ use cnidarium::{
 
 use crate::{
     authority::state_ext::StateReadExt as _,
-    state_ext::StateWriteExt as _,
+    state_ext::{
+        StateReadExt as _,
+        StateWriteExt as _,
+    },
     transaction::action_handler::ActionHandler,
 };
 
@@ -40,6 +44,10 @@ impl ActionHandler for FeeAssetChangeAction {
             }
             FeeAssetChangeAction::Removal(asset) => {
                 state.delete_allowed_fee_asset(*asset);
+
+                if state.get_allowed_fee_assets().await?.is_empty() {
+                    bail!("cannot remove last allowed fee asset");
+                }
             }
         }
         Ok(())

--- a/crates/astria-sequencer/src/fee_asset_change.rs
+++ b/crates/astria-sequencer/src/fee_asset_change.rs
@@ -1,0 +1,47 @@
+use anyhow::{
+    ensure,
+    Context as _,
+    Result,
+};
+use astria_core::sequencer::v1alpha1::{
+    transaction::action::FeeAssetChangeAction,
+    Address,
+};
+use async_trait::async_trait;
+use cnidarium::{
+    StateRead,
+    StateWrite,
+};
+
+use crate::{
+    authority::state_ext::StateReadExt as _,
+    state_ext::StateWriteExt as _,
+    transaction::action_handler::ActionHandler,
+};
+
+#[async_trait]
+impl ActionHandler for FeeAssetChangeAction {
+    async fn check_stateful<S: StateRead + 'static>(&self, state: &S, from: Address) -> Result<()> {
+        let authority_sudo_address = state
+            .get_sudo_address()
+            .await
+            .context("failed to get authority sudo address")?;
+        ensure!(
+            authority_sudo_address == from,
+            "unauthorized address for fee asset change"
+        );
+        Ok(())
+    }
+
+    async fn execute<S: StateWrite>(&self, state: &mut S, _from: Address) -> Result<()> {
+        match self {
+            FeeAssetChangeAction::Addition(asset) => {
+                state.put_allowed_fee_asset(*asset);
+            }
+            FeeAssetChangeAction::Removal(asset) => {
+                state.delete_allowed_fee_asset(*asset);
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/astria-sequencer/src/lib.rs
+++ b/crates/astria-sequencer/src/lib.rs
@@ -4,6 +4,7 @@ pub(crate) mod asset;
 pub(crate) mod authority;
 pub(crate) mod component;
 pub mod config;
+pub(crate) mod fee_asset_change;
 pub(crate) mod genesis;
 pub(crate) mod host_interface;
 #[cfg(feature = "mint")]

--- a/crates/astria-sequencer/src/state_ext.rs
+++ b/crates/astria-sequencer/src/state_ext.rs
@@ -214,6 +214,11 @@ pub(crate) trait StateWriteExt: StateWrite {
     fn put_allowed_fee_asset(&mut self, asset: asset::Id) {
         self.nonverifiable_put_raw(fee_asset_key(asset), vec![]);
     }
+
+    #[instrument(skip(self))]
+    fn delete_allowed_fee_asset(&mut self, asset: asset::Id) {
+        self.nonverifiable_delete(fee_asset_key(asset));
+    }
 }
 
 impl<T: StateWrite> StateWriteExt for T {}

--- a/crates/astria-sequencer/src/transaction/mod.rs
+++ b/crates/astria-sequencer/src/transaction/mod.rs
@@ -124,6 +124,10 @@ impl ActionHandler for UnsignedTransaction {
                     .check_stateless()
                     .await
                     .context("stateless check failed for IbcRelayerChangeAction")?,
+                Action::FeeAssetChange(act) => act
+                    .check_stateless()
+                    .await
+                    .context("stateless check failed for FeeAssetChangeAction")?,
                 #[cfg(feature = "mint")]
                 Action::Mint(act) => act
                     .check_stateless()
@@ -181,6 +185,10 @@ impl ActionHandler for UnsignedTransaction {
                     .check_stateful(state, from)
                     .await
                     .context("stateful check failed for IbcRelayerChangeAction")?,
+                Action::FeeAssetChange(act) => act
+                    .check_stateful(state, from)
+                    .await
+                    .context("stateful check failed for FeeAssetChangeAction")?,
                 #[cfg(feature = "mint")]
                 Action::Mint(act) => act
                     .check_stateful(state, from)
@@ -254,6 +262,11 @@ impl ActionHandler for UnsignedTransaction {
                     act.execute(state, from)
                         .await
                         .context("execution failed for IbcRelayerChangeAction")?;
+                }
+                Action::FeeAssetChange(act) => {
+                    act.execute(state, from)
+                        .await
+                        .context("execution failed for FeeAssetChangeAction")?;
                 }
                 #[cfg(feature = "mint")]
                 Action::Mint(act) => {

--- a/proto/sequencerapis/astria/sequencer/v1alpha1/transaction.proto
+++ b/proto/sequencerapis/astria/sequencer/v1alpha1/transaction.proto
@@ -117,9 +117,9 @@ message IbcRelayerChangeAction {
   }
 }
 
-// `FeeAssetChangeAction` represents a transaction that adds 
+// `FeeAssetChangeAction` represents a transaction that adds
 // or removes an asset for fee payments.
-// The bytes contained in each variant are the 32-byte asset ID 
+// The bytes contained in each variant are the 32-byte asset ID
 // to add or remove.
 message FeeAssetChangeAction {
   oneof value {

--- a/proto/sequencerapis/astria/sequencer/v1alpha1/transaction.proto
+++ b/proto/sequencerapis/astria/sequencer/v1alpha1/transaction.proto
@@ -34,6 +34,7 @@ message Action {
     astria_vendored.penumbra.core.component.ibc.v1.IbcRelay ibc_action = 6;
     Ics20Withdrawal ics20_withdrawal = 7;
     IbcRelayerChangeAction ibc_relayer_change_action = 8;
+    FeeAssetChangeAction fee_asset_change_action = 9;
   }
 }
 

--- a/proto/sequencerapis/astria/sequencer/v1alpha1/transaction.proto
+++ b/proto/sequencerapis/astria/sequencer/v1alpha1/transaction.proto
@@ -115,3 +115,14 @@ message IbcRelayerChangeAction {
     bytes removal = 2;
   }
 }
+
+// `FeeAssetChangeAction` represents a transaction that adds 
+// or removes an asset for fee payments.
+// The bytes contained in each variant are the 32-byte asset ID 
+// to add or remove.
+message FeeAssetChangeAction {
+  oneof value {
+    bytes addition = 1;
+    bytes removal = 2;
+  }
+}


### PR DESCRIPTION
## Summary
as title says, implement ability to update fee assets using sudo key.

## Background
need to be able to update the assets allowed for fee payment while the chain is running.

## Changes
- add `FeeAssetChangeAction` which represents the addition or deletion of an authorized fee asset
- ensure that at least one asset has to be allowed for fee payment (should we make it impossible to delete the default asset? probably?)

## Testing
unit tests

## Related Issues

closes #731
