### PR TITLE
feat(relayer): warn if submission tracking is inconsistent, but continue operation

### DIFF
--- a/crates/astria-sequencer-relayer/src/relayer/mod.rs
+++ b/crates/astria-sequencer-relayer/src/relayer/mod.rs
@@ -301,11 +301,14 @@ async fn read_submission_state<P1: AsRef<Path>, P2: AsRef<Path>>(
     pre: P1,
     post: P2,
 ) -> eyre::Result<SubmissionState> {
+    const LEANIENT_CONSISTENCY_CHECK: bool = true;
     let pre = pre.as_ref().to_path_buf();
     let post = post.as_ref().to_path_buf();
     crate::utils::flatten(
-        tokio::task::spawn_blocking(move || submission::SubmissionState::from_paths(pre, post))
-            .await,
+        tokio::task::spawn_blocking(move || {
+            submission::SubmissionState::from_paths::<LEANIENT_CONSISTENCY_CHECK, _, _>(pre, post)
+        })
+        .await,
     )
     .wrap_err(
         "failed reading submission state from the configured pre- and post-submit files. Refer to \


### PR DESCRIPTION
## Summary
Warns if pre- and post-submission files are inconsistent, but doesn't exit and instead starts relaying from the state recorded in the post-submission file.

## Background
Sequencer-relayer refuses operation if pre- and post-submission files provided via env vars are inconsistent. This inconsistency happens if a submission was started but not completed. As sequencer-relayer lacks graceful shutdown, this is guaranteed to happen on a ragular basis.

For most expected operations this patch means that a double-submission from the last state might occur, which is a cost we are willing to accept.

Note that if sequencer-relayer gets killed while *writing* either file and the file getting corrupted, then relayer will refuse operation on a subsequent restart.

## Changes
- Warn if the pre-submission and post-submission states are inconsistent
- Set pre-submission state to `ignore`
- Continue operation from post-submission state

## Testing
Added tests for leanient submission state reads. These are duplicates of the normal checks but leanient, and should thus return a positive result.