### PR TITLE
chore(sequencer): logging as human readable for account state

### DIFF
--- a/crates/astria-sequencer/src/accounts/state_ext.rs
+++ b/crates/astria-sequencer/src/accounts/state_ext.rs
@@ -51,7 +51,7 @@ fn nonce_storage_key(address: Address) -> String {
 
 #[async_trait]
 pub(crate) trait StateReadExt: StateRead {
-    #[instrument(skip(self))]
+    #[instrument(skip_all, fields(address=%address))]
     async fn get_account_balances(&self, address: Address) -> Result<Vec<AssetBalance>> {
         use crate::asset::state_ext::StateReadExt as _;
 
@@ -101,7 +101,7 @@ pub(crate) trait StateReadExt: StateRead {
         Ok(balances)
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip_all, fields(address=%address, asset_id=%asset))]
     async fn get_account_balance(&self, address: Address, asset: asset::Id) -> Result<u128> {
         let Some(bytes) = self
             .get_raw(&balance_storage_key(address, asset))
@@ -115,7 +115,7 @@ pub(crate) trait StateReadExt: StateRead {
         Ok(balance)
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip_all, fields(address=%address))]
     async fn get_account_nonce(&self, address: Address) -> Result<u32> {
         let bytes = self
             .get_raw(&nonce_storage_key(address))


### PR DESCRIPTION
## Summary
Updates instrumentation of account state to be human readable hex instead of arrays.

## Background
Logs were byte arrays which are not useful for debugging.

## Changes
- Update to use display traits, and skip all

## Related Issues
Part of fixing #897 
