### PR TITLE
Superfluffy/quiet node warnings

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,20 +1,36 @@
 ci:
-  - '.github/**'
+  - changed-files:
+    - any-glob-to-any-file:
+      - '.github/**'
 conductor:
-  - 'crates/astria-conductor/**'
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'crates/astria-conductor/**'
 composer:
-  - 'crates/astria-composer/**'
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'crates/astria-composer/**'
 docker:
-  - 'containerfiles/**'
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'containerfiles/**'
 proto:
-  - 'proto/**'
-  - 'crates/astria-core/src/generated/**'
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'proto/**'
+      - 'crates/astria-core/src/generated/**'
 sequencer:
-  - 'crates/astria-sequencer/**'
-  - 'crates/astria-sequencer-client/**'
-  - 'crates/astria-sequencer-utils/**'
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'crates/astria-sequencer/**'
+      - 'crates/astria-sequencer-client/**'
+      - 'crates/astria-sequencer-utils/**'
 sequencer-relayer:
-  - 'crates/astria-sequencer-relayer/**'
-  - 'crates/astria-gossipnet/**'
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'crates/astria-sequencer-relayer/**'
+      - 'crates/astria-gossipnet/**'
 documentation:
-  - 'specs/**'
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'specs/**'

--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -1,11 +1,14 @@
 name: Repo Admin
 on:
-  pull_request_target:
-    types:
-      - opened
-      - edited
-      - synchronize
-      - reopened
+  # TODO(!!!): Remove before merge
+  - pull_request
+  # TODO(!!!): Uncomment before merge
+  # pull_request_target:
+  #   types:
+  #     - opened
+  #     - edited
+  #     - synchronize
+  #     - reopened
 
 jobs:
   triage:
@@ -14,7 +17,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v4
+    - uses: actions/labeler@v5
 
   pr_title:
     runs-on: ubuntu-latest

--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: CondeNast/conventional-pull-request-action@v0.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
     needs: run_checker
     if: needs.run_checker.outputs.run_lint_proto == 'true'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: bufbuild/buf-setup-action@v1
         with:
           version: "1.15.1"
@@ -37,7 +37,7 @@ jobs:
     needs: run_checker
     if: needs.run_checker.outputs.run_lint_rust == 'true'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2024-02-07
@@ -50,7 +50,7 @@ jobs:
     needs: run_checker
     if: needs.run_checker.outputs.run_lint_toml == 'true'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: download taplo
         run: |
           curl -fsSL https://github.com/tamasfe/taplo/releases/download/0.8.1/taplo-full-linux-x86_64.gz \
@@ -64,7 +64,7 @@ jobs:
     needs: run_checker
     if: needs.run_checker.outputs.run_lint_markdown == 'true'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: DavidAnson/markdownlint-cli2-action@v11
         with:
           globs: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     needs: run_checker
     if: needs.run_checker.outputs.run_release_proto == 'true' && github.repository_owner == 'astriaorg'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: bufbuild/buf-setup-action@v1
         with:
           version: "1.15.1"

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           ref: ${{ inputs.tag }}
       - uses: dtolnay/rust-toolchain@1.76.0
-      - uses: arduino/setup-protoc@v2
+      - uses: arduino/setup-protoc@v3
         with:
           version: "24.4"
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -27,7 +27,7 @@ jobs:
     if: ${{ startsWith(inputs.tag, inputs.package-name) || startsWith(github.ref, format('refs/tags/{0}-v', inputs.package-name)) || github.ref == 'refs/heads/main' || github.ref == 'pull_request' }}
     steps:
       # Checking out the repo
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.tag }}
       # https://github.com/docker/setup-qemu-action

