### PR TITLE
feat(relayer)!: provide address, not port, to serve API requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -763,6 +763,7 @@ dependencies = [
 name = "astria-sequencer-relayer"
 version = "0.10.0"
 dependencies = [
+ "assert-json-diff",
  "astria-build-info",
  "astria-celestia-client",
  "astria-celestia-mock",

--- a/crates/astria-sequencer-relayer/Cargo.toml
+++ b/crates/astria-sequencer-relayer/Cargo.toml
@@ -30,7 +30,6 @@ humantime = { workspace = true }
 hyper = { workspace = true }
 metrics = { workspace = true }
 prost = { workspace = true }
-reqwest = { workspace = true, features = ["json"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
@@ -62,12 +61,14 @@ config = { package = "astria-config", path = "../astria-config", features = [
 astria-core = { path = "../astria-core", features = ["test-utils"] }
 merkle = { package = "astria-merkle", path = "../astria-merkle" }
 rand_core = { version = "0.6", features = ["getrandom"] }
+reqwest = { workspace = true, features = ["json"] }
 
 jsonrpsee = { workspace = true, features = ["server"] }
 once_cell = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 wiremock = { workspace = true }
+assert-json-diff = "2.0.2"
 
 [build-dependencies]
 astria-build-info = { path = "../astria-build-info", features = ["build"] }

--- a/crates/astria-sequencer-relayer/local.env.example
+++ b/crates/astria-sequencer-relayer/local.env.example
@@ -45,8 +45,8 @@ ASTRIA_SEQUENCER_RELAYER_RELAY_ONLY_VALIDATOR_KEY_BLOCKS=false
 # Ignored if `ASTRIA_SEQUENCER_RELAYER_DISABLE_RELAY_ALL=false`.
 ASTRIA_SEQUENCER_RELAYER_VALIDATOR_KEY_FILE=.cometbft/config/priv_validator_key.json
 
-# The port that sequencer relayer will bind on 127.0.0.1 to serve RPCs.
-ASTRIA_SEQUENCER_RELAYER_RPC_PORT=2450
+# The socket address at which sequencer relayer will server healthz, readyz, and status calls.
+ASTRIA_SEQUENCER_RELAYER_API_ADDR=127.0.0.1:2450
 
 # Set to true to enable prometheus metrics.
 ASTRIA_SEQUENCER_RELAYER_NO_METRICS=true

--- a/crates/astria-sequencer-relayer/src/api.rs
+++ b/crates/astria-sequencer-relayer/src/api.rs
@@ -39,8 +39,7 @@ impl FromRef<AppState> for RelayerState {
     }
 }
 
-pub(crate) fn start(port: u16, relayer_state: RelayerState) -> ApiServer {
-    let socket_addr = SocketAddr::from(([127, 0, 0, 1], port));
+pub(crate) fn start(socket_addr: SocketAddr, relayer_state: RelayerState) -> ApiServer {
     let app = Router::new()
         .route("/healthz", get(get_healthz))
         .route("/readyz", get(get_readyz))
@@ -94,7 +93,7 @@ impl IntoResponse for Healthz {
         }
         let (status, msg) = match self {
             Self::Ok => (StatusCode::OK, "ok"),
-            Self::Degraded => (StatusCode::GATEWAY_TIMEOUT, "degraded"),
+            Self::Degraded => (StatusCode::INTERNAL_SERVER_ERROR, "degraded"),
         };
         let mut response = Json(ReadyzBody {
             status: msg,

--- a/crates/astria-sequencer-relayer/src/config.rs
+++ b/crates/astria-sequencer-relayer/src/config.rs
@@ -15,7 +15,8 @@ pub struct Config {
     pub block_time: u64,
     pub relay_only_validator_key_blocks: bool,
     pub validator_key_file: Option<String>,
-    pub rpc_port: u16,
+    // The socket address at which sequencer relayer will server healthz, readyz, and status calls.
+    pub api_addr: String,
     pub log: String,
     /// Forces writing trace data to stdout no matter if connected to a tty or not.
     pub force_stdout: bool,

--- a/crates/astria-sequencer-relayer/src/sequencer_relayer.rs
+++ b/crates/astria-sequencer-relayer/src/sequencer_relayer.rs
@@ -29,7 +29,13 @@ impl SequencerRelayer {
             .await
             .wrap_err("failed to create relayer")?;
         let state_rx = relayer.subscribe_to_state();
-        let api_server = api::start(cfg.rpc_port, state_rx);
+        let api_socket_addr = cfg.api_addr.parse::<SocketAddr>().wrap_err_with(|| {
+            format!(
+                "failed to parse provided `api_addr` string as socket address: `{}`",
+                cfg.api_addr
+            )
+        })?;
+        let api_server = api::start(api_socket_addr, state_rx);
         Ok(Self {
             api_server,
             relayer,


### PR DESCRIPTION
## Summary
Lets sequencer-relayer bind to a configurable socket address (instead of localhost + a configurable port).

## Background
It is best practice to provide a socket address which a service is supposed to bind so that an operator can specify any IP range and network interface, and not restrict their choice to the loopback device. Coincidentally, this makes it work with ipv6 without needing any extra work.

## Changes
- Add the `api_addr` field of type `String` to the sequencer relayer config
- Add corresponding `ASTRIA_SEQUENCER_RELAYER_API_ADDR` to example config env file
- Remove `rpc_port` from config and `ASTRIA_SEQUENCER_RELAYER_RPC_PORT` from example config env file
- Update API server constructors, tests

## Testing
Added a test to check readyz and degraded healthz.

## Breaking Changelist
- Changed sequencer-relayer configuration