### PR TITLE
fix(docs): Fix doc for running a smoke test

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -168,7 +168,7 @@ To deploy and run this:
 > just deploy cluster 
 > just deploy smoke-test
 # deploys all components needed to run the smoke test
-> just run smoke-test
+> just run-smoke-test
 # Runs the smoke test will return failure if fails
 > just delete smoke-test
 # Clean up deployed test


### PR DESCRIPTION
## Summary
Fix doc for running a smoke-test in the `charts` directory.

## Background
The doc should be `just run-smoke-test` instead of `just run smoke-test`

## Changes
- Update the docs

## Testing
By running `just run-smoke-test` and ensuring that it is successfully triggered.
