### PR TITLE
fix(ci): build composer, and allow builds on old tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,12 @@ name: Build Binaries
 on:
   # TODO: allow workflow dispatch to specify which binaries to build
   workflow_dispatch:
+    inputs:
+      ref:
+        description: |
+          Fully qualified git ref which will be checked out and built. Defaults to using the branch workflow is run on.
+          Example: refs/tags/sequencer-v0.8.0 will then only build sequencer code at that tag.
+        required: false
   push:
     tags:
       - "**-v[0-9]+.[0-9]+.[0-9]+"
@@ -10,31 +16,35 @@ on:
       - "**-v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+"
 
 jobs:
-  # TODO: Make generic and run on any tagged release
   cli:
     uses: './.github/workflows/reusable-build.yml'
     with:
       package-name: 'cli'
+      git-ref: ${{ inputs.ref || github.ref }}
 
   conductor:
     uses: './.github/workflows/reusable-build.yml'
     with:
       package-name: 'conductor'
+      git-ref: ${{ inputs.ref || github.ref }}
   
   composer:
     uses: './.github/workflows/reusable-build.yml'
     with:
-      package-name: 'conductor'
+      package-name: 'composer'
+      git-ref: ${{ inputs.ref || github.ref }}
 
   sequencer:
     uses: './.github/workflows/reusable-build.yml'
     with:
       package-name: 'sequencer'
+      git-ref: ${{ inputs.ref || github.ref }}
 
   relayer:
     uses: './.github/workflows/reusable-build.yml'
     with:
       package-name: 'sequencer-relayer'
+      git-ref: ${{ inputs.ref || github.ref }}
 
   build:
     if: ${{ always() && !cancelled() }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,10 +3,8 @@ on:
   # TODO: allow workflow dispatch to specify which binaries to build
   workflow_dispatch:
     inputs:
-      ref:
-        description: |
-          Fully qualified git ref which will be checked out and built. Defaults to using the branch workflow is run on.
-          Example: refs/tags/sequencer-v0.8.0 will then only build sequencer code at that tag.
+      tag:
+        description: Git branch, or tag to build from
         required: false
   push:
     tags:
@@ -20,31 +18,31 @@ jobs:
     uses: './.github/workflows/reusable-build.yml'
     with:
       package-name: 'cli'
-      git-ref: ${{ inputs.ref || github.ref }}
+      tag: ${{ inputs.tag }}
 
   conductor:
     uses: './.github/workflows/reusable-build.yml'
     with:
       package-name: 'conductor'
-      git-ref: ${{ inputs.ref || github.ref }}
+      tag: ${{ inputs.tag }}
   
   composer:
     uses: './.github/workflows/reusable-build.yml'
     with:
       package-name: 'composer'
-      git-ref: ${{ inputs.ref || github.ref }}
+      tag: ${{ inputs.tag }}
 
   sequencer:
     uses: './.github/workflows/reusable-build.yml'
     with:
       package-name: 'sequencer'
-      git-ref: ${{ inputs.ref || github.ref }}
+      tag: ${{ inputs.tag }}
 
   relayer:
     uses: './.github/workflows/reusable-build.yml'
     with:
       package-name: 'sequencer-relayer'
-      git-ref: ${{ inputs.ref || github.ref }}
+      tag: ${{ inputs.tag }}
 
   build:
     if: ${{ always() && !cancelled() }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,10 +4,8 @@ name: Docker
 on:
   workflow_dispatch:
     inputs:
-      ref:
-        description: |
-          Fully qualified git ref which will be checked out and built. Defaults to using the branch workflow is run on.
-          Example: refs/tags/sequencer-v0.8.0 will then only build sequencer code at that tag.
+      tag:
+        description: Git branch, or tag to build from.
         required: false
   push:
     branches:
@@ -38,7 +36,7 @@ jobs:
     with:
       package-name: composer
       target-binary: astria-composer
-      git-ref: ${{ inputs.ref || github.ref }}
+      tag: ${{ inputs.tag }}
     secrets: inherit
 
   conductor:
@@ -48,7 +46,7 @@ jobs:
     with:
       package-name: conductor
       target-binary: astria-conductor
-      git-ref: ${{ inputs.ref || github.ref }}
+      tag: ${{ inputs.tag }}
     secrets: inherit
 
   sequencer:
@@ -58,7 +56,7 @@ jobs:
     with:
       package-name: sequencer
       target-binary: astria-sequencer
-      git-ref: ${{ inputs.ref || github.ref }}
+      tag: ${{ inputs.tag }}
     secrets: inherit
 
   sequencer-relayer:
@@ -68,7 +66,7 @@ jobs:
     with:
       package-name: sequencer-relayer
       target-binary: astria-sequencer-relayer
-      git-ref: ${{ inputs.ref || github.ref }}
+      tag: ${{ inputs.tag }}
     secrets: inherit
 
   docker:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -3,6 +3,12 @@ name: Docker
 # Trigger on pushes to master branch, new semantic version tags, and pull request updates
 on:
   workflow_dispatch:
+    inputs:
+      ref:
+        description: |
+          Fully qualified git ref which will be checked out and built. Defaults to using the branch workflow is run on.
+          Example: refs/tags/sequencer-v0.8.0 will then only build sequencer code at that tag.
+        required: false
   push:
     branches:
       - "main"
@@ -32,6 +38,7 @@ jobs:
     with:
       package-name: composer
       target-binary: astria-composer
+      git-ref: ${{ inputs.ref || github.ref }}
     secrets: inherit
 
   conductor:
@@ -41,6 +48,7 @@ jobs:
     with:
       package-name: conductor
       target-binary: astria-conductor
+      git-ref: ${{ inputs.ref || github.ref }}
     secrets: inherit
 
   sequencer:
@@ -50,6 +58,7 @@ jobs:
     with:
       package-name: sequencer
       target-binary: astria-sequencer
+      git-ref: ${{ inputs.ref || github.ref }}
     secrets: inherit
 
   sequencer-relayer:
@@ -59,6 +68,7 @@ jobs:
     with:
       package-name: sequencer-relayer
       target-binary: astria-sequencer-relayer
+      git-ref: ${{ inputs.ref || github.ref }}
     secrets: inherit
 
   docker:

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -6,13 +6,16 @@ on:
       package-name:
         required: true
         type: string
+      git-ref:
+        required: true
+        type: string
 
 env:
   REGISTRY: ghcr.io
 
 jobs:
   upload-binaries:
-    if: startsWith(github.ref, format('refs/tags/{0}-v', inputs.package-name)) || github.event_name == 'workflow_dispatch'
+    if: startsWith(inputs.git-ref, format('refs/tags/{0}-v', inputs.package-name)) || github.event_name == 'workflow_dispatch'
     strategy:
       matrix:
         include:
@@ -28,6 +31,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.git-ref }}
       - uses: dtolnay/rust-toolchain@1.76.0
       - uses: arduino/setup-protoc@v2
         with:
