### PR TITLE
feat(core): generate names for protobuf rust types

### DIFF
--- a/crates/astria-core/src/generated/astria.composer.v1alpha1.rs
+++ b/crates/astria-core/src/generated/astria.composer.v1alpha1.rs
@@ -10,11 +10,25 @@ pub struct SubmitRollupTransactionRequest {
     #[prost(bytes = "vec", tag = "2")]
     pub data: ::prost::alloc::vec::Vec<u8>,
 }
+impl ::prost::Name for SubmitRollupTransactionRequest {
+    const NAME: &'static str = "SubmitRollupTransactionRequest";
+    const PACKAGE: &'static str = "astria.composer.v1alpha1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.composer.v1alpha1.{}", Self::NAME)
+    }
+}
 /// SubmitRollupTransactionResponse is a message that represents a response to a request to submit a rollup.
 /// It's currently an empty response which can be evolved in the future to include more information
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SubmitRollupTransactionResponse {}
+impl ::prost::Name for SubmitRollupTransactionResponse {
+    const NAME: &'static str = "SubmitRollupTransactionResponse";
+    const PACKAGE: &'static str = "astria.composer.v1alpha1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.composer.v1alpha1.{}", Self::NAME)
+    }
+}
 /// Generated client implementations.
 #[cfg(feature = "client")]
 pub mod grpc_collector_service_client {

--- a/crates/astria-core/src/generated/astria.execution.v1alpha1.rs
+++ b/crates/astria-core/src/generated/astria.execution.v1alpha1.rs
@@ -8,11 +8,25 @@ pub struct DoBlockRequest {
     #[prost(message, optional, tag = "3")]
     pub timestamp: ::core::option::Option<::pbjson_types::Timestamp>,
 }
+impl ::prost::Name for DoBlockRequest {
+    const NAME: &'static str = "DoBlockRequest";
+    const PACKAGE: &'static str = "astria.execution.v1alpha1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.execution.v1alpha1.{}", Self::NAME)
+    }
+}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DoBlockResponse {
     #[prost(bytes = "vec", tag = "1")]
     pub block_hash: ::prost::alloc::vec::Vec<u8>,
+}
+impl ::prost::Name for DoBlockResponse {
+    const NAME: &'static str = "DoBlockResponse";
+    const PACKAGE: &'static str = "astria.execution.v1alpha1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.execution.v1alpha1.{}", Self::NAME)
+    }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -20,17 +34,45 @@ pub struct FinalizeBlockRequest {
     #[prost(bytes = "vec", tag = "1")]
     pub block_hash: ::prost::alloc::vec::Vec<u8>,
 }
+impl ::prost::Name for FinalizeBlockRequest {
+    const NAME: &'static str = "FinalizeBlockRequest";
+    const PACKAGE: &'static str = "astria.execution.v1alpha1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.execution.v1alpha1.{}", Self::NAME)
+    }
+}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FinalizeBlockResponse {}
+impl ::prost::Name for FinalizeBlockResponse {
+    const NAME: &'static str = "FinalizeBlockResponse";
+    const PACKAGE: &'static str = "astria.execution.v1alpha1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.execution.v1alpha1.{}", Self::NAME)
+    }
+}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InitStateRequest {}
+impl ::prost::Name for InitStateRequest {
+    const NAME: &'static str = "InitStateRequest";
+    const PACKAGE: &'static str = "astria.execution.v1alpha1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.execution.v1alpha1.{}", Self::NAME)
+    }
+}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InitStateResponse {
     #[prost(bytes = "vec", tag = "1")]
     pub block_hash: ::prost::alloc::vec::Vec<u8>,
+}
+impl ::prost::Name for InitStateResponse {
+    const NAME: &'static str = "InitStateResponse";
+    const PACKAGE: &'static str = "astria.execution.v1alpha1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.execution.v1alpha1.{}", Self::NAME)
+    }
 }
 /// Generated client implementations.
 #[cfg(feature = "client")]

--- a/crates/astria-core/src/generated/astria.execution.v1alpha2.rs
+++ b/crates/astria-core/src/generated/astria.execution.v1alpha2.rs
@@ -18,6 +18,13 @@ pub struct GenesisInfo {
     #[prost(uint32, tag = "4")]
     pub celestia_block_variance: u32,
 }
