### PR TITLE
ci: add Fraser999 to codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-*	@joroshiba @noot @SuperFluffy
+*	@joroshiba @noot @SuperFluffy @Fraser999
 
 /.github/	@astriaorg/infra
 /containerfiles/	@astriaorg/infra


### PR DESCRIPTION
## Summary
Add @Fraser999 to CODEOWNERS.

## Background
We need better infra configuration on selecting individual reviewers for specific PRs. In the absence of that this patch is adding a new CODEOWNER so that approval rights are more distributed.

## Changes
- Add @Fraser999 to CODEOWNERS