### PR TITLE
fix(conductor): keep wsclient alive

### DIFF
--- a/crates/astria-conductor/src/celestia/mod.rs
+++ b/crates/astria-conductor/src/celestia/mod.rs
@@ -159,8 +159,6 @@ impl Reader {
                 .await
                 .wrap_err("failed to subscribe to celestia headers")?;
 
-        info!("subscribed to celestia headers, in theory");
-
         let latest_celestia_height = match headers.next().await {
             Some(Ok(header)) => header.height(),
             Some(Err(e)) => {
@@ -594,7 +592,6 @@ async fn subscribe_to_celestia_headers(
                 futures::future::ready(())
             },
         );
-
 
     tryhard::retry_fn(|| async move {
         let client = connect(endpoint, token)


### PR DESCRIPTION
## Summary
Updates to keep the client alive so that the subscription is kept alive.

## Background
Websocket connection was terminated after retry return, causing subscription to fail.

## Changes
- Return both subscription + client when subscribing to celestia headers.

## Testing
Built and manually run in dev-cluster