+impl ::prost::Name for GenesisInfo {
+    const NAME: &'static str = "GenesisInfo";
+    const PACKAGE: &'static str = "astria.execution.v1alpha2";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.execution.v1alpha2.{}", Self::NAME)
+    }
+}
 /// The set of information which deterministic driver of block production
 /// must know about a given rollup Block
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -35,6 +42,13 @@ pub struct Block {
     /// Timestamp on the block, standardized to google protobuf standard.
     #[prost(message, optional, tag = "4")]
     pub timestamp: ::core::option::Option<::pbjson_types::Timestamp>,
+}
+impl ::prost::Name for Block {
+    const NAME: &'static str = "Block";
+    const PACKAGE: &'static str = "astria.execution.v1alpha2";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.execution.v1alpha2.{}", Self::NAME)
+    }
 }
 /// Fields which are indexed for finding blocks on a blockchain.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -54,15 +68,36 @@ pub mod block_identifier {
         BlockHash(::prost::bytes::Bytes),
     }
 }
+impl ::prost::Name for BlockIdentifier {
+    const NAME: &'static str = "BlockIdentifier";
+    const PACKAGE: &'static str = "astria.execution.v1alpha2";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.execution.v1alpha2.{}", Self::NAME)
+    }
+}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetGenesisInfoRequest {}
+impl ::prost::Name for GetGenesisInfoRequest {
+    const NAME: &'static str = "GetGenesisInfoRequest";
+    const PACKAGE: &'static str = "astria.execution.v1alpha2";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.execution.v1alpha2.{}", Self::NAME)
+    }
+}
 /// Used in GetBlock to find a single block.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetBlockRequest {
     #[prost(message, optional, tag = "1")]
     pub identifier: ::core::option::Option<BlockIdentifier>,
+}
+impl ::prost::Name for GetBlockRequest {
+    const NAME: &'static str = "GetBlockRequest";
+    const PACKAGE: &'static str = "astria.execution.v1alpha2";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.execution.v1alpha2.{}", Self::NAME)
+    }
 }
 /// Used in BatchGetBlocks, will find all or none based on the list of
 /// identifiers.
@@ -72,12 +107,26 @@ pub struct BatchGetBlocksRequest {
     #[prost(message, repeated, tag = "1")]
     pub identifiers: ::prost::alloc::vec::Vec<BlockIdentifier>,
 }
+impl ::prost::Name for BatchGetBlocksRequest {
+    const NAME: &'static str = "BatchGetBlocksRequest";
+    const PACKAGE: &'static str = "astria.execution.v1alpha2";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.execution.v1alpha2.{}", Self::NAME)
+    }
+}
 /// The list of blocks in response to BatchGetBlocks.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BatchGetBlocksResponse {
     #[prost(message, repeated, tag = "1")]
     pub blocks: ::prost::alloc::vec::Vec<Block>,
+}
+impl ::prost::Name for BatchGetBlocksResponse {
+    const NAME: &'static str = "BatchGetBlocksResponse";
+    const PACKAGE: &'static str = "astria.execution.v1alpha2";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.execution.v1alpha2.{}", Self::NAME)
+    }
 }
 /// ExecuteBlockRequest contains all the information needed to create a new rollup
 /// block.
@@ -97,6 +146,13 @@ pub struct ExecuteBlockRequest {
     #[prost(message, optional, tag = "3")]
     pub timestamp: ::core::option::Option<::pbjson_types::Timestamp>,
 }
+impl ::prost::Name for ExecuteBlockRequest {
+    const NAME: &'static str = "ExecuteBlockRequest";
+    const PACKAGE: &'static str = "astria.execution.v1alpha2";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.execution.v1alpha2.{}", Self::NAME)
+    }
+}
 /// The CommitmentState holds the block at each stage of sequencer commitment
 /// level
 ///
@@ -115,16 +171,37 @@ pub struct CommitmentState {
     #[prost(message, optional, tag = "2")]
     pub firm: ::core::option::Option<Block>,
 }
+impl ::prost::Name for CommitmentState {
+    const NAME: &'static str = "CommitmentState";
+    const PACKAGE: &'static str = "astria.execution.v1alpha2";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.execution.v1alpha2.{}", Self::NAME)
+    }
+}
 /// There is only one CommitmentState object, so the request is empty.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetCommitmentStateRequest {}
+impl ::prost::Name for GetCommitmentStateRequest {
+    const NAME: &'static str = "GetCommitmentStateRequest";
+    const PACKAGE: &'static str = "astria.execution.v1alpha2";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.execution.v1alpha2.{}", Self::NAME)
+    }
+}
 /// The CommitmentState to set, must include complete state.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateCommitmentStateRequest {
     #[prost(message, optional, tag = "1")]
     pub commitment_state: ::core::option::Option<CommitmentState>,