--- a/.github/workflows/reusable-release-cargo.yml
+++ b/.github/workflows/reusable-release-cargo.yml
@@ -16,7 +16,7 @@ jobs:
     outputs: 
       release-cut: ${{ steps.output.outputs.release_cut }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: git fetch --all --tags
       - name: Check Release Version
         id: release_version

--- a/.github/workflows/reusable-run-checker.yml
+++ b/.github/workflows/reusable-run-checker.yml
@@ -46,7 +46,7 @@ jobs:
       rustfmt: ${{ steps.filters.outputs.rustfmt }}
     steps:
       - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@v3
         id: filters
         with:
           list-files: json

--- a/.github/workflows/reusable-run-checker.yml
+++ b/.github/workflows/reusable-run-checker.yml
@@ -45,7 +45,7 @@ jobs:
       markdown: ${{ steps.filters.outputs.markdown }}
       rustfmt: ${{ steps.filters.outputs.rustfmt }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v2
         id: filters
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2.7.3
         with:
           cache-provider: "buildjet"
-      - uses: arduino/setup-protoc@v2
+      - uses: arduino/setup-protoc@v3
         with:
           version: "24.4"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -89,7 +89,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2.7.3
         with:
           cache-provider: "buildjet"
-      - uses: arduino/setup-protoc@v2
+      - uses: arduino/setup-protoc@v3
         with:
           version: "24.4"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -116,7 +116,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2.7.3
         with:
           cache-provider: "buildjet"
-      - uses: arduino/setup-protoc@v2
+      - uses: arduino/setup-protoc@v3
         with:
           version: "24.4"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -135,7 +135,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2.7.3
         with:
           cache-provider: "buildjet"
-      - uses: arduino/setup-protoc@v2
+      - uses: arduino/setup-protoc@v3
         with:
           version: "24.4"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -165,7 +165,7 @@ jobs:
           cache-provider: "buildjet"
       - name: install cargo-dylint and dylint-link
         run: cargo install cargo-dylint@2.6.1 dylint-link@2.6.1 --locked
-      - uses: arduino/setup-protoc@v2
+      - uses: arduino/setup-protoc@v3
         with:
           version: "24.4"
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     needs: run_checker
     if: needs.run_checker.outputs.run_tests == 'true'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install `buf` protobuf manager
         uses: bufbuild/buf-setup-action@v1
         with:
@@ -48,7 +48,7 @@ jobs:
     needs: run_checker
     if: needs.run_checker.outputs.run_tests == 'true'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.76.0
       - uses: taiki-e/install-action@v2.15.2
         with:
@@ -71,7 +71,7 @@ jobs:
     needs: run_checker
     if: needs.run_checker.outputs.run_tests == 'true'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.76.0
       - uses: Swatinem/rust-cache@v2.6.1
         with:
@@ -84,7 +84,7 @@ jobs:
     needs: run_checker
     if: needs.run_checker.outputs.run_tests == 'true'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.76.0
       - uses: Swatinem/rust-cache@v2.6.1
         with:
@@ -111,7 +111,7 @@ jobs:
     needs: run_checker
     if: needs.run_checker.outputs.run_tests == 'true'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.76.0
       - uses: Swatinem/rust-cache@v2.6.1
         with:
@@ -128,7 +128,7 @@ jobs:
     needs: run_checker
     if: needs.run_checker.outputs.run_tests == 'true' && needs.run_checker.outputs.run_lint_rust == 'true'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.76.0
         with:
           components: clippy
@@ -154,7 +154,7 @@ jobs:
     needs: run_checker
     if: needs.run_checker.outputs.run_tests == 'true' && needs.run_checker.outputs.run_lint_rust == 'true'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@v1
         with:
           # This has to match `rust-toolchain` in the rust-toolchain file of the dylint lints

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.76.0
-      - uses: Swatinem/rust-cache@v2.6.1
+      - uses: Swatinem/rust-cache@v2.7.3
         with:
           cache-provider: "buildjet"
       - name: Install just
@@ -53,7 +53,7 @@ jobs:
       - uses: taiki-e/install-action@v2.15.2
         with:
           tool: cargo-hack@0.5.29
-      - uses: Swatinem/rust-cache@v2.6.1
+      - uses: Swatinem/rust-cache@v2.7.3
         with:
           cache-provider: "buildjet"
       - uses: arduino/setup-protoc@v2
@@ -73,7 +73,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.76.0
-      - uses: Swatinem/rust-cache@v2.6.1
+      - uses: Swatinem/rust-cache@v2.7.3
         with:
           cache-provider: "github"
       - name: Check that the lockfile is updated
@@ -86,7 +86,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.76.0
-      - uses: Swatinem/rust-cache@v2.6.1
+      - uses: Swatinem/rust-cache@v2.7.3
         with:
           cache-provider: "buildjet"
       - uses: arduino/setup-protoc@v2
@@ -113,7 +113,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.76.0
-      - uses: Swatinem/rust-cache@v2.6.1
+      - uses: Swatinem/rust-cache@v2.7.3
         with:
           cache-provider: "buildjet"
       - uses: arduino/setup-protoc@v2
@@ -132,7 +132,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@1.76.0
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@v2.6.1
+      - uses: Swatinem/rust-cache@v2.7.3
         with:
           cache-provider: "buildjet"
       - uses: arduino/setup-protoc@v2
@@ -160,7 +160,7 @@ jobs:
           # This has to match `rust-toolchain` in the rust-toolchain file of the dylint lints
           toolchain: nightly-2023-12-28
           components: "clippy, llvm-tools-preview, rustc-dev"
-      - uses: Swatinem/rust-cache@v2.6.1
+      - uses: Swatinem/rust-cache@v2.7.3
         with:
           cache-provider: "buildjet"
       - name: install cargo-dylint and dylint-link


### PR DESCRIPTION
## Summary
Bumps all dependencies that generate warnings about Node.js 16 being deprecated on github.

## Background

github blog post:
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.


## Changes
- bump `actions/checkout` from `v2` to `v3`
- bump `actions/labeler` from `v4` to `v5` and update the labeler config (incompatible between versions)
- bump `dorny/paths-filter` from `v3` to `v4`
- bump `Swatinem/rust-cache` from `v2.6.1` to `v2.7.3`
- bump `ardunio/setup-protoc` from `v2` to `v3`

## Testing
CI hopefully still works