### PR TITLE
chore(core): Update docs to reference astria-core instead of astria-proto

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ To learn more about Astria, please visit [astria.org](https://astria.org).
 
 * [conductor](https://github.com/astriaorg/astria/tree/main/crates/astria-conductor):
   conducts blocks from the data availability layer to the execution layer.
-* [proto](https://github.com/astriaorg/astria/tree/main/crates/astria-proto):
-  relevant protobufs for Astria types.
+* [proto](https://github.com/astriaorg/astria/tree/main/proto):
+  the protobuf spec to interact with Astria services.
 * [sequencer](https://github.com/astriaorg/astria/tree/main/crates/astria-sequencer):
   ABCI application that defines the sequencer state transition logic.
 * [sequencer-relayer](https://github.com/astriaorg/astria/tree/main/crates/astria-sequencer-relayer):
@@ -71,10 +71,6 @@ To run unit tests:
 ```sh
 cargo test
 ```
-
-Note that the `astria-proto` generates its code by running tests (and verifying
-that nothing changed). In order for its tests to run you also need
-[Buf](https://buf.build/docs/installation/) installed.
 
 ## Formatting
 

--- a/crates/astria-core/README.md
+++ b/crates/astria-core/README.md
@@ -1,4 +1,4 @@
-# Astria Proto
+# Astria Core
 
 This crate contains code to interact with the public API of Astria. In particularly
 it contains definitions to convert Rust sources generated from the Astria protobuf

--- a/proto/README.md
+++ b/proto/README.md
@@ -1,7 +1,7 @@
 # The Astria protobuf specifications
 
 This directory holds the Protobuf specifications that are used
-by all Astria services. See the [`astria-proto`](../crates/astria-proto) crate
+by all Astria services. See the [`astria-core`](../crates/astria-core) crate
 for how to use them.
 
 ## Protos and Buf Build

--- a/tools/protobuf-compiler/README.md
+++ b/tools/protobuf-compiler/README.md
@@ -3,8 +3,8 @@
 This small binary invokes the `buf` protobuf management cli and
 `tonic-build` to compile the Astria protobuf specifications at
 [`../proto/`](../proto/) and writes them to
-[`../crates/astria-proto/src/proto/generated`](../crates/astria-proto/src/proto/generated).
+[`../crates/astria-core/src/generated`](../crates/astria-core/src/generated).
 
 See [`proto/README.md`](../proto/README.md) and
-[`astria-proto/README.md`](../crates/astria-proto/README.md) for how to use this
+[`astria-core/README.md`](../crates/astria-core/README.md) for how to use this
 tool.


### PR DESCRIPTION
## Summary
astria-proto repo was renamed to astria-core in https://github.com/astriaorg/astria/pull/644 . This PR addresses the corresponding README changes to change `astria-proto` to `astria-core`

## Background
The [https://github.com/astriaorg/astria/tools/protobuf-compiler/README.md](https://github.com/astriaorg/astria/tools/protobuf-compiler/README.md) includes the path which points to where the generated code for the protobufs resides. It points to a stale `astria-proto` link which can be confusing to new developers looking at the codebase. The other README changes come as a result of this observation. 

## Changes
- Updates to READMEs

## Testing
No need of testing

## Metrics
No need of metrics

## Breaking Changelist
No breaking changes

## Related Issues


closes <!-- list any issues closed here -->