+}
+impl ::prost::Name for UpdateCommitmentStateRequest {
+    const NAME: &'static str = "UpdateCommitmentStateRequest";
+    const PACKAGE: &'static str = "astria.execution.v1alpha2";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.execution.v1alpha2.{}", Self::NAME)
+    }
 }
 /// Generated client implementations.
 #[cfg(feature = "client")]

--- a/crates/astria-core/src/generated/astria.primitive.v1.rs
+++ b/crates/astria-core/src/generated/astria.primitive.v1.rs
@@ -18,3 +18,10 @@ pub struct Uint128 {
     #[prost(uint64, tag = "2")]
     pub hi: u64,
 }
+impl ::prost::Name for Uint128 {
+    const NAME: &'static str = "Uint128";
+    const PACKAGE: &'static str = "astria.primitive.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.primitive.v1.{}", Self::NAME)
+    }
+}

--- a/crates/astria-core/src/generated/astria.sequencer.v1.rs
+++ b/crates/astria-core/src/generated/astria.sequencer.v1.rs
@@ -12,6 +12,13 @@ pub struct Proof {
     #[prost(uint64, tag = "3")]
     pub tree_size: u64,
 }
+impl ::prost::Name for Proof {
+    const NAME: &'static str = "Proof";
+    const PACKAGE: &'static str = "astria.sequencer.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.sequencer.v1.{}", Self::NAME)
+    }
+}
 /// `RollupTransactions` are a sequence of opaque bytes together with a 32 byte
 /// identifier of that rollup.
 ///
@@ -31,6 +38,13 @@ pub struct RollupTransactions {
     /// `astria.sequencer.v1alpha.SequencerBlock.rollup_transactions_proof`.
     #[prost(message, optional, tag = "3")]
     pub proof: ::core::option::Option<Proof>,
+}
+impl ::prost::Name for RollupTransactions {
+    const NAME: &'static str = "RollupTransactions";
+    const PACKAGE: &'static str = "astria.sequencer.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.sequencer.v1.{}", Self::NAME)
+    }
 }
 /// `SequencerBlock` is constructed from a tendermint/cometbft block by
 /// converting its opaque `data` bytes into sequencer specific types.
@@ -63,6 +77,13 @@ pub struct SequencerBlock {
     #[prost(message, optional, tag = "4")]
     pub rollup_ids_proof: ::core::option::Option<Proof>,
 }
+impl ::prost::Name for SequencerBlock {
+    const NAME: &'static str = "SequencerBlock";
+    const PACKAGE: &'static str = "astria.sequencer.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.sequencer.v1.{}", Self::NAME)
+    }
+}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SequencerBlockHeader {
@@ -76,6 +97,13 @@ pub struct SequencerBlockHeader {
     /// The 32-byte merkle root of all the rollup IDs in the block.
     #[prost(bytes = "vec", tag = "3")]
     pub rollup_ids_root: ::prost::alloc::vec::Vec<u8>,
+}
+impl ::prost::Name for SequencerBlockHeader {
+    const NAME: &'static str = "SequencerBlockHeader";
+    const PACKAGE: &'static str = "astria.sequencer.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.sequencer.v1.{}", Self::NAME)
+    }
 }
 /// `Deposit` represents a deposit from the sequencer
 /// to a rollup.
@@ -106,6 +134,13 @@ pub struct Deposit {
     /// will receive the bridged funds
     #[prost(string, tag = "5")]
     pub destination_chain_address: ::prost::alloc::string::String,
+}
+impl ::prost::Name for Deposit {
+    const NAME: &'static str = "Deposit";
+    const PACKAGE: &'static str = "astria.sequencer.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.sequencer.v1.{}", Self::NAME)
+    }
 }
 /// `FilteredSequencerBlock` is similar to `SequencerBlock` but with a subset
 /// of the rollup transactions.
@@ -150,6 +185,13 @@ pub struct FilteredSequencerBlock {
     #[prost(message, optional, tag = "6")]
     pub rollup_ids_proof: ::core::option::Option<Proof>,
 }
+impl ::prost::Name for FilteredSequencerBlock {
+    const NAME: &'static str = "FilteredSequencerBlock";
+    const PACKAGE: &'static str = "astria.sequencer.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.sequencer.v1.{}", Self::NAME)
+    }
+}
 /// A piece of data that is sent to a rollup execution node.
 ///
 /// The data can be either sequenced data (originating from a `SequenceAction`
