### PR TITLE
fix(conductor): try adding path, scheme to Celestia RPC URL

### DIFF
--- a/crates/astria-conductor/src/celestia/builder.rs
+++ b/crates/astria-conductor/src/celestia/builder.rs
@@ -335,9 +335,9 @@ impl FromStr for Endpoints {
             .wrap_err("failed to parse as URI")?;
         let is_tls = matches!(uri.scheme().map(Scheme::as_str), Some("https" | "wss"));
 
-        let http = make_uri(uri.clone(), EndpointKind::Http, is_tls)
+        let http = make_uri(&uri, EndpointKind::Http, is_tls)
             .wrap_err("failed constructing http endpoint from parsed URI")?;
-        let websocket = make_uri(uri.clone(), EndpointKind::Ws, is_tls)
+        let websocket = make_uri(&uri, EndpointKind::Ws, is_tls)
             .wrap_err("failed constructing websocket endpoint parsed URI")?;
 
         Ok(Self {
@@ -352,7 +352,7 @@ enum EndpointKind {
     Ws,
 }
 
-fn make_uri(uri: Uri, kind: EndpointKind, tls: bool) -> Result<Uri, http::uri::InvalidUriParts> {
+fn make_uri(uri: &Uri, kind: EndpointKind, tls: bool) -> Result<Uri, http::uri::InvalidUriParts> {
     let mut parts = uri.clone().into_parts();
     let scheme = match (kind, tls) {
         (EndpointKind::Http, true) => Scheme::HTTPS,


### PR DESCRIPTION
## Summary
If missing, adds a dummy scheme and/or empty path, to the provided celestia RPC URI if missing.

## Background
Conductor fails when trying to construct Celestia endpoints from URIs like `astria.org` (set via the env var `ASTRIA_CONDUCTOR_CELESTIA_NODE_URL`) that contain only an authority but no scheme nor path with errors like this:
```
2024-02-16T16:21:08.212985Z ERROR astria_conductor: failed initializing conductor error=failed constructing data availability reader error.sources=[failed constructing websocket endpoint from provided celestia endpoint URL, path missing]
```

On the other hand, the following strings would work: `http://astria.org`, `http://astria.org/` or `wss://astria.org/` (notice that the first input lacks both scheme and path, and the latter are trailed by a `/` "path").

## Changes
- Set `/` as the URI path if missing.
- Set URI scheme if missing
- Provide tests to check various input scenarios

## Testing
Provided new tests. Ran conductor in dev cluster with a value for `ASTRIA_CONDUCTOR_CELESTIA_NODE_URL` that was previously broken and now works.