### PR TITLE
chore(ci): add metrics to pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,9 @@ Brief background on why these changes were made, ie "why?"
 ## Testing
 How are these changes tested?
 
+## Metrics
+- List out metrics added by PR, delete section if none. 
+
 ## Breaking Changelist
 - Bulleted list of breaking changes, any notes on migration. Delete section if none.
 


### PR DESCRIPTION
## Summary
Update the PR template to list out metrics added.

## Background
We now support adding metrics cleanly in the monorepo and adding them is notable for PRs.

## Changes
- Modify issue template
