### PR TITLE
test(sequencer): add unit tests for src/api_state_ext

### DIFF
--- a/crates/astria-sequencer/src/api_state_ext.rs
+++ b/crates/astria-sequencer/src/api_state_ext.rs
@@ -441,7 +441,7 @@ mod test {
         // create inner rollup id/tx data
         let mut deposits = HashMap::new();
         for _ in 0..2 {
-            let rollup_id = RollupId::new([rng.gen(); 32]);
+            let rollup_id = RollupId::new(rng.gen());
             let bridge_address = Address::try_from_slice(&[rng.gen(); 20]).unwrap();
             let amount = rng.gen::<u128>();
             let asset_id = Id::from_denom(&rng.gen::<u8>().to_string());


### PR DESCRIPTION
## Summary
Seventh set of state-ext unit tests. In total there are seven files which
need tests:
- ~`astria-sequencer/src/api_state_ext.rs`~ (This PR)
- ~`astria-sequencer/src/state_ext.rs`~
- ~`astria-sequencer/src/accounts/state_ext.rs`~
- ~`astria-sequencer/src/asset/state_ext.rs`~
- ~`astria-sequencer/src/authority/state_ext.rs`~ 
- ~`astria-sequencer/src/bridge/state_ext.rs`~
- ~`astria-sequencer/src/ibc/state_ext.rs`~

This PR just tests the `src/api_state_ext/state_ext.rs` file.

## Background
It is good to have unit tests to ensure that the database works as intended.

## Changes
Unit tests for the functionality in the file `src/api_state_ext/state_ext.rs` were added.

## Testing
:)