@@ -173,6 +215,13 @@ pub mod rollup_data {
         Deposit(super::Deposit),
     }
 }
+impl ::prost::Name for RollupData {
+    const NAME: &'static str = "RollupData";
+    const PACKAGE: &'static str = "astria.sequencer.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.sequencer.v1.{}", Self::NAME)
+    }
+}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AssetBalance {
@@ -180,6 +229,13 @@ pub struct AssetBalance {
     pub denom: ::prost::alloc::string::String,
     #[prost(message, optional, tag = "2")]
     pub balance: ::core::option::Option<super::super::primitive::v1::Uint128>,
+}
+impl ::prost::Name for AssetBalance {
+    const NAME: &'static str = "AssetBalance";
+    const PACKAGE: &'static str = "astria.sequencer.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.sequencer.v1.{}", Self::NAME)
+    }
 }
 /// A response containing the balance of an account.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -190,6 +246,13 @@ pub struct BalanceResponse {
     #[prost(message, repeated, tag = "3")]
     pub balances: ::prost::alloc::vec::Vec<AssetBalance>,
 }
+impl ::prost::Name for BalanceResponse {
+    const NAME: &'static str = "BalanceResponse";
+    const PACKAGE: &'static str = "astria.sequencer.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.sequencer.v1.{}", Self::NAME)
+    }
+}
 /// A response containing the current nonce for an account.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -198,6 +261,13 @@ pub struct NonceResponse {
     pub height: u64,
     #[prost(uint32, tag = "3")]
     pub nonce: u32,
+}
+impl ::prost::Name for NonceResponse {
+    const NAME: &'static str = "NonceResponse";
+    const PACKAGE: &'static str = "astria.sequencer.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.sequencer.v1.{}", Self::NAME)
+    }
 }
 /// / Represents a denomination of some asset used within the sequencer.
 /// / The `id` is used to identify the asset and for balance accounting.
@@ -208,6 +278,13 @@ pub struct Denom {
     pub id: ::prost::alloc::vec::Vec<u8>,
     #[prost(string, tag = "2")]
     pub base_denom: ::prost::alloc::string::String,
+}
+impl ::prost::Name for Denom {
+    const NAME: &'static str = "Denom";
+    const PACKAGE: &'static str = "astria.sequencer.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.sequencer.v1.{}", Self::NAME)
+    }
 }
 /// A collection of transactions belonging to a specific rollup that are submitted to celestia.
 ///
@@ -231,6 +308,13 @@ pub struct CelestiaRollupBlob {
     /// `astria.sequencer.v1alpha.SequencerBlock.rollup_transactions_proof`.
     #[prost(message, optional, tag = "4")]
     pub proof: ::core::option::Option<Proof>,
+}
+impl ::prost::Name for CelestiaRollupBlob {
+    const NAME: &'static str = "CelestiaRollupBlob";
+    const PACKAGE: &'static str = "astria.sequencer.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.sequencer.v1.{}", Self::NAME)
+    }
 }
 /// The metadata of a sequencer block that is submitted to celestia.
 ///
@@ -267,12 +351,26 @@ pub struct CelestiaSequencerBlob {
     #[prost(message, optional, tag = "5")]
     pub rollup_ids_proof: ::core::option::Option<Proof>,
 }
+impl ::prost::Name for CelestiaSequencerBlob {
+    const NAME: &'static str = "CelestiaSequencerBlob";
+    const PACKAGE: &'static str = "astria.sequencer.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.sequencer.v1.{}", Self::NAME)
+    }
+}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetSequencerBlockRequest {
     /// The height of the block to retrieve.
     #[prost(uint64, tag = "1")]
     pub height: u64,
+}
+impl ::prost::Name for GetSequencerBlockRequest {
+    const NAME: &'static str = "GetSequencerBlockRequest";
+    const PACKAGE: &'static str = "astria.sequencer.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.sequencer.v1.{}", Self::NAME)
+    }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -283,6 +381,13 @@ pub struct GetFilteredSequencerBlockRequest {
     /// The 32 bytes identifying a rollup. Usually the sha256 hash of a plain rollup name.
     #[prost(bytes = "vec", repeated, tag = "2")]
     pub rollup_ids: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+}
+impl ::prost::Name for GetFilteredSequencerBlockRequest {
+    const NAME: &'static str = "GetFilteredSequencerBlockRequest";
+    const PACKAGE: &'static str = "astria.sequencer.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.sequencer.v1.{}", Self::NAME)
+    }
 }
 /// Generated client implementations.
 #[cfg(feature = "client")]
