### PR TITLE
feat(composer): Implement graceful shutdown

### DIFF
--- a/crates/astria-composer/Cargo.toml
+++ b/crates/astria-composer/Cargo.toml
@@ -44,6 +44,7 @@ tokio = { workspace = true, features = [
   "rt-multi-thread",
   "sync",
   "time",
+  "signal",
 ] }
 tokio-util = { workspace = true, features = ["rt"] }
 tracing = { workspace = true, features = ["attributes"] }

--- a/crates/astria-composer/src/composer.rs
+++ b/crates/astria-composer/src/composer.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::HashMap,
     net::SocketAddr,
+    time::Duration,
 };
 
 use astria_core::sequencer::v1::transaction::action::SequenceAction;
@@ -10,8 +11,13 @@ use astria_eyre::eyre::{
 };
 use tokio::{
     net::TcpListener,
+    signal::unix::{
+        signal,
+        SignalKind,
+    },
     sync::{
         mpsc::Sender,
+        oneshot,
         watch,
     },
     task::JoinError,
@@ -51,11 +57,13 @@ pub struct Composer {
     executor_handle: ExecutorHandle,
     /// `GethCollectorStatuses` The collection of the geth collector statuses.
     geth_collector_statuses: HashMap<String, watch::Receiver<geth_collector::Status>>,
+    geth_collector_shutdown_channels: HashMap<String, oneshot::Sender<()>>,
     /// `GethCollectorTasks` is the set of tasks tracking if the geth collectors are still running.
     geth_collector_tasks: JoinMap<String, eyre::Result<()>>,
     /// `ComposerTasks` is the set of tasks tracking if the composer is still running.
     /// It mainly consists of the API server, executor and grpc collector.
     composer_tasks: JoinMap<String, eyre::Result<()>>,
+    composer_tasks_shutdown_channels: HashMap<String, oneshot::Sender<()>>,
     /// `Rollups` The map of chain ID to the URLs to which geth collectors should connect.
     rollups: HashMap<String, String>,
     /// `GrpcCollectorAddr` is the address of the gRPC server of the gRPC collector.
@@ -76,13 +84,18 @@ impl Composer {
     pub async fn from_config(cfg: &Config) -> eyre::Result<Self> {
         let (composer_status_sender, _) = watch::channel(ComposerStatus::default());
 
+        let mut composer_tasks_shutdown_channels = HashMap::new();
+
+        let (executor_shutdown_tx, executor_shutdown_rx) = oneshot::channel();
         let (executor, sequence_action_tx) = Executor::new(
             &cfg.sequencer_url,
             &cfg.private_key,
             cfg.block_time_ms,
             cfg.max_bytes_per_bundle,
+            executor_shutdown_rx,
         )
         .wrap_err("executor construction from config failed")?;
+        composer_tasks_shutdown_channels.insert(Self::EXECUTOR.to_string(), executor_shutdown_tx);
 
         let executor_status = executor.subscribe();
 
@@ -90,23 +103,38 @@ impl Composer {
             sequence_action_tx: sequence_action_tx.clone(),
         };
 
+        let (grpc_collector_shutdown_tx, grpc_collector_shutdown_rx) = oneshot::channel();
         let grpc_collector_listener = TcpListener::bind(cfg.grpc_collector_addr).await?;
         let grpc_collector_addr = grpc_collector_listener.local_addr()?;
-        let grpc_collector = GrpcCollector::new(grpc_collector_listener, executor_handle.clone());
+        let grpc_collector = GrpcCollector::new(
+            grpc_collector_listener,
+            executor_handle.clone(),
+            grpc_collector_shutdown_rx,
+        );
+        composer_tasks_shutdown_channels
+            .insert(Self::GRPC_COLLECTOR.to_string(), grpc_collector_shutdown_tx);
 
+        let (api_server_shutdown_tx, api_server_shutdown_rx) = oneshot::channel();
         let api_server = api::start(cfg.api_listen_addr, composer_status_sender.subscribe());
         let api_server_addr = api_server.local_addr();
         info!(
             listen_addr = %api_server_addr,
             "API server listening"
         );
+        composer_tasks_shutdown_channels
+            .insert(Self::API_SERVER.to_string(), api_server_shutdown_tx);
 
         // spin up composer tasks
         let mut composer_tasks = JoinMap::new();
 
         // spin up the api server
         composer_tasks.spawn(Self::API_SERVER.to_string(), async move {
-            api_server.await.wrap_err("api server ended unexpectedly")
+            api_server
+                .with_graceful_shutdown(async move {
+                    let _ = api_server_shutdown_rx.await;
+                })
+                .await
+                .wrap_err("api server ended unexpectedly")
         });
 
         // spin up the executor
@@ -132,14 +160,18 @@ impl Composer {
             .collect::<Result<HashMap<_, _>, _>>()
             .wrap_err("failed parsing provided <rollup_name>::<url> pairs as rollups")?;
 
+        let mut geth_collector_shutdown_channels = HashMap::new();
         let mut geth_collectors = rollups
             .iter()
             .map(|(rollup_name, url)| {
+                let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
                 let collector = GethCollector::new(
                     rollup_name.clone(),
                     url.clone(),
                     sequence_action_tx.clone(),
+                    shutdown_rx,
                 );
+                geth_collector_shutdown_channels.insert(rollup_name.clone(), shutdown_tx);
                 (rollup_name.clone(), collector)
             })
             .collect::<HashMap<_, _>>();
@@ -163,10 +195,12 @@ impl Composer {
             api_server_addr,
             executor_handle,
             geth_collector_statuses,
+            geth_collector_shutdown_channels,
             geth_collector_tasks,
             composer_tasks,
             rollups,
             grpc_collector_addr,
+            composer_tasks_shutdown_channels,
         })
     }
 
@@ -188,34 +222,80 @@ impl Composer {
     ///
     /// # Errors
     /// It errors out if the API Server, Executor or any of the Geth Collectors fail to start.
-    pub async fn run_until_stopped(self) -> eyre::Result<()> {
-        let Self {
-            mut composer_tasks,
-            executor_handle,
-            mut geth_collector_tasks,
-            rollups,
-            mut geth_collector_statuses,
-            ..
-        } = self;
+    pub async fn run_until_stopped(mut self) -> eyre::Result<()> {
+        let mut sigterm = signal(SignalKind::terminate()).expect(
+            "setting a SIGTERM listener should always work on unix; is this running on unix?",
+        );
 
         loop {
             tokio::select!(
-            Some((task, err)) = composer_tasks.join_next() => {
+            Some((task, err)) = self.composer_tasks.join_next() => {
                 report_exit(format!("composer task: {task}").as_str(), err);
                 return Ok(());
             },
-            Some((rollup, collector_exit)) = geth_collector_tasks.join_next() => {
+            Some((rollup, collector_exit)) = self.geth_collector_tasks.join_next() => {
                 // TODO - do we really need to restart the geth collector?
                 reconnect_exited_collector(
-                    &mut geth_collector_statuses,
-                    &mut geth_collector_tasks,
-                    executor_handle.sequence_action_tx.clone(),
-                    &rollups,
+                    &mut self.geth_collector_statuses,
+                    &mut self.geth_collector_tasks,
+                    &mut self.geth_collector_shutdown_channels,
+                    self.executor_handle.sequence_action_tx.clone(),
+                    &self.rollups,
                     rollup,
                     collector_exit,
                 );
-            });
+            },
+            _ = sigterm.recv() => {
+                info!("received SIGTERM, issuing shutdown to all services");
+                break;
+            },
+            );
         }
+
+        self.shutdown().await?;
+
+        Ok(())
+    }
+
+    pub async fn shutdown(mut self) -> eyre::Result<()> {
+        info!("shutting down composer");
+        // send shutdown to all geth collectors
+        for (rollup, shutdown_tx) in self.geth_collector_shutdown_channels {
+            info!("shutting down geth collector: {}", rollup);
+            let _ = shutdown_tx.send(());
+        }
+        // send shutdown to all composer tasks
+        for (task, shutdown_tx) in self.composer_tasks_shutdown_channels {
+            info!("shutting down composer task: {}", task);
+            let _ = shutdown_tx.send(());
+        }
+
+        // wait for 5s for all tasks to shutdown
+        info!("waiting for 5 seconds for geth collector tasks to shutdown");
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while let Some((task, err)) = self.geth_collector_tasks.join_next().await {
+                report_exit(format!("geth collector task: {}", task).as_str(), err);
+            }
+        })
+        .await?;
+        if !self.geth_collector_tasks.is_empty() {
+            error!("geth collector tasks did not shutdown in time");
+            self.geth_collector_tasks.shutdown().await;
+        }
+
+        info!("waiting for 5 seconds for composer tasks to shutdown");
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while let Some((task, err)) = self.composer_tasks.join_next().await {
+                report_exit(format!("composer task: {}", task).as_str(), err);
+            }
+        })
+        .await?;
+        if !self.composer_tasks.is_empty() {
+            error!("composer tasks did not shutdown in time");
+            self.composer_tasks.shutdown().await;
+        }
+
+        Ok(())
     }
 }
 
