### PR TITLE
feat: replace hex by base64 for display formatting, emitting tracing events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -825,6 +825,7 @@ name = "astria-telemetry"
 version = "0.1.0"
 dependencies = [
  "base64 0.21.7",
+ "base64-serde",
  "metrics-exporter-prometheus",
  "opentelemetry",
  "opentelemetry-otlp",
@@ -833,7 +834,6 @@ dependencies = [
  "opentelemetry_sdk",
  "serde",
  "serde_json",
- "serde_with",
  "thiserror",
  "tracing",
  "tracing-opentelemetry",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -648,7 +648,6 @@ dependencies = [
  "bytes",
  "celestia-tendermint",
  "ed25519-consensus",
- "hex",
  "ibc-types",
  "indexmap 2.2.3",
  "pbjson",

--- a/crates/astria-celestia-client/src/client.rs
+++ b/crates/astria-celestia-client/src/client.rs
@@ -143,7 +143,7 @@ pub trait CelestiaClientExt: BlobClient {
     #[instrument(skip_all, fields(
         height = height.into(),
         namespace = %telemetry::display::base64(&namespace.as_bytes()),
-        block_hash = %telemetry::display::hex(&sequencer_blob.block_hash()),
+        block_hash = %telemetry::display::base64(&sequencer_blob.block_hash()),
     ))]
     async fn get_rollup_blobs_matching_sequencer_blob<T>(
         &self,

--- a/crates/astria-composer/src/executor/mod.rs
+++ b/crates/astria-composer/src/executor/mod.rs
@@ -425,7 +425,7 @@ impl Future for SubmitFut {
                     info!(
                         nonce.actual = *this.nonce,
                         bundle = %telemetry::display::json(&SizedBundleReport(this.bundle)),
-                        transaction.hash = %telemetry::display::hex(&tx.sha256_of_proto_encoding()),
+                        transaction.hash = %telemetry::display::base64(&tx.sha256_of_proto_encoding()),
                         "submitting transaction to sequencer",
                     );
                     SubmitState::WaitingForSend {
@@ -483,7 +483,7 @@ impl Future for SubmitFut {
                         info!(
                             nonce.resubmission = *this.nonce,
                             bundle = %telemetry::display::json(&SizedBundleReport(this.bundle)),
-                            transaction.hash = %telemetry::display::hex(&tx.sha256_of_proto_encoding()),
+                            transaction.hash = %telemetry::display::base64(&tx.sha256_of_proto_encoding()),
                             "resubmitting transaction to sequencer with new nonce",
                         );
                         SubmitState::WaitingForSend {

--- a/crates/astria-composer/tests/blackbox/grpc_collector.rs
+++ b/crates/astria-composer/tests/blackbox/grpc_collector.rs
@@ -67,7 +67,7 @@ async fn invalid_nonce_causes_resubmission_under_different_nonce() {
     // Spawn a composer with a mock sequencer and a mock rollup node
     // Initial nonce is 0
     let rollup_id = RollupId::from_unhashed_bytes("test1");
-    let test_composer = spawn_composer(&[rollup_id.to_string().as_str()]).await;
+    let test_composer = spawn_composer(&[]).await;
     tokio::time::timeout(
         Duration::from_millis(100),
         test_composer.setup_guard.wait_until_satisfied(),

--- a/crates/astria-conductor/src/celestia/block_verifier.rs
+++ b/crates/astria-conductor/src/celestia/block_verifier.rs
@@ -35,7 +35,7 @@ impl BlockVerifier {
 
     #[instrument(skip_all, fields(
         height.in_blob = %blob.height(),
-        block_hash.in_blob = %telemetry::display::hex(&blob.block_hash()),
+        block_hash.in_blob = %telemetry::display::base64(&blob.block_hash()),
     ))]
     pub(super) async fn verify_blob(&self, blob: &CelestiaSequencerBlob) -> eyre::Result<()> {
         Verify::at_height(self.client.clone(), blob.height())

--- a/crates/astria-conductor/src/celestia/mod.rs
+++ b/crates/astria-conductor/src/celestia/mod.rs
@@ -53,7 +53,7 @@ use sequencer_client::tendermint::{
     block::Height as SequencerHeight,
 };
 use telemetry::display::{
-    hex,
+    base64,
     json,
 };
 use tokio::{
@@ -213,8 +213,8 @@ impl Reader {
         }
         .instrument(info_span!(
             "celestia_block_stream",
-            namespace.rollup = %hex(&rollup_namespace.as_bytes()),
-            namespace.sequencer = %hex(&self.sequencer_namespace.as_bytes()),
+            namespace.rollup = %base64(&rollup_namespace.as_bytes()),
+            namespace.sequencer = %base64(&self.sequencer_namespace.as_bytes()),
         ));
 
         // Enqueued block waiting for executor to free up. Set if the executor exhibits
@@ -521,8 +521,8 @@ impl Stream for ReconstructedBlocksStream {
     skip_all,
     fields(
         %celestia_height,
-        namespace.sequencer = %hex(&sequencer_namespace.as_bytes()),
-        namespace.rollup = %hex(&rollup_namespace.as_bytes()),
+        namespace.sequencer = %base64(&sequencer_namespace.as_bytes()),
+        namespace.rollup = %base64(&rollup_namespace.as_bytes()),
     ),
     err
 )]
@@ -597,8 +597,8 @@ async fn fetch_blocks_at_celestia_height(
     skip_all,
     fields(
         blob.sequencer_height = sequencer_blob.height().value(),
-        blob.block_hash = %hex(&sequencer_blob.block_hash()),
-        celestia_rollup_namespace = %hex(rollup_namespace.as_bytes()),
+        blob.block_hash = %base64(&sequencer_blob.block_hash()),
+        celestia_rollup_namespace = %base64(rollup_namespace.as_bytes()),
     ),
     err,
 )]

--- a/crates/astria-conductor/src/celestia/reporting.rs
+++ b/crates/astria-conductor/src/celestia/reporting.rs
@@ -4,7 +4,7 @@ use serde::ser::{
     SerializeSeq,
     SerializeStruct,
 };
-use telemetry::display::hex;
+use telemetry::display::base64;
 
 use super::{
     ReconstructedBlock,
@@ -44,8 +44,8 @@ impl<'a> Serialize for ReportReconstructedBlocks<'a> {
         ];
         let mut state = serializer.serialize_struct("ReconstructedBlocksInfo", FIELDS.len())?;
         state.serialize_field(FIELDS[0], &self.0.celestia_height)?;
-        state.serialize_field(FIELDS[1], &hex(&self.0.sequencer_namespace.as_bytes()))?;
-        state.serialize_field(FIELDS[2], &hex(self.0.rollup_namespace.as_bytes()))?;
+        state.serialize_field(FIELDS[1], &base64(&self.0.sequencer_namespace.as_bytes()))?;
+        state.serialize_field(FIELDS[2], &base64(self.0.rollup_namespace.as_bytes()))?;
         state.serialize_field(FIELDS[3], &ReportReconstructedBlocksSeq(&self.0.blocks))?;
         state.end()
     }
@@ -79,7 +79,7 @@ impl<'a> Serialize for ReportReconstructedBlock<'a> {
         ];
         let mut state = serializer.serialize_struct("ReconstructedBlockInfo", FIELDS.len())?;
         state.serialize_field(FIELDS[0], &self.0.celestia_height)?;
-        state.serialize_field(FIELDS[1], &hex(&self.0.block_hash))?;
+        state.serialize_field(FIELDS[1], &base64(&self.0.block_hash))?;
         state.serialize_field(FIELDS[2], &self.0.transactions.len())?;
         state.serialize_field(FIELDS[3], &self.0.celestia_height)?;
         state.end()

--- a/crates/astria-conductor/src/executor/mod.rs
+++ b/crates/astria-conductor/src/executor/mod.rs
@@ -226,7 +226,7 @@ impl Executor {
                 Some(block) = self.firm_blocks.recv() => {
                     debug!(
                         block.height = %block.sequencer_height(),
-                        block.hash = %telemetry::display::hex(&block.block_hash),
+                        block.hash = %telemetry::display::base64(&block.block_hash),
                         "received block from celestia reader",
                     );
                     if let Err(error) = self.execute_firm(client.clone(), block).await {
@@ -237,7 +237,7 @@ impl Executor {
                 Some(block) = self.soft_blocks.recv(), if spread_not_too_large => {
                     debug!(
                         block.height = %block.height(),
-                        block.hash = %telemetry::display::hex(&block.block_hash()),
+                        block.hash = %telemetry::display::base64(&block.block_hash()),
                         "received block from sequencer reader",
                     );
                     if let Err(error) = self.execute_soft(client.clone(), block).await {
@@ -307,7 +307,7 @@ impl Executor {
     }
 
     #[instrument(skip_all, fields(
-        block.hash = %telemetry::display::hex(&block.block_hash()),
+        block.hash = %telemetry::display::base64(&block.block_hash()),
         block.height = block.height().value(),
     ))]
     async fn execute_soft(
@@ -362,7 +362,7 @@ impl Executor {
     }
 
     #[instrument(skip_all, fields(
-        block.hash = %telemetry::display::hex(&block.block_hash),
+        block.hash = %telemetry::display::base64(&block.block_hash),
         block.height = block.sequencer_height().value(),
     ))]
     async fn execute_firm(
@@ -408,10 +408,10 @@ impl Executor {
     /// This function is called via [`Executor::execute_firm`] or [`Executor::execute_soft`],
     /// and should not be called directly.
     #[instrument(skip_all, fields(
-        block.hash = %telemetry::display::hex(&block.hash),
+        block.hash = %telemetry::display::base64(&block.hash),
         block.height = block.height.value(),
         block.num_of_transactions = block.transactions.len(),
-        rollup.parent_hash = %telemetry::display::hex(&parent_block_hash),
+        rollup.parent_hash = %telemetry::display::base64(&parent_block_hash),
     ))]
     async fn execute_block(
         &mut self,
@@ -431,7 +431,7 @@ impl Executor {
             .wrap_err("failed to run execute_block RPC")?;
 
         info!(
-            executed_block.hash = %telemetry::display::hex(&executed_block.hash()),
+            executed_block.hash = %telemetry::display::base64(&executed_block.hash()),
             executed_block.number = executed_block.number(),
             "executed block",
         );
@@ -497,9 +497,9 @@ impl Executor {
             .wrap_err("failed updating remote commitment state")?;
         info!(
             soft.number = new_state.soft().number(),
-            soft.hash = %telemetry::display::hex(&new_state.soft().hash()),
+            soft.hash = %telemetry::display::base64(&new_state.soft().hash()),
             firm.number = new_state.firm().number(),
-            firm.hash = %telemetry::display::hex(&new_state.firm().hash()),
+            firm.hash = %telemetry::display::base64(&new_state.firm().hash()),
             "updated commitment state",
         );
         self.state

--- a/crates/astria-core/Cargo.toml
+++ b/crates/astria-core/Cargo.toml
@@ -23,7 +23,6 @@ merkle = { package = "astria-merkle", path = "../astria-merkle" }
 bytes = { workspace = true }
 celestia-tendermint = { workspace = true }
 ed25519-consensus = { workspace = true }
-hex = { workspace = true }
 ibc-types = { workspace = true }
 indexmap = { workspace = true }
 pbjson-types = { workspace = true }
@@ -39,15 +38,14 @@ thiserror = { workspace = true }
 tonic = { workspace = true, optional = true }
 tracing = { workspace = true }
 base64-serde = { workspace = true, optional = true }
-base64 = { workspace = true, optional = true }
+base64 = { workspace = true }
 
 [features]
 client = ["dep:tonic"]
-serde = ["dep:serde", "dep:pbjson", "dep:base64", "dep:base64-serde"]
+serde = ["dep:serde", "dep:pbjson", "dep:base64-serde"]
 server = ["dep:tonic"]
 test-utils = ["dep:rand"]
 base64-serde = ["dep:base64-serde"]
-base64 = ["dep:base64"]
 
 [dev-dependencies]
 rand = { workspace = true }

--- a/crates/astria-core/src/sequencer/v1/asset.rs
+++ b/crates/astria-core/src/sequencer/v1/asset.rs
@@ -172,10 +172,11 @@ impl AsRef<[u8]> for Id {
 
 impl Display for Id {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        for byte in self.0 {
-            write!(f, "{byte:02x}")?;
-        }
-        Ok(())
+        use base64::{
+            display::Base64Display,
+            prelude::BASE64_STANDARD,
+        };
+        Base64Display::new(self.as_ref(), &BASE64_STANDARD).fmt(f)
     }
 }
 

--- a/crates/astria-core/src/sequencer/v1/mod.rs
+++ b/crates/astria-core/src/sequencer/v1/mod.rs
@@ -1,3 +1,7 @@
+use base64::{
+    display::Base64Display,
+    prelude::BASE64_STANDARD,
+};
 use indexmap::IndexMap;
 use sha2::{
     Digest as _,
@@ -101,10 +105,7 @@ impl From<[u8; ADDRESS_LEN]> for Address {
 
 impl std::fmt::Display for Address {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        for byte in self.0 {
-            write!(f, "{byte:02x}")?;
-        }
-        Ok(())
+        Base64Display::new(self.as_ref(), &BASE64_STANDARD).fmt(f)
     }
 }
 
@@ -242,10 +243,7 @@ impl From<&RollupId> for RollupId {
 
 impl std::fmt::Display for RollupId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        for byte in self.inner {
-            write!(f, "{byte:02x}")?;
-        }
-        Ok(())
+        Base64Display::new(self.as_ref(), &BASE64_STANDARD).fmt(f)
     }
 }
 

--- a/crates/astria-sequencer-relayer/src/relayer/write/conversion.rs
+++ b/crates/astria-sequencer-relayer/src/relayer/write/conversion.rs
@@ -25,7 +25,7 @@ where
     S: serde::ser::Serializer,
 {
     use serde::ser::Serialize as _;
-    telemetry::display::hex(namespace.as_bytes()).serialize(serializer)
+    telemetry::display::base64(namespace.as_bytes()).serialize(serializer)
 }
 
 #[derive(Debug, serde::Serialize)]

--- a/crates/astria-sequencer/src/api_state_ext.rs
+++ b/crates/astria-sequencer/src/api_state_ext.rs
@@ -29,39 +29,28 @@ use cnidarium::{
 use prost::Message;
 use tracing::instrument;
 
-struct Hex<'a>(&'a [u8]);
-
-impl<'a> std::fmt::Display for Hex<'a> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        for byte in self.0 {
-            f.write_fmt(format_args!("{byte:02x}"))?;
-        }
-        Ok(())
-    }
-}
-
 fn block_hash_by_height_key(height: u64) -> String {
     format!("blockhash/{height}")
 }
 
 fn sequencer_block_header_by_hash_key(hash: &[u8]) -> String {
-    format!("blockheader/{}", Hex(hash))
+    format!("blockheader/{}", crate::utils::Hex(hash))
 }
 
 fn rollup_data_by_hash_and_rollup_id_key(hash: &[u8], rollup_id: &RollupId) -> String {
-    format!("rollupdata/{}/{}", Hex(hash), rollup_id)
+    format!("rollupdata/{}/{}", crate::utils::Hex(hash), rollup_id)
 }
 
 fn rollup_ids_by_hash_key(hash: &[u8]) -> String {
-    format!("rollupids/{}", Hex(hash))
+    format!("rollupids/{}", crate::utils::Hex(hash))
 }
 
 fn rollup_transactions_proof_by_hash_key(hash: &[u8]) -> String {
-    format!("rolluptxsproof/{}", Hex(hash))
+    format!("rolluptxsproof/{}", crate::utils::Hex(hash))
 }
 
 fn rollup_ids_proof_by_hash_key(hash: &[u8]) -> String {
-    format!("rollupidsproof/{}", Hex(hash))
+    format!("rollupidsproof/{}", crate::utils::Hex(hash))
 }
 
 #[derive(BorshSerialize, BorshDeserialize)]

--- a/crates/astria-sequencer/src/app.rs
+++ b/crates/astria-sequencer/src/app.rs
@@ -377,7 +377,7 @@ impl App {
                 > MAX_SEQUENCE_DATA_BYTES_PER_BLOCK
             {
                 debug!(
-                    transaction_hash = %telemetry::display::hex(&tx_hash),
+                    transaction_hash = %telemetry::display::base64(&tx_hash),
                     included_data_bytes = block_sequence_data_bytes,
                     tx_data_bytes = tx_sequence_data_bytes,
                     max_data_bytes = MAX_SEQUENCE_DATA_BYTES_PER_BLOCK,
@@ -397,7 +397,7 @@ impl App {
                 }
                 Err(e) => {
                     debug!(
-                        transaction_hash = %telemetry::display::hex(&tx_hash),
+                        transaction_hash = %telemetry::display::base64(&tx_hash),
                         error = AsRef::<dyn std::error::Error>::as_ref(&e),
                         "failed to execute transaction, not including in block"
                     );
@@ -474,7 +474,7 @@ impl App {
     /// Note that the first two "transactions" in the block, which are the proposer-generated
     /// commitments, are ignored.
     #[instrument(name = "App::deliver_tx_after_proposal", skip_all, fields(
-        tx_hash =  %telemetry::display::hex(&Sha256::digest(&tx.tx)),
+        tx_hash =  %telemetry::display::base64(&Sha256::digest(&tx.tx)),
     ))]
     pub(crate) async fn deliver_tx_after_proposal(
         &mut self,
@@ -529,7 +529,7 @@ impl App {
     ///
     /// Note that `begin_block` is now called *after* transaction execution.
     #[instrument(name = "App::deliver_tx", skip_all, fields(
-        signed_transaction_hash = %telemetry::display::hex(&signed_tx.sha256_of_proto_encoding()),
+        signed_transaction_hash = %telemetry::display::base64(&signed_tx.sha256_of_proto_encoding()),
         sender = %Address::from_verification_key(signed_tx.verification_key()),
     ))]
     pub(crate) async fn deliver_tx(
@@ -701,7 +701,7 @@ impl App {
             .await
             .expect("must be able to successfully commit to storage");
         tracing::debug!(
-            app_hash = %telemetry::display::hex(&app_hash),
+            app_hash = %telemetry::display::base64(&app_hash),
             "finished committing state",
         );
 

--- a/crates/astria-sequencer/src/lib.rs
+++ b/crates/astria-sequencer/src/lib.rs
@@ -19,6 +19,7 @@ mod sequencer;
 pub(crate) mod service;
 pub(crate) mod state_ext;
 pub(crate) mod transaction;
+mod utils;
 
 pub use build_info::BUILD_INFO;
 pub use config::Config;

--- a/crates/astria-sequencer/src/service/consensus.rs
+++ b/crates/astria-sequencer/src/service/consensus.rs
@@ -184,8 +184,8 @@ impl Consensus {
         time = %process_proposal.time,
         tx_count = process_proposal.txs.len(),
         proposer = %process_proposal.proposer_address,
-        hash = %telemetry::display::hex(&process_proposal.hash),
-        next_validators_hash = %telemetry::display::hex(&process_proposal.next_validators_hash),
+        hash = %telemetry::display::base64(&process_proposal.hash),
+        next_validators_hash = %telemetry::display::base64(&process_proposal.next_validators_hash),
     ))]
     async fn handle_process_proposal(
         &mut self,
@@ -217,7 +217,7 @@ impl Consensus {
     }
 
     #[instrument(skip_all, fields(
-        tx_hash = %telemetry::display::hex(&Sha256::digest(&deliver_tx.tx))
+        tx_hash = %telemetry::display::base64(&Sha256::digest(&deliver_tx.tx))
     ))]
     async fn deliver_tx(&mut self, deliver_tx: request::DeliverTx) -> response::DeliverTx {
         use crate::transaction::InvalidNonce;

--- a/crates/astria-sequencer/src/state_ext.rs
+++ b/crates/astria-sequencer/src/state_ext.rs
@@ -22,11 +22,11 @@ fn storage_version_by_height_key(height: u64) -> Vec<u8> {
 }
 
 fn block_fees_key(asset: asset::Id) -> Vec<u8> {
-    format!("{BLOCK_FEES_PREFIX}{asset}").into()
+    format!("{BLOCK_FEES_PREFIX}{}", crate::utils::Hex(asset.as_ref())).into()
 }
 
 fn fee_asset_key(asset: asset::Id) -> Vec<u8> {
-    format!("{FEE_ASSET_PREFIX}{asset}").into()
+    format!("{FEE_ASSET_PREFIX}{}", crate::utils::Hex(asset.as_ref())).into()
 }
 
 #[async_trait]

--- a/crates/astria-sequencer/src/utils.rs
+++ b/crates/astria-sequencer/src/utils.rs
@@ -1,0 +1,10 @@
+pub(crate) struct Hex<'a>(pub(crate) &'a [u8]);
+
+impl<'a> std::fmt::Display for Hex<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for byte in self.0 {
+            f.write_fmt(format_args!("{byte:02x}"))?;
+        }
+        Ok(())
+    }
+}

--- a/crates/astria-telemetry/Cargo.toml
+++ b/crates/astria-telemetry/Cargo.toml
@@ -26,7 +26,6 @@ opentelemetry-stdout = { version = "0.3.0", features = ["trace"] }
 opentelemetry_sdk = { version = "0.22.1", features = ["rt-tokio"] }
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
-# serde_with = { version = "3.7.0", optional = true }
 thiserror = { workspace = true }
 tracing-opentelemetry = "0.23.0"
 tracing-subscriber = { version = "0.3.17", features = [
@@ -39,5 +38,4 @@ tracing-subscriber = { version = "0.3.17", features = [
 tracing = { workspace = true }
 
 [features]
-# display = ["dep:base64", "dep:serde", "dep:serde_json", "dep:serde_with"]
 display = ["dep:base64", "dep:serde", "dep:serde_json", "dep:base64-serde"]

--- a/crates/astria-telemetry/Cargo.toml
+++ b/crates/astria-telemetry/Cargo.toml
@@ -12,6 +12,7 @@ homepage = "https://astria.org"
 
 [dependencies]
 base64 = { workspace = true, optional = true }
+base64-serde = { workspace = true, optional = true }
 
 metrics-exporter-prometheus = { version = "0.13.1", default-features = false, features = [
   "http-listener",
@@ -25,7 +26,7 @@ opentelemetry-stdout = { version = "0.3.0", features = ["trace"] }
 opentelemetry_sdk = { version = "0.22.1", features = ["rt-tokio"] }
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
-serde_with = { version = "3.7.0", optional = true }
+# serde_with = { version = "3.7.0", optional = true }
 thiserror = { workspace = true }
 tracing-opentelemetry = "0.23.0"
 tracing-subscriber = { version = "0.3.17", features = [
@@ -38,4 +39,5 @@ tracing-subscriber = { version = "0.3.17", features = [
 tracing = { workspace = true }
 
 [features]
-display = ["dep:base64", "dep:serde", "dep:serde_json", "dep:serde_with"]
+# display = ["dep:base64", "dep:serde", "dep:serde_json", "dep:serde_with"]
+display = ["dep:base64", "dep:serde", "dep:serde_json", "dep:base64-serde"]

--- a/crates/astria-telemetry/src/display.rs
+++ b/crates/astria-telemetry/src/display.rs
@@ -10,43 +10,34 @@ use std::{
     str,
 };
 
-use base64::{
-    display::Base64Display,
-    engine::general_purpose::GeneralPurpose,
-};
-use serde_with::SerializeDisplay;
+use base64_serde::base64_serde_type;
 
 /// Format `bytes` using standard base64 formatting.
 ///
 /// See the [`base64::engine::general_purpose::STANDARD`] for the formatting definition.
-pub fn base64<T: AsRef<[u8]>>(bytes: &T) -> Base64Display<'_, 'static, GeneralPurpose> {
-    Base64Display::new(bytes.as_ref(), &base64::engine::general_purpose::STANDARD)
+pub fn base64<T: AsRef<[u8]> + ?Sized>(bytes: &T) -> Base64<'_> {
+    Base64(bytes.as_ref())
 }
 
-/// Format `bytes` as lower-cased hex.
-///
-/// # Example
-/// ```
-/// use astria_telemetry::display;
-/// let signature = vec![1u8, 2, 3, 4, 5, 6, 7, 8];
-/// tracing::info!(signature = %display::hex(&signature), "received signature");
-/// ```
-pub fn hex<T: AsRef<[u8]> + ?Sized>(bytes: &T) -> Hex<'_> {
-    Hex(bytes.as_ref())
-}
+pub struct Base64<'a>(&'a [u8]);
 
-/// A newtype wrapper of a byte slice that implements [`std::fmt::Display`].
-///
-/// To be used in tracing contexts. See the [`self::hex`] utility.
-#[derive(SerializeDisplay)]
-pub struct Hex<'a>(&'a [u8]);
-
-impl<'a> Display for Hex<'a> {
+impl<'a> Display for Base64<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        for byte in self.0 {
-            f.write_fmt(format_args!("{byte:02x}"))?;
-        }
-        Ok(())
+        use base64::{
+            display::Base64Display,
+            engine::general_purpose::STANDARD,
+        };
+        Base64Display::new(self.0, &STANDARD).fmt(f)
+    }
+}
+
+impl<'a> serde::Serialize for Base64<'a> {
+    fn serialize<S>(&self, serializer: S) -> std::prelude::v1::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        base64_serde_type!(Base64Standard, base64::engine::general_purpose::STANDARD);
+        Base64Standard::serialize(self.0, serializer)
     }
 }
 
@@ -56,7 +47,7 @@ impl<'a> Display for Hex<'a> {
 /// ```
 /// use astria_telemetry::display;
 /// let signature = vec![1u8, 2, 3, 4, 5, 6, 7, 8];
-/// tracing::info!(signature = %display::hex(&signature), "received signature");
+/// tracing::info!(signature = %display::base64(&signature), "received signature");
 /// ```
 pub fn json<T>(serializable: &T) -> Json<'_, T>
 where


### PR DESCRIPTION
## Summary
All tracing events that report byte slices now use base64 encoding instead of hex.

This applies especially to rollup IDs, sequencer addresses, and sequencer asset IDs.

## Background

Google's Protobuf to JSON mapping prescribes base64 be used when encoding byte slices. So far the astria codebase was arbitrarily using hex encoding, but this requirement justifies unifying everything to base64.

## Changes
- change the display formatting for rollup IDs, sequencer addresses, asset IDs from hex to base64
- remove the `display::hex` utility form `astria-telemetry`
- update all instances that used `display::hex` to use `display::base64` instead
- make the rocks db key construction involving asset IDs independent of the asset ID `Display` impl (always use hex instead)

## Testing
These changes should be entirely cosmetic. If they are not then our code relying on a particular display impl must be fixed.

## Related Issues
Closes https://github.com/astriaorg/astria/issues/903