### PR TITLE
fix(charts): use statefulsets appropriately for rollup

### DIFF
--- a/charts/evm-rollup/Chart.yaml
+++ b/charts/evm-rollup/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.11.1
+version: 0.12.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.9.0"
+appVersion: "0.9.1"
 
 dependencies:
   - name: celestia-node

--- a/charts/evm-rollup/templates/deployments.yaml
+++ b/charts/evm-rollup/templates/deployments.yaml
@@ -1,0 +1,64 @@
+{{- if .Values.config.faucet.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.config.rollup.name }}-faucet
+  labels:
+    app: {{ .Values.config.rollup.name }}-astria-dev-cluster
+  namespace: {{ include "rollup.namespace" . }}
+spec:
+  replicas : {{ .Values.global.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ .Values.config.rollup.name }}-astria-dev-cluster
+  template:
+    metadata:
+      name: {{ .Values.config.rollup.name }}-faucet
+      labels:
+        app: {{ .Values.config.rollup.name }}-astria-dev-cluster
+    spec:
+      containers:
+        - name: faucet
+          command: [ "/app/eth-faucet" ]
+          args:
+            - -httpport=$(ETH_FAUCET_PORT)
+            - -wallet.provider=$(ETH_FAUCET_EVM_PROVIDER_URL)
+            - -wallet.privkey=$(ETH_FAUCET_EVM_PRIVATE_KEY)
+            - -faucet.amount=$(ETH_FAUCET_AMOUNT)
+            - -proxycount=$(ETH_FAUCET_PROXYCOUNT)
+          image: {{ .Values.images.faucet }}
+          envFrom:
+            - configMapRef:
+                name: {{ .Values.config.rollup.name }}-faucet-env
+          {{- if .Values.secretProvider.enabled }}
+          env:
+            - name: ETH_FAUCET_EVM_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: evm-private-key
+                  key: {{ .Values.secretProvider.secrets.evmPrivateKey.key }}
+          {{- end }}
+          volumeMounts:
+            - mountPath: /home/faucet
+              name: {{ .Values.config.rollup.name }}-faucet-home-vol
+              subPath: {{ .Values.config.rollup.name }}/faucet
+            {{- if .Values.secretProvider.enabled }}
+            - mountPath: /var/secrets
+              name: evm-private-key
+            {{- end }}
+          ports:
+            - containerPort: {{ .Values.ports.faucet }}
+              name: faucet
+      volumes:
+        - emptyDir: {}
+          name: {{ .Values.config.rollup.name }}-faucet-home-vol
+        {{- if .Values.secretProvider.enabled }}
+        - name: evm-private-key
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: evm-private-key
+        {{- end }}
+---
+{{- end }}

--- a/charts/evm-rollup/templates/statefulsets.yaml
+++ b/charts/evm-rollup/templates/statefulsets.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ .Values.config.rollup.name }}-geth
   labels:
@@ -157,73 +157,9 @@ spec:
               secretProviderClass: sequencer-private-key
         {{- end }}
 ---
-{{- if .Values.config.faucet.enabled }}
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: {{ .Values.config.rollup.name }}-faucet
-  labels:
-    app: {{ .Values.config.rollup.name }}-astria-dev-cluster
-  namespace: {{ include "rollup.namespace" . }}
-spec:
-  replicas : {{ .Values.global.replicaCount }}
-  selector:
-    matchLabels:
-      app: {{ .Values.config.rollup.name }}-astria-dev-cluster
-  template:
-    metadata:
-      name: {{ .Values.config.rollup.name }}-faucet
-      labels:
-        app: {{ .Values.config.rollup.name }}-astria-dev-cluster
-    spec:
-      containers:
-        - name: faucet
-          command: [ "/app/eth-faucet" ]
-          args:
-            - -httpport=$(ETH_FAUCET_PORT)
-            - -wallet.provider=$(ETH_FAUCET_EVM_PROVIDER_URL)
-            - -wallet.privkey=$(ETH_FAUCET_EVM_PRIVATE_KEY)
-            - -faucet.amount=$(ETH_FAUCET_AMOUNT)
-            - -proxycount=$(ETH_FAUCET_PROXYCOUNT)
-          image: {{ .Values.images.faucet }}
-          envFrom:
-            - configMapRef:
-                name: {{ .Values.config.rollup.name }}-faucet-env
-          {{- if .Values.secretProvider.enabled }}
-          env:
-            - name: ETH_FAUCET_EVM_PRIVATE_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: evm-private-key
-                  key: {{ .Values.secretProvider.secrets.evmPrivateKey.key }}
-          {{- end }}
-          volumeMounts:
-            - mountPath: /home/faucet
-              name: {{ .Values.config.rollup.name }}-faucet-home-vol
-              subPath: {{ .Values.config.rollup.name }}/faucet
-            {{- if .Values.secretProvider.enabled }}
-            - mountPath: /var/secrets
-              name: evm-private-key
-            {{- end }}
-          ports:
-            - containerPort: {{ .Values.ports.faucet }}
-              name: faucet
-      volumes:
-        - emptyDir: {}
-          name: {{ .Values.config.rollup.name }}-faucet-home-vol
-        {{- if .Values.secretProvider.enabled }}
-        - name: evm-private-key
-          csi:
-            driver: secrets-store.csi.k8s.io
-            readOnly: true
-            volumeAttributes:
-              secretProviderClass: evm-private-key
-        {{- end }}
----
-{{- end }}
 {{- if .Values.config.blockscout.enabled }}
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ .Values.config.rollup.name }}-blockscout
   labels:

--- a/charts/evm-rollup/templates/storageclasses.yaml
+++ b/charts/evm-rollup/templates/storageclasses.yaml
@@ -5,7 +5,15 @@
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: {{ $.Values.config.rollup.name }}-{{ $value.persistentVolumeName }}-local
+  name: {{ $.Values.config.rollup.name }}-{{ $value.persistentVolumeName }}-geth-local
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Retain
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ $.Values.config.rollup.name }}-{{ $value.persistentVolumeName }}-blockscout-local
 provisioner: kubernetes.io/no-provisioner
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Retain

--- a/charts/evm-rollup/templates/volumes.yaml
+++ b/charts/evm-rollup/templates/volumes.yaml
@@ -6,7 +6,7 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: {{ $.Values.config.rollup.name }}-{{ $value.persistentVolumeName }}-pv
+  name: {{ $.Values.config.rollup.name }}-{{ $value.persistentVolumeName }}-geth-pv
 spec:
   capacity:
     storage: {{ $value.size }}
@@ -14,7 +14,31 @@ spec:
   accessModes:
     - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain
-  storageClassName: {{ $.Values.config.rollup.name }}-{{ $value.persistentVolumeName }}-local
+  storageClassName: {{ $.Values.config.rollup.name }}-{{ $value.persistentVolumeName }}-geth-local
+  local:
+    path: {{ $value.path }}
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: kubernetes.io/hostname
+              operator: In
+              values:
+                - astria-dev-cluster-control-plane
+                - astria-dev-cluster-worker
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ $.Values.config.rollup.name }}-{{ $value.persistentVolumeName }}-blockscout-pv
+spec:
+  capacity:
+    storage: {{ $value.size }}
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: {{ $.Values.config.rollup.name }}-{{ $value.persistentVolumeName }}-blockscout-local
   local:
     path: {{ $value.path }}
   nodeAffinity:
@@ -39,7 +63,7 @@ metadata:
     "helm.sh/chart": {{ $.Chart.Name }}-{{ $.Chart.Version | replace "+" "_" }}
 spec:
   {{- if $.Values.storage.local }}
-  storageClassName: {{ $.Values.config.rollup.name }}-{{ $value.persistentVolumeName }}-local
+  storageClassName: {{ $.Values.config.rollup.name }}-{{ $value.persistentVolumeName }}-geth-local
   {{- end }}
   {{- if $value.storageClassName }}
   storageClassName: {{ $value.storageClassName }}
@@ -61,7 +85,7 @@ metadata:
     "helm.sh/chart": {{ $.Chart.Name }}-{{ $.Chart.Version | replace "+" "_" }}
 spec:
   {{- if $.Values.storage.local }}
-  storageClassName: {{ $.Values.config.rollup.name }}-{{ $value.persistentVolumeName }}-local
+  storageClassName: {{ $.Values.config.rollup.name }}-{{ $value.persistentVolumeName }}-blockscout-local
   {{- end }}
   {{- if $value.storageClassName }}
   storageClassName: {{ $value.storageClassName }}

--- a/dev/values/rollup/dev.yaml
+++ b/dev/values/rollup/dev.yaml
@@ -10,3 +10,6 @@ config:
 
 celestia-node:
   enabled: false
+
+storage:
+  enabled: false


### PR DESCRIPTION
## Summary
Moves geth rollup & blockscout into statefulsets to enable simple upgrades, fixes local storage for testing locally.

## Background
When upgrading geth nodes realized that updating geth version with deployments will never succeed. Ended up having to resync the whole geth node which over time will become expensive. Moving to statefulset enables cleaner upgrades.

## Changes
- StatefulSets for geth & blockscout
- Fixed local storage for rollup for testing 

## Testing
Run locally and manually trigerred helm upgrades to make sure they go through.