@@ -275,6 +355,7 @@ async fn wait_for_collectors(
 fn reconnect_exited_collector(
     collector_statuses: &mut HashMap<String, watch::Receiver<geth_collector::Status>>,
     collector_tasks: &mut JoinMap<String, eyre::Result<()>>,
+    collector_shutdown_channels: &mut HashMap<String, oneshot::Sender<()>>,
     serialized_rolup_transactions_tx: Sender<SequenceAction>,
     rollups: &HashMap<String, String>,
     rollup: String,
@@ -289,13 +370,16 @@ fn reconnect_exited_collector(
         return;
     };
 
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
     let collector = GethCollector::new(
         rollup.clone(),
         url.clone(),
         serialized_rolup_transactions_tx,
+        shutdown_rx,
     );
     collector_statuses.insert(rollup.clone(), collector.subscribe());
-    collector_tasks.spawn(rollup, collector.run_until_stopped());
+    collector_tasks.spawn(rollup.clone(), collector.run_until_stopped());
+    collector_shutdown_channels.insert(rollup, shutdown_tx);
 }
 
 fn report_exit(task_name: &str, outcome: Result<eyre::Result<()>, JoinError>) {
@@ -338,7 +422,15 @@ mod tests {
         let (tx, mut rx) = tokio::sync::mpsc::channel(16);
 
         let mut collector_tasks = JoinMap::new();
-        let collector = GethCollector::new(rollup_name.clone(), rollup_url.clone(), tx.clone());
+        let mut collector_shutdown_channels = HashMap::new();
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+        collector_shutdown_channels.insert(rollup_name.clone(), shutdown_tx);
+        let collector = GethCollector::new(
+            rollup_name.clone(),
+            rollup_url.clone(),
+            tx.clone(),
+            shutdown_rx,
+        );
         let mut status = collector.subscribe();
         collector_tasks.spawn(rollup_name.clone(), collector.run_until_stopped());
         status
@@ -374,6 +466,7 @@ mod tests {
         super::reconnect_exited_collector(
             &mut statuses,
             &mut collector_tasks,
+            &mut collector_shutdown_channels,
             tx.clone(),
             &rollups,
             rollup_name.clone(),

--- a/crates/astria-composer/src/executor/tests.rs
+++ b/crates/astria-composer/src/executor/tests.rs
@@ -18,7 +18,10 @@ use tendermint_rpc::{
     Id,
 };
 use tokio::{
-    sync::watch,
+    sync::{
+        oneshot,
+        watch,
+    },
     time,
 };
 use tracing::debug;
@@ -194,12 +197,14 @@ async fn wait_for_startup(
 #[tokio::test]
 async fn full_bundle() {
     // set up the executor, channel for writing seq actions, and the sequencer mock
+    let (_shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
     let (sequencer, nonce_guard, cfg) = setup().await;
     let (executor, seq_actions_tx) = Executor::new(
         &cfg.sequencer_url,
         &cfg.private_key,
         cfg.block_time_ms,
         cfg.max_bytes_per_bundle,
+        shutdown_rx,
     )
     .unwrap();
 
@@ -274,12 +279,14 @@ async fn full_bundle() {
 #[tokio::test]
 async fn bundle_triggered_by_block_timer() {
     // set up the executor, channel for writing seq actions, and the sequencer mock
+    let (_shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
     let (sequencer, nonce_guard, cfg) = setup().await;
     let (executor, seq_actions_tx) = Executor::new(
         &cfg.sequencer_url,
         &cfg.private_key,
         cfg.block_time_ms,
         cfg.max_bytes_per_bundle,
+        shutdown_rx,
     )
     .unwrap();
 
@@ -350,12 +357,14 @@ async fn bundle_triggered_by_block_timer() {
 #[tokio::test]
 async fn two_seq_actions_single_bundle() {
     // set up the executor, channel for writing seq actions, and the sequencer mock
+    let (_shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
     let (sequencer, nonce_guard, cfg) = setup().await;
     let (executor, seq_actions_tx) = Executor::new(
         &cfg.sequencer_url,
         &cfg.private_key,
         cfg.block_time_ms,
         cfg.max_bytes_per_bundle,
+        shutdown_rx,
     )
     .unwrap();
 


### PR DESCRIPTION
## Summary
Implement graceful shutdown for composer tasks.

## Background
Currently, composer tasks do not support any sort of graceful shutdown on a SIGTERM or so. Also, when certain tasks error out, there is no graceful way of exiting all the composer tasks.

## Changes
- Add a field to `composer` called `composer_shutdown_channels` which consists of the shutdown channels of the ApiServer, gRPC collector and Executor.
- Add a field to `composer` called `geth_collector_shutdown_channels` which consists of the shutdown channels of each individual collector.
- Implement a `shutdown` function which is called after a task exits due to an error or when a SIGTERM is called.

## Testing
Builds and tests run successfully. Need to test it by deploying it. 

## Related Issues
https://github.com/astriaorg/astria/issues/795

closes <!-- list any issues closed here -->
