### PR TITLE
chore(ci): bump cargo chef to 0.1.66

### DIFF
--- a/containerfiles/Dockerfile
+++ b/containerfiles/Dockerfile
@@ -1,5 +1,5 @@
 # build stage
-FROM --platform=$BUILDPLATFORM lukemathwalker/cargo-chef:0.1.63-rust-1.76.0-bookworm AS chef
+FROM --platform=$BUILDPLATFORM lukemathwalker/cargo-chef:0.1.66-rust-1.76.0-bookworm AS chef
 
 WORKDIR /build/
 
@@ -44,7 +44,7 @@ RUN \
 FROM chef AS planner
 ARG TARGETBINARY
 COPY . .
-RUN cargo chef prepare --bin crates/$TARGETBINARY --recipe-path recipe.json
+RUN cargo chef prepare --bin $TARGETBINARY --recipe-path recipe.json
 
 FROM chef as builder
 COPY --from=planner /build/recipe.json recipe.json


### PR DESCRIPTION
## Summary
Bumps cargo chef to 0.1.66 in base container image.

## Background
Cargo chef fixed how it prepares its recipe when supplying the `--bin` argument. Because our crates are nested under `./crates` we needed to provide a path to the binary crate. It can now figure it out itself.

## Changes
- Update base container image to `cargo-chef:0.1.66-rust-1.76.0-bookworm`
- Update containerfile to supply `--bin` option with just the crate name (no path)

## Testing
Container image is still built by docker.