### PR TITLE
refactor: generate Arc<Self> target for grpc servers

### DIFF
--- a/crates/astria-conductor/src/executor/tests.rs
+++ b/crates/astria-conductor/src/executor/tests.rs
@@ -1,7 +1,10 @@
 use std::{
     collections::HashMap,
     net::SocketAddr,
-    sync::Mutex,
+    sync::{
+        Arc,
+        Mutex,
+    },
 };
 
 use astria_core::{
@@ -129,14 +132,14 @@ impl ExecutionServiceImpl {
 #[tonic::async_trait]
 impl ExecutionService for ExecutionServiceImpl {
     async fn get_block(
-        &self,
+        self: Arc<Self>,
         _request: tonic::Request<GetBlockRequest>,
     ) -> std::result::Result<tonic::Response<raw::Block>, tonic::Status> {
         unimplemented!("get_block")
     }
 
     async fn get_genesis_info(
-        &self,
+        self: Arc<Self>,
         _request: tonic::Request<GetGenesisInfoRequest>,
     ) -> std::result::Result<tonic::Response<raw::GenesisInfo>, tonic::Status> {
         Ok(tonic::Response::new(
@@ -145,14 +148,14 @@ impl ExecutionService for ExecutionServiceImpl {
     }
 
     async fn batch_get_blocks(
-        &self,
+        self: Arc<Self>,
         _request: tonic::Request<BatchGetBlocksRequest>,
     ) -> std::result::Result<tonic::Response<BatchGetBlocksResponse>, tonic::Status> {
         unimplemented!("batch_get_blocks")
     }
 
     async fn execute_block(
-        &self,
+        self: Arc<Self>,
         request: tonic::Request<ExecuteBlockRequest>,
     ) -> std::result::Result<tonic::Response<raw::Block>, tonic::Status> {
         let request = request.into_inner();
@@ -175,7 +178,7 @@ impl ExecutionService for ExecutionServiceImpl {
     }
 
     async fn get_commitment_state(
-        &self,
+        self: Arc<Self>,
         _request: tonic::Request<GetCommitmentStateRequest>,
     ) -> std::result::Result<tonic::Response<raw::CommitmentState>, tonic::Status> {
         Ok(tonic::Response::new(
@@ -184,7 +187,7 @@ impl ExecutionService for ExecutionServiceImpl {
     }
 
     async fn update_commitment_state(
-        &self,
+        self: Arc<Self>,
         request: tonic::Request<UpdateCommitmentStateRequest>,
     ) -> std::result::Result<tonic::Response<raw::CommitmentState>, tonic::Status> {
         let new_state = {

--- a/crates/astria-core/src/generated/astria.execution.v1alpha1.rs
+++ b/crates/astria-core/src/generated/astria.execution.v1alpha1.rs
@@ -219,18 +219,18 @@ pub mod execution_service_server {
     #[async_trait]
     pub trait ExecutionService: Send + Sync + 'static {
         async fn init_state(
-            &self,
+            self: std::sync::Arc<Self>,
             request: tonic::Request<super::InitStateRequest>,
         ) -> std::result::Result<
             tonic::Response<super::InitStateResponse>,
             tonic::Status,
         >;
         async fn do_block(
-            &self,
+            self: std::sync::Arc<Self>,
             request: tonic::Request<super::DoBlockRequest>,
         ) -> std::result::Result<tonic::Response<super::DoBlockResponse>, tonic::Status>;
         async fn finalize_block(
-            &self,
+            self: std::sync::Arc<Self>,
             request: tonic::Request<super::FinalizeBlockRequest>,
         ) -> std::result::Result<
             tonic::Response<super::FinalizeBlockResponse>,
@@ -334,7 +334,7 @@ pub mod execution_service_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as ExecutionService>::init_state(&inner, request).await
+                                <T as ExecutionService>::init_state(inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -380,7 +380,7 @@ pub mod execution_service_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as ExecutionService>::do_block(&inner, request).await
+                                <T as ExecutionService>::do_block(inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -426,7 +426,7 @@ pub mod execution_service_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as ExecutionService>::finalize_block(&inner, request)
+                                <T as ExecutionService>::finalize_block(inner, request)
                                     .await
                             };
                             Box::pin(fut)

--- a/crates/astria-core/src/generated/astria.execution.v1alpha2.rs
+++ b/crates/astria-core/src/generated/astria.execution.v1alpha2.rs
@@ -409,18 +409,18 @@ pub mod execution_service_server {
     pub trait ExecutionService: Send + Sync + 'static {
         /// GetGenesisInfo returns the necessary genesis information for rollup chain.
         async fn get_genesis_info(
-            &self,
+            self: std::sync::Arc<Self>,
             request: tonic::Request<super::GetGenesisInfoRequest>,
         ) -> std::result::Result<tonic::Response<super::GenesisInfo>, tonic::Status>;
         /// GetBlock will return a block given an identifier.
         async fn get_block(
-            &self,
+            self: std::sync::Arc<Self>,
             request: tonic::Request<super::GetBlockRequest>,
         ) -> std::result::Result<tonic::Response<super::Block>, tonic::Status>;
         /// BatchGetBlocks will return an array of Blocks given an array of block
         /// identifiers.
         async fn batch_get_blocks(
-            &self,
+            self: std::sync::Arc<Self>,
             request: tonic::Request<super::BatchGetBlocksRequest>,
         ) -> std::result::Result<
             tonic::Response<super::BatchGetBlocksResponse>,
@@ -429,18 +429,18 @@ pub mod execution_service_server {
         /// ExecuteBlock is called to deterministically derive a rollup block from
         /// filtered sequencer block information.
         async fn execute_block(
-            &self,
+            self: std::sync::Arc<Self>,
             request: tonic::Request<super::ExecuteBlockRequest>,
         ) -> std::result::Result<tonic::Response<super::Block>, tonic::Status>;
         /// GetCommitmentState fetches the current CommitmentState of the chain.
         async fn get_commitment_state(
-            &self,
+            self: std::sync::Arc<Self>,
             request: tonic::Request<super::GetCommitmentStateRequest>,
         ) -> std::result::Result<tonic::Response<super::CommitmentState>, tonic::Status>;
         /// UpdateCommitmentState replaces the whole CommitmentState with a new
         /// CommitmentState.
         async fn update_commitment_state(
-            &self,
+            self: std::sync::Arc<Self>,
             request: tonic::Request<super::UpdateCommitmentStateRequest>,
         ) -> std::result::Result<tonic::Response<super::CommitmentState>, tonic::Status>;
     }
@@ -546,7 +546,7 @@ pub mod execution_service_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as ExecutionService>::get_genesis_info(&inner, request)
+                                <T as ExecutionService>::get_genesis_info(inner, request)
                                     .await
                             };
                             Box::pin(fut)
@@ -593,7 +593,7 @@ pub mod execution_service_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as ExecutionService>::get_block(&inner, request).await
+                                <T as ExecutionService>::get_block(inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -639,7 +639,7 @@ pub mod execution_service_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as ExecutionService>::batch_get_blocks(&inner, request)
+                                <T as ExecutionService>::batch_get_blocks(inner, request)
                                     .await
                             };
                             Box::pin(fut)
@@ -686,8 +686,7 @@ pub mod execution_service_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as ExecutionService>::execute_block(&inner, request)
-                                    .await
+                                <T as ExecutionService>::execute_block(inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -734,7 +733,7 @@ pub mod execution_service_server {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 <T as ExecutionService>::get_commitment_state(
-                                        &inner,
+                                        inner,
                                         request,
                                     )
                                     .await
@@ -784,7 +783,7 @@ pub mod execution_service_server {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 <T as ExecutionService>::update_commitment_state(
-                                        &inner,
+                                        inner,
                                         request,
                                     )
                                     .await

--- a/crates/astria-core/src/generated/astria.sequencer.v1.rs
+++ b/crates/astria-core/src/generated/astria.sequencer.v1.rs
@@ -480,13 +480,13 @@ pub mod sequencer_service_server {
     pub trait SequencerService: Send + Sync + 'static {
         /// Given a block height, returns the sequencer block at that height.
         async fn get_sequencer_block(
-            &self,
+            self: std::sync::Arc<Self>,
             request: tonic::Request<super::GetSequencerBlockRequest>,
         ) -> std::result::Result<tonic::Response<super::SequencerBlock>, tonic::Status>;
         /// Given a block height and set of rollup ids, returns a SequencerBlock which
         /// is filtered to contain only the transactions that are relevant to the given rollup.
         async fn get_filtered_sequencer_block(
-            &self,
+            self: std::sync::Arc<Self>,
             request: tonic::Request<super::GetFilteredSequencerBlockRequest>,
         ) -> std::result::Result<
             tonic::Response<super::FilteredSequencerBlock>,
@@ -590,10 +590,7 @@ pub mod sequencer_service_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as SequencerService>::get_sequencer_block(
-                                        &inner,
-                                        request,
-                                    )
+                                <T as SequencerService>::get_sequencer_block(inner, request)
                                     .await
                             };
                             Box::pin(fut)
@@ -644,7 +641,7 @@ pub mod sequencer_service_server {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 <T as SequencerService>::get_filtered_sequencer_block(
-                                        &inner,
+                                        inner,
                                         request,
                                     )
                                     .await

--- a/crates/astria-sequencer-relayer/tests/blackbox/helper.rs
+++ b/crates/astria-sequencer-relayer/tests/blackbox/helper.rs
@@ -123,7 +123,7 @@ pub struct MockSequencerServer {
 #[async_trait::async_trait]
 impl SequencerService for MockSequencerServer {
     async fn get_sequencer_block(
-        &self,
+        self: Arc<Self>,
         _request: Request<GetSequencerBlockRequest>,
     ) -> Result<Response<RawSequencerBlock>, Status> {
         let mut blocks = self.blocks.lock().unwrap();
@@ -137,7 +137,7 @@ impl SequencerService for MockSequencerServer {
     }
 
     async fn get_filtered_sequencer_block(
-        &self,
+        self: Arc<Self>,
         _request: Request<GetFilteredSequencerBlockRequest>,
     ) -> Result<Response<RawFilteredSequencerBlock>, Status> {
         return Err(Status::internal("unimplemented"));

--- a/crates/astria-sequencer/src/grpc/sequencer.rs
+++ b/crates/astria-sequencer/src/grpc/sequencer.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use astria_core::{
     generated::sequencer::v1::{
         sequencer_service_server::SequencerService,
@@ -38,7 +40,7 @@ impl SequencerService for SequencerServer {
     /// Given a block height, returns the sequencer block at that height.
     #[instrument(skip_all, fields(height = request.get_ref().height))]
     async fn get_sequencer_block(
-        &self,
+        self: Arc<Self>,
         request: Request<GetSequencerBlockRequest>,
     ) -> Result<Response<RawSequencerBlock>, Status> {
         let snapshot = self.storage.latest_snapshot();
@@ -68,7 +70,7 @@ impl SequencerService for SequencerServer {
     /// is filtered to contain only the transactions that are relevant to the given rollup.
     #[instrument(skip_all, fields(height = request.get_ref().height))]
     async fn get_filtered_sequencer_block(
-        &self,
+        self: Arc<Self>,
         request: Request<GetFilteredSequencerBlockRequest>,
     ) -> Result<Response<RawFilteredSequencerBlock>, Status> {
         let snapshot = self.storage.latest_snapshot();
@@ -220,7 +222,7 @@ mod test {
         state_tx.put_sequencer_block(block.clone()).unwrap();
         storage.commit(state_tx).await.unwrap();
 
-        let server = SequencerServer::new(storage.clone());
+        let server = Arc::new(SequencerServer::new(storage.clone()));
         let request = GetSequencerBlockRequest {
             height: 1,
         };

--- a/tools/protobuf-compiler/src/main.rs
+++ b/tools/protobuf-compiler/src/main.rs
@@ -66,12 +66,25 @@ fn main() {
         .bytes([".astria.execution.v1alpha2"])
         .client_mod_attribute(".", "#[cfg(feature=\"client\")]")
         .server_mod_attribute(".", "#[cfg(feature=\"server\")]")
-        .extern_path(".astria_vendored.tendermint.abci", "::tendermint-proto::abci")
-        .extern_path(".astria_vendored.tendermint.crypto", "::tendermint-proto::crypto")
-        .extern_path(".astria_vendored.tendermint.version", "::tendermint-proto::version")
-        .extern_path(".astria_vendored.tendermint.types", "::tendermint-proto::types")
+        .extern_path(
+            ".astria_vendored.tendermint.abci",
+            "::tendermint-proto::abci",
+        )
+        .extern_path(
+            ".astria_vendored.tendermint.crypto",
+            "::tendermint-proto::crypto",
+        )
+        .extern_path(
+            ".astria_vendored.tendermint.version",
+            "::tendermint-proto::version",
+        )
+        .extern_path(
+            ".astria_vendored.tendermint.types",
+            "::tendermint-proto::types",
+        )
         .extern_path(".astria_vendored.penumbra", "::penumbra-proto")
         .type_attribute(".astria.primitive.v1.Uint128", "#[derive(Copy)]")
+        .use_arc_self(true)
         .out_dir(&out_dir)
         .file_descriptor_set_path(buf_img.path())
         .skip_protoc_run()


### PR DESCRIPTION
## Summary
Change code generation to emit `Arc<Self>` as the target for tonic gRPC service traits.

## Background
Using `self: Arc<Self>` instead of `&self` is more convenient because it allows access to a service's inner attributes. The motivation for doing this is writing tests for mocks right now, but also streaming gRPC services later.

## Changes
- Add `use_arc_self(true)` to the tonic builder inside the protobuf generation tool.
- Update all types that implement generated gRPC services (mainly in sequencer, but also in sequencer-relayer and conductor for mocks).

## Testing
Tests still run, code still compiles. This change should be entirely opaque.
