### PR TITLE
chore(docs): Add sequencer RPC and EVM rollup RPCs/WSS endpoints in docs

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -96,8 +96,8 @@ The default EVM rollup has an RPC endpoint available at <http://executor.astria.
 
 There is also a default WSS endpoint available at <ws://ws-executor.astria.localdev.me>.
 
-If you deploy a custom rollup, then the endpoints will be `http://executor.<rollup_name>.localdev.me` and
-`ws://ws-executor.<rollup_name>.localdev.me`
+If you deploy a custom rollup, then the endpoints will be
+`http://executor.<rollup_name>.localdev.me` and `ws://ws-executor.<rollup_name>.localdev.me`
 
 ### Connecting Metamask
 

--- a/charts/README.md
+++ b/charts/README.md
@@ -86,6 +86,19 @@ The default Blockscout app is available at <http://blockscout.astria.localdev.me
 If you deploy a custom Blockscout app, it will be available at
 `http://blockscout.<rollup_name>.localdev.me`.
 
+### Sequencer
+
+The default sequencer RPC is available at <http://rpc.sequencer.localdev.me/health>.
+
+### EVM Rollup
+
+The default EVM rollup has an RPC endpoint available at <http://executor.astria.localdev.me>.
+
+There is also a default WSS endpoint available at <ws://ws-executor.astria.localdev.me>.
+
+If you deploy a custom rollup, then the endpoints will be `http://executor.<rollup_name>.localdev.me` and
+`ws://ws-executor.<rollup_name>.localdev.me`
+
 ### Connecting Metamask
 
 * adding the default network


### PR DESCRIPTION
## Summary
Add information on the Sequencer and EVM rollup endpoints in the README.md of the dev-cluster charts in the `charts` directory.

## Background
When launching applications which are built on top of the shared sequencer like Composer. We require the URL of the shared sequencer RPC which requires some digging into k8s ingresses to get. 

This PR explicitly adds it to the doc.

## Changes
- Update the docs to include the sequencer and evm rollup endpoints.

## Testing
no testing required since these a documentation changes.

## Related Issues
https://github.com/astriaorg/astria/issues/886

closes <!-- list any issues closed here -->
