### PR TITLE
fix(composer): reset timer when bundle empty

### DIFF
--- a/crates/astria-composer/src/searcher/executor/mod.rs
+++ b/crates/astria-composer/src/searcher/executor/mod.rs
@@ -194,7 +194,7 @@ impl Executor {
         let block_timer = time::sleep(self.block_time);
         tokio::pin!(block_timer);
         let mut bundle_factory = BundleFactory::new(self.max_bytes_per_bundle);
-        let reset_time = || { Instant::now() + self.block_time };
+        let reset_time = || Instant::now() + self.block_time;
 
         loop {
             select! {


### PR DESCRIPTION
## Summary
Updates the timer when clicked over and bundle is empty.

## Background
Once an empty bundle was encountered we would log endlessly, hitting OOM, and loop quickly killing CPU cycles. We should have been resetting the timer.

## Changes
- Reset timer after empty bundle time.

## Testing
Manually tested with k8s in dev-cluster and metrics server to observer resource consumption.
