### PR TITLE
review fixes for #787

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -690,7 +690,7 @@ dependencies = [
  "astria-merkle",
  "astria-telemetry",
  "async-trait",
- "borsh",
+ "borsh 1.3.1",
  "bytes",
  "cnidarium",
  "cnidarium-component",
@@ -1229,8 +1229,18 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
 dependencies = [
- "borsh-derive",
+ "borsh-derive 0.10.3",
  "hashbrown 0.13.2",
+]
+
+[[package]]
+name = "borsh"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f58b559fd6448c6e2fd0adb5720cd98a2506594cafa4737ff98c396f3e82f667"
+dependencies = [
+ "borsh-derive 1.3.1",
+ "cfg_aliases",
 ]
 
 [[package]]
@@ -1244,6 +1254,20 @@ dependencies = [
  "proc-macro-crate 0.1.5",
  "proc-macro2 1.0.78",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aadb5b6ccbd078890f6d7003694e33816e6b784358f18e15e7e6d9f065a57cd"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate 3.1.0",
+ "proc-macro2 1.0.78",
+ "quote",
+ "syn 2.0.48",
+ "syn_derive",
 ]
 
 [[package]]
@@ -1452,6 +1476,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
 name = "chacha20"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1600,7 +1630,7 @@ source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.68.1#c462e9a6
 dependencies = [
  "anyhow",
  "async-trait",
- "borsh",
+ "borsh 0.10.3",
  "futures",
  "hex",
  "ibc-types",
@@ -3978,7 +4008,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2950721a65dff82492e30fe67076127135d0d710aa0140f21efafda2aee7849"
 dependencies = [
  "anyhow",
- "borsh",
+ "borsh 0.10.3",
  "digest 0.10.7",
  "hashbrown 0.13.2",
  "hex",
@@ -7115,6 +7145,18 @@ dependencies = [
  "proc-macro2 1.0.78",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn_derive"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1329189c02ff984e9736652b1631330da25eaa6bc639089ed4915d25446cbe7b"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2 1.0.78",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]

--- a/crates/astria-core/src/generated/astria.sequencer.v1alpha1.rs
+++ b/crates/astria-core/src/generated/astria.sequencer.v1alpha1.rs
@@ -142,8 +142,8 @@ pub struct SequencerBlockHeader {
     /// The original CometBFT header that was the input to this sequencer block.
     #[prost(message, optional, tag = "1")]
     pub cometbft_header: ::core::option::Option<::tendermint_proto::types::Header>,
-    /// The 32-byte merkle root of all the rollup transactions in the block (not just the
-    /// subset included). Corresponds to `MHT(astria.sequencer.v1alpha.SequencerBlock.rollup_transactions)`,
+    /// The 32-byte merkle root of all the rollup transactions in the block,
+    /// Corresponds to `MHT(astria.sequencer.v1alpha.SequencerBlock.rollup_transactions)`,
     #[prost(bytes = "vec", tag = "2")]
     pub rollup_transactions_root: ::prost::alloc::vec::Vec<u8>,
     /// The 32-byte merkle root of all the rollup IDs in the block.
@@ -187,7 +187,7 @@ pub struct Deposit {
 pub struct FilteredSequencerBlock {
     /// The original CometBFT header that was the input to this sequencer block.
     #[prost(message, optional, tag = "1")]
-    pub header: ::core::option::Option<::tendermint_proto::types::Header>,
+    pub cometbft_header: ::core::option::Option<::tendermint_proto::types::Header>,
     /// A subset of rollup transactions that were included in this block.
     #[prost(message, repeated, tag = "2")]
     pub rollup_transactions: ::prost::alloc::vec::Vec<RollupTransactions>,

--- a/crates/astria-core/src/sequencer/v1alpha1/account.rs
+++ b/crates/astria-core/src/sequencer/v1alpha1/account.rs
@@ -19,7 +19,7 @@ impl AssetBalance {
             balance,
         } = proto;
         Self {
-            denom: Denom::from(denom.as_str()),
+            denom: Denom::from(denom.to_owned()),
             balance: balance.map_or(0, Into::into),
         }
     }

--- a/crates/astria-core/src/sequencer/v1alpha1/account.rs
+++ b/crates/astria-core/src/sequencer/v1alpha1/account.rs
@@ -165,7 +165,7 @@ mod tests {
     #[test]
     fn balance_roundtrip_is_correct() {
         let balances = vec![AssetBalance {
-            denom: "nria".into(),
+            denom: "nria".to_owned().into(),
             balance: 999,
         }];
         let expected = BalanceResponse {

--- a/crates/astria-core/src/sequencer/v1alpha1/asset.rs
+++ b/crates/astria-core/src/sequencer/v1alpha1/asset.rs
@@ -110,17 +110,16 @@ impl From<String> for Denom {
     }
 }
 
-impl From<&str> for Denom {
-    fn from(denom: &str) -> Self {
-        Self::from(denom.to_string())
-    }
-}
-
 /// Asset ID, which is the hash of the denomination trace.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Id([u8; 32]);
 
 impl Id {
+    #[must_use]
+    pub fn get(self) -> [u8; 32] {
+        self.0
+    }
+
     #[must_use]
     pub fn from_denom(denom: &str) -> Self {
         use sha2::Digest as _;

--- a/crates/astria-core/src/sequencer/v1alpha1/asset.rs
+++ b/crates/astria-core/src/sequencer/v1alpha1/asset.rs
@@ -127,11 +127,6 @@ impl Id {
         Self(hash.into())
     }
 
-    #[must_use]
-    pub fn as_bytes(&self) -> &[u8; 32] {
-        &self.0
-    }
-
     /// Returns an ID given a 32-byte slice.
     ///
     /// # Errors

--- a/crates/astria-core/src/sequencer/v1alpha1/block/mod.rs
+++ b/crates/astria-core/src/sequencer/v1alpha1/block/mod.rs
@@ -55,9 +55,9 @@ enum RollupTransactionsErrorKind {
     ProofInvalid(#[source] merkle::audit::InvalidProof),
 }
 
-/// The individual parts that make up a [`RollupTransaction`].
+/// The individual parts that make up a [`RollupTransactions`] type.
 ///
-/// Provides convenient access to the fields of a rollup transaction.
+/// Provides convenient access to the fields of [`RollupTransactions`].
 #[derive(Clone, Debug, PartialEq)]
 pub struct RollupTransactionsParts {
     pub id: RollupId,

--- a/crates/astria-core/src/sequencer/v1alpha1/block/mod.rs
+++ b/crates/astria-core/src/sequencer/v1alpha1/block/mod.rs
@@ -1200,7 +1200,7 @@ impl Deposit {
             bridge_address: bridge_address.to_vec(),
             rollup_id: rollup_id.to_vec(),
             amount: Some(amount.into()),
-            asset_id: asset_id.as_bytes().to_vec(),
+            asset_id: asset_id.get().to_vec(),
             destination_chain_address,
         }
     }

--- a/crates/astria-core/src/sequencer/v1alpha1/block/mod.rs
+++ b/crates/astria-core/src/sequencer/v1alpha1/block/mod.rs
@@ -250,7 +250,7 @@ enum SequencerBlockErrorKind {
     #[error("the expected field in the raw source type was not set: `{0}`")]
     FieldNotSet(&'static str),
     #[error("failed constructing a sequencer block header from the raw protobuf header")]
-    Header(#[from] SequencerBlockHeaderError),
+    Header(#[source] SequencerBlockHeaderError),
     #[error(
         "failed parsing a raw protobuf rollup transaction because it contained an invalid rollup \
          ID"
@@ -1263,11 +1263,11 @@ impl DepositError {
 #[derive(Debug, thiserror::Error)]
 enum DepositErrorKind {
     #[error("the address length is not 20 bytes")]
-    IncorrectAddressLength(#[from] IncorrectAddressLength),
+    IncorrectAddressLength(#[source] IncorrectAddressLength),
     #[error("the expected field in the raw source type was not set: `{0}`")]
     FieldNotSet(&'static str),
     #[error("the rollup ID length is not 32 bytes")]
-    IncorrectRollupIdLength(#[from] IncorrectRollupIdLength),
+    IncorrectRollupIdLength(#[source] IncorrectRollupIdLength),
     #[error("the asset ID length is not 32 bytes")]
-    IncorrectAssetIdLength(#[from] asset::IncorrectAssetIdLength),
+    IncorrectAssetIdLength(#[source] asset::IncorrectAssetIdLength),
 }

--- a/crates/astria-core/src/sequencer/v1alpha1/mod.rs
+++ b/crates/astria-core/src/sequencer/v1alpha1/mod.rs
@@ -39,9 +39,14 @@ pub const ADDRESS_LEN: usize = 20;
 pub const ROLLUP_ID_LEN: usize = 32;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Address(pub [u8; ADDRESS_LEN]);
+pub struct Address([u8; ADDRESS_LEN]);
 
 impl Address {
+    #[must_use]
+    pub fn get(self) -> [u8; ADDRESS_LEN] {
+        self.0
+    }
+
     #[must_use]
     pub fn to_vec(&self) -> Vec<u8> {
         self.0.to_vec()

--- a/crates/astria-core/src/sequencer/v1alpha1/mod.rs
+++ b/crates/astria-core/src/sequencer/v1alpha1/mod.rs
@@ -23,10 +23,7 @@ pub use account::{
     BalanceResponse,
     NonceResponse,
 };
-pub use block::{
-    SequencerBlock,
-    UncheckedSequencerBlock,
-};
+pub use block::SequencerBlock;
 pub use celestia::{
     CelestiaRollupBlob,
     CelestiaSequencerBlob,

--- a/crates/astria-core/src/sequencer/v1alpha1/mod.rs
+++ b/crates/astria-core/src/sequencer/v1alpha1/mod.rs
@@ -82,7 +82,7 @@ impl Address {
     }
 
     #[must_use]
-    pub fn from_array(array: [u8; ADDRESS_LEN]) -> Self {
+    pub const fn from_array(array: [u8; ADDRESS_LEN]) -> Self {
         Self(array)
     }
 }

--- a/crates/astria-core/src/sequencer/v1alpha1/transaction/action.rs
+++ b/crates/astria-core/src/sequencer/v1alpha1/transaction/action.rs
@@ -403,7 +403,7 @@ impl TransferAction {
         raw::TransferAction {
             to: to.to_vec(),
             amount: Some(amount.into()),
-            asset_id: asset_id.as_bytes().to_vec(),
+            asset_id: asset_id.get().to_vec(),
             fee_asset_id: fee_asset_id.as_ref().to_vec(),
         }
     }
@@ -419,7 +419,7 @@ impl TransferAction {
         raw::TransferAction {
             to: to.to_vec(),
             amount: Some((*amount).into()),
-            asset_id: asset_id.as_bytes().to_vec(),
+            asset_id: asset_id.get().to_vec(),
             fee_asset_id: fee_asset_id.as_ref().to_vec(),
         }
     }
@@ -704,7 +704,7 @@ impl Ics20Withdrawal {
             timeout_height: Some(self.timeout_height.into_raw()),
             timeout_time: self.timeout_time,
             source_channel: self.source_channel.to_string(),
-            fee_asset_id: self.fee_asset_id.as_bytes().to_vec(),
+            fee_asset_id: self.fee_asset_id.get().to_vec(),
         }
     }
 
@@ -718,7 +718,7 @@ impl Ics20Withdrawal {
             timeout_height: Some(self.timeout_height.into_raw()),
             timeout_time: self.timeout_time,
             source_channel: self.source_channel.to_string(),
-            fee_asset_id: self.fee_asset_id.as_bytes().to_vec(),
+            fee_asset_id: self.fee_asset_id.get().to_vec(),
         }
     }
 
@@ -935,12 +935,12 @@ impl FeeAssetChangeAction {
         match self {
             FeeAssetChangeAction::Addition(asset_id) => raw::FeeAssetChangeAction {
                 value: Some(raw::fee_asset_change_action::Value::Addition(
-                    asset_id.as_bytes().to_vec(),
+                    asset_id.get().to_vec(),
                 )),
             },
             FeeAssetChangeAction::Removal(asset_id) => raw::FeeAssetChangeAction {
                 value: Some(raw::fee_asset_change_action::Value::Removal(
-                    asset_id.as_bytes().to_vec(),
+                    asset_id.get().to_vec(),
                 )),
             },
         }
@@ -951,12 +951,12 @@ impl FeeAssetChangeAction {
         match self {
             FeeAssetChangeAction::Addition(asset_id) => raw::FeeAssetChangeAction {
                 value: Some(raw::fee_asset_change_action::Value::Addition(
-                    asset_id.as_bytes().to_vec(),
+                    asset_id.get().to_vec(),
                 )),
             },
             FeeAssetChangeAction::Removal(asset_id) => raw::FeeAssetChangeAction {
                 value: Some(raw::fee_asset_change_action::Value::Removal(
-                    asset_id.as_bytes().to_vec(),
+                    asset_id.get().to_vec(),
                 )),
             },
         }
@@ -1030,12 +1030,8 @@ impl InitBridgeAccountAction {
     pub fn into_raw(self) -> raw::InitBridgeAccountAction {
         raw::InitBridgeAccountAction {
             rollup_id: self.rollup_id.to_vec(),
-            asset_ids: self
-                .asset_ids
-                .iter()
-                .map(|id| id.as_bytes().to_vec())
-                .collect(),
-            fee_asset_id: self.fee_asset_id.as_bytes().to_vec(),
+            asset_ids: self.asset_ids.iter().map(|id| id.get().to_vec()).collect(),
+            fee_asset_id: self.fee_asset_id.get().to_vec(),
         }
     }
 
@@ -1043,12 +1039,8 @@ impl InitBridgeAccountAction {
     pub fn to_raw(&self) -> raw::InitBridgeAccountAction {
         raw::InitBridgeAccountAction {
             rollup_id: self.rollup_id.to_vec(),
-            asset_ids: self
-                .asset_ids
-                .iter()
-                .map(|id| id.as_bytes().to_vec())
-                .collect(),
-            fee_asset_id: self.fee_asset_id.as_bytes().to_vec(),
+            asset_ids: self.asset_ids.iter().map(|id| id.get().to_vec()).collect(),
+            fee_asset_id: self.fee_asset_id.get().to_vec(),
         }
     }
 
@@ -1133,7 +1125,7 @@ impl BridgeLockAction {
         raw::BridgeLockAction {
             to: self.to.to_vec(),
             amount: Some(self.amount.into()),
-            asset_id: self.asset_id.as_bytes().to_vec(),
+            asset_id: self.asset_id.get().to_vec(),
             fee_asset_id: self.fee_asset_id.as_ref().to_vec(),
             destination_chain_address: self.destination_chain_address,
         }
@@ -1144,7 +1136,7 @@ impl BridgeLockAction {
         raw::BridgeLockAction {
             to: self.to.to_vec(),
             amount: Some(self.amount.into()),
-            asset_id: self.asset_id.as_bytes().to_vec(),
+            asset_id: self.asset_id.get().to_vec(),
             fee_asset_id: self.fee_asset_id.as_ref().to_vec(),
             destination_chain_address: self.destination_chain_address.clone(),
         }

--- a/crates/astria-core/src/sequencer/v1alpha1/transaction/action.rs
+++ b/crates/astria-core/src/sequencer/v1alpha1/transaction/action.rs
@@ -742,7 +742,7 @@ impl Ics20Withdrawal {
 
         Ok(Self {
             amount: amount.into(),
-            denom: proto.denom.as_str().into(),
+            denom: proto.denom.to_owned().into(),
             destination_chain_address: proto.destination_chain_address,
             return_address,
             timeout_height,

--- a/crates/astria-core/src/sequencer/v1alpha1/transaction/action.rs
+++ b/crates/astria-core/src/sequencer/v1alpha1/transaction/action.rs
@@ -742,7 +742,7 @@ impl Ics20Withdrawal {
 
         Ok(Self {
             amount: amount.into(),
-            denom: proto.denom.to_owned().into(),
+            denom: proto.denom.clone().into(),
             destination_chain_address: proto.destination_chain_address,
             return_address,
             timeout_height,

--- a/crates/astria-core/src/sequencer/v1alpha1/transaction/mod.rs
+++ b/crates/astria-core/src/sequencer/v1alpha1/transaction/mod.rs
@@ -50,6 +50,14 @@ enum SignedTransactionErrorKind {
     Verification(ed25519_consensus::Error),
 }
 
+/// The individual parts of a [`SignedTransaction`].
+#[derive(Debug)]
+pub struct SignedTransactionParts {
+    pub signature: Signature,
+    pub verification_key: VerificationKey,
+    pub transaction: UnsignedTransaction,
+}
+
 /// A signed transaction.
 ///
 /// [`SignedTransaction`] contains an [`UnsignedTransaction`] together
@@ -140,14 +148,19 @@ impl SignedTransaction {
         })
     }
 
+    /// Converts a [`SignedTransaction`] into its [`SignedTransactionParts`].
     #[must_use]
-    pub fn into_parts(self) -> (Signature, VerificationKey, UnsignedTransaction) {
+    pub fn into_parts(self) -> SignedTransactionParts {
         let Self {
             signature,
             verification_key,
             transaction,
         } = self;
-        (signature, verification_key, transaction)
+        SignedTransactionParts {
+            signature,
+            verification_key,
+            transaction,
+        }
     }
 
     #[must_use]

--- a/crates/astria-sequencer-client/src/extension_trait.rs
+++ b/crates/astria-sequencer-client/src/extension_trait.rs
@@ -442,7 +442,7 @@ pub trait SequencerClientExt: Client {
     {
         const PREFIX: &[u8] = b"accounts/balance/";
 
-        let path = make_path_from_prefix_and_address(PREFIX, address.into().0);
+        let path = make_path_from_prefix_and_address(PREFIX, address.into().get());
 
         let response = self
             .abci_query(Some(path), vec![], Some(height.into()), false)
@@ -493,7 +493,7 @@ pub trait SequencerClientExt: Client {
     {
         const PREFIX: &[u8] = b"accounts/nonce/";
 
-        let path = make_path_from_prefix_and_address(PREFIX, address.into().0);
+        let path = make_path_from_prefix_and_address(PREFIX, address.into().get());
 
         let response = self
             .abci_query(Some(path), vec![], Some(height.into()), false)

--- a/crates/astria-sequencer-client/src/tests/http.rs
+++ b/crates/astria-sequencer-client/src/tests/http.rs
@@ -35,7 +35,7 @@ use crate::{
 };
 
 const ALICE_ADDRESS: [u8; 20] = hex!("1c0c490f1b5528d8173c5de46d131160e4b2c0c3");
-const BOB_ADDRESS: Address = Address(hex!("34fec43c7fcab9aef3b3cf8aba855e41ee69ca3a"));
+const BOB_ADDRESS: Address = Address::from_array(hex!("34fec43c7fcab9aef3b3cf8aba855e41ee69ca3a"));
 
 struct MockSequencer {
     server: MockServer,

--- a/crates/astria-sequencer/Cargo.toml
+++ b/crates/astria-sequencer/Cargo.toml
@@ -25,7 +25,7 @@ telemetry = { package = "astria-telemetry", path = "../astria-telemetry", featur
 ] }
 
 anyhow = "1"
-borsh = "0.10.3"
+borsh = { version = "1", features = ["derive"] }
 matchit = "0.7.2"
 tower = "0.4"
 tower-abci = "0.11.0"

--- a/crates/astria-sequencer/src/accounts/state_ext.rs
+++ b/crates/astria-sequencer/src/accounts/state_ext.rs
@@ -142,18 +142,14 @@ pub(crate) trait StateWriteExt: StateWrite {
         asset: asset::Id,
         balance: u128,
     ) -> Result<()> {
-        let bytes = Balance(balance)
-            .try_to_vec()
-            .context("failed to serialize balance")?;
+        let bytes = borsh::to_vec(&Balance(balance)).context("failed to serialize balance")?;
         self.put_raw(balance_storage_key(address, asset), bytes);
         Ok(())
     }
 
     #[instrument(skip(self))]
     fn put_account_nonce(&mut self, address: Address, nonce: u32) -> Result<()> {
-        let bytes = Nonce(nonce)
-            .try_to_vec()
-            .context("failed to serialize nonce")?;
+        let bytes = borsh::to_vec(&Nonce(nonce)).context("failed to serialize nonce")?;
         self.put_raw(nonce_storage_key(address), bytes);
         Ok(())
     }

--- a/crates/astria-sequencer/src/accounts/state_ext.rs
+++ b/crates/astria-sequencer/src/accounts/state_ext.rs
@@ -85,7 +85,7 @@ pub(crate) trait StateReadExt: StateRead {
                 // TODO: this is jank, just have 1 denom type.
                 balances.push(AssetBalance {
                     denom: astria_core::sequencer::v1alpha1::asset::Denom::from(
-                        native_asset.base_denom(),
+                        native_asset.base_denom().to_owned(),
                     ),
                     balance,
                 });

--- a/crates/astria-sequencer/src/api_state_ext.rs
+++ b/crates/astria-sequencer/src/api_state_ext.rs
@@ -33,23 +33,23 @@ fn block_hash_by_height_key(height: u64) -> String {
 }
 
 fn sequencer_block_header_by_hash_key(hash: &[u8]) -> String {
-    format!("blockheader/{}", hex::encode(hash))
+    format!("blockheader/{}", telemetry::display::hex(hash))
 }
 
 fn rollup_data_by_hash_and_rollup_id_key(hash: &[u8], rollup_id: &RollupId) -> String {
-    format!("rollupdata/{}/{}", hex::encode(hash), rollup_id)
+    format!("rollupdata/{}/{}", telemetry::display::hex(hash), rollup_id)
 }
 
 fn rollup_ids_by_hash_key(hash: &[u8]) -> String {
-    format!("rollupids/{}", hex::encode(hash))
+    format!("rollupids/{}", telemetry::display::hex(hash))
 }
 
 fn rollup_transactions_proof_by_hash_key(hash: &[u8]) -> String {
-    format!("rolluptxsproof/{}", hex::encode(hash))
+    format!("rolluptxsproof/{}", telemetry::display::hex(hash))
 }
 
 fn rollup_ids_proof_by_hash_key(hash: &[u8]) -> String {
-    format!("rollupidsproof/{}", hex::encode(hash))
+    format!("rollupidsproof/{}", telemetry::display::hex(hash))
 }
 
 /// Wrapper type for writing a list of rollup IDs to state

--- a/crates/astria-sequencer/src/api_state_ext.rs
+++ b/crates/astria-sequencer/src/api_state_ext.rs
@@ -1,5 +1,5 @@
 use anyhow::{
-    anyhow,
+    bail,
     Context as _,
     Result,
 };
@@ -66,7 +66,7 @@ pub(crate) trait StateReadExt: StateRead {
             .await
             .context("failed to read block hash by height from state")?
         else {
-            return Err(anyhow!("block hash not found for given height"));
+            bail!("block hash not found for given height");
         };
 
         let hash: [u8; 32] = hash
@@ -87,7 +87,7 @@ pub(crate) trait StateReadExt: StateRead {
             .await
             .context("failed to read raw sequencer block from state")?
         else {
-            return Err(anyhow!("header not found for given block hash"));
+            bail!("header not found for given block hash");
         };
 
         let raw = raw::SequencerBlockHeader::decode(header_bytes.as_slice())
@@ -105,7 +105,7 @@ pub(crate) trait StateReadExt: StateRead {
             .await
             .context("failed to read rollup IDs by block hash from state")?
         else {
-            return Err(anyhow!("rollup IDs not found for given block hash"));
+            bail!("rollup IDs not found for given block hash");
         };
 
         let rollup_ids: Vec<RollupId> = RollupIds::try_from_slice(&rollup_ids_bytes)
@@ -124,7 +124,7 @@ pub(crate) trait StateReadExt: StateRead {
             .await
             .context("failed to read raw sequencer block from state")?
         else {
-            return Err(anyhow!("header not found for given block hash"));
+            bail!("header not found for given block hash");
         };
 
         let header_raw = raw::SequencerBlockHeader::decode(header_bytes.as_slice())
@@ -155,9 +155,7 @@ pub(crate) trait StateReadExt: StateRead {
             .await
             .context("failed to read rollup transactions proof by block hash from state")?
         else {
-            return Err(anyhow!(
-                "rollup transactions proof not found for given block hash"
-            ));
+            bail!("rollup transactions proof not found for given block hash");
         };
 
         let rollup_transactions_proof = raw::Proof::decode(rollup_transactions_proof.as_slice())
@@ -168,7 +166,7 @@ pub(crate) trait StateReadExt: StateRead {
             .await
             .context("failed to read rollup IDs proof by block hash from state")?
         else {
-            return Err(anyhow!("rollup IDs proof not found for given block hash"));
+            bail!("rollup IDs proof not found for given block hash");
         };
 
         let rollup_ids_proof = raw::Proof::decode(rollup_ids_proof.as_slice())
@@ -210,9 +208,7 @@ pub(crate) trait StateReadExt: StateRead {
             .await
             .context("failed to read rollup data by block hash and rollup ID from state")?
         else {
-            return Err(anyhow!(
-                "rollup data not found for given block hash and rollup ID"
-            ));
+            bail!("rollup data not found for given block hash and rollup ID");
         };
         let raw = raw::RollupTransactions::decode(bytes.as_slice())
             .context("failed to decode rollup data from raw bytes")?;
@@ -233,9 +229,7 @@ pub(crate) trait StateReadExt: StateRead {
             .await
             .context("failed to read rollup transactions proof by block hash from state")?
         else {
-            return Err(anyhow!(
-                "rollup transactions proof not found for given block hash"
-            ));
+            bail!("rollup transactions proof not found for given block hash");
         };
 
         let rollup_transactions_proof = raw::Proof::decode(rollup_transactions_proof.as_slice())
@@ -246,7 +240,7 @@ pub(crate) trait StateReadExt: StateRead {
             .await
             .context("failed to read rollup IDs proof by block hash from state")?
         else {
-            return Err(anyhow!("rollup IDs proof not found for given block hash"));
+            bail!("rollup IDs proof not found for given block hash");
         };
 
         let rollup_ids_proof = raw::Proof::decode(rollup_ids_proof.as_slice())

--- a/crates/astria-sequencer/src/api_state_ext.rs
+++ b/crates/astria-sequencer/src/api_state_ext.rs
@@ -98,7 +98,7 @@ mod rollup_id_impl {
     }
 
     pub(super) fn serialize_many<W: borsh::io::Write>(
-        obj: &Vec<RollupId>,
+        obj: &[RollupId],
         writer: &mut W,
     ) -> ::core::result::Result<(), borsh::io::Error> {
         let inner: Vec<_> = obj.iter().copied().map(RollupIdSer::from).collect();

--- a/crates/astria-sequencer/src/api_state_ext.rs
+++ b/crates/astria-sequencer/src/api_state_ext.rs
@@ -10,6 +10,7 @@ use astria_core::{
             RollupTransactions,
             SequencerBlock,
             SequencerBlockHeader,
+            SequencerBlockParts,
         },
         RollupId,
     },
@@ -285,9 +286,14 @@ pub(crate) trait StateWriteExt: StateWrite {
                 .context("failed to serialize rollup IDs list")?,
         );
 
+        let block_hash = block.block_hash();
         let key = sequencer_block_header_by_hash_key(&block.block_hash());
-        let (block_hash, header, rollup_transactions, rollup_transactions_proof, rollup_ids_proof) =
-            block.into_values();
+        let SequencerBlockParts {
+            header,
+            rollup_transactions,
+            rollup_transactions_proof,
+            rollup_ids_proof,
+        } = block.into_parts();
         let header = header.into_raw();
         self.put_raw(key, header.encode_to_vec());
 

--- a/crates/astria-sequencer/src/app.rs
+++ b/crates/astria-sequencer/src/app.rs
@@ -861,7 +861,7 @@ mod test {
             ibc_relayer_addresses: vec![],
             native_asset_base_denomination: DEFAULT_NATIVE_ASSET_DENOM.to_string(),
             ibc_params: IBCParameters::default(),
-            allowed_fee_assets: vec![DEFAULT_NATIVE_ASSET_DENOM.into()],
+            allowed_fee_assets: vec![DEFAULT_NATIVE_ASSET_DENOM.to_owned().into()],
         });
 
         app.init_chain(genesis_state, genesis_validators, "test".to_string())
@@ -1215,7 +1215,7 @@ mod test {
             ibc_relayer_addresses: vec![],
             native_asset_base_denomination: DEFAULT_NATIVE_ASSET_DENOM.to_string(),
             ibc_params: IBCParameters::default(),
-            allowed_fee_assets: vec![DEFAULT_NATIVE_ASSET_DENOM.into()],
+            allowed_fee_assets: vec![DEFAULT_NATIVE_ASSET_DENOM.to_owned().into()],
         };
         let mut app = initialize_app(Some(genesis_state), vec![]).await;
 
@@ -1249,7 +1249,7 @@ mod test {
             ibc_sudo_address: alice_address,
             ibc_relayer_addresses: vec![],
             native_asset_base_denomination: DEFAULT_NATIVE_ASSET_DENOM.to_string(),
-            allowed_fee_assets: vec![DEFAULT_NATIVE_ASSET_DENOM.into()],
+            allowed_fee_assets: vec![DEFAULT_NATIVE_ASSET_DENOM.to_owned().into()],
             ibc_params: IBCParameters::default(),
         };
         let mut app = initialize_app(Some(genesis_state), vec![]).await;
@@ -1275,7 +1275,7 @@ mod test {
             ibc_sudo_address: alice_address,
             ibc_relayer_addresses: vec![alice_address],
             native_asset_base_denomination: DEFAULT_NATIVE_ASSET_DENOM.to_string(),
-            allowed_fee_assets: vec![DEFAULT_NATIVE_ASSET_DENOM.into()],
+            allowed_fee_assets: vec![DEFAULT_NATIVE_ASSET_DENOM.to_owned().into()],
             ibc_params: IBCParameters::default(),
         };
         let mut app = initialize_app(Some(genesis_state), vec![]).await;
@@ -1301,7 +1301,7 @@ mod test {
             ibc_sudo_address: Address::from([0; 20]),
             ibc_relayer_addresses: vec![alice_address],
             native_asset_base_denomination: DEFAULT_NATIVE_ASSET_DENOM.to_string(),
-            allowed_fee_assets: vec![DEFAULT_NATIVE_ASSET_DENOM.into()],
+            allowed_fee_assets: vec![DEFAULT_NATIVE_ASSET_DENOM.to_owned().into()],
             ibc_params: IBCParameters::default(),
         };
         let mut app = initialize_app(Some(genesis_state), vec![]).await;
@@ -1326,7 +1326,7 @@ mod test {
             ibc_relayer_addresses: vec![],
             native_asset_base_denomination: DEFAULT_NATIVE_ASSET_DENOM.to_string(),
             ibc_params: IBCParameters::default(),
-            allowed_fee_assets: vec![DEFAULT_NATIVE_ASSET_DENOM.into()],
+            allowed_fee_assets: vec![DEFAULT_NATIVE_ASSET_DENOM.to_owned().into()],
         };
         let mut app = initialize_app(Some(genesis_state), vec![]).await;
 
@@ -1359,7 +1359,7 @@ mod test {
             ibc_relayer_addresses: vec![],
             native_asset_base_denomination: DEFAULT_NATIVE_ASSET_DENOM.to_string(),
             ibc_params: IBCParameters::default(),
-            allowed_fee_assets: vec![DEFAULT_NATIVE_ASSET_DENOM.into()],
+            allowed_fee_assets: vec![DEFAULT_NATIVE_ASSET_DENOM.to_owned().into()],
         };
         let mut app = initialize_app(Some(genesis_state), vec![]).await;
 
@@ -1393,7 +1393,7 @@ mod test {
             ibc_relayer_addresses: vec![],
             native_asset_base_denomination: DEFAULT_NATIVE_ASSET_DENOM.to_string(),
             ibc_params: IBCParameters::default(),
-            allowed_fee_assets: vec![DEFAULT_NATIVE_ASSET_DENOM.into()],
+            allowed_fee_assets: vec![DEFAULT_NATIVE_ASSET_DENOM.to_owned().into()],
         };
         let mut app = initialize_app(Some(genesis_state), vec![]).await;
 
@@ -1427,7 +1427,10 @@ mod test {
             ibc_relayer_addresses: vec![],
             native_asset_base_denomination: DEFAULT_NATIVE_ASSET_DENOM.to_string(),
             ibc_params: IBCParameters::default(),
-            allowed_fee_assets: vec![DEFAULT_NATIVE_ASSET_DENOM.into(), test_asset.clone()],
+            allowed_fee_assets: vec![
+                DEFAULT_NATIVE_ASSET_DENOM.to_owned().into(),
+                test_asset.clone(),
+            ],
         };
         let mut app = initialize_app(Some(genesis_state), vec![]).await;
 
@@ -1463,7 +1466,7 @@ mod test {
             ibc_relayer_addresses: vec![],
             native_asset_base_denomination: DEFAULT_NATIVE_ASSET_DENOM.to_string(),
             ibc_params: IBCParameters::default(),
-            allowed_fee_assets: vec![DEFAULT_NATIVE_ASSET_DENOM.into()],
+            allowed_fee_assets: vec![DEFAULT_NATIVE_ASSET_DENOM.to_owned().into()],
         };
         let mut app = initialize_app(Some(genesis_state), vec![]).await;
 
@@ -1746,7 +1749,7 @@ mod test {
             ibc_relayer_addresses: vec![],
             native_asset_base_denomination: DEFAULT_NATIVE_ASSET_DENOM.to_string(),
             ibc_params: IBCParameters::default(),
-            allowed_fee_assets: vec![DEFAULT_NATIVE_ASSET_DENOM.into()],
+            allowed_fee_assets: vec![DEFAULT_NATIVE_ASSET_DENOM.to_owned().into()],
         };
         let mut app = initialize_app(Some(genesis_state), vec![]).await;
 
@@ -1899,7 +1902,7 @@ mod test {
             ibc_relayer_addresses: vec![],
             native_asset_base_denomination: DEFAULT_NATIVE_ASSET_DENOM.to_string(),
             ibc_params: IBCParameters::default(),
-            allowed_fee_assets: vec![DEFAULT_NATIVE_ASSET_DENOM.into()],
+            allowed_fee_assets: vec![DEFAULT_NATIVE_ASSET_DENOM.to_owned().into()],
         };
 
         let (mut app, storage) = initialize_app_with_storage(Some(genesis_state), vec![]).await;

--- a/crates/astria-sequencer/src/asset/state_ext.rs
+++ b/crates/astria-sequencer/src/asset/state_ext.rs
@@ -64,8 +64,7 @@ impl<T: ?Sized + StateRead> StateReadExt for T {}
 pub(crate) trait StateWriteExt: StateWrite {
     #[instrument(skip(self))]
     fn put_ibc_asset(&mut self, id: asset::Id, asset: &Denom) -> Result<()> {
-        let bytes = DenominationTrace(asset.denomination_trace())
-            .try_to_vec()
+        let bytes = borsh::to_vec(&DenominationTrace(asset.denomination_trace()))
             .context("failed to serialize asset")?;
         self.put_raw(asset_storage_key(id), bytes);
         Ok(())

--- a/crates/astria-sequencer/src/asset/state_ext.rs
+++ b/crates/astria-sequencer/src/asset/state_ext.rs
@@ -53,7 +53,7 @@ pub(crate) trait StateReadExt: StateRead {
 
         let DenominationTrace(denom_str) =
             DenominationTrace::try_from_slice(&bytes).context("invalid asset bytes")?;
-        let denom: Denom = denom_str.as_str().into();
+        let denom: Denom = denom_str.into();
         Ok(denom)
     }
 }

--- a/crates/astria-sequencer/src/authority/state_ext.rs
+++ b/crates/astria-sequencer/src/authority/state_ext.rs
@@ -146,8 +146,7 @@ pub(crate) trait StateWriteExt: StateWrite {
     fn put_sudo_address(&mut self, address: Address) -> Result<()> {
         self.put_raw(
             SUDO_STORAGE_KEY.to_string(),
-            SudoAddress(address.0)
-                .try_to_vec()
+            borsh::to_vec(&SudoAddress(address.0))
                 .context("failed to convert sudo address to vec")?,
         );
         Ok(())

--- a/crates/astria-sequencer/src/authority/state_ext.rs
+++ b/crates/astria-sequencer/src/authority/state_ext.rs
@@ -102,7 +102,7 @@ pub(crate) trait StateReadExt: StateRead {
         };
         let SudoAddress(address) =
             SudoAddress::try_from_slice(&bytes).context("invalid sudo key bytes")?;
-        Ok(Address(address))
+        Ok(Address::from(address))
     }
 
     #[instrument(skip(self))]
@@ -146,7 +146,7 @@ pub(crate) trait StateWriteExt: StateWrite {
     fn put_sudo_address(&mut self, address: Address) -> Result<()> {
         self.put_raw(
             SUDO_STORAGE_KEY.to_string(),
-            borsh::to_vec(&SudoAddress(address.0))
+            borsh::to_vec(&SudoAddress(address.get()))
                 .context("failed to convert sudo address to vec")?,
         );
         Ok(())

--- a/crates/astria-sequencer/src/authority/state_ext.rs
+++ b/crates/astria-sequencer/src/authority/state_ext.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeMap;
 
 use anyhow::{
-    anyhow,
     bail,
     Context,
     Result,
@@ -99,7 +98,7 @@ pub(crate) trait StateReadExt: StateRead {
             .context("failed reading raw sudo key from state")?
         else {
             // return error because sudo key must be set
-            return Err(anyhow!("sudo key not found"));
+            bail!("sudo key not found");
         };
         let SudoAddress(address) =
             SudoAddress::try_from_slice(&bytes).context("invalid sudo key bytes")?;

--- a/crates/astria-sequencer/src/bridge/init_bridge_account_action.rs
+++ b/crates/astria-sequencer/src/bridge/init_bridge_account_action.rs
@@ -1,5 +1,5 @@
 use anyhow::{
-    anyhow,
+    bail,
     ensure,
     Context as _,
     Result,
@@ -53,7 +53,7 @@ impl ActionHandler for InitBridgeAccountAction {
         // after the account becomes a bridge account, it can no longer receive funds
         // via `TransferAction`, only via `BridgeLockAction`.
         if state.get_bridge_account_rollup_id(&from).await?.is_some() {
-            return Err(anyhow!("bridge account already exists"));
+            bail!("bridge account already exists");
         }
 
         ensure!(

--- a/crates/astria-sequencer/src/bridge/state_ext.rs
+++ b/crates/astria-sequencer/src/bridge/state_ext.rs
@@ -161,9 +161,7 @@ pub(crate) trait StateWriteExt: StateWrite {
     ) -> Result<()> {
         self.put_raw(
             asset_ids_storage_key(address),
-            AssetIds::from(asset_ids)
-                .try_to_vec()
-                .context("failed to serialize asset IDs")?,
+            borsh::to_vec(&AssetIds::from(asset_ids)).context("failed to serialize asset IDs")?,
         );
         Ok(())
     }

--- a/crates/astria-sequencer/src/bridge/state_ext.rs
+++ b/crates/astria-sequencer/src/bridge/state_ext.rs
@@ -43,7 +43,7 @@ struct AssetIds(Vec<[u8; 32]>);
 
 impl From<&[asset::Id]> for AssetIds {
     fn from(ids: &[asset::Id]) -> Self {
-        Self(ids.iter().map(|id| *id.as_bytes()).collect())
+        Self(ids.iter().copied().map(asset::Id::get).collect())
     }
 }
 

--- a/crates/astria-sequencer/src/grpc/sequencer.rs
+++ b/crates/astria-sequencer/src/grpc/sequencer.rs
@@ -138,7 +138,7 @@ impl SequencerService for SequencerServer {
         }
 
         let block = RawFilteredSequencerBlock {
-            header: Some(header_parts.cometbft_header.into()),
+            cometbft_header: Some(header_parts.cometbft_header.into()),
             rollup_transactions,
             rollup_transactions_root: header_parts.rollup_transactions_root.to_vec(),
             rollup_transactions_proof: rollup_transactions_proof.into(),

--- a/crates/astria-sequencer/src/grpc/sequencer.rs
+++ b/crates/astria-sequencer/src/grpc/sequencer.rs
@@ -99,7 +99,7 @@ impl SequencerService for SequencerServer {
             .await
             .map_err(|e| Status::internal(format!("failed to get block hash from storage: {e}")))?;
 
-        let (header, rollup_transactions_root, _) = snapshot
+        let header_parts = snapshot
             .get_sequencer_block_header_by_hash(&block_hash)
             .await
             .map_err(|e| {
@@ -107,7 +107,7 @@ impl SequencerService for SequencerServer {
                     "failed to get sequencer block header from storage: {e}"
                 ))
             })?
-            .into_values();
+            .into_parts();
 
         let (rollup_transactions_proof, rollup_ids_proof) = snapshot
             .get_block_proofs_by_block_hash(&block_hash)
@@ -138,9 +138,9 @@ impl SequencerService for SequencerServer {
         }
 
         let block = RawFilteredSequencerBlock {
-            header: Some(header.into()),
+            header: Some(header_parts.cometbft_header.into()),
             rollup_transactions,
-            rollup_transactions_root: rollup_transactions_root.to_vec(),
+            rollup_transactions_root: header_parts.rollup_transactions_root.to_vec(),
             rollup_transactions_proof: rollup_transactions_proof.into(),
             rollup_ids_proof: rollup_ids_proof.into(),
             all_rollup_ids,

--- a/crates/astria-sequencer/src/ibc/ics20_transfer.rs
+++ b/crates/astria-sequencer/src/ibc/ics20_transfer.rs
@@ -168,7 +168,7 @@ async fn refund_tokens_check<S: StateRead>(
 ) -> Result<()> {
     let packet_data: FungibleTokenPacketData =
         serde_json::from_slice(data).context("failed to decode fungible token packet data json")?;
-    let mut denom: Denom = packet_data.denom.as_str().into();
+    let mut denom: Denom = packet_data.denom.clone().into();
 
     // if the asset is prefixed with `ibc`, the rest of the denomination string is the asset ID,
     // so we need to look up the full trace from storage.
@@ -330,7 +330,7 @@ async fn execute_ics20_transfer<S: StateWriteExt>(
         &hex::decode(packet_data.receiver).context("failed to decode receiver as hex string")?,
     )
     .context("invalid receiver address")?;
-    let mut denom: Denom = packet_data.denom.as_str().into();
+    let mut denom: Denom = packet_data.denom.clone().into();
 
     // if the asset is prefixed with `ibc`, the rest of the denomination string is the asset ID,
     // so we need to look up the full trace from storage.
@@ -382,7 +382,7 @@ async fn execute_ics20_transfer<S: StateWriteExt>(
             format!("{dest_port}/{dest_channel}/{}", packet_data.denom)
         };
 
-        let denom: Denom = prefixed_denomination.as_str().into();
+        let denom: Denom = prefixed_denomination.into();
 
         // register denomination in global ID -> denom map if it's not already there
         if !state

--- a/crates/astria-sequencer/src/ibc/state_ext.rs
+++ b/crates/astria-sequencer/src/ibc/state_ext.rs
@@ -1,4 +1,5 @@
 use anyhow::{
+    bail,
     Context,
     Result,
 };
@@ -68,7 +69,7 @@ pub(crate) trait StateReadExt: StateRead {
             .context("failed reading raw ibc sudo key from state")?
         else {
             // ibc sudo key must be set
-            return Err(anyhow::anyhow!("ibc sudo key not found"));
+            bail!("ibc sudo key not found");
         };
         let SudoAddress(address) =
             SudoAddress::try_from_slice(&bytes).context("invalid ibc sudo key bytes")?;

--- a/crates/astria-sequencer/src/ibc/state_ext.rs
+++ b/crates/astria-sequencer/src/ibc/state_ext.rs
@@ -97,9 +97,7 @@ pub(crate) trait StateWriteExt: StateWrite {
         asset: asset::Id,
         balance: u128,
     ) -> Result<()> {
-        let bytes = Balance(balance)
-            .try_to_vec()
-            .context("failed to serialize balance")?;
+        let bytes = borsh::to_vec(&Balance(balance)).context("failed to serialize balance")?;
         self.put_raw(channel_balance_storage_key(channel, asset), bytes);
         Ok(())
     }
@@ -108,8 +106,7 @@ pub(crate) trait StateWriteExt: StateWrite {
     fn put_ibc_sudo_address(&mut self, address: Address) -> Result<()> {
         self.put_raw(
             IBC_SUDO_STORAGE_KEY.to_string(),
-            SudoAddress(address.0)
-                .try_to_vec()
+            borsh::to_vec(&SudoAddress(address.0))
                 .context("failed to convert sudo address to vec")?,
         );
         Ok(())

--- a/crates/astria-sequencer/src/ibc/state_ext.rs
+++ b/crates/astria-sequencer/src/ibc/state_ext.rs
@@ -73,7 +73,7 @@ pub(crate) trait StateReadExt: StateRead {
         };
         let SudoAddress(address) =
             SudoAddress::try_from_slice(&bytes).context("invalid ibc sudo key bytes")?;
-        Ok(Address(address))
+        Ok(Address::from(address))
     }
 
     #[instrument(skip(self))]
@@ -106,7 +106,7 @@ pub(crate) trait StateWriteExt: StateWrite {
     fn put_ibc_sudo_address(&mut self, address: Address) -> Result<()> {
         self.put_raw(
             IBC_SUDO_STORAGE_KEY.to_string(),
-            borsh::to_vec(&SudoAddress(address.0))
+            borsh::to_vec(&SudoAddress(address.get()))
                 .context("failed to convert sudo address to vec")?,
         );
         Ok(())

--- a/crates/astria-sequencer/src/proposal/commitment.rs
+++ b/crates/astria-sequencer/src/proposal/commitment.rs
@@ -89,7 +89,7 @@ mod test {
             fee_asset_id: get_native_asset().id(),
         };
         let transfer_action = TransferAction {
-            to: Address([0u8; 20]),
+            to: Address::from([0u8; 20]),
             amount: 1,
             asset_id: get_native_asset().id(),
             fee_asset_id: get_native_asset().id(),
@@ -138,7 +138,7 @@ mod test {
             fee_asset_id: get_native_asset().id(),
         };
         let transfer_action = TransferAction {
-            to: Address([0u8; 20]),
+            to: Address::from([0u8; 20]),
             amount: 1,
             asset_id: get_native_asset().id(),
             fee_asset_id: get_native_asset().id(),

--- a/crates/astria-sequencer/src/service/consensus.rs
+++ b/crates/astria-sequencer/src/service/consensus.rs
@@ -507,7 +507,7 @@ mod test {
                 ibc_relayer_addresses: vec![],
                 native_asset_base_denomination: DEFAULT_NATIVE_ASSET_DENOM.to_string(),
                 ibc_params: penumbra_ibc::params::IBCParameters::default(),
-                allowed_fee_assets: vec![DEFAULT_NATIVE_ASSET_DENOM.into()],
+                allowed_fee_assets: vec![DEFAULT_NATIVE_ASSET_DENOM.to_owned().into()],
             }
         }
     }

--- a/crates/astria-telemetry/src/display.rs
+++ b/crates/astria-telemetry/src/display.rs
@@ -19,7 +19,7 @@ pub fn base64<T: AsRef<[u8]>>(bytes: &T) -> Base64Display<'_, 'static, GeneralPu
 /// let signature = vec![1u8, 2, 3, 4, 5, 6, 7, 8];
 /// tracing::info!(signature = %display::hex(&signature), "received signature");
 /// ```
-pub fn hex<T: AsRef<[u8]>>(bytes: &T) -> Hex<'_> {
+pub fn hex<T: AsRef<[u8]> + ?Sized>(bytes: &T) -> Hex<'_> {
     Hex(bytes.as_ref())
 }
 

--- a/proto/sequencerapis/astria/sequencer/v1alpha1/block.proto
+++ b/proto/sequencerapis/astria/sequencer/v1alpha1/block.proto
@@ -85,7 +85,7 @@ message Deposit {
 // of the rollup transactions.
 message FilteredSequencerBlock {
   // The original CometBFT header that was the input to this sequencer block.
-  astria_vendored.tendermint.types.Header header = 1;
+  astria_vendored.tendermint.types.Header cometbft_header = 1;
   // A subset of rollup transactions that were included in this block.
   repeated RollupTransactions rollup_transactions = 2;
   // The Merkle Tree Hash of all the rollup transactions in the block (not just the


### PR DESCRIPTION
various fixes https://github.com/astriaorg/astria/pull/787 instead of review comments:

+ prefer `into_parts` instead of `into_values`, and `*Parts` types with public fields into of tuples
+ rename `header -> cometbft_header` to make the difference to the new `SequencerHeader` type explicit
+ prefer `#[source]` over `#[from]` in thiserrors (`From::from` with `?` was not used anyway).
+ replace all `Err(anyhow!())` with `bail!`
+ prefer non-allocation hex-encoding vs `hex` crate
+ bump borsh to stable version 1
+ make public fields private
+ make implicit allocations explicit