### PR TITLE
test(sequencer): add unit tests for src/authority/state_ext

### DIFF
--- a/crates/astria-sequencer/src/authority/state_ext.rs
+++ b/crates/astria-sequencer/src/authority/state_ext.rs
@@ -417,7 +417,7 @@ mod test {
                 .await
                 .expect("if no updates have been written return empty set"),
             empty_validator_set,
-            "returned empty validator set different than expected"
+            "returned validator set different than expected"
         );
     }
 


### PR DESCRIPTION
## Summary
Fourth set of state-ext unit tests. In total there are seven files which
need tests:
- `astria-sequencer/src/api_state_ext.rs`
- ~`astria-sequencer/src/state_ext.rs`~
- ~`astria-sequencer/src/accounts/state_ext.rs`~
- ~`astria-sequencer/src/asset/state_ext.rs`~
- ~`astria-sequencer/src/authority/state_ext.rs`~ (This PR)
- `astria-sequencer/src/bridge/state_ext.rs`
- `astria-sequencer/src/ibc/state_ext.rs`

This PR just tests the `src/authority/state_ext.rs` file.

## Background
It is good to have unit tests to ensure that the database works as
intended.

## Changes
Unit tests for the functionality in the file `src/authority/state_ext.rs` were
added.

## Testing
:)