### PR TITLE
feat(composer): add graceful shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,6 +560,7 @@ dependencies = [
  "humantime",
  "hyper",
  "insta",
+ "itertools 0.11.0",
  "once_cell",
  "pin-project-lite",
  "prost",

--- a/crates/astria-composer/Cargo.toml
+++ b/crates/astria-composer/Cargo.toml
@@ -22,6 +22,8 @@ telemetry = { package = "astria-telemetry", path = "../astria-telemetry", featur
 
 pin-project-lite = "0.2.13"
 secrecy = { version = "0.8", features = ["serde"] }
+tonic-health = "0.10.2"
+itertools = "0.11.0"
 
 async-trait = { workspace = true }
 axum = { workspace = true }
@@ -46,13 +48,13 @@ tokio = { workspace = true, features = [
   "rt-multi-thread",
   "sync",
   "time",
+  "signal",
 ] }
 tokio-util = { workspace = true, features = ["rt"] }
 tracing = { workspace = true, features = ["attributes"] }
 tryhard = { workspace = true }
 tonic = { workspace = true }
 tokio-stream = { workspace = true, features = ["net"] }
-tonic-health = "0.10.2"
 
 [dependencies.sequencer-client]
 package = "astria-sequencer-client"

--- a/crates/astria-composer/src/collectors/geth.rs
+++ b/crates/astria-composer/src/collectors/geth.rs
@@ -47,12 +47,13 @@ use tracing::{
     warn,
 };
 
-use crate::executor;
+use crate::{
+    collectors::EXECUTOR_SEND_TIMEOUT,
+    executor,
+};
 type StdError = dyn std::error::Error;
 
 const WSS_UNSUBSCRIBE_TIMEOUT: Duration = Duration::from_secs(2);
-
-pub(super) const EXECUTOR_SEND_TIMEOUT: Duration = Duration::from_millis(500);
 
 /// `GethCollector` Collects transactions submitted to a Geth rollup node and passes
 /// them downstream for further processing.

--- a/crates/astria-composer/src/collectors/grpc.rs
+++ b/crates/astria-composer/src/collectors/grpc.rs
@@ -1,9 +1,6 @@
 //! `GrpcCollector` implements the `GrpcCollectorService` rpc service.
 
-use std::{
-    sync::Arc,
-    time::Duration,
-};
+use std::sync::Arc;
 
 use astria_core::{
     generated::composer::v1alpha1::{
@@ -24,7 +21,10 @@ use tonic::{
     Status,
 };
 
-use crate::executor;
+use crate::{
+    collectors::geth::EXECUTOR_SEND_TIMEOUT,
+    executor,
+};
 
 /// Implements the `GrpcCollectorService` which listens for incoming gRPC requests and
 /// sends the Rollup transactions to the Executor. The Executor then sends the transactions
@@ -61,7 +61,7 @@ impl GrpcCollectorService for Grpc {
 
         match self
             .executor
-            .send_timeout(sequence_action, Duration::from_millis(500))
+            .send_timeout(sequence_action, EXECUTOR_SEND_TIMEOUT)
             .await
         {
             Ok(()) => {}

--- a/crates/astria-composer/src/collectors/grpc.rs
+++ b/crates/astria-composer/src/collectors/grpc.rs
@@ -22,7 +22,7 @@ use tonic::{
 };
 
 use crate::{
-    collectors::geth::EXECUTOR_SEND_TIMEOUT,
+    collectors::EXECUTOR_SEND_TIMEOUT,
     executor,
 };
 

--- a/crates/astria-composer/src/collectors/mod.rs
+++ b/crates/astria-composer/src/collectors/mod.rs
@@ -1,5 +1,9 @@
 pub(crate) mod geth;
 pub(crate) mod grpc;
 
+const EXECUTOR_SEND_TIMEOUT: Duration = Duration::from_millis(500);
+
+use std::time::Duration;
+
 pub(crate) use geth::Geth;
 pub(crate) use grpc::Grpc;

--- a/crates/astria-composer/src/composer.rs
+++ b/crates/astria-composer/src/composer.rs
@@ -1,21 +1,35 @@
 use std::{
     collections::HashMap,
     net::SocketAddr,
+    time::Duration,
 };
 
 use astria_eyre::eyre::{
     self,
     WrapErr as _,
 };
+use itertools::Itertools as _;
 use tokio::{
     io,
+    signal::unix::{
+        signal,
+        SignalKind,
+    },
     sync::watch,
-    task::JoinError,
+    task::{
+        JoinError,
+        JoinHandle,
+    },
+    time::timeout,
 };
-use tokio_util::task::JoinMap;
+use tokio_util::{
+    sync::CancellationToken,
+    task::JoinMap,
+};
 use tracing::{
     error,
     info,
+    warn,
 };
 
 use crate::{
@@ -32,6 +46,10 @@ use crate::{
     rollup::Rollup,
     Config,
 };
+
+const API_SERVER_SHUTDOWN_DURATION: Duration = Duration::from_secs(2);
+const GRPC_SERVER_SHUTDOWN_DURATION: Duration = Duration::from_secs(5);
+const GETH_COLLECTOR_SHUTDOWN_DURATION: Duration = Duration::from_secs(5);
 
 /// `Composer` is a service responsible for spinning up `GethCollectors` which are responsible
 /// for fetching pending transactions submitted to the rollup Geth nodes and then passing them
@@ -61,6 +79,8 @@ pub struct Composer {
     /// The gRPC server that listens for incoming requests from the collectors via the
     /// GrpcCollector service. It also exposes a health service.
     grpc_server: GrpcServer,
+    /// Used to signal the Composer to shut down.
+    shutdown_token: CancellationToken,
 }
 
 /// Announces the current status of the Composer for other modules in the crate to use
@@ -93,17 +113,24 @@ impl Composer {
     /// See `[from_config]` for its error scenarios.
     pub async fn from_config(cfg: &Config) -> eyre::Result<Self> {
         let (composer_status_sender, _) = watch::channel(Status::default());
+        let shutdown_token = CancellationToken::new();
+
         let (executor, executor_handle) = Executor::new(
             &cfg.sequencer_url,
             &cfg.private_key,
             cfg.block_time_ms,
             cfg.max_bytes_per_bundle,
+            shutdown_token.clone(),
         )
         .wrap_err("executor construction from config failed")?;
 
-        let grpc_server = GrpcServer::new(cfg.grpc_addr, executor_handle.clone())
-            .await
-            .wrap_err("failed to create grpc server")?;
+        let grpc_server = GrpcServer::new(
+            cfg.grpc_addr,
+            executor_handle.clone(),
+            shutdown_token.clone(),
+        )
+        .await
+        .wrap_err("grpc collector construction from config failed")?;
 
         info!(
             listen_addr = %grpc_server.local_addr().wrap_err("grpc server listener not bound")?,
@@ -128,8 +155,12 @@ impl Composer {
         let geth_collectors = rollups
             .iter()
             .map(|(rollup_name, url)| {
-                let collector =
-                    Geth::new(rollup_name.clone(), url.clone(), executor_handle.clone());
+                let collector = Geth::new(
+                    rollup_name.clone(),
+                    url.clone(),
+                    executor_handle.clone(),
+                    shutdown_token.clone(),
+                );
                 (rollup_name.clone(), collector)
             })
             .collect::<HashMap<_, _>>();
@@ -149,6 +180,7 @@ impl Composer {
             geth_collector_statuses,
             geth_collector_tasks: JoinMap::new(),
             grpc_server,
+            shutdown_token,
         })
     }
 
@@ -168,10 +200,13 @@ impl Composer {
     ///
     /// # Errors
     /// It errors out if the API Server, Executor or any of the Geth Collectors fail to start.
+    ///
+    /// # Panics
+    /// It panics if the Composer cannot set the SIGTERM listener.
     pub async fn run_until_stopped(self) -> eyre::Result<()> {
         let Self {
             api_server,
-            composer_status_sender,
+            mut composer_status_sender,
             executor,
             executor_handle,
             mut geth_collector_tasks,
@@ -179,28 +214,35 @@ impl Composer {
             rollups,
             mut geth_collector_statuses,
             grpc_server,
+            shutdown_token,
         } = self;
 
+        // we need the API server to shutdown at the end, since it is used by k8s
+        // to report the liveness of the service
+        let api_server_shutdown_token = CancellationToken::new();
+
+        let api_server_task_shutdown_token = api_server_shutdown_token.clone();
         // run the api server
-        let mut api_task =
-            tokio::spawn(async move { api_server.await.wrap_err("api server ended unexpectedly") });
+        let mut api_task = tokio::spawn(async move {
+            api_server
+                .with_graceful_shutdown(api_server_task_shutdown_token.cancelled())
+                .await
+                .wrap_err("api server ended unexpectedly")
+        });
 
         // run the collectors and executor
-        for (chain_id, collector) in geth_collectors.drain() {
-            geth_collector_tasks.spawn(chain_id, collector.run_until_stopped());
-        }
+        spawn_geth_collectors(&mut geth_collectors, &mut geth_collector_tasks);
+
         let executor_status = executor.subscribe().clone();
         let mut executor_task = tokio::spawn(executor.run_until_stopped());
 
         // wait for collectors and executor to come online
-        wait_for_collectors(&geth_collector_statuses).await?;
-        composer_status_sender.send_modify(|status| {
-            status.set_all_collectors_connected(true);
-        });
-        wait_for_executor(executor_status).await?;
-        composer_status_sender.send_modify(|status| {
-            status.set_executor_connected(true);
-        });
+        wait_for_collectors(&geth_collector_statuses, &mut composer_status_sender)
+            .await
+            .wrap_err("geth collectors failed to become ready")?;
+        wait_for_executor(executor_status, &mut composer_status_sender)
+            .await
+            .wrap_err("executor failed to become ready")?;
 
         // run the grpc server
         let mut grpc_server_handle = tokio::spawn(async move {
@@ -210,19 +252,56 @@ impl Composer {
                 .wrap_err("grpc server failed")
         });
 
-        loop {
+        let mut sigterm = signal(SignalKind::terminate()).expect(
+            "setting a SIGTERM listener should always work on unix; is this running on unix?",
+        );
+
+        let shutdown_info = loop {
             tokio::select!(
+            biased;
+            _ = sigterm.recv() => {
+                    info!("received SIGTERM; shutting down");
+                    break ShutdownInfo {
+                        api_server_shutdown_token,
+                        composer_shutdown_token: shutdown_token,
+                        api_server_task_handle: Some(api_task),
+                        executor_task_handle: Some(executor_task),
+                        grpc_server_task_handle: Some(grpc_server_handle),
+                        geth_collector_tasks,
+                    };
+            },
             o = &mut api_task => {
                     report_exit("api server unexpectedly ended", o);
-                    return Ok(());
+                    break ShutdownInfo {
+                        api_server_shutdown_token,
+                        composer_shutdown_token: shutdown_token,
+                        api_server_task_handle: None,
+                        executor_task_handle: Some(executor_task),
+                        grpc_server_task_handle: Some(grpc_server_handle),
+                        geth_collector_tasks,
+                    };
             },
             o = &mut executor_task => {
                     report_exit("executor unexpectedly ended", o);
-                    return Ok(());
+                    break ShutdownInfo {
+                        api_server_shutdown_token,
+                        composer_shutdown_token: shutdown_token,
+                        api_server_task_handle: Some(api_task),
+                        executor_task_handle: None,
+                        grpc_server_task_handle: Some(grpc_server_handle),
+                        geth_collector_tasks,
+                    };
             },
             o = &mut grpc_server_handle => {
                     report_exit("grpc server unexpectedly ended", o);
-                    return Ok(());
+                    break ShutdownInfo {
+                        api_server_shutdown_token,
+                        composer_shutdown_token: shutdown_token,
+                        api_server_task_handle: Some(api_task),
+                        executor_task_handle: Some(executor_task),
+                        grpc_server_task_handle: None,
+                        geth_collector_tasks,
+                    };
             },
             Some((rollup, collector_exit)) = geth_collector_tasks.join_next() => {
                    reconnect_exited_collector(
@@ -232,19 +311,136 @@ impl Composer {
                     &rollups,
                     rollup,
                     collector_exit,
+                    shutdown_token.clone()
                 );
             });
+        };
+
+        shutdown_info.run().await
+    }
+}
+
+struct ShutdownInfo {
+    api_server_shutdown_token: CancellationToken,
+    composer_shutdown_token: CancellationToken,
+    api_server_task_handle: Option<JoinHandle<eyre::Result<()>>>,
+    executor_task_handle: Option<JoinHandle<eyre::Result<()>>>,
+    grpc_server_task_handle: Option<JoinHandle<eyre::Result<()>>>,
+    geth_collector_tasks: JoinMap<String, eyre::Result<()>>,
+}
+
+impl ShutdownInfo {
+    async fn run(self) -> eyre::Result<()> {
+        let Self {
+            composer_shutdown_token,
+            api_server_shutdown_token,
+            api_server_task_handle,
+            executor_task_handle,
+            grpc_server_task_handle,
+            mut geth_collector_tasks,
+        } = self;
+
+        // if the composer is shutting down because of an unexpected shutdown from any one of the
+        // components(and not because of a SIGTERM), we need to send the cancel signal to all
+        // the other components.
+        composer_shutdown_token.cancel();
+        // k8s issues SIGKILL in 30s, so we need to make sure that the shutdown happens before 30s.
+
+        // We give executor 17 seconds to shut down. The logic to timeout is in the
+        // executor itself. We wait 17s for all the bundles to be drained.
+        if let Some(executor_task_handle) = executor_task_handle {
+            match executor_task_handle.await {
+                Ok(Ok(())) => info!("executor shut down successfully"),
+                Ok(Err(error)) => error!(%error, "executor task shut down with error"),
+                Err(error) => error!(%error, "executor task didn't complete successfully"),
+            }
+        } else {
+            info!("executor task was already dead");
+        };
+
+        // We give the grpc server 5 seconds to shut down.
+        if let Some(grpc_server_task_handle) = grpc_server_task_handle {
+            match tokio::time::timeout(GRPC_SERVER_SHUTDOWN_DURATION, grpc_server_task_handle)
+                .await
+                .map(flatten_result)
+            {
+                Ok(Ok(())) => info!("grpc server task shut down"),
+                Ok(Err(error)) => error!(%error, "grpc server task shut down with error"),
+                Err(error) => error!(%error, "grpc server task failed to shut down in time"),
+            }
+        } else {
+            info!("grpc server task was already dead");
+        };
+
+        let shutdown_loop = async {
+            while let Some((name, res)) = geth_collector_tasks.join_next().await {
+                let message = "task shut down";
+                match flatten_result(res) {
+                    Ok(()) => info!(name, message),
+                    Err(error) => error!(name, %error, message),
+                }
+            }
+        };
+
+        // we give 5s to shut down all the other geth collectors. geth collectors shouldn't take
+        // too long to shutdown since they just need to unsubscribe to their WSS
+        // streams.
+        if timeout(GETH_COLLECTOR_SHUTDOWN_DURATION, shutdown_loop)
+            .await
+            .is_err()
+        {
+            let tasks = geth_collector_tasks.keys().join(", ");
+            warn!(
+                tasks = format_args!("[{tasks}]"),
+                "aborting all geth collector tasks that have not yet shut down",
+            );
+            geth_collector_tasks.abort_all();
+        } else {
+            info!("all geth collector tasks shut down regularly");
         }
+
+        // cancel the api server at the end
+        // we give the api server 2s, since it shouldn't be getting too much traffic and should
+        // be able to shut down faster.
+        api_server_shutdown_token.cancel();
+        if let Some(api_server_task_handle) = api_server_task_handle {
+            match tokio::time::timeout(API_SERVER_SHUTDOWN_DURATION, api_server_task_handle)
+                .await
+                .map(flatten_result)
+            {
+                Ok(Ok(())) => info!("api server task shut down"),
+                Ok(Err(error)) => error!(%error, "api server task shutdown with error"),
+                Err(error) => error!(%error, "api server task failed to shutdown in time"),
+            }
+        } else {
+            info!("api server task was already dead");
+        };
+
+        Ok(())
+    }
+}
+
+fn spawn_geth_collectors(
+    geth_collectors: &mut HashMap<String, collectors::Geth>,
+    geth_collector_tasks: &mut JoinMap<String, eyre::Result<()>>,
+) {
+    for (chain_id, collector) in geth_collectors.drain() {
+        geth_collector_tasks.spawn(chain_id, collector.run_until_stopped());
     }
 }
 
 async fn wait_for_executor(
     mut executor_status: watch::Receiver<executor::Status>,
+    composer_status_sender: &mut watch::Sender<composer::Status>,
 ) -> eyre::Result<()> {
     executor_status
         .wait_for(executor::Status::is_connected)
         .await
         .wrap_err("executor failed while waiting for it to become ready")?;
+
+    composer_status_sender.send_modify(|status| {
+        status.set_executor_connected(true);
+    });
 
     Ok(())
 }
@@ -252,6 +448,7 @@ async fn wait_for_executor(
 /// Waits for all collectors to come online.
 async fn wait_for_collectors(
     collector_statuses: &HashMap<String, watch::Receiver<collectors::geth::Status>>,
+    composer_status_sender: &mut watch::Sender<composer::Status>,
 ) -> eyre::Result<()> {
     use futures::{
         future::FutureExt as _,
@@ -291,6 +488,10 @@ async fn wait_for_collectors(
         }
     }
 
+    composer_status_sender.send_modify(|status| {
+        status.set_all_collectors_connected(true);
+    });
+
     Ok(())
 }
 
@@ -301,6 +502,7 @@ pub(super) fn reconnect_exited_collector(
     rollups: &HashMap<String, String>,
     rollup: String,
     exit_result: Result<eyre::Result<()>, JoinError>,
+    shutdown_token: CancellationToken,
 ) {
     report_exit("collector", exit_result);
     let Some(url) = rollups.get(&rollup) else {
@@ -311,7 +513,7 @@ pub(super) fn reconnect_exited_collector(
         return;
     };
 
-    let collector = Geth::new(rollup.clone(), url.clone(), executor_handle);
+    let collector = Geth::new(rollup.clone(), url.clone(), executor_handle, shutdown_token);
     collector_statuses.insert(rollup.clone(), collector.subscribe());
     collector_tasks.spawn(rollup, collector.run_until_stopped());
 }
@@ -325,5 +527,13 @@ fn report_exit(task_name: &str, outcome: Result<eyre::Result<()>, JoinError>) {
         Err(error) => {
             error!(%error, task = task_name, "task failed to complete");
         }
+    }
+}
+
+pub(crate) fn flatten_result<T>(res: Result<eyre::Result<T>, JoinError>) -> eyre::Result<T> {
+    match res {
+        Ok(Ok(val)) => Ok(val),
+        Ok(Err(err)) => Err(err).wrap_err("task returned with error"),
+        Err(err) => Err(err).wrap_err("task panicked"),
     }
 }

--- a/crates/astria-composer/src/executor/mod.rs
+++ b/crates/astria-composer/src/executor/mod.rs
@@ -397,7 +397,12 @@ impl Executor {
             Err(error) => error!(%error, "executor shutdown tasks failed to complete in time"),
         }
 
-        if !bundles_to_drain.is_empty() {
+        if bundles_to_drain.is_empty() {
+            info!(
+                number_of_submitted_bundles = bundles_drained,
+                "submitted all outstanding bundles to sequencer during shutdown"
+            );
+        } else {
             // log all the bundles that have not been drained
             let report: Vec<SizedBundleReport> =
                 bundles_to_drain.iter().map(SizedBundleReport).collect();
@@ -407,11 +412,6 @@ impl Executor {
                 number_of_missing_bundles = report.len(),
                 missing_bundles = %telemetry::display::json(&report),
                 "unable to drain all bundles within the allocated time"
-            );
-        } else {
-            info!(
-                number_of_submitted_bundles = bundles_drained,
-                "submitted all outstanding bundles to sequencer during shutdown"
             );
         }
 

--- a/crates/astria-composer/src/executor/mod.rs
+++ b/crates/astria-composer/src/executor/mod.rs
@@ -81,7 +81,7 @@ mod bundle_factory;
 #[cfg(test)]
 mod tests;
 
-const EXECUTOR_SHUTDOWN_DURATION: Duration = Duration::from_secs(17);
+const BUNDLE_DRAINING_DURATION: Duration = Duration::from_secs(16);
 
 type StdError = dyn std::error::Error;
 
@@ -382,7 +382,7 @@ impl Executor {
             Ok(())
         };
 
-        match tokio::time::timeout(EXECUTOR_SHUTDOWN_DURATION, shutdown_logic).await {
+        match tokio::time::timeout(BUNDLE_DRAINING_DURATION, shutdown_logic).await {
             Ok(Ok(())) => info!("executor shutdown tasks completed successfully"),
             Ok(Err(error)) => error!(%error, "executor shutdown tasks failed"),
             Err(error) => error!(%error, "executor shutdown tasks failed to complete in time"),

--- a/crates/astria-composer/src/executor/mod.rs
+++ b/crates/astria-composer/src/executor/mod.rs
@@ -1,10 +1,10 @@
-use std::collections::VecDeque;
 /// ! The `Executor` is responsible for:
 /// - Nonce management
 /// - Transaction signing
 /// - Managing the connection to the sequencer
 /// - Submitting transactions to the sequencer
 use std::{
+    collections::VecDeque,
     pin::Pin,
     task::Poll,
     time::Duration,

--- a/crates/astria-composer/src/executor/tests.rs
+++ b/crates/astria-composer/src/executor/tests.rs
@@ -21,6 +21,7 @@ use tokio::{
     sync::watch,
     time,
 };
+use tokio_util::sync::CancellationToken;
 use tracing::debug;
 use wiremock::{
     matchers::{
@@ -195,11 +196,13 @@ async fn wait_for_startup(
 async fn full_bundle() {
     // set up the executor, channel for writing seq actions, and the sequencer mock
     let (sequencer, nonce_guard, cfg) = setup().await;
+    let shutdown_token = CancellationToken::new();
     let (executor, executor_handle) = Executor::new(
         &cfg.sequencer_url,
         &cfg.private_key,
         cfg.block_time_ms,
         cfg.max_bytes_per_bundle,
+        shutdown_token,
     )
     .unwrap();
 
@@ -281,11 +284,13 @@ async fn full_bundle() {
 async fn bundle_triggered_by_block_timer() {
     // set up the executor, channel for writing seq actions, and the sequencer mock
     let (sequencer, nonce_guard, cfg) = setup().await;
+    let shutdown_token = CancellationToken::new();
     let (executor, executor_handle) = Executor::new(
         &cfg.sequencer_url,
         &cfg.private_key,
         cfg.block_time_ms,
         cfg.max_bytes_per_bundle,
+        shutdown_token,
     )
     .unwrap();
 
@@ -360,11 +365,13 @@ async fn bundle_triggered_by_block_timer() {
 async fn two_seq_actions_single_bundle() {
     // set up the executor, channel for writing seq actions, and the sequencer mock
     let (sequencer, nonce_guard, cfg) = setup().await;
+    let shutdown_token = CancellationToken::new();
     let (executor, executor_handle) = Executor::new(
         &cfg.sequencer_url,
         &cfg.private_key,
         cfg.block_time_ms,
         cfg.max_bytes_per_bundle,
+        shutdown_token.clone(),
     )
     .unwrap();
 


### PR DESCRIPTION
## Summary
Implements graceful shutdown for Composer components. 

## Background
Composer has 3 main components:
1. Geth Collectors
2. Grpc Server/Collector
3. Executor

Currently, we do not have any sort of graceful shutdown for these Components. This PR implements it.

When a Geth Collector shuts down, we do the following:
1. We need to unsubscribe to the websocket stream
2. We need to set the status of the geth collector to false(not connected)

For the Grpc Server, we just pass in a future which resolves when a shutdown signal is passed to the server by running it as `serve_with_incoming_shutdown`. 

When an Executor shuts down, we do the following:
1. Close the `serialized_rollup_transactions` channel to avoid receiving transactions. 
2. Set Executor status to false(not connected).
3. Drain any remaining bundles

We ensure that the API server shuts down at the end by giving it its own CancellationToken. This is because we need the API server to be up in order for k8s to report liveness.

## Changes
- Add a shutdown token which is a tokio CancellationToken
- Pass it to the GethCollectors, GrpcServer and Executor
- Convert the while loop which listens to txs on the Geth Wss stream to a select stmt in a loop to listen for the shutdown signal from the shutdown CancellationToken.
- Add shutdown logic to Executor
- Pass in the shutdown CancellationToken to the gRPC server with the `serve_with_incoming_shutdown` method.
- Pass a new CancellationToken to the API server and ensure it shuts down after every other task is shutdown.

**Note:** 
I had to refactor the run_until_stopped method in Composer as Clippy was complaining a lot about the below:
https://rust-lang.github.io/rust-clippy/master/index.html#/too_many_lines

## Testing
Tested by manually deploying a local shared sequencer cluster and running a Composer instance against it. Sent a SIGTERM signal to Composer and tested the shutdown.
