### PR TITLE
fix(conductor): simplify mapping Celestia heights to Sequencer heights

### DIFF
--- a/crates/astria-conductor/src/celestia/mod.rs
+++ b/crates/astria-conductor/src/celestia/mod.rs
@@ -314,8 +314,10 @@ impl TrackHeights {
         }
     }
 
-    fn increment_next(&mut self) {
-        self.next_height += 1;
+    fn increment_next_height_to_fetch(&mut self) {
+        self.next_height
+            .checked_add(1)
+            .expect("this value should never reach u64::MAX");
     }
 
     fn update_reference_height_if_greater(&mut self, height: u64) -> bool {
@@ -391,7 +393,7 @@ impl Stream for ReconstructedBlocksStream {
                 }
                 Ok(()) => {
                     debug!(height = %height, "scheduled fetch of blocks");
-                    this.track_heights.increment_next();
+                    this.track_heights.increment_next_height_to_fetch();
                 }
             }
         }

--- a/crates/astria-conductor/src/executor/mod.rs
+++ b/crates/astria-conductor/src/executor/mod.rs
@@ -232,7 +232,7 @@ impl Executor {
 
                 Some(block) = self.firm_blocks.recv() => {
                     debug!(
-                        block.height = %block.height(),
+                        block.height = %block.sequencer_height(),
                         block.hash = %telemetry::display::hex(&block.block_hash),
                         "received block from celestia reader",
                     );
@@ -358,7 +358,7 @@ impl Executor {
 
     #[instrument(skip_all, fields(
         block.hash = %telemetry::display::hex(&block.block_hash),
-        block.height = block.height().value(),
+        block.height = block.sequencer_height().value(),
     ))]
     async fn execute_firm(
         &mut self,
@@ -523,6 +523,7 @@ impl ExecutableBlock {
             block_hash,
             header,
             transactions,
+            ..
         } = block;
         let timestamp = convert_tendermint_to_prost_timestamp(header.time);
         Self {

--- a/crates/astria-conductor/src/executor/tests.rs
+++ b/crates/astria-conductor/src/executor/tests.rs
@@ -217,6 +217,7 @@ fn make_reconstructed_block() -> ReconstructedBlock {
         block_hash: hash(b"block1"),
         header: block.header,
         transactions: vec![],
+        celestia_height: 1,
     }
 }
 
@@ -347,6 +348,7 @@ async fn first_firm_then_soft_leads_to_soft_being_dropped() {
             .unwrap()
             .transactions()
             .to_vec(),
+        celestia_height: 1,
     };
     mock.executor
         .execute_firm(mock.client.clone(), firm_block)
@@ -400,6 +402,7 @@ async fn first_soft_then_firm_update_state_correctly() {
             .unwrap()
             .transactions()
             .to_vec(),
+        celestia_height: 1,
     };
     mock.executor
         .execute_soft(mock.client.clone(), soft_block)


### PR DESCRIPTION
## Summary
Simplifies mapping Celestia heights to Sequencer heights by adding the source Celestia height to final type that contains the reconstructed sequencer block information. Fixes an assertion (and panic) being triggered by making it unecessary.

## Background
Conductor kept a map of `sequencer_height -> celestia_height` to track which blobs contained which sequencer height. This implementation was unnecessary and error prone, and ultimately out-of-sync with the rest of the Celestia reader. It's select-loop contained an `assert!` macro intended to tie assumptions about height-progress together and ultimately revealed a bug.

Instead of keeping an extra map, the Celestia heights can be flattened directly into the objects that are reconstructed from the blobs read off of Celestia. This makes the assertion unnecessary and simplifies the code.

## Changes
- Add a field `ReconstructedSequencerBlock::celestia_height` to track the Celestia source heights.
- Remove the `SequencerHeightToCelestiaHeight` map
- Streamline the height tracking in the block stream.

## Testing
Should be tested end-to-end
