### PR TITLE
feat(grpc-mock): utility methods for mounting mocks

### DIFF
--- a/crates/astria-grpc-mock/src/mock.rs
+++ b/crates/astria-grpc-mock/src/mock.rs
@@ -12,6 +12,10 @@ use super::{
     response::Respond,
     AnyMessage,
 };
+use crate::{
+    mock_server::MockGuard,
+    MockServer,
+};
 
 pub trait Match: Send + Sync {
     fn matches(&self, req: &tonic::Request<AnyMessage>) -> bool;
@@ -52,6 +56,14 @@ impl Mock {
     pub fn with_name(mut self, name: impl Into<String>) -> Self {
         self.name.replace(name.into());
         self
+    }
+
+    pub async fn mount(self, server: &MockServer) {
+        server.register(self).await;
+    }
+
+    pub async fn mount_as_scoped(self, server: &MockServer) -> MockGuard {
+        server.register_as_scoped(self).await
     }
 }
 


### PR DESCRIPTION
## Summary
Added `Mock::mount` and `Mock::mount_as_scoped` methods on mocks.

## Background
Similar to wiremock, these methods are useful to chain construction and mounting mocks in one go. These were useful in https://github.com/astriaorg/astria/pull/917

## Changes
- Added `Mock::mount` and `Mock::mount_as_scoped` convenience methods to mount mocks on mock servers.