@@ -35,8 +40,9 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: taiki-e/upload-rust-binary-action@v1
         with:
+          ref: ${{ inputs.git-ref }}
           bin: astria-${{ inputs.package-name }}
-          dry-run: ${{ !startsWith(github.ref, format('refs/tags/{0}-v', inputs.package-name)) }}
+          dry-run: ${{ !startsWith(inputs.git-ref, format('refs/tags/{0}-v', inputs.package-name)) }}
           # (optional) Target triple, default is host triple.
           target: ${{ matrix.target }}
           # (optional) Tool to build binaries (cargo, cross, or cargo-zigbuild)

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -6,16 +6,17 @@ on:
       package-name:
         required: true
         type: string
-      git-ref:
-        required: true
+      tag:
+        required: false
         type: string
 
 env:
   REGISTRY: ghcr.io
+  FULL_REF: ${{ inputs.tag && format('refs/tags/{0}', inputs.tag) || github.ref }}
 
 jobs:
   upload-binaries:
-    if: startsWith(inputs.git-ref, format('refs/tags/{0}-v', inputs.package-name)) || github.event_name == 'workflow_dispatch'
+    if: startsWith(github.ref, format('refs/tags/{0}-v', inputs.package-name)) || !inputs.tag && github.event_name == 'workflow_dispatch' || startsWith(inputs.tag, inputs.package-name)
     strategy:
       matrix:
         include:
@@ -32,7 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.git-ref }}
+          ref: ${{ inputs.tag }}
       - uses: dtolnay/rust-toolchain@1.76.0
       - uses: arduino/setup-protoc@v2
         with:
@@ -40,9 +41,9 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: taiki-e/upload-rust-binary-action@v1
         with:
-          ref: ${{ inputs.git-ref }}
+          ref: ${{ env.FULL_REF }}
           bin: astria-${{ inputs.package-name }}
