### PR TITLE
feat(ci): ensure all crate targets can be built outside the workspace

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Check that each crate compiles individually (circumventing workspace wide dependency resolution)
         run: |
           : # exclude all lints because cargo-hack ignores default-members and operates on all workspace members
-          cargo hack check --workspace --all-features \
+          cargo hack check --workspace --all-targets --all-features \
           --exclude tracing_debug_field
 
   lockfile:


### PR DESCRIPTION
## Summary
Added the `--all-targets` flag to `cargo hack check` to ensure tests can also be built outside the workspace.

## Background
While implementing https://github.com/astriaorg/astria/pull/889 it was found that sequencer-relayer tests can only be run from the repository root but not from the crate directory itself. The CI job that is supposed to ensure this failed because it was not running with the right flags.

## Changes
- Added `--all-targets` flag to `cargo hack check` in the rust test github workflow.
- 
## Related Issues
Closes https://github.com/astriaorg/astria/issues/893