@@ -689,6 +794,13 @@ pub struct SignedTransaction {
     #[prost(message, optional, tag = "3")]
     pub transaction: ::core::option::Option<UnsignedTransaction>,
 }
+impl ::prost::Name for SignedTransaction {
+    const NAME: &'static str = "SignedTransaction";
+    const PACKAGE: &'static str = "astria.sequencer.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.sequencer.v1.{}", Self::NAME)
+    }
+}
 /// `UnsignedTransaction` is a transaction that does
 /// not have an attached signature.
 /// Note: `value` must be set, it cannot be `None`.
@@ -699,6 +811,13 @@ pub struct UnsignedTransaction {
     pub nonce: u32,
     #[prost(message, repeated, tag = "2")]
     pub actions: ::prost::alloc::vec::Vec<Action>,
+}
+impl ::prost::Name for UnsignedTransaction {
+    const NAME: &'static str = "UnsignedTransaction";
+    const PACKAGE: &'static str = "astria.sequencer.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.sequencer.v1.{}", Self::NAME)
+    }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -735,6 +854,13 @@ pub mod action {
         BridgeLockAction(super::BridgeLockAction),
     }
 }
+impl ::prost::Name for Action {
+    const NAME: &'static str = "Action";
+    const PACKAGE: &'static str = "astria.sequencer.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.sequencer.v1.{}", Self::NAME)
+    }
+}
 /// `TransferAction` represents a value transfer transaction.
 ///
 /// Note: all values must be set (ie. not `None`), otherwise it will
@@ -753,6 +879,13 @@ pub struct TransferAction {
     #[prost(bytes = "vec", tag = "4")]
     pub fee_asset_id: ::prost::alloc::vec::Vec<u8>,
 }
+impl ::prost::Name for TransferAction {
+    const NAME: &'static str = "TransferAction";
+    const PACKAGE: &'static str = "astria.sequencer.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.sequencer.v1.{}", Self::NAME)
+    }
+}
 /// `SequenceAction` represents a transaction destined for another
 /// chain, ordered by the sequencer.
 ///
@@ -769,6 +902,13 @@ pub struct SequenceAction {
     #[prost(bytes = "vec", tag = "3")]
     pub fee_asset_id: ::prost::alloc::vec::Vec<u8>,
 }
+impl ::prost::Name for SequenceAction {
+    const NAME: &'static str = "SequenceAction";
+    const PACKAGE: &'static str = "astria.sequencer.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.sequencer.v1.{}", Self::NAME)
+    }
+}
 /// / `SudoAddressChangeAction` represents a transaction that changes
 /// / the sudo address of the chain, which is the address authorized to
 /// / make validator update actions.
@@ -779,6 +919,13 @@ pub struct SequenceAction {
 pub struct SudoAddressChangeAction {
     #[prost(bytes = "vec", tag = "1")]
     pub new_address: ::prost::alloc::vec::Vec<u8>,
+}
+impl ::prost::Name for SudoAddressChangeAction {
+    const NAME: &'static str = "SudoAddressChangeAction";
+    const PACKAGE: &'static str = "astria.sequencer.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.sequencer.v1.{}", Self::NAME)
+    }
 }
 /// `MintAction` represents a minting transaction.
 /// It can only be executed by the chain's sudo address.
@@ -791,6 +938,13 @@ pub struct MintAction {
     pub to: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag = "2")]
     pub amount: ::core::option::Option<super::super::primitive::v1::Uint128>,
+}
+impl ::prost::Name for MintAction {
+    const NAME: &'static str = "MintAction";
+    const PACKAGE: &'static str = "astria.sequencer.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.sequencer.v1.{}", Self::NAME)
+    }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -822,6 +976,13 @@ pub struct Ics20Withdrawal {
     #[prost(bytes = "vec", tag = "8")]
     pub fee_asset_id: ::prost::alloc::vec::Vec<u8>,
 }
+impl ::prost::Name for Ics20Withdrawal {
+    const NAME: &'static str = "Ics20Withdrawal";
+    const PACKAGE: &'static str = "astria.sequencer.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.sequencer.v1.{}", Self::NAME)
+    }
+}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct IbcHeight {
@@ -829,6 +990,13 @@ pub struct IbcHeight {
     pub revision_number: u64,
     #[prost(uint64, tag = "2")]
     pub revision_height: u64,
+}
+impl ::prost::Name for IbcHeight {
+    const NAME: &'static str = "IbcHeight";
+    const PACKAGE: &'static str = "astria.sequencer.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.sequencer.v1.{}", Self::NAME)
+    }
 }
 /// `IbcRelayerChangeAction` represents a transaction that adds
 /// or removes an IBC relayer address.
