### PR TITLE
fix(ci): fixes docker builds

### DIFF
--- a/.github/workflows/reusable-run-checker.yml
+++ b/.github/workflows/reusable-run-checker.yml
@@ -61,6 +61,7 @@ jobs:
               - '.github/workflows/reusable-docker-build.yml'
               - 'containerfiles/**'
               - '.dockerignore'
+              - 'Cargo.lock'
             lint_workflow:
               - '.github/workflows/lint.yml'
             crates:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2943,21 +2943,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3483,19 +3468,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper",
- "native-tls",
- "tokio",
- "tokio-native-tls",
 ]
 
 [[package]]
@@ -4476,7 +4448,6 @@ checksum = "9bf4e7146e30ad172c42c39b3246864bd2d3c6396780711a1baf749cfe423e21"
 dependencies = [
  "base64 0.21.7",
  "hyper",
- "hyper-tls",
  "indexmap 2.2.3",
  "ipnet",
  "metrics",
@@ -4484,7 +4455,6 @@ dependencies = [
  "quanta",
  "thiserror",
  "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -4627,24 +4597,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bddcd3bf5144b6392de80e04c347cd7fab2508f6df16a85fc496ecd5cec39bc"
 dependencies = [
  "rand 0.8.5",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -4850,32 +4802,6 @@ dependencies = [
  "proc-macro2 1.0.78",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "openssl"
-version = "0.10.63"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c9d69dd87a29568d4d017cfe8ec518706046a05184e5aea92d0af890b803c8"
-dependencies = [
- "bitflags 2.4.2",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2 1.0.78",
- "quote",
- "syn 2.0.48",
 ]
 
 [[package]]
@@ -7573,16 +7499,6 @@ dependencies = [
  "proc-macro2 1.0.78",
  "quote",
  "syn 2.0.48",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]

--- a/crates/astria-telemetry/Cargo.toml
+++ b/crates/astria-telemetry/Cargo.toml
@@ -9,7 +9,7 @@ rust-version = "1.70.0"
 [dependencies]
 base64 = { workspace = true, optional = true }
 
-metrics-exporter-prometheus = "0.13.1"
+metrics-exporter-prometheus = { version = "0.13.1", default-features = false, features = ["http-listener"] }
 # When updating ensure that `opentelemetry-semantic-conventions` matches
 # that used by `opentelemetry-otlp`.
 opentelemetry = "0.21.0"

--- a/crates/astria-telemetry/Cargo.toml
+++ b/crates/astria-telemetry/Cargo.toml
@@ -9,7 +9,9 @@ rust-version = "1.70.0"
 [dependencies]
 base64 = { workspace = true, optional = true }
 
-metrics-exporter-prometheus = { version = "0.13.1", default-features = false, features = ["http-listener"] }
+metrics-exporter-prometheus = { version = "0.13.1", default-features = false, features = [
+  "http-listener",
+] }
 # When updating ensure that `opentelemetry-semantic-conventions` matches
 # that used by `opentelemetry-otlp`.
 opentelemetry = "0.21.0"


### PR DESCRIPTION
## Summary
Updates docker builds to run anytime cargo.lock changes to ensure new dependencies and linkages don't break docker, and fixes current issue with docker builds by disabling unused feature in prometheus exporter.

## Background
Docker builds are broken in main, due to a deeply nested openssl dependency.

## Changes
- Only use required features of prometheus exporter
- Update to run docker builds during PR anytime Cargo.lock changes.

## Testing
Docker build CI
