### PR TITLE
fix(conductor): don't panic while shutting down

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -602,6 +602,7 @@ dependencies = [
  "humantime",
  "indexmap 2.2.3",
  "insta",
+ "itertools 0.12.1",
  "itoa",
  "jsonrpsee",
  "pin-project-lite",
@@ -4099,6 +4100,15 @@ name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]

--- a/crates/astria-conductor/Cargo.toml
+++ b/crates/astria-conductor/Cargo.toml
@@ -50,6 +50,7 @@ sequencer-client = { package = "astria-sequencer-client", path = "../astria-sequ
 telemetry = { package = "astria-telemetry", path = "../astria-telemetry", features = [
   "display",
 ] }
+itertools = "0.12.1"
 
 [dev-dependencies]
 jsonrpsee = { workspace = true, features = ["server"] }

--- a/crates/astria-conductor/src/utils.rs
+++ b/crates/astria-conductor/src/utils.rs
@@ -26,7 +26,7 @@ impl IncrementableHeight for SequencerHeight {
 pub(crate) fn flatten<T>(res: Result<eyre::Result<T>, JoinError>) -> eyre::Result<T> {
     match res {
         Ok(Ok(val)) => Ok(val),
-        Ok(Err(err)) => Err(err).wrap_err("fask returned with error"),
+        Ok(Err(err)) => Err(err).wrap_err("task returned with error"),
         Err(err) => Err(err).wrap_err("task panicked"),
     }
 }

--- a/crates/astria-conductor/src/utils.rs
+++ b/crates/astria-conductor/src/utils.rs
@@ -1,5 +1,10 @@
+use astria_eyre::eyre::{
+    self,
+    WrapErr as _,
+};
 use celestia_client::celestia_types::Height as CelestiaHeight;
 use sequencer_client::tendermint::block::Height as SequencerHeight;
+use tokio::task::JoinError;
 
 /// A necessary evil because the celestia client code uses a forked tendermint-rs.
 pub(crate) trait IncrementableHeight {
@@ -15,5 +20,13 @@ impl IncrementableHeight for CelestiaHeight {
 impl IncrementableHeight for SequencerHeight {
     fn increment(self) -> Self {
         self.increment()
+    }
+}
+
+pub(crate) fn flatten<T>(res: Result<eyre::Result<T>, JoinError>) -> eyre::Result<T> {
+    match res {
+        Ok(Ok(val)) => Ok(val),
+        Ok(Err(err)) => Err(err).wrap_err("fask returned with error"),
+        Err(err) => Err(err).wrap_err("task panicked"),
     }
 }

--- a/crates/astria-sequencer-relayer/src/utils.rs
+++ b/crates/astria-sequencer-relayer/src/utils.rs
@@ -7,7 +7,7 @@ use tokio::task::JoinError;
 pub(crate) fn flatten<T>(res: Result<eyre::Result<T>, JoinError>) -> eyre::Result<T> {
     match res {
         Ok(Ok(val)) => Ok(val),
-        Ok(Err(err)) => Err(err).wrap_err("fask returned with error"),
+        Ok(Err(err)) => Err(err).wrap_err("task returned with error"),
         Err(err) => Err(err).wrap_err("task panicked"),
     }
 }


### PR DESCRIPTION
## Summary
Fixes conductor panicking during shutdown.

## Background
Conductor was using a tokio `LocalSet` together with an `Rc` to run its shutdown logic. This was entirely unnecessary and panicky (since the `Rc` was cloned into multiple tasks, which was obviously wrong).

Note that this PR does not address conductor ignoring `SIGTERM` during initialization.

## Changes
- Simplify the awkward `LocalSet` + `Rc` to shutdown conductor tasks
- Simplify reporting task failure and exist

## Testing
This needs to be tested end to end (since conductor receives an external signal).

## Related Issues
Closes #828 