@@ -848,6 +1016,13 @@ pub mod ibc_relayer_change_action {
         Addition(::prost::alloc::vec::Vec<u8>),
         #[prost(bytes, tag = "2")]
         Removal(::prost::alloc::vec::Vec<u8>),
+    }
+}
+impl ::prost::Name for IbcRelayerChangeAction {
+    const NAME: &'static str = "IbcRelayerChangeAction";
+    const PACKAGE: &'static str = "astria.sequencer.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.sequencer.v1.{}", Self::NAME)
     }
 }
 /// `FeeAssetChangeAction` represents a transaction that adds
@@ -871,6 +1046,13 @@ pub mod fee_asset_change_action {
         Removal(::prost::alloc::vec::Vec<u8>),
     }
 }
+impl ::prost::Name for FeeAssetChangeAction {
+    const NAME: &'static str = "FeeAssetChangeAction";
+    const PACKAGE: &'static str = "astria.sequencer.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.sequencer.v1.{}", Self::NAME)
+    }
+}
 /// `InitBridgeAccountAction` represents a transaction that initializes
 /// a bridge account for the given rollup on the chain.
 ///
@@ -889,6 +1071,13 @@ pub struct InitBridgeAccountAction {
     /// the asset used to pay the transaction fee
     #[prost(bytes = "vec", tag = "3")]
     pub fee_asset_id: ::prost::alloc::vec::Vec<u8>,
+}
+impl ::prost::Name for InitBridgeAccountAction {
+    const NAME: &'static str = "InitBridgeAccountAction";
+    const PACKAGE: &'static str = "astria.sequencer.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.sequencer.v1.{}", Self::NAME)
+    }
 }
 /// `BridgeLockAction` represents a transaction that transfers
 /// funds from a sequencer account to a bridge account.
@@ -914,4 +1103,11 @@ pub struct BridgeLockAction {
     /// will receive the bridged funds
     #[prost(string, tag = "5")]
     pub destination_chain_address: ::prost::alloc::string::String,
+}
+impl ::prost::Name for BridgeLockAction {
+    const NAME: &'static str = "BridgeLockAction";
+    const PACKAGE: &'static str = "astria.sequencer.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.sequencer.v1.{}", Self::NAME)
+    }
 }

--- a/tools/protobuf-compiler/Cargo.lock
+++ b/tools/protobuf-compiler/Cargo.lock
@@ -22,6 +22,7 @@ name = "astria-protobuf-compiler"
 version = "0.1.0"
 dependencies = [
  "pbjson-build",
+ "prost-build",
  "tempfile",
  "tonic-build",
  "walkdir",

--- a/tools/protobuf-compiler/Cargo.toml
+++ b/tools/protobuf-compiler/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 pbjson-build = "0.6.2"
+prost-build = "0.12.3"
 tempfile = "3.8.1"
 tonic-build = "0.10.2"
 walkdir = "2.4.0"

--- a/tools/protobuf-compiler/src/main.rs
+++ b/tools/protobuf-compiler/src/main.rs
@@ -91,7 +91,7 @@ fn main() {
         .file_descriptor_set_path(buf_img.path())
         .skip_protoc_run()
         .out_dir(&out_dir)
-        .compile(&files, INCLUDES)
+        .compile_with_config(prost_build_config(), &files, INCLUDES)
         .expect("should be able to compile protobuf using tonic");
 
     let descriptor_set = std::fs::read(buf_img.path())
@@ -113,6 +113,12 @@ fn main() {
 
     let mut after_build = build_content_map(&out_dir);
     clean_non_astria_code(&mut after_build);
+}
+
+fn prost_build_config() -> prost_build::Config {
+    let mut config = prost_build::Config::new();
+    config.enable_type_names();
+    config
 }
 
 fn emit_buf_stdout(buf: &[u8]) -> std::io::Result<()> {


### PR DESCRIPTION
## Summary
Generate type names for all Rust protobuf types.

## Background
Prost introduced the the `Name` trait to allow referring to protobuf messages by their full name. It's useful being able to refer to the full protobuf name (instead of just its Rust type) in observability and tests.

## Changes
- Updated the proto compiler tool to also emit `impl prost::Name for <proto_type>`

## Testing
n/a Only generating code