### PR TITLE
fix(conductor): serialize rollup IDs as strings so telemetry doesn't crash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,6 +601,7 @@ dependencies = [
  "hex",
  "humantime",
  "indexmap 2.2.3",
+ "insta",
  "itoa",
  "jsonrpsee",
  "pin-project-lite",
@@ -1852,6 +1853,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "const-hex"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2512,6 +2525,12 @@ checksum = "c533630cf40e9caa44bd91aadc88a75d75a4c3a12b4cfde353cbed41daa1e1f1"
 dependencies = [
  "log",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
@@ -4025,6 +4044,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7c22c4d34ef4788c351e971c52bfdfe7ea2766f8c5466bc175dd46e52ac22e"
+dependencies = [
+ "console",
+ "lazy_static",
+ "linked-hash-map",
+ "serde",
+ "similar",
+ "yaml-rust",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4438,6 +4471,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -6969,6 +7008,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "similar"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32fea41aca09ee824cc9724996433064c89f7777e60762749a4170a14abbfa21"
+
+[[package]]
 name = "simple_asn1"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8645,6 +8690,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]

--- a/crates/astria-conductor/Cargo.toml
+++ b/crates/astria-conductor/Cargo.toml
@@ -60,6 +60,7 @@ astria-core = { path = "../astria-core", features = ["server", "test-utils"] }
 config = { package = "astria-config", path = "../astria-config", features = [
   "tests",
 ] }
+insta = { version = "1.36.1", features = ["json"] }
 
 [build-dependencies]
 astria-build-info = { path = "../astria-build-info", features = ["build"] }

--- a/crates/astria-conductor/src/sequencer/snapshots/astria_conductor__sequencer__reporting__tests__snapshots-2.snap
+++ b/crates/astria-conductor/src/sequencer/snapshots/astria_conductor__sequencer__reporting__tests__snapshots-2.snap
@@ -1,0 +1,11 @@
+---
+source: crates/astria-conductor/src/sequencer/reporting.rs
+expression: ReportFilteredSequencerBlock(&block)
+---
+{
+  "sequencer_height": 100,
+  "rollups": {
+    "2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a": 2,
+    "4545454545454545454545454545454545454545454545454545454545454545": 1
+  }
+}

--- a/crates/astria-conductor/src/sequencer/snapshots/astria_conductor__sequencer__reporting__tests__snapshots.snap
+++ b/crates/astria-conductor/src/sequencer/snapshots/astria_conductor__sequencer__reporting__tests__snapshots.snap
@@ -1,0 +1,8 @@
+---
+source: crates/astria-conductor/src/sequencer/reporting.rs
+expression: ReportRollups(block.rollup_transactions())
+---
+{
+  "2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a": 2,
+  "4545454545454545454545454545454545454545454545454545454545454545": 1
+}

--- a/crates/astria-core/src/sequencer/v1/mod.rs
+++ b/crates/astria-core/src/sequencer/v1/mod.rs
@@ -110,6 +110,7 @@ impl std::fmt::Display for Address {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
 pub struct RollupId {
     #[cfg_attr(feature = "serde", serde(serialize_with = "crate::serde::string::hex"))]
     inner: [u8; 32],


### PR DESCRIPTION
## Summary
Ensures that rollup IDs are serialized as strings.

## Background
The serde derivation for `RollupId` was missing a `serde(transparent)` attribute. This means that, for JSON, rollup IDs were not serialized has `"<hex-of-32-bytes>"` but as `{ "inner": "<hex-of-32-bytes>" }`.

This in turn caused the JSON-serialization of some structs used for reporting received blocks from sequencer to fail, causing a panic in the tracing stack (as it assumes that `Display` formatting won't fail).

## Changes
- Add `serde(transparent)` attribute on `RollupId`
- Add snapshot tests to reporting types

## Testing
Added snapshot tests for types used in conductor tracing (that's where we saw the failed display formatting and subsequent panic).