### PR TITLE
chore(charts): update rollup for new geth version

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -94,11 +94,18 @@ jobs:
           install_only: true
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+      - name: Log in to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Smoke Test Environment
         timeout-minutes: 5
         run: |
           TAG=sha-$(git rev-parse --short HEAD)
           just deploy cluster
+          kubectl create secret generic regcred --from-file=.dockerconfigjson=$HOME/.docker/config.json --type=kubernetes.io/dockerconfigjson
           echo "Deploying with astria images tagged $TAG"
           just deploy smoke-test $TAG
       - name: Run Smoke test

--- a/charts/evm-rollup/Chart.yaml
+++ b/charts/evm-rollup/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.10.4
+version: 0.11.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.7.0"
+appVersion: "0.9.0"
 
 dependencies:
   - name: celestia-node

--- a/charts/evm-rollup/files/genesis/geth-genesis.json
+++ b/charts/evm-rollup/files/genesis/geth-genesis.json
@@ -22,8 +22,8 @@
         "astriaRollupName": "{{ .Values.config.rollup.name }}",
         "astriaCelestiaInitialHeight": {{ toString .Values.config.celestia.initialBlockHeight | replace "\"" "" }},
         "astriaCelestiaHeightVariance": {{ toString .Values.config.celestia.heightVariance | replace "\"" "" }},
-        "astriaBridgeAddresses": [{{ .Values.config.rollup.genesis.bridgeAddresses }}],
-        "astriaBridgeAllowedAssetDenom": {{ .Values.config.rollup.genesis.bridgeAllowedAssetDenom }},
+        "astriaBridgeAddresses": [{{ .Values.config.rollup.genesis.bridgeAddresses | quote }}],
+        "astriaBridgeAllowedAssetDenom": {{ .Values.config.rollup.genesis.bridgeAllowedAssetDenom | quote }}
         {{- if not .Values.global.dev }}
         {{- else }}
         {{- end }}

--- a/charts/evm-rollup/files/genesis/geth-genesis.json
+++ b/charts/evm-rollup/files/genesis/geth-genesis.json
@@ -22,7 +22,7 @@
         "astriaRollupName": "{{ .Values.config.rollup.name }}",
         "astriaCelestiaInitialHeight": {{ toString .Values.config.celestia.initialBlockHeight | replace "\"" "" }},
         "astriaCelestiaHeightVariance": {{ toString .Values.config.celestia.heightVariance | replace "\"" "" }},
-        "astriaBridgeAddresses": [{{ .Values.config.rollup.genesis.bridgeAddresses | quote }}],
+        "astriaBridgeAddresses": [{{ .Values.config.rollup.genesis.bridgeAddress | quote }}],
         "astriaBridgeAllowedAssetDenom": {{ .Values.config.rollup.genesis.bridgeAllowedAssetDenom | quote }}
         {{- if not .Values.global.dev }}
         {{- else }}

--- a/charts/evm-rollup/files/genesis/geth-genesis.json
+++ b/charts/evm-rollup/files/genesis/geth-genesis.json
@@ -21,7 +21,9 @@
         "astriaSequencerInitialHeight": {{ toString .Values.config.sequencer.initialBlockHeight | replace "\"" "" }},
         "astriaRollupName": "{{ .Values.config.rollup.name }}",
         "astriaCelestiaInitialHeight": {{ toString .Values.config.celestia.initialBlockHeight | replace "\"" "" }},
-        "astriaCelestiaHeightVariance": {{ toString .Values.config.celestia.heightVariance | replace "\"" "" }}
+        "astriaCelestiaHeightVariance": {{ toString .Values.config.celestia.heightVariance | replace "\"" "" }},
+        "astriaBridgeAddresses": [{{ .Values.config.rollup.genesis.bridgeAddresses }}],
+        "astriaBridgeAllowedAssetDenom": {{ .Values.config.rollup.genesis.bridgeAllowedAssetDenom }},
         {{- if not .Values.global.dev }}
         {{- else }}
         {{- end }}

--- a/charts/evm-rollup/values.yaml
+++ b/charts/evm-rollup/values.yaml
@@ -9,7 +9,7 @@ global:
 images:
   geth:
     repo: ghcr.io/astriaorg/go-ethereum
-    tag: "0.7.0"
+    tag: "0.9.0"
     devTag: latest
   conductor:
     repo: ghcr.io/astriaorg/conductor
@@ -59,6 +59,10 @@ config:
       extraDataOverride: ""
       # If set to true the genesis block will contain extra data
       overrideGenesisExtraData: true
+      # Configure the sequencer bridge address and allowed asset denom if using 
+      # the astria canonical bridge. Recommend removing alloc values if so.
+      bridgeAddress: ""
+      bridgeAllowedAssetDenom: nria
       alloc:
         - address: "0xaC21B97d35Bf75A7dAb16f35b111a50e78A72F30"
           value:

--- a/charts/evm-rollup/values.yaml
+++ b/charts/evm-rollup/values.yaml
@@ -59,7 +59,7 @@ config:
       extraDataOverride: ""
       # If set to true the genesis block will contain extra data
       overrideGenesisExtraData: true
-      # Configure the sequencer bridge address and allowed asset denom if using 
+      # Configure the sequencer bridge address and allowed asset denom if using
       # the astria canonical bridge. Recommend removing alloc values if so.
       bridgeAddress: ""
       bridgeAllowedAssetDenom: nria


### PR DESCRIPTION
## Summary
Updates the rollup chart to support latest release of Geth.

## Background
Geth was updated to support bridge transactions & locking to specific bridges on EVM.

## Changes
- Update geth genesis, and version.

## Testing
Running smoke test
