### PR TITLE
chore: update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1597,8 +1597,8 @@ dependencies = [
 
 [[package]]
 name = "cnidarium"
-version = "0.66.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.66.0#29b93231c6dc4a534b7a1177790d3d39d2dfb52c"
+version = "0.68.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.1#c462e9a6cc86a37d42a9d75f1ab9ceb0e3789f77"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1625,8 +1625,8 @@ dependencies = [
 
 [[package]]
 name = "cnidarium-component"
-version = "0.66.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.66.0#29b93231c6dc4a534b7a1177790d3d39d2dfb52c"
+version = "0.68.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.1#c462e9a6cc86a37d42a9d75f1ab9ceb0e3789f77"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2075,8 +2075,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-fmd"
-version = "0.66.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.66.0#29b93231c6dc4a534b7a1177790d3d39d2dfb52c"
+version = "0.68.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.1#c462e9a6cc86a37d42a9d75f1ab9ceb0e3789f77"
 dependencies = [
  "ark-ff 0.4.2",
  "ark-serialize 0.4.2",
@@ -2089,8 +2089,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-ka"
-version = "0.66.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.66.0#29b93231c6dc4a534b7a1177790d3d39d2dfb52c"
+version = "0.68.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.1#c462e9a6cc86a37d42a9d75f1ab9ceb0e3789f77"
 dependencies = [
  "ark-ff 0.4.2",
  "decaf377 0.5.0",
@@ -2103,9 +2103,9 @@ dependencies = [
 
 [[package]]
 name = "decaf377-rdsa"
-version = "0.7.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc48f39a9939244f1d1e043b8065330022b8c4337cf359f32231fed8b2165973"
+checksum = "2356bb010273c2b6e4e928b2bb442ddaa255ec242c16ff46cf9c3811fefa5ace"
 dependencies = [
  "ark-ff 0.4.2",
  "ark-serialize 0.4.2",
@@ -3498,9 +3498,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-proto"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4222cfac37f21da28292db0f2673fdb8455284895891ff09979680243efb9a20"
+checksum = "dd4ee32b22d3b06f31529b956f4928e5c9a068d71e46cf6abfa19c31ca550553"
 dependencies = [
  "base64 0.21.7",
  "bytes",
@@ -3516,9 +3516,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3178d46ae589af5cab981989a8c631a76d12411edc54d23fd35a52e2fffee07f"
+checksum = "ba606d86e2015991f86a129935dbaeacd94beab72fb90a733c1b1ea76be708a2"
 dependencies = [
  "ibc-types-core-channel",
  "ibc-types-core-client",
@@ -3534,9 +3534,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-core-channel"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743cdc9ec7f4b2c0985136ee0af8f24536b5e1624fb5d88fde7c300881322a82"
+checksum = "86fb64ef52086b727e5ae01da0e773f8ca9172ec1fd9d0aa1a79c0c2c610b17a"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3567,9 +3567,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-core-client"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab7ff8d18f423c0ec0614104f3c07e320cdce2ae5d395606c7d83e4e25a34afc"
+checksum = "4db9d4b136b9e84ccf581fec02bb9ebc4478ac0f145c526760ed4310b98741e7"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3594,9 +3594,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-core-commitment"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "421f7cdfc48065437b276a2abe597ef47d6ffaff4815ba4efd111d5a3af43998"
+checksum = "7e2c527e14707dd0b2c7e6e2f6f62b0655c83154ae3eb1504e441d9d8f454ac6"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3629,9 +3629,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-core-connection"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f79832a232d5a69325f87aff6a4703c5490f39107a223998b30e83bc3a69510"
+checksum = "5a8a326c00e9ba48059407478c826237fe39cc90dd2b47182484192926904fe7"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3659,9 +3659,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-domain-type"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73649683daa4fa967f54ef7cf3f98429522895c37fc2dee2a94d490969444779"
+checksum = "3abc9619b9dd7201804f45fc7f335dda72d2e4d6f82d96e8fe3abf4585e6101b"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3670,9 +3670,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-identifier"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e007333cded43d125cacb26aeb1a3630a8ffe03144d798ad9a8f2c99e4529a3a"
+checksum = "405880cf06fef65f51c5c91b7efbdcbc8d7eba0ac16b43538b36ebd17f21edea"
 dependencies = [
  "displaydoc",
  "serde",
@@ -3681,9 +3681,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-lightclients-tendermint"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7f9305a26e8d78faca85ac5414d5432549bb6c196a49032c00e723c9054d7b5"
+checksum = "2ab22446058bd5afa50d64f8519a9107bbc5101ee65373df896314f52afa0fc6"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3718,9 +3718,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-path"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a22688a533f90b48e6fde7a1271028f01b66f7a44d298747403bc346fdf08529"
+checksum = "a29e6fd8871fdced76402a3008219abf8773e527a46f120e0d76d6a3bb9706c1"
 dependencies = [
  "bytes",
  "derive_more",
@@ -3741,9 +3741,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-timestamp"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e93de4be3480445111959b61b10b4f1865e6cad206961a46cb5170b88fdfc0"
+checksum = "93d2e763838dbef62ca8a1344b4dd5b3919d685b4c61874183724644c912237a"
 dependencies = [
  "bytes",
  "displaydoc",
@@ -3760,9 +3760,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-transfer"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45f7420000987bca27f718a44a220efbf4114dcf8dffbfea1aaed6e9b1e9551a"
+checksum = "ad973ca1fbad8d0d1632ec0a329aecff8731bbb96395b7553d6b9fd749356d34"
 dependencies = [
  "displaydoc",
  "serde",
@@ -4498,9 +4498,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
@@ -5158,8 +5158,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-asset"
-version = "0.66.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.66.0#29b93231c6dc4a534b7a1177790d3d39d2dfb52c"
+version = "0.68.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.1#c462e9a6cc86a37d42a9d75f1ab9ceb0e3789f77"
 dependencies = [
  "anyhow",
  "ark-ff 0.4.2",
@@ -5195,8 +5195,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-ibc"
-version = "0.66.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.66.0#29b93231c6dc4a534b7a1177790d3d39d2dfb52c"
+version = "0.68.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.1#c462e9a6cc86a37d42a9d75f1ab9ceb0e3789f77"
 dependencies = [
  "anyhow",
  "ark-ff 0.4.2",
@@ -5230,8 +5230,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-keys"
-version = "0.66.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.66.0#29b93231c6dc4a534b7a1177790d3d39d2dfb52c"
+version = "0.68.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.1#c462e9a6cc86a37d42a9d75f1ab9ceb0e3789f77"
 dependencies = [
  "aes",
  "anyhow",
@@ -5274,8 +5274,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-num"
-version = "0.66.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.66.0#29b93231c6dc4a534b7a1177790d3d39d2dfb52c"
+version = "0.68.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.1#c462e9a6cc86a37d42a9d75f1ab9ceb0e3789f77"
 dependencies = [
  "anyhow",
  "ark-ff 0.4.2",
@@ -5310,8 +5310,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-proto"
-version = "0.66.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.66.0#29b93231c6dc4a534b7a1177790d3d39d2dfb52c"
+version = "0.68.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.1#c462e9a6cc86a37d42a9d75f1ab9ceb0e3789f77"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5339,8 +5339,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sct"
-version = "0.66.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.66.0#29b93231c6dc4a534b7a1177790d3d39d2dfb52c"
+version = "0.68.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.1#c462e9a6cc86a37d42a9d75f1ab9ceb0e3789f77"
 dependencies = [
  "anyhow",
  "ark-ff 0.4.2",
@@ -5373,8 +5373,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-tct"
-version = "0.66.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.66.0#29b93231c6dc4a534b7a1177790d3d39d2dfb52c"
+version = "0.68.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.1#c462e9a6cc86a37d42a9d75f1ab9ceb0e3789f77"
 dependencies = [
  "ark-ed-on-bls12-377",
  "ark-ff 0.4.2",
@@ -5401,8 +5401,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-tower-trace"
-version = "0.66.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.66.0#29b93231c6dc4a534b7a1177790d3d39d2dfb52c"
+version = "0.68.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.1#c462e9a6cc86a37d42a9d75f1ab9ceb0e3789f77"
 dependencies = [
  "futures",
  "hex",
@@ -5423,8 +5423,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-txhash"
-version = "0.66.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.66.0#29b93231c6dc4a534b7a1177790d3d39d2dfb52c"
+version = "0.68.1"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.1#c462e9a6cc86a37d42a9d75f1ab9ceb0e3789f77"
 dependencies = [
  "anyhow",
  "blake2b_simd 1.0.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ hex = "0.4"
 hex-literal = "0.4.1"
 humantime = "2.1.0"
 hyper = "0.14"
-ibc-types = "0.11.1"
+ibc-types = "0.12"
 jsonrpsee = { version = "0.20" }
 once_cell = "1.17.1"
 sha2 = "0.10"
@@ -66,9 +66,9 @@ serde = "1"
 serde_json = "1"
 metrics = "0.22.1"
 # Note that when updating the penumbra versions, vendored types in `proto/sequencerapis/astria_vendored` may need to be updated as well.
-penumbra-ibc = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.66.0", default-features = false }
-penumbra-proto = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.66.0" }
-penumbra-tower-trace = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.66.0" }
+penumbra-ibc = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.68.1", default-features = false }
+penumbra-proto = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.68.1" }
+penumbra-tower-trace = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.68.1" }
 prost = "0.12"
 prost-types = "0.12"
 rand = "0.8.5"

--- a/crates/astria-core/src/sequencer/v1alpha1/transaction/action.rs
+++ b/crates/astria-core/src/sequencer/v1alpha1/transaction/action.rs
@@ -653,7 +653,7 @@ impl Ics20Withdrawal {
             denom: self.denom.to_string(),
             sender: self.return_address.to_string(),
             receiver: self.destination_chain_address.clone(),
-            memo: "".to_string(),
+            memo: String::new(),
         }
     }
 

--- a/crates/astria-core/src/sequencer/v1alpha1/transaction/action.rs
+++ b/crates/astria-core/src/sequencer/v1alpha1/transaction/action.rs
@@ -653,6 +653,7 @@ impl Ics20Withdrawal {
             denom: self.denom.to_string(),
             sender: self.return_address.to_string(),
             receiver: self.destination_chain_address.clone(),
+            memo: "".to_string(),
         }
     }
 

--- a/crates/astria-sequencer/Cargo.toml
+++ b/crates/astria-sequencer/Cargo.toml
@@ -33,8 +33,8 @@ matchit = "0.7.2"
 tower = "0.4"
 tower-abci = "0.11.0"
 tower-actor = "0.1.0"
-cnidarium = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.66.0" }
-cnidarium-component = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.66.0" }
+cnidarium = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.68.1" }
+cnidarium-component = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.68.1" }
 
 async-trait = { workspace = true }
 bytes = { workspace = true }
@@ -55,7 +55,7 @@ tendermint = { workspace = true }
 tokio = { workspace = true, features = ["rt", "tracing"] }
 tracing = { workspace = true }
 
-ibc-proto = { version = "0.40.0", features = ["server"] }
+ibc-proto = { version = "0.41.0", features = ["server"] }
 tonic = "0.10"
 tower-http = { version = "0.4", features = ["cors"] }
 


### PR DESCRIPTION
## Summary
Updated to latest penumbra dependencies, and updated one crate identified with `cargo audit`