-          dry-run: ${{ !startsWith(inputs.git-ref, format('refs/tags/{0}-v', inputs.package-name)) }}
+          dry-run: ${{ !startsWith(env.FULL_REF, format('refs/tags/{0}-v', inputs.package-name)) }}
           # (optional) Target triple, default is host triple.
           target: ${{ matrix.target }}
           # (optional) Tool to build binaries (cargo, cross, or cargo-zigbuild)

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -9,6 +9,9 @@ on:
       target-binary:
         required: true
         type: string
+      git-ref:
+        required: true
+        type: string
     secrets:
       DOCKER_TOKEN:
         required: true
@@ -20,10 +23,12 @@ env:
 jobs:
   build-and-push:
     runs-on: buildjet-8vcpu-ubuntu-2204
-    if: ${{ startsWith(github.ref, format('refs/tags/{0}-v', inputs.package-name)) || github.ref == 'refs/heads/main' || github.event_name == 'pull_request' }}
+    if: ${{ startsWith(inputs.git-ref, format('refs/tags/{0}-v', inputs.package-name)) || inputs.git-ref == 'refs/heads/main' || github.event_name == 'pull_request' }}
     steps:
       # Checking out the repo
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.git-ref }}
       # https://github.com/docker/setup-qemu-action
       - name: Login to Docker Hub
         uses: docker/login-action@v2
@@ -50,10 +55,10 @@ jobs:
           images: ${{ format('ghcr.io/astriaorg/{0}', inputs.package-name) }}
           tags: |
             type=ref,event=pr
-            type=match,pattern=([a-z-]+)-v(.*),group=2
+            type=match,pattern=refs/tags/([a-z-]+)-v(.*),group=2,enable=${{ startsWith('refs/tags/', inputs.git-ref) }},value=${{ inputs.git-ref }}
             type=sha
             # set latest tag for `main` branch
-            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=latest,enable=${{ inputs.git-ref == format('refs/heads/{0}', 'main') }}
       - name: Build and push
         uses: docker/build-push-action@v4
         with:

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -9,8 +9,8 @@ on:
       target-binary:
         required: true
         type: string
-      git-ref:
-        required: true
+      tag:
+        required: false
         type: string
     secrets:
       DOCKER_TOKEN:
@@ -19,16 +19,17 @@ on:
         required: true
 env:
   REGISTRY: ghcr.io
+  FULL_REF: ${{ inputs.tag && format('refs/tags/{0}', inputs.tag) || github.ref }}
 
 jobs:
   build-and-push:
     runs-on: buildjet-8vcpu-ubuntu-2204
-    if: ${{ startsWith(inputs.git-ref, format('refs/tags/{0}-v', inputs.package-name)) || inputs.git-ref == 'refs/heads/main' || github.event_name == 'pull_request' }}
+    if: ${{ startsWith(inputs.tag, inputs.package-name) || startsWith(github.ref, format('refs/tags/{0}-v', inputs.package-name)) || github.ref == 'refs/heads/main' || github.ref == 'pull_request' }}
     steps:
       # Checking out the repo
       - uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.git-ref }}
+          ref: ${{ inputs.tag }}
       # https://github.com/docker/setup-qemu-action
       - name: Login to Docker Hub
         uses: docker/login-action@v2
@@ -55,10 +56,10 @@ jobs:
           images: ${{ format('ghcr.io/astriaorg/{0}', inputs.package-name) }}
           tags: |
             type=ref,event=pr
-            type=match,pattern=refs/tags/([a-z-]+)-v(.*),group=2,enable=${{ startsWith('refs/tags/', inputs.git-ref) }},value=${{ inputs.git-ref }}
+            type=match,pattern=refs/tags/([a-z-]+)-v(.*),group=2,enable=${{ startsWith('refs/tags/', env.FULL_REF) }},value=${{ env.FULL_REF }}
             type=sha
             # set latest tag for `main` branch
-            type=raw,value=latest,enable=${{ inputs.git-ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=latest,enable=${{ env.FULL_REF == format('refs/heads/{0}', 'main') }}
       - name: Build and push
         uses: docker/build-push-action@v4
         with:


### PR DESCRIPTION
## Summary
Enables workflow dispatches to build old tags for docker and binaries with newer workflows, fixes the binary to build composer correctly.

## Background
We didn't build composer correctly last release, want to cut on that tag, and want some flexibility when workflow files don't work as intended.

## Changes
- fix binary build
- add ability to docker & binary builds to checkout old refs.

## Testing
Will need to be tested after approval

