### PR TITLE
ci: add cargo audit

### DIFF
--- a/.github/workflows/reusable-run-checker.yml
+++ b/.github/workflows/reusable-run-checker.yml
@@ -6,6 +6,9 @@ on:
       run_tests:
         description: If tests need to be run, will be 'true'
         value: ${{ github.event_name != 'pull_request' || jobs.changes.outputs.test_workflow == 'true' || jobs.changes.outputs.crates == 'true' }}
+      run_audit:
+        description: If cargo audit needs to be run, will be 'true'
+        value: ${{ github.event_name != 'pull_request' || jobs.changes.outputs.test_workflow == 'true' || jobs.changes.outputs.lockfile == 'true' }}
       run_docker:
         description: If docker workflow needs to be run, will be 'true'
         value: ${{ github.event_name != 'pull_request' || jobs.changes.outputs.docker_workflow == 'true' || contains(github.event.pull_request.labels.*.name, 'docker-build') }}
@@ -52,6 +55,7 @@ jobs:
       markdown: ${{ steps.filters.outputs.markdown }}
       rustfmt: ${{ steps.filters.outputs.rustfmt }}
       charts: ${{ steps.filters.outputs.charts }}
+      lockfile: ${{ steps.filters.outputs.lockfile }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -89,3 +93,5 @@ jobs:
               - 'rustfmt.toml'
             charts:
               - 'charts/**'
+            lockfile:
+              - 'Cargo.lock'

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -2,8 +2,12 @@ name: Scheduled
 on:
   schedule:
     - cron: '0 0 * * *'
+
 jobs:
   audit:
+    permissions:
+      issues: write
+      checks: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1,0 +1,12 @@
+name: Scheduled
+on:
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: rustsec/audit-check@v1.4.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test
 env:
   CI: true
   RUSTFLAGS: "-D warnings -D unreachable-pub --cfg tokio_unstable"
-on: 
+on:
   pull_request:
   merge_group:
   push:
@@ -79,7 +79,17 @@ jobs:
           cache-provider: "github"
       - name: Check that the lockfile is updated
         run: cargo fetch --locked
-    
+
+  audit:
+    runs-on: buildjet-2vcpu-ubuntu-2204
+    needs: run_checker
+    if: needs.run_checker.outputs.run_tests == 'true'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.76.0
+      - uses: rustsec/audit-check@v1.4.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
   rust:
     runs-on: buildjet-8vcpu-ubuntu-2204
     needs: run_checker

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,9 +81,9 @@ jobs:
         run: cargo fetch --locked
 
   audit:
-    runs-on: buildjet-2vcpu-ubuntu-2204
+    runs-on: ubuntu-22.04
     needs: run_checker
-    if: needs.run_checker.outputs.run_tests == 'true'
+    if: needs.run_checker.outputs.run_audit == 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.76.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,6 +90,7 @@ jobs:
       - uses: rustsec/audit-check@v1.4.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
   rust:
     runs-on: buildjet-8vcpu-ubuntu-2204
     needs: run_checker


### PR DESCRIPTION
## Summary
This adds `cargo audit` to the CI pipeline.

## Background
This is useful to catch issues published to [RUSTSEC](https://rustsec.org/).

## Changes
Added a job to test.yml to run it.  I used the instructions from [`audit-check`](https://github.com/rustsec/audit-check) (as recommended by `cargo-audit` [here](https://github.com/rustsec/rustsec/blob/main/cargo-audit/README.md#using-cargo-audit-on-github-action)), but chose to not restrict the check to run only if `Cargo.[toml|lock]` are modified, since `cargo audit` can start warning on a given dependency at any time.  We could probably change to follow their suggestion fully, i.e. run audit nightly and otherwise only run on changes to those two files, but I'll leave that up to SRE to decide :)

Note that we currently have three audit warnings, but they're all deemed as "allowed" by default (i.e. they're all informational only).  It seems like we should maybe look to address [the borsch one](https://rustsec.org/advisories/RUSTSEC-2023-0033) since, while it's not deemed a security issue, it's still best to avoid unsound code!

## Testing
N/A
