### PR TITLE
feat(conductor): assert host fulfills execution API contract

### DIFF
--- a/crates/astria-conductor/src/executor/tests.rs
+++ b/crates/astria-conductor/src/executor/tests.rs
@@ -36,7 +36,6 @@ use astria_core::{
 };
 use bytes::Bytes;
 use ethers::{
-    abi::Tokenizable,
     prelude::{
         k256::ecdsa::SigningKey,
         Middleware as _,

--- a/crates/astria-conductor/src/executor/tests.rs
+++ b/crates/astria-conductor/src/executor/tests.rs
@@ -9,17 +9,20 @@ use std::{
 
 use ::optimism::test_utils::deploy_mock_optimism_portal;
 use astria_core::{
+    execution::v1alpha2::{
+        Block,
+        CommitmentState,
+        GenesisInfo,
+    },
     generated::execution::v1alpha2::{
+        self as raw,
         execution_service_server::{
             ExecutionService,
             ExecutionServiceServer,
         },
         BatchGetBlocksRequest,
         BatchGetBlocksResponse,
-        Block,
-        CommitmentState,
         ExecuteBlockRequest,
-        GenesisInfo,
         GetBlockRequest,
         GetCommitmentStateRequest,
         GetGenesisInfoRequest,
@@ -29,9 +32,11 @@ use astria_core::{
         make_cometbft_block,
         ConfigureCometBftBlock,
     },
+    Protobuf,
 };
 use bytes::Bytes;
 use ethers::{
+    abi::Tokenizable,
     prelude::{
         k256::ecdsa::SigningKey,
         Middleware as _,
@@ -89,8 +94,8 @@ impl MockExecutionServer {
     }
 }
 
-fn make_genesis_block() -> Block {
-    Block {
+fn make_genesis_block() -> raw::Block {
+    raw::Block {
         number: 0,
         hash: GENESIS_HASH,
         parent_block_hash: GENESIS_HASH,
@@ -100,8 +105,8 @@ fn make_genesis_block() -> Block {
 
 struct ExecutionServiceImpl {
     hash_to_number: Mutex<HashMap<Bytes, u32>>,
-    commitment_state: Mutex<CommitmentState>,
-    genesis_info: Mutex<GenesisInfo>,
+    commitment_state: Mutex<raw::CommitmentState>,
+    genesis_info: Mutex<raw::GenesisInfo>,
 }
 
 impl ExecutionServiceImpl {
@@ -111,12 +116,12 @@ impl ExecutionServiceImpl {
         hash_to_number.insert(GENESIS_HASH, 0);
         Self {
             hash_to_number: hash_to_number.into(),
-            commitment_state: CommitmentState {
+            commitment_state: raw::CommitmentState {
                 soft: Some(make_genesis_block()),
                 firm: Some(make_genesis_block()),
             }
             .into(),
-            genesis_info: GenesisInfo {
+            genesis_info: raw::GenesisInfo {
                 rollup_id: vec![42u8; 32].into(),
                 sequencer_genesis_block_height: 100,
                 celestia_base_block_height: 1,
@@ -132,14 +137,14 @@ impl ExecutionService for ExecutionServiceImpl {
     async fn get_block(
         &self,
         _request: tonic::Request<GetBlockRequest>,
-    ) -> std::result::Result<tonic::Response<Block>, tonic::Status> {
+    ) -> std::result::Result<tonic::Response<raw::Block>, tonic::Status> {
         unimplemented!("get_block")
     }
 
     async fn get_genesis_info(
         &self,
         _request: tonic::Request<GetGenesisInfoRequest>,
-    ) -> std::result::Result<tonic::Response<GenesisInfo>, tonic::Status> {
+    ) -> std::result::Result<tonic::Response<raw::GenesisInfo>, tonic::Status> {
         Ok(tonic::Response::new(
             self.genesis_info.lock().unwrap().clone(),
         ))
@@ -155,7 +160,7 @@ impl ExecutionService for ExecutionServiceImpl {
     async fn execute_block(
         &self,
         request: tonic::Request<ExecuteBlockRequest>,
-    ) -> std::result::Result<tonic::Response<Block>, tonic::Status> {
+    ) -> std::result::Result<tonic::Response<raw::Block>, tonic::Status> {
         let request = request.into_inner();
         let parent_block_hash: Bytes = request.prev_block_hash.clone();
         let hash = get_expected_execution_hash(&parent_block_hash, &request.transactions);
@@ -167,7 +172,7 @@ impl ExecutionService for ExecutionServiceImpl {
         };
 
         let timestamp = request.timestamp.unwrap_or_default();
-        Ok(tonic::Response::new(Block {
+        Ok(tonic::Response::new(raw::Block {
             number: new_number,
             hash,
             parent_block_hash,
@@ -178,7 +183,7 @@ impl ExecutionService for ExecutionServiceImpl {
     async fn get_commitment_state(
         &self,
         _request: tonic::Request<GetCommitmentStateRequest>,
-    ) -> std::result::Result<tonic::Response<CommitmentState>, tonic::Status> {
+    ) -> std::result::Result<tonic::Response<raw::CommitmentState>, tonic::Status> {
         Ok(tonic::Response::new(
             self.commitment_state.lock().unwrap().clone(),
         ))
@@ -187,7 +192,7 @@ impl ExecutionService for ExecutionServiceImpl {
     async fn update_commitment_state(
         &self,
         request: tonic::Request<UpdateCommitmentStateRequest>,
-    ) -> std::result::Result<tonic::Response<CommitmentState>, tonic::Status> {
+    ) -> std::result::Result<tonic::Response<raw::CommitmentState>, tonic::Status> {
         let new_state = {
             let mut guard = self.commitment_state.lock().unwrap();
             *guard = request.into_inner().commitment_state.unwrap();
@@ -589,4 +594,139 @@ mod optimism_tests {
             mock.executor.state.borrow().firm().hash(),
         );
     }
+}
+
+fn make_block(number: u32) -> raw::Block {
+    raw::Block {
+        number,
+        hash: Bytes::from_static(&[0u8; 32]),
+        parent_block_hash: Bytes::from_static(&[0u8; 32]),
+        timestamp: Some(prost_types::Timestamp {
+            seconds: 0,
+            nanos: 0,
+        }),
+    }
+}
+
+struct MakeState {
+    firm: u32,
+    soft: u32,
+}
+
+fn make_state(
+    MakeState {
+        firm,
+        soft,
+    }: MakeState,
+) -> super::State {
+    let genesis_info = GenesisInfo::try_from_raw(raw::GenesisInfo {
+        rollup_id: Bytes::from_static(&[0u8; 32]),
+        sequencer_genesis_block_height: 1,
+        celestia_base_block_height: 1,
+        celestia_block_variance: 1,
+    })
+    .unwrap();
+    let commitment_state = CommitmentState::try_from_raw(raw::CommitmentState {
+        firm: Some(make_block(firm)),
+        soft: Some(make_block(soft)),
+    })
+    .unwrap();
+    let mut state = super::State::new();
+    state.init(genesis_info, commitment_state);
+    state
+}
+
+#[track_caller]
+fn assert_contract_fulfilled(kind: super::ExecutionKind, state: MakeState, number: u32) {
+    let block = Block::try_from_raw(make_block(number)).unwrap();
+    let state = make_state(state);
+    super::does_block_response_fulfill_contract(kind, &state, &block)
+        .expect("number stored in response block must be one more than in tracked state");
+}
+
+#[track_caller]
+fn assert_contract_violated(kind: super::ExecutionKind, state: MakeState, number: u32) {
+    let block = Block::try_from_raw(make_block(number)).unwrap();
+    let state = make_state(state);
+    super::does_block_response_fulfill_contract(kind, &state, &block)
+        .expect_err("number stored in response block must not be one more than in tracked state");
+}
+
+#[test]
+fn foo() {
+    use super::ExecutionKind::{
+        Firm,
+        Soft,
+    };
+    assert_contract_fulfilled(
+        Firm,
+        MakeState {
+            firm: 2,
+            soft: 3,
+        },
+        3,
+    );
+
+    assert_contract_fulfilled(
+        Soft,
+        MakeState {
+            firm: 2,
+            soft: 3,
+        },
+        4,
+    );
+
+    assert_contract_violated(
+        Firm,
+        MakeState {
+            firm: 2,
+            soft: 3,
+        },
+        1,
+    );
+
+    assert_contract_violated(
+        Firm,
+        MakeState {
+            firm: 2,
+            soft: 3,
+        },
+        2,
+    );
+
+    assert_contract_violated(
+        Firm,
+        MakeState {
+            firm: 2,
+            soft: 3,
+        },
+        4,
+    );
+
+    assert_contract_violated(
+        Soft,
+        MakeState {
+            firm: 2,
+            soft: 3,
+        },
+        2,
+    );
+
+    assert_contract_violated(
+        Soft,
+        MakeState {
+            firm: 2,
+            soft: 3,
+        },
+        3,
+    );
+
+    assert_contract_violated(
+        Soft,
+        MakeState {
+            firm: 2,
+            soft: 3,
+        },
+        5,
+    );
 }


### PR DESCRIPTION
## Summary
Check that the host response to `astria.execution.v1alpha2.ExecuteBlock` fulfills the contract (namely, that the number in the response is +1 the current number tracked by conductor).

## Background
Conductor implicitly checked the contract by enforcing that the blocks received from sequencer and/or celestia have the expected rollup block number. There was no test however that the execution API server (i.e. the rollup node) responds with the expected block number. This lead to confusing error logs.

## Changes
- Assert that the host response to the `astria.execution.v1alpha2.ExecuteBlock` RPC is as expected.

## Testing
Added unit tests to check that the assertion is correct.