### PR TITLE
feat(relayer): implement graceful shutdown

### DIFF
--- a/crates/astria-sequencer-relayer/Cargo.toml
+++ b/crates/astria-sequencer-relayer/Cargo.toml
@@ -38,8 +38,8 @@ tendermint-config = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 tryhard = { workspace = true }
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
-tokio-util = { workspace = true, features = ["rt"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal"] }
+tokio-util = { workspace = true }
 tonic = { workspace = true }
 
 astria-build-info = { path = "../astria-build-info", features = ["runtime"] }

--- a/crates/astria-sequencer-relayer/src/api.rs
+++ b/crates/astria-sequencer-relayer/src/api.rs
@@ -39,7 +39,11 @@ impl FromRef<AppState> for RelayerState {
     }
 }
 
-pub(crate) fn start(socket_addr: SocketAddr, relayer_state: RelayerState) -> ApiServer {
+pub(crate) fn start(
+    socket_addr: SocketAddr,
+    relayer_state: RelayerState,
+    // shutdown: oneshot::Receiver<()>,
+) -> ApiServer {
     let app = Router::new()
         .route("/healthz", get(get_healthz))
         .route("/readyz", get(get_readyz))

--- a/crates/astria-sequencer-relayer/src/api.rs
+++ b/crates/astria-sequencer-relayer/src/api.rs
@@ -39,11 +39,7 @@ impl FromRef<AppState> for RelayerState {
     }
 }
 
-pub(crate) fn start(
-    socket_addr: SocketAddr,
-    relayer_state: RelayerState,
-    // shutdown: oneshot::Receiver<()>,
-) -> ApiServer {
+pub(crate) fn start(socket_addr: SocketAddr, relayer_state: RelayerState) -> ApiServer {
     let app = Router::new()
         .route("/healthz", get(get_healthz))
         .route("/readyz", get(get_readyz))

--- a/crates/astria-sequencer-relayer/src/relayer/builder.rs
+++ b/crates/astria-sequencer-relayer/src/relayer/builder.rs
@@ -20,6 +20,7 @@ use super::state::State;
 use crate::validator::Validator;
 
 pub(crate) struct Builder {
+    pub(crate) shutdown_token: tokio_util::sync::CancellationToken,
     pub(crate) celestia_endpoint: String,
     pub(crate) celestia_bearer_token: String,
     pub(crate) cometbft_endpoint: String,
@@ -34,6 +35,7 @@ impl Builder {
     /// Instantiates a `Relayer`.
     pub(crate) fn build(self) -> eyre::Result<super::Relayer> {
         let Self {
+            shutdown_token,
             celestia_endpoint,
             celestia_bearer_token,
             cometbft_endpoint,
@@ -65,6 +67,7 @@ impl Builder {
         let state = Arc::new(State::new());
 
         Ok(super::Relayer {
+            shutdown_token,
             sequencer_cometbft_client,
             sequencer_grpc_client,
             sequencer_poll_period,

--- a/crates/astria-sequencer-relayer/src/relayer/mod.rs
+++ b/crates/astria-sequencer-relayer/src/relayer/mod.rs
@@ -141,6 +141,7 @@ impl Relayer {
                 biased;
 
                 () = self.shutdown_token.cancelled() => {
+                    info!("received shutdown signal");
                     break Ok("shutdown signal received");
                 }
 

--- a/crates/astria-sequencer-relayer/src/relayer/mod.rs
+++ b/crates/astria-sequencer-relayer/src/relayer/mod.rs
@@ -140,7 +140,7 @@ impl Relayer {
             select!(
                 biased;
 
-                _ = self.shutdown_token.cancelled() => {
+                () = self.shutdown_token.cancelled() => {
                     break Ok("shutdown signal received");
                 }
 

--- a/crates/astria-sequencer-relayer/src/relayer/mod.rs
+++ b/crates/astria-sequencer-relayer/src/relayer/mod.rs
@@ -202,8 +202,8 @@ impl Relayer {
         };
 
         match &reason {
-            Ok(reason) => info!(reason, "shutting down"),
-            Err(reason) => error!(%reason, "shutting down"),
+            Ok(reason) => info!(reason, "starting shutdown"),
+            Err(reason) => error!(%reason, "starting shutdown"),
         }
 
         debug!("waiting for Celestia submission task to exit");

--- a/crates/astria-sequencer-relayer/src/relayer/mod.rs
+++ b/crates/astria-sequencer-relayer/src/relayer/mod.rs
@@ -39,6 +39,7 @@ use tokio::{
     task::JoinHandle,
 };
 use tokio_stream::StreamExt;
+use tokio_util::sync::CancellationToken;
 use tracing::{
     debug,
     error,
@@ -63,6 +64,9 @@ pub(crate) use state::StateSnapshot;
 use self::submission::SubmissionState;
 
 pub(crate) struct Relayer {
+    /// A token to notify relayer that it should shut down.
+    shutdown_token: tokio_util::sync::CancellationToken,
+
     /// The client used to query the sequencer cometbft endpoint.
     sequencer_cometbft_client: SequencerClient,
 
@@ -114,6 +118,7 @@ impl Relayer {
             self.celestia_client.clone(),
             self.state.clone(),
             submission_state,
+            self.shutdown_token.clone(),
         );
 
         let mut block_stream = read::BlockStream::builder()
@@ -134,6 +139,10 @@ impl Relayer {
         let reason = loop {
             select!(
                 biased;
+
+                _ = self.shutdown_token.cancelled() => {
+                    break Ok("shutdown signal received");
+                }
 
                 res = &mut forward_once_free, if !forward_once_free.is_terminated() => {
                     // XXX: exiting because submitter only returns an error after u32::MAX
@@ -192,11 +201,17 @@ impl Relayer {
             );
         };
 
-        submitter_task.abort();
-        if let Err(error) = crate::utils::flatten(submitter_task.await) {
-            error!(%error, "Celestia blob submission task failed");
+        match &reason {
+            Ok(reason) => info!(reason, "shutting down"),
+            Err(reason) => error!(%reason, "shutting down"),
         }
-        reason
+
+        debug!("waiting for Celestia submission task to exit");
+        if let Err(error) = submitter_task.await {
+            error!(%error, "Celestia submission task failed while waiting for it to exit before shutdown");
+        }
+
+        reason.map(|_| ())
     }
 
     fn report_validator(&self) -> Option<DisplayValue<ReportValidator<'_>>> {
@@ -281,8 +296,10 @@ fn spawn_submitter(
     client: CelestiaClient,
     state: Arc<State>,
     submission_state: submission::SubmissionState,
+    shutdown_token: CancellationToken,
 ) -> (JoinHandle<eyre::Result<()>>, write::BlobSubmitterHandle) {
-    let (submitter, handle) = write::BlobSubmitter::new(client, state, submission_state);
+    let (submitter, handle) =
+        write::BlobSubmitter::new(client, state, submission_state, shutdown_token);
     (tokio::spawn(submitter.run()), handle)
 }
 

--- a/crates/astria-sequencer-relayer/src/relayer/write/mod.rs
+++ b/crates/astria-sequencer-relayer/src/relayer/write/mod.rs
@@ -246,7 +246,7 @@ impl BlobSubmitter {
             select!(
                 biased;
 
-                _ = self.shutdown_token.cancelled() => {
+                () = self.shutdown_token.cancelled() => {
                     break Ok("received shutdown signal");
                 }
 
@@ -295,7 +295,7 @@ impl BlobSubmitter {
                         }
                     };
                 }
-            )
+            );
         };
 
         match &reason {

--- a/crates/astria-sequencer-relayer/src/sequencer_relayer.rs
+++ b/crates/astria-sequencer-relayer/src/sequencer_relayer.rs
@@ -7,8 +7,24 @@ use astria_eyre::eyre::{
     self,
     WrapErr as _,
 };
-use tokio::task::JoinError;
-use tracing::info;
+use tokio::{
+    select,
+    signal::unix::{
+        signal,
+        SignalKind,
+    },
+    sync::oneshot,
+    task::{
+        JoinError,
+        JoinHandle,
+    },
+    time::timeout,
+};
+use tokio_util::sync::CancellationToken;
+use tracing::{
+    error,
+    info,
+};
 
 use crate::{
     api,
@@ -19,9 +35,20 @@ use crate::{
     },
 };
 
+pub struct Handle {
+    shutdown_token: CancellationToken,
+}
+
+impl Handle {
+    pub fn shutdown(self) {
+        self.shutdown_token.cancel()
+    }
+}
+
 pub struct SequencerRelayer {
     api_server: api::ApiServer,
     relayer: Relayer,
+    shutdown_token: CancellationToken,
 }
 
 impl SequencerRelayer {
@@ -31,6 +58,7 @@ impl SequencerRelayer {
     ///
     /// Returns an error if constructing the inner relayer type failed.
     pub fn new(cfg: Config) -> eyre::Result<Self> {
+        let shutdown_token = CancellationToken::new();
         let Config {
             cometbft_endpoint,
             sequencer_grpc_endpoint,
@@ -47,6 +75,7 @@ impl SequencerRelayer {
 
         let validator_key_path = relay_only_validator_key_blocks.then_some(validator_key_file);
         let relayer = relayer::Builder {
+            shutdown_token: shutdown_token.clone(),
             celestia_endpoint,
             celestia_bearer_token,
             cometbft_endpoint,
@@ -67,6 +96,7 @@ impl SequencerRelayer {
         Ok(Self {
             api_server,
             relayer,
+            shutdown_token,
         })
     }
 
@@ -78,20 +108,46 @@ impl SequencerRelayer {
         let Self {
             api_server,
             relayer,
+            shutdown_token,
         } = self;
-        // Wrap the API server in an async block so we can easily turn the result
-        // of the future into an eyre report.
-        let api_task =
-            tokio::spawn(async move { api_server.await.wrap_err("api server ended unexpectedly") });
+        // Separate the API shutdown signal from the cancellation token because we want it to live
+        // until the very end.
+        let (api_shutdown_signal, api_shutdown_signal_rx) = oneshot::channel::<()>();
+        let mut api_task = tokio::spawn(async move {
+            api_server
+                .with_graceful_shutdown(async move {
+                    let _ = api_shutdown_signal_rx.await;
+                })
+                .await
+                .wrap_err("api server ended unexpectedly")
+        });
         info!("spawned API server");
 
-        let relayer_task = tokio::spawn(relayer.run());
+        let mut relayer_task = tokio::spawn(relayer.run());
         info!("spawned relayer task");
 
-        tokio::select!(
-            o = api_task => report_exit("api server", o),
-            o = relayer_task => report_exit("relayer worker", o),
+        let mut sigterm = signal(SignalKind::terminate()).expect(
+            "setting a SIGTERM listener should always work on unix; is this running on unix?",
         );
+
+        let shutdown = select!(
+            _ = sigterm.recv() => {
+                info!("received SIGTERM, issuing shutdown to all services");
+                shutdown_token.cancel();
+                Shutdown { api_task: Some(api_task), relayer_task: Some(relayer_task), api_shutdown_signal, }
+            },
+
+            o = &mut api_task => {
+                report_exit("api server", o);
+                Shutdown { api_task: None, relayer_task: Some(relayer_task), api_shutdown_signal, }
+            }
+            o = &mut relayer_task => {
+                report_exit("relayer worker", o);
+                Shutdown { api_task: Some(api_task), relayer_task: None, api_shutdown_signal, }
+            }
+
+        );
+        shutdown.run().await;
     }
 }
 
@@ -107,6 +163,61 @@ fn report_exit(task_name: &str, outcome: Result<eyre::Result<()>, JoinError>) {
                 error = &e as &dyn std::error::Error,
                 "task failed to complete"
             );
+        }
+    }
+}
+
+struct Shutdown {
+    api_task: Option<JoinHandle<eyre::Result<()>>>,
+    relayer_task: Option<JoinHandle<eyre::Result<()>>>,
+    api_shutdown_signal: oneshot::Sender<()>,
+}
+
+impl Shutdown {
+    async fn run(self) {
+        let Self {
+            api_task,
+            relayer_task,
+            api_shutdown_signal,
+        } = self;
+        // Giving relayer 25 seconds to shutdown because Kubernetes issues a SIGKILL after 30.
+        match relayer_task {
+            Some(mut relayer_task) => {
+                info!("waiting for relayer task to shut down");
+                match timeout(Duration::from_secs(25), &mut relayer_task)
+                    .await
+                    .map(crate::utils::flatten)
+                {
+                    Ok(Ok(())) => info!("relayer exited gracefully"),
+                    Ok(Err(error)) => error!(%error, "relayer exited with an error"),
+                    Err(_) => {
+                        error!("relayer did not shut down after 25 seconds; killing it");
+                        relayer_task.abort();
+                    }
+                }
+                info!("sending shutdown signal to API server");
+            }
+            None => info!("relayer task was already dead"),
+        }
+
+        // Giving the API task another 4 seconds. 25 for relayer + 4s = 29s (out of 30s for k8s).
+        match api_task {
+            Some(mut api_task) => {
+                info!("sending shutdown signal to API server");
+                let _ = api_shutdown_signal.send(());
+                match timeout(Duration::from_secs(4), &mut api_task)
+                    .await
+                    .map(crate::utils::flatten)
+                {
+                    Ok(Ok(())) => info!("api server exited gracefully"),
+                    Ok(Err(error)) => error!(%error, "api server exited with an error"),
+                    Err(_) => {
+                        error!("api server did not shut down after 25 seconds; killing it");
+                        api_task.abort();
+                    }
+                }
+            }
+            None => info!("API server was already dead"),
         }
     }
 }


### PR DESCRIPTION
## Summary
Adds graceful shutdown to relayer.

## Background
Because relayer did not previously respond to SIGTERM, it would eventually just get killed off (for example by kubernetes after 30s). This could potentially lead to situations where relayer would try to submit blocks to Celestia right before shutdown, potentially leaving its state tracking file in a bad state.

## Changes
- Add a SIGTERM listener to sequener-relayer, initiating a shutdown of all its services.
- The relayer task proper will immediately exit its event-loop and wait until its last submission is complete.
- Sequencer-Relayer itself waits 25 seconds for its relayer service to finish, hard-killing it otherwise
- The API task is issues an explicit shutdown signal last and has 4s to finish, before being killed.

## Testing
This should be tested end to end by sending sequencer-relayer SIGTERM

## Related Issues
Closes https://github.com/astriaorg/astria/issues/357