### PR TITLE
fix(conductor): update reference celestia height correctly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,6 +601,7 @@ dependencies = [
  "futures-bounded",
  "hex",
  "humantime",
+ "itoa",
  "jsonrpsee",
  "pin-project-lite",
  "prost 0.12.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ hex-literal = "0.4.1"
 humantime = "2.1.0"
 hyper = "0.14"
 ibc-types = "0.12"
+itoa = "1.0.10"
 jsonrpsee = { version = "0.20" }
 once_cell = "1.17.1"
 sha2 = "0.10"

--- a/crates/astria-conductor/Cargo.toml
+++ b/crates/astria-conductor/Cargo.toml
@@ -26,6 +26,7 @@ ed25519-consensus = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }
 humantime = { workspace = true }
+itoa = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
 rand = { workspace = true }

--- a/crates/astria-conductor/src/block_cache.rs
+++ b/crates/astria-conductor/src/block_cache.rs
@@ -4,6 +4,7 @@ use std::{
     future::Future,
 };
 
+use astria_core::sequencer::v1alpha1::CelestiaSequencerBlob;
 use pin_project_lite::pin_project;
 use sequencer_client::{
     tendermint::block::Height,
@@ -15,6 +16,12 @@ pub(crate) trait GetSequencerHeight {
 }
 
 impl GetSequencerHeight for SequencerBlock {
+    fn get_height(&self) -> Height {
+        self.height()
+    }
+}
+
+impl GetSequencerHeight for CelestiaSequencerBlob {
     fn get_height(&self) -> Height {
         self.height()
     }

--- a/crates/astria-conductor/src/celestia/mod.rs
+++ b/crates/astria-conductor/src/celestia/mod.rs
@@ -55,7 +55,10 @@ use sequencer_client::tendermint::{
 use tokio::{
     select,
     sync::{
-        mpsc::error::{SendError, TrySendError},
+        mpsc::error::{
+            SendError,
+            TrySendError,
+        },
         oneshot,
     },
 };
@@ -197,7 +200,8 @@ impl Reader {
             namespace.sequencer = %telemetry::display::base64(&self.sequencer_namespace.as_bytes()),
         ));
 
-        let mut scheduled_block: Fuse<BoxFuture<Result<_, SendError<ReconstructedBlock>>>> = future::Fuse::terminated();
+        let mut scheduled_block: Fuse<BoxFuture<Result<_, SendError<ReconstructedBlock>>>> =
+            future::Fuse::terminated();
         let mut resubscribing = Fuse::terminated();
         loop {
             select!(

--- a/crates/astria-conductor/src/celestia/mod.rs
+++ b/crates/astria-conductor/src/celestia/mod.rs
@@ -235,7 +235,7 @@ impl Reader {
                         Err(TrySendError::Full(block)) => {
                             trace!("executor channel is full; rescheduling block fetch until the channel opens up");
                             let executor_clone = executor.clone();
-                            // Using async block returning celestia height so reference height be updated
+                            // must return the celestia height to update the reference height upon completion
                             scheduled_block = async move {
                                 let celestia_height = block.celestia_height;
                                 executor_clone.send_firm_block(block).await?;

--- a/crates/astria-conductor/src/celestia/mod.rs
+++ b/crates/astria-conductor/src/celestia/mod.rs
@@ -55,7 +55,7 @@ use sequencer_client::tendermint::{
 use tokio::{
     select,
     sync::{
-        mpsc::error::TrySendError,
+        mpsc::error::{SendError, TrySendError},
         oneshot,
     },
 };
@@ -197,7 +197,7 @@ impl Reader {
             namespace.sequencer = %telemetry::display::base64(&self.sequencer_namespace.as_bytes()),
         ));
 
-        let mut scheduled_block: Fuse<BoxFuture<Result<_, _>>> = future::Fuse::terminated();
+        let mut scheduled_block: Fuse<BoxFuture<Result<_, SendError<ReconstructedBlock>>>> = future::Fuse::terminated();
         let mut resubscribing = Fuse::terminated();
         loop {
             select!(
@@ -211,12 +211,17 @@ impl Reader {
                     break;
                 }
 
+                // Processing block executions which were scheduled due to channel being full
                 res = &mut scheduled_block, if !scheduled_block.is_terminated() => {
-                    if res.is_err() {
-                        bail!("executor channel closed while waiting for it to free up");
+                    match res {
+                        Ok(celestia_height) => {
+                            block_stream.inner_mut().update_reference_height_if_greater(celestia_height);
+                        }
+                        Err(_) => bail!("executor channel closed while waiting for it to free up"),
                     }
                 }
 
+                // Attempt sending next sequential block, if channel is full will be scheduled
                 Some(block) = sequential_blocks.next_block(), if scheduled_block.is_terminated() => {
                     let celestia_height = block.celestia_height;
                     match executor.try_send_firm_block(block) {
@@ -225,7 +230,13 @@ impl Reader {
                         }
                         Err(TrySendError::Full(block)) => {
                             trace!("executor channel is full; rescheduling block fetch until the channel opens up");
-                            scheduled_block = executor.clone().send_firm_block(block).boxed().fuse();
+                            let executor_clone = executor.clone();
+                            // Using async block returning celestia height so reference height be updated
+                            scheduled_block = async move {
+                                let celestia_height = block.celestia_height;
+                                executor_clone.send_firm_block(block).await?;
+                                Ok(celestia_height)
+                            }.boxed().fuse();
                         }
 
                         Err(TrySendError::Closed(_)) => bail!("exiting because executor channel is closed"),
@@ -289,7 +300,8 @@ impl Reader {
                     debug!(
                         height.celestia = %celestia_height,
                         num_sequencer_blocks = blocks.len(),
-                        "read sequencer blocks from celestia",
+                        sequencer_heights = %ReportSequencerHeights(&blocks),
+                        "validated sequencer blocks from celestia",
                     );
                     for block in blocks {
                         if let Err(e) = sequential_blocks.insert(block) {
@@ -374,7 +386,7 @@ pin_project! {
 
 impl ReconstructedBlocksStream {
     fn is_exhausted(&self) -> bool {
-        self.in_progress.is_empty() && self.track_heights.next_height_to_fetch().is_some()
+        self.in_progress.is_empty() && self.track_heights.next_height_to_fetch().is_none()
     }
 
     fn update_reference_height_if_greater(&mut self, height: u64) -> bool {
@@ -509,6 +521,13 @@ async fn fetch_blocks_at_celestia_height(
         Err(e) => return Err(e).wrap_err("failed to fetch sequencer data from celestia"),
         Ok(response) => response.sequencer_blobs,
     };
+
+    debug!(
+        celestia_height = height,
+        num_sequencer_blocks = sequencer_blobs.len(),
+        sequencer_heights = %ReportSequencerHeights(&sequencer_blobs),
+        "received sequencer blobs from Celestia"
+    );
 
     // FIXME(https://github.com/astriaorg/astria/issues/729): Sequencer blobs can have duplicate block hashes.
     // We ignore this here and handle that in downstream processing (the sequential cash will reject
@@ -655,6 +674,29 @@ async fn connect_to_celestia(endpoint: &str, token: &str) -> eyre::Result<HttpCl
         .wrap_err("retry attempts exhausted; bailing")
 }
 
+struct ReportSequencerHeights<'a, T>(&'a [T]);
+
+impl<'a, T> std::fmt::Display for ReportSequencerHeights<'a, T>
+where
+    T: GetSequencerHeight,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use std::fmt::Write as _;
+        f.write_char('[')?;
+        let mut blobs = self.0.iter();
+        if let Some(blob) = blobs.next() {
+            let mut buf = itoa::Buffer::new();
+            f.write_str(buf.format(blob.get_height().value()))?;
+        }
+        for blob in blobs {
+            f.write_str(", ")?;
+            let mut buf = itoa::Buffer::new();
+            f.write_str(buf.format(blob.get_height().value()))?;
+        }
+        f.write_char(']')?;
+        Ok(())
+    }
+}
 #[cfg(test)]
 mod tests {
     use super::TrackHeights;

--- a/crates/astria-sequencer-relayer/Cargo.toml
+++ b/crates/astria-sequencer-relayer/Cargo.toml
@@ -15,7 +15,6 @@ name = "astria-sequencer-relayer"
 dirs = "5.0"
 futures-bounded = "0.2.3"
 http = "0.2.9"
-itoa = "1.0.10"
 pin-project-lite = "0.2"
 serde_path_to_error = "0.1.13"
 zeroize = { version = "1.6.0", features = ["zeroize_derive"] }
@@ -28,6 +27,7 @@ futures = { workspace = true }
 hex = { workspace = true, features = ["serde"] }
 humantime = { workspace = true }
 hyper = { workspace = true }
+itoa = { workspace = true }
 metrics = { workspace = true }
 prost = { workspace = true }
 serde = { workspace = true, features = ["derive"] }


### PR DESCRIPTION
## Summary
Updates the celestia reference height even when the execution channel is full

## Background
During large syncs the channel gets full of blocks to execute from celestia and then with smaller variance heights especially would exit the window since the window wasn't being updated on scheduled block updates.

## Changes
- Add logs about sequencer blocks received from Celestia
- Update the reference base for celestia variance window correctly.

## Testing
Run manually via dev-cluster
