### PR TITLE
fix(relayer): add metrics

### DIFF
--- a/crates/astria-sequencer-relayer/src/metrics_init.rs
+++ b/crates/astria-sequencer-relayer/src/metrics_init.rs
@@ -14,27 +14,46 @@ pub fn register() {
     celestia_client::metrics_init::register();
 
     describe_counter!(
-        CELESTIA_SUBMISSION_HEIGHT,
-        Unit::Count,
-        "The height of the last blob submitted to Celestia"
-    );
-
-    describe_counter!(
         CELESTIA_SUBMISSION_COUNT,
         Unit::Count,
         "The number of calls made to submit to celestia"
     );
 
     describe_counter!(
-        CELESTIA_SUBMISSION_COUNT,
+        CELESTIA_SUBMISSION_HEIGHT,
+        Unit::Count,
+        "The height of the last blob submitted to Celestia"
+    );
+
+    describe_counter!(
+        CELESTIA_SUBMISSION_FAILURE_COUNT,
         Unit::Count,
         "The number of calls made to submit to celestia which have failed"
+    );
+
+    describe_counter!(
+        SEQUENCER_BLOCK_FETCH_FAILURE_COUNT,
+        Unit::Count,
+        "The number of calls made to fetch a block from sequencer which have failed"
+    );
+
+    describe_counter!(
+        SEQUENCER_HEIGHT_FETCH_FAILURE_COUNT,
+        Unit::Count,
+        "The number of calls made to fetch the current height from sequencer which have failed"
     );
 
     describe_gauge!(
         BLOCKS_PER_CELESTIA_TX,
         Unit::Count,
-        "The number of astria blocks included in the last Celestia submission"
+        "The number of Astria blocks included in the last Celestia submission"
+    );
+
+    describe_gauge!(
+        BLOBS_PER_CELESTIA_TX,
+        Unit::Count,
+        "The number of blobs (Astria blobs converted to Celestia blobs) included in the last \
+         Celestia submission"
     );
 
     describe_histogram!(
@@ -51,13 +70,29 @@ pub const HISTOGRAM_BUCKETS: &[f64; 5] = &[0.00001, 0.0001, 0.001, 0.01, 0.1];
 
 pub const CELESTIA_SUBMISSION_HEIGHT: &str =
     concat!(env!("CARGO_CRATE_NAME"), "_celestia_submission_height");
+
 pub const CELESTIA_SUBMISSION_COUNT: &str =
     concat!(env!("CARGO_CRATE_NAME"), "_celestia_submission_count");
+
 pub const CELESTIA_SUBMISSION_FAILURE_COUNT: &str = concat!(
     env!("CARGO_CRATE_NAME"),
     "_celestia_submission_failure_count"
 );
+
 pub const BLOCKS_PER_CELESTIA_TX: &str =
     concat!(env!("CARGO_CRATE_NAME"), "_blocks_per_celestia_tx");
+
+pub const BLOBS_PER_CELESTIA_TX: &str = concat!(env!("CARGO_CRATE_NAME"), "_blobs_per_celestia_tx");
+
 pub const CELESTIA_SUBMISSION_LATENCY: &str =
     concat!(env!("CARGO_CRATE_NAME"), "_celestia_submission_latency");
+
+pub const SEQUENCER_BLOCK_FETCH_FAILURE_COUNT: &str = concat!(
+    env!("CARGO_CRATE_NAME"),
+    "_sequencer_block_fetch_failure_count",
+);
+
+pub const SEQUENCER_HEIGHT_FETCH_FAILURE_COUNT: &str = concat!(
+    env!("CARGO_CRATE_NAME"),
+    "_sequencer_height_fetch_failure_count",
+);

--- a/crates/astria-sequencer-relayer/src/relayer/mod.rs
+++ b/crates/astria-sequencer-relayer/src/relayer/mod.rs
@@ -170,6 +170,8 @@ impl Relayer {
                             block_stream.set_latest_sequencer_height(height);
                         }
                         Err(error) => {
+                            metrics::counter!(crate::metrics_init::SEQUENCER_HEIGHT_FETCH_FAILURE_COUNT)
+                                .increment(1);
                             self.state.set_sequencer_connected(false);
                             warn!(
                                 %error,

--- a/crates/astria-sequencer-relayer/src/relayer/read.rs
+++ b/crates/astria-sequencer-relayer/src/relayer/read.rs
@@ -182,6 +182,9 @@ async fn fetch_block(
         .max_delay(block_time)
         .on_retry(
             |attempt: u32, next_delay: Option<Duration>, error: &eyre::Report| {
+                metrics::counter!(crate::metrics_init::SEQUENCER_BLOCK_FETCH_FAILURE_COUNT)
+                    .increment(1);
+
                 let state = Arc::clone(&state);
                 state.set_sequencer_connected(false);
 


### PR DESCRIPTION
## Summary
Adds metrics to relayer.

## Background
Some metrics were not ported when refactoring relayer in https://github.com/astriaorg/astria/pull/769, some other metrics did not make sense where they were.

## Changes
- Add new metrics to relayer
- 
## Metrics

- `astria_sequencer_relayer_blobs_per_celestia_tx`
- `astria_sequencer_relayer_celestia_submission_latency`
- `astria_sequencer_relayer_sequencer_block_fetch_failure_count`
- `astria_sequencer_relayer_sequencer_height_fetch_failure_count`