### PR TITLE
feat(composer): add initial set of metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -576,6 +576,7 @@ dependencies = [
  "hyper",
  "insta",
  "itertools 0.11.0",
+ "metrics",
  "once_cell",
  "pin-project-lite",
  "prost",

--- a/crates/astria-composer/Cargo.toml
+++ b/crates/astria-composer/Cargo.toml
@@ -55,6 +55,7 @@ tracing = { workspace = true, features = ["attributes"] }
 tryhard = { workspace = true }
 tonic = { workspace = true }
 tokio-stream = { workspace = true, features = ["net"] }
+metrics = { workspace = true }
 
 [dependencies.sequencer-client]
 package = "astria-sequencer-client"

--- a/crates/astria-composer/src/collectors/geth.rs
+++ b/crates/astria-composer/src/collectors/geth.rs
@@ -51,8 +51,8 @@ use tracing::{
 
 use crate::{
     collectors::{
-        CollectorType,
         EXECUTOR_SEND_TIMEOUT,
+        GETH,
     },
     executor,
     metrics_init::{
@@ -218,7 +218,7 @@ impl Geth {
                             crate::metrics_init::TRANSACTIONS_RECEIVED,
                             &[
                                 (ROLLUP_ID_LABEL, chain_name.clone()),
-                                (COLLECTOR_TYPE_LABEL, CollectorType::Geth.to_string())
+                                (COLLECTOR_TYPE_LABEL, GETH.to_string())
                             ]).increment(1);
 
                         match executor_handle
@@ -236,7 +236,7 @@ impl Geth {
                                     crate::metrics_init::TRANSACTIONS_DROPPED,
                                     &[
                                         (ROLLUP_ID_LABEL, chain_name.clone()),
-                                        (COLLECTOR_TYPE_LABEL, CollectorType::Geth.to_string())
+                                        (COLLECTOR_TYPE_LABEL, GETH.to_string())
                                     ]
                                 ).increment(1);
                             }
@@ -250,7 +250,7 @@ impl Geth {
                                     crate::metrics_init::TRANSACTIONS_DROPPED,
                                     &[
                                         (ROLLUP_ID_LABEL, chain_name.clone()),
-                                        (COLLECTOR_TYPE_LABEL, CollectorType::Geth.to_string())
+                                        (COLLECTOR_TYPE_LABEL, GETH.to_string())
                                     ]
                                 ).increment(1);
                                 break Err(eyre!("executor channel closed while sending transaction"));

--- a/crates/astria-composer/src/collectors/geth.rs
+++ b/crates/astria-composer/src/collectors/geth.rs
@@ -215,7 +215,7 @@ impl Geth {
                         };
 
                         metrics::counter!(
-                            crate::metrics_init::TRANSACTIONS_COLLECTED,
+                            crate::metrics_init::TRANSACTIONS_RECEIVED,
                             &[
                                 (ROLLUP_ID_LABEL, chain_name.clone()),
                                 (COLLECTOR_TYPE_LABEL, CollectorType::Geth.to_string())
@@ -225,15 +225,7 @@ impl Geth {
                             .send_timeout(seq_action, EXECUTOR_SEND_TIMEOUT)
                             .await
                         {
-                            Ok(()) => {
-                                metrics::counter!(
-                                    crate::metrics_init::TRANSACTIONS_FORWARDED,
-                                    &[
-                                        (ROLLUP_ID_LABEL, chain_name.clone()),
-                                        (COLLECTOR_TYPE_LABEL, CollectorType::Geth.to_string())
-                                    ]
-                                ).increment(1);
-                            },
+                            Ok(()) => {},
                             Err(SendTimeoutError::Timeout(_seq_action)) => {
                                 warn!(
                                     transaction.hash = %tx_hash,

--- a/crates/astria-composer/src/collectors/grpc.rs
+++ b/crates/astria-composer/src/collectors/grpc.rs
@@ -23,8 +23,8 @@ use tonic::{
 
 use crate::{
     collectors::{
-        CollectorType,
         EXECUTOR_SEND_TIMEOUT,
+        GRPC,
     },
     executor,
     metrics_init::{
@@ -70,7 +70,7 @@ impl GrpcCollectorService for Grpc {
             crate::metrics_init::TRANSACTIONS_RECEIVED,
             &[
                 (ROLLUP_ID_LABEL, rollup_id.to_string()),
-                (COLLECTOR_TYPE_LABEL, CollectorType::Grpc.to_string())
+                (COLLECTOR_TYPE_LABEL, GRPC.to_string())
             ]
         )
         .increment(1);
@@ -85,7 +85,7 @@ impl GrpcCollectorService for Grpc {
                     crate::metrics_init::TRANSACTIONS_DROPPED,
                     &[
                         (ROLLUP_ID_LABEL, rollup_id.to_string()),
-                        (COLLECTOR_TYPE_LABEL, CollectorType::Grpc.to_string())
+                        (COLLECTOR_TYPE_LABEL, GRPC.to_string())
                     ]
                 )
                 .increment(1);
@@ -99,7 +99,7 @@ impl GrpcCollectorService for Grpc {
                     crate::metrics_init::TRANSACTIONS_DROPPED,
                     &[
                         (ROLLUP_ID_LABEL, rollup_id.to_string()),
-                        (COLLECTOR_TYPE_LABEL, CollectorType::Grpc.to_string())
+                        (COLLECTOR_TYPE_LABEL, GRPC.to_string())
                     ]
                 )
                 .increment(1);

--- a/crates/astria-composer/src/collectors/grpc.rs
+++ b/crates/astria-composer/src/collectors/grpc.rs
@@ -67,7 +67,7 @@ impl GrpcCollectorService for Grpc {
         };
 
         metrics::counter!(
-            crate::metrics_init::TRANSACTIONS_COLLECTED,
+            crate::metrics_init::TRANSACTIONS_RECEIVED,
             &[
                 (ROLLUP_ID_LABEL, rollup_id.to_string()),
                 (COLLECTOR_TYPE_LABEL, CollectorType::Grpc.to_string())
@@ -79,16 +79,7 @@ impl GrpcCollectorService for Grpc {
             .send_timeout(sequence_action, EXECUTOR_SEND_TIMEOUT)
             .await
         {
-            Ok(()) => {
-                metrics::counter!(
-                    crate::metrics_init::TRANSACTIONS_FORWARDED,
-                    &[
-                        (ROLLUP_ID_LABEL, rollup_id.to_string()),
-                        (COLLECTOR_TYPE_LABEL, CollectorType::Grpc.to_string())
-                    ]
-                )
-                .increment(1);
-            }
+            Ok(()) => {}
             Err(SendTimeoutError::Timeout(_seq_action)) => {
                 metrics::counter!(
                     crate::metrics_init::TRANSACTIONS_DROPPED,

--- a/crates/astria-composer/src/collectors/grpc.rs
+++ b/crates/astria-composer/src/collectors/grpc.rs
@@ -22,9 +22,15 @@ use tonic::{
 };
 
 use crate::{
-    collectors::EXECUTOR_SEND_TIMEOUT,
+    collectors::{
+        CollectorType,
+        EXECUTOR_SEND_TIMEOUT,
+    },
     executor,
-    metrics_init::ROLLUP_ID_LABEL,
+    metrics_init::{
+        COLLECTOR_TYPE_LABEL,
+        ROLLUP_ID_LABEL,
+    },
 };
 
 /// Implements the `GrpcCollectorService` which listens for incoming gRPC requests and
@@ -60,28 +66,52 @@ impl GrpcCollectorService for Grpc {
             fee_asset_id: default_native_asset_id(),
         };
 
-        metrics::counter!(crate::metrics_init::GRPC_COLLECTOR_TRANSACTIONS_COLLECTED, ROLLUP_ID_LABEL => rollup_id.to_string()).increment(1);
-
+        metrics::counter!(
+            crate::metrics_init::TRANSACTIONS_COLLECTED,
+            &[
+                (ROLLUP_ID_LABEL, rollup_id.to_string()),
+                (COLLECTOR_TYPE_LABEL, CollectorType::Grpc.to_string())
+            ]
+        )
+        .increment(1);
         match self
             .executor
             .send_timeout(sequence_action, EXECUTOR_SEND_TIMEOUT)
             .await
         {
             Ok(()) => {
-                metrics::counter!(crate::metrics_init::GRPC_COLLECTOR_TRANSACTIONS_FORWARDED)
-                    .increment(1);
+                metrics::counter!(
+                    crate::metrics_init::TRANSACTIONS_FORWARDED,
+                    &[
+                        (ROLLUP_ID_LABEL, rollup_id.to_string()),
+                        (COLLECTOR_TYPE_LABEL, CollectorType::Grpc.to_string())
+                    ]
+                )
+                .increment(1);
             }
             Err(SendTimeoutError::Timeout(_seq_action)) => {
-                metrics::counter!(crate::metrics_init::GRPC_COLLECTOR_TRANSACTIONS_DROPPED)
-                    .increment(1);
+                metrics::counter!(
+                    crate::metrics_init::TRANSACTIONS_DROPPED,
+                    &[
+                        (ROLLUP_ID_LABEL, rollup_id.to_string()),
+                        (COLLECTOR_TYPE_LABEL, CollectorType::Grpc.to_string())
+                    ]
+                )
+                .increment(1);
 
                 return Err(tonic::Status::unavailable(
                     "timeout while sending txs to composer",
                 ));
             }
             Err(SendTimeoutError::Closed(_seq_action)) => {
-                metrics::counter!(crate::metrics_init::GRPC_COLLECTOR_TRANSACTIONS_DROPPED)
-                    .increment(1);
+                metrics::counter!(
+                    crate::metrics_init::TRANSACTIONS_DROPPED,
+                    &[
+                        (ROLLUP_ID_LABEL, rollup_id.to_string()),
+                        (COLLECTOR_TYPE_LABEL, CollectorType::Grpc.to_string())
+                    ]
+                )
+                .increment(1);
 
                 return Err(tonic::Status::failed_precondition(
                     "composer is not available",

--- a/crates/astria-composer/src/collectors/mod.rs
+++ b/crates/astria-composer/src/collectors/mod.rs
@@ -1,9 +1,30 @@
 pub(crate) mod geth;
 pub(crate) mod grpc;
 
+use std::{
+    fmt::{
+        Display,
+        Formatter,
+    },
+    time::Duration,
+};
+
 const EXECUTOR_SEND_TIMEOUT: Duration = Duration::from_millis(500);
 
-use std::time::Duration;
+#[derive(Debug)]
+pub(crate) enum CollectorType {
+    Grpc,
+    Geth,
+}
+
+impl Display for CollectorType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CollectorType::Grpc => write!(f, "grpc"),
+            CollectorType::Geth => write!(f, "geth"),
+        }
+    }
+}
 
 pub(crate) use geth::Geth;
 pub(crate) use grpc::Grpc;

--- a/crates/astria-composer/src/collectors/mod.rs
+++ b/crates/astria-composer/src/collectors/mod.rs
@@ -1,30 +1,12 @@
 pub(crate) mod geth;
 pub(crate) mod grpc;
 
-use std::{
-    fmt::{
-        Display,
-        Formatter,
-    },
-    time::Duration,
-};
+use std::time::Duration;
 
 const EXECUTOR_SEND_TIMEOUT: Duration = Duration::from_millis(500);
 
-#[derive(Debug)]
-pub(crate) enum CollectorType {
-    Grpc,
-    Geth,
-}
-
-impl Display for CollectorType {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            CollectorType::Grpc => write!(f, "grpc"),
-            CollectorType::Geth => write!(f, "geth"),
-        }
-    }
-}
+const GETH: &str = "geth";
+const GRPC: &str = "grpc";
 
 pub(crate) use geth::Geth;
 pub(crate) use grpc::Grpc;

--- a/crates/astria-composer/src/executor/bundle_factory/mod.rs
+++ b/crates/astria-composer/src/executor/bundle_factory/mod.rs
@@ -117,7 +117,7 @@ impl SizedBundle {
     }
 
     /// Returns the number of sequence actions in the bundle.
-    pub(super) fn no_of_seq_actions(&self) -> usize {
+    pub(super) fn actions_count(&self) -> usize {
         self.buffer.len()
     }
 

--- a/crates/astria-composer/src/executor/mod.rs
+++ b/crates/astria-composer/src/executor/mod.rs
@@ -472,8 +472,7 @@ async fn submit_tx(
     tx: SignedTransaction,
 ) -> eyre::Result<tx_sync::Response> {
     let nonce = tx.unsigned_transaction().params.nonce;
-    metrics::gauge!(crate::metrics_init::CURRENT_NONCE)
-        .set(nonce);
+    metrics::gauge!(crate::metrics_init::CURRENT_NONCE).set(nonce);
 
     // TODO: change to info and log tx hash (to match info log in `SubmitFut`'s response handling
     // logic)

--- a/crates/astria-composer/src/executor/mod.rs
+++ b/crates/astria-composer/src/executor/mod.rs
@@ -176,6 +176,15 @@ impl Executor {
     /// Create a future to submit a bundle to the sequencer.
     #[instrument(skip_all, fields(nonce.initial = %nonce))]
     fn submit_bundle(&self, nonce: u32, bundle: SizedBundle) -> Fuse<Instrumented<SubmitFut>> {
+        #[allow(clippy::cast_precision_loss)]
+        metrics::histogram!(crate::metrics_init::BUNDLES_OUTGOING_BYTES)
+            .record(bundle.get_size() as f64);
+        let no_of_seq_actions = bundle.no_of_seq_actions();
+
+        #[allow(clippy::cast_precision_loss)]
+        metrics::histogram!(crate::metrics_init::BUNDLES_OUTGOING_TRANSACTIONS_COUNT)
+            .record(no_of_seq_actions as f64);
+
         SubmitFut {
             client: self.sequencer_client.clone(),
             address: self.address,
@@ -200,6 +209,8 @@ impl Executor {
             .await
             .wrap_err("failed getting initial nonce from sequencer")?;
 
+        metrics::gauge!(crate::metrics_init::CURRENT_NONCE).set(nonce);
+
         self.status.send_modify(|status| status.is_connected = true);
 
         let block_timer = time::sleep(self.block_time);
@@ -219,13 +230,14 @@ impl Executor {
                 // process submission result and update nonce
                 rsp = &mut submission_fut, if !submission_fut.is_terminated() => {
                     match rsp {
-                        Ok(new_nonce) => nonce = new_nonce,
+                        Ok(new_nonce) => nonce = {
+                            new_nonce
+                        },
                         Err(error) => {
                             error!(%error, "failed submitting bundle to sequencer; aborting executor");
                             break Err(error).wrap_err("failed submitting bundle to sequencer");
                         }
                     }
-
                     block_timer.as_mut().reset(reset_time());
                 }
 
@@ -239,6 +251,7 @@ impl Executor {
                 // receive new seq_action and bundle it. will not pull from the channel if `bundle_factory` is full
                 Some(seq_action) = self.serialized_rollup_transactions.recv(), if !bundle_factory.is_full() => {
                     let rollup_id = seq_action.rollup_id;
+
                     if let Err(e) = bundle_factory.try_push(seq_action) {
                             warn!(
                                 rollup_id = %rollup_id,
@@ -284,13 +297,14 @@ impl Executor {
         };
 
         let mut bundles_to_drain: VecDeque<SizedBundle> = VecDeque::new();
-        let mut bundles_drained = 0;
+        let mut bundles_drained: u64 = 0;
 
         info!("draining already received transactions");
 
         // drain the receiver channel
         while let Ok(seq_action) = self.serialized_rollup_transactions.try_recv() {
             let rollup_id = seq_action.rollup_id;
+
             if let Err(e) = bundle_factory.try_push(seq_action) {
                 warn!(
                     rollup_id = %rollup_id,
@@ -310,6 +324,7 @@ impl Executor {
 
             bundles_to_drain.push_back(bundle);
         }
+
         info!(
             no_of_bundles_to_drain = bundles_to_drain.len(),
             "submitting remaining transaction bundles to sequencer"
@@ -327,11 +342,13 @@ impl Executor {
                             new_nonce = new_nonce,
                             "successfully submitted bundle of transactions"
                         );
+
                         nonce = new_nonce;
                     }
                     Err(error) => {
                         error!(%error, "failed submitting bundle to sequencer during shutdown; \
                                 aborting shutdown");
+
                         return Err(error);
                     }
                 }
@@ -345,15 +362,17 @@ impl Executor {
                             new_nonce = new_nonce,
                             "successfully submitted transction bundle"
                         );
+
                         nonce = new_nonce;
                         bundles_drained += 1;
                     }
                     Err(error) => {
-                        error!(bundle = %telemetry::display::json(&SizedBundleReport(&bundle)),
-                                %error, "failed submitting bundle to sequencer during shutdown; \
-                                    aborting shutdown");
+                        error!(bundle =  %telemetry::display::json(&SizedBundleReport(&bundle)),
+                            %error, "failed submitting bundle to sequencer during shutdown; \
+                                aborting shutdown");
                         // if we can't submit a bundle after multiple retries, we can abort
                         // the shutdown process
+
                         return Err(error);
                     }
                 }
@@ -378,6 +397,8 @@ impl Executor {
             let report: Vec<SizedBundleReport> =
                 bundles_to_drain.iter().map(SizedBundleReport).collect();
 
+            metrics::counter!(crate::metrics_init::BUNDLES_NOT_DRAINED)
+                .increment(report.len() as u64);
             warn!(
                 number_of_bundles_submitted = bundles_drained,
                 number_of_missing_bundles = report.len(),
@@ -385,6 +406,8 @@ impl Executor {
                 "unable to drain all bundles within the allocated time"
             );
         }
+
+        metrics::counter!(crate::metrics_init::BUNDLES_DRAINED).increment(bundles_drained);
 
         reason.map(|_| ())
     }
@@ -397,7 +420,9 @@ async fn get_latest_nonce(
     address: Address,
 ) -> eyre::Result<u32> {
     debug!("fetching latest nonce from sequencer");
+    metrics::counter!(crate::metrics_init::NONCE_FETCH_COUNT).increment(1);
     let span = Span::current();
+    let start = Instant::now();
     let retry_config = tryhard::RetryFutureConfig::new(1024)
         .exponential_backoff(Duration::from_millis(200))
         .max_delay(Duration::from_secs(60))
@@ -418,14 +443,22 @@ async fn get_latest_nonce(
                 async move {}
             },
         );
-    tryhard::retry_fn(|| {
+    let res = tryhard::retry_fn(|| {
         let client = client.clone();
         let span = info_span!(parent: span.clone(), "attempt get nonce");
         async move { client.get_latest_nonce(address).await.map(|rsp| rsp.nonce) }.instrument(span)
     })
     .with_config(retry_config)
     .await
-    .wrap_err("failed getting latest nonce from sequencer after 1024 attempts")
+    .wrap_err("failed getting latest nonce from sequencer after 1024 attempts");
+
+    if res.is_err() {
+        metrics::counter!(crate::metrics_init::NONCE_FETCH_FAILURE_COUNT).increment(1);
+    }
+
+    metrics::histogram!(crate::metrics_init::NONCE_FETCH_LATENCY).record(start.elapsed());
+
+    res
 }
 /// Queries the sequencer for the latest nonce with an exponential backoff
 #[instrument(
@@ -442,6 +475,7 @@ async fn submit_tx(
 ) -> eyre::Result<tx_sync::Response> {
     // TODO: change to info and log tx hash (to match info log in `SubmitFut`'s response handling
     // logic)
+    let start = std::time::Instant::now();
     debug!("submitting signed transaction to sequencer");
     let span = Span::current();
     let retry_config = tryhard::RetryFutureConfig::new(1024)
@@ -464,7 +498,7 @@ async fn submit_tx(
                 async move {}
             },
         );
-    tryhard::retry_fn(|| {
+    let res = tryhard::retry_fn(|| {
         let client = client.clone();
         let tx = tx.clone();
         let span = info_span!(parent: span.clone(), "attempt send");
@@ -472,7 +506,16 @@ async fn submit_tx(
     })
     .with_config(retry_config)
     .await
-    .wrap_err("failed sending transaction after 1024 attempts")
+    .wrap_err("failed sending transaction after 1024 attempts");
+
+    if res.is_err() {
+        metrics::counter!(crate::metrics_init::TRANSACTION_SUBMISSION_FAILURE_COUNT).increment(1);
+    }
+
+    metrics::histogram!(crate::metrics_init::TRANSACTION_SUBMISSION_LATENCY)
+        .record(start.elapsed());
+
+    res
 }
 
 pin_project! {
@@ -553,6 +596,14 @@ impl Future for SubmitFut {
                     Ok(rsp) => {
                         let tendermint::abci::Code::Err(code) = rsp.code else {
                             info!("sequencer responded with ok; submission successful");
+
+                            metrics::gauge!(crate::metrics_init::CURRENT_NONCE)
+                                .set(*this.nonce + 1);
+                            metrics::counter!(
+                                crate::metrics_init::BUNDLES_SUBMISSION_SUCCESS_COUNT
+                            )
+                            .increment(1);
+
                             return Poll::Ready(Ok(*this.nonce + 1));
                         };
                         match AbciErrorCode::from(code) {
@@ -572,12 +623,24 @@ impl Future for SubmitFut {
                                     abci.log = rsp.log,
                                     "sequencer rejected the transaction; the bundle is likely lost",
                                 );
+
+                                metrics::gauge!(crate::metrics_init::CURRENT_NONCE)
+                                    .set(*this.nonce);
+                                metrics::counter!(
+                                    crate::metrics_init::BUNDLES_SUBMISSION_FAILURE_COUNT
+                                )
+                                .increment(1);
+
                                 return Poll::Ready(Ok(*this.nonce));
                             }
                         }
                     }
                     Err(error) => {
                         error!(%error, "failed sending transaction to sequencer");
+
+                        metrics::counter!(crate::metrics_init::BUNDLES_SUBMISSION_FAILURE_COUNT)
+                            .increment(1);
+
                         return Poll::Ready(
                             Err(error).wrap_err("failed sending transaction to sequencer"),
                         );
@@ -610,6 +673,10 @@ impl Future for SubmitFut {
                     }
                     Err(error) => {
                         error!(%error, "critically failed getting a new nonce from the sequencer");
+
+                        metrics::counter!(crate::metrics_init::BUNDLES_SUBMISSION_FAILURE_COUNT)
+                            .increment(1);
+
                         return Poll::Ready(
                             Err(error).wrap_err("failed getting nonce from sequencer"),
                         );

--- a/crates/astria-composer/src/executor/mod.rs
+++ b/crates/astria-composer/src/executor/mod.rs
@@ -179,11 +179,10 @@ impl Executor {
         #[allow(clippy::cast_precision_loss)]
         metrics::histogram!(crate::metrics_init::BUNDLES_OUTGOING_BYTES)
             .record(bundle.get_size() as f64);
-        let no_of_seq_actions = bundle.no_of_seq_actions();
 
         #[allow(clippy::cast_precision_loss)]
         metrics::histogram!(crate::metrics_init::BUNDLES_OUTGOING_TRANSACTIONS_COUNT)
-            .record(no_of_seq_actions as f64);
+            .record(bundle.no_of_seq_actions() as f64);
 
         SubmitFut {
             client: self.sequencer_client.clone(),
@@ -564,6 +563,7 @@ pin_project! {
 impl Future for SubmitFut {
     type Output = eyre::Result<u32>;
 
+    #[allow(clippy::too_many_lines)]
     fn poll(mut self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
         loop {
             let this = self.as_mut().project();

--- a/crates/astria-composer/src/lib.rs
+++ b/crates/astria-composer/src/lib.rs
@@ -45,6 +45,7 @@ mod composer;
 pub mod config;
 mod executor;
 mod grpc;
+pub mod metrics_init;
 mod rollup;
 
 pub use build_info::BUILD_INFO;

--- a/crates/astria-composer/src/main.rs
+++ b/crates/astria-composer/src/main.rs
@@ -1,6 +1,7 @@
 use std::process::ExitCode;
 
 use astria_composer::{
+    metrics_init,
     Composer,
     Config,
     BUILD_INFO,
@@ -40,6 +41,8 @@ async fn main() -> ExitCode {
             .service_name(env!("CARGO_PKG_NAME"));
     }
 
+    metrics_init::register();
+
     if let Err(e) = telemetry_conf
         .try_init()
         .wrap_err("failed to setup telemetry")
@@ -51,7 +54,6 @@ async fn main() -> ExitCode {
     let cfg_ser = serde_json::to_string(&cfg)
         .expect("the json serializer should never fail when serializing to a string");
     eprintln!("config:\n{cfg_ser}");
-
     info!(config = cfg_ser, "initializing composer",);
 
     let composer = match Composer::from_config(&cfg).await {

--- a/crates/astria-composer/src/metrics_init.rs
+++ b/crates/astria-composer/src/metrics_init.rs
@@ -11,50 +11,29 @@ use metrics::{
 
 /// Labels
 pub(crate) const ROLLUP_ID_LABEL: &str = "rollup_id";
+pub(crate) const COLLECTOR_TYPE_LABEL: &str = "collector_type";
 
 /// Registers all metrics used by this crate.
 #[allow(clippy::too_many_lines)]
 pub fn register() {
-    // geth collectors metrics
+    // collectors metrics
     describe_counter!(
-        GETH_COLLECTOR_TRANSACTIONS_COLLECTED,
+        TRANSACTIONS_COLLECTED,
         Unit::Count,
-        "The number of transactions received by the geth collector labelled by rollup"
+        "The number of transactions received by the collectors labelled by rollup and collector \
+         type"
     );
     describe_counter!(
-        GETH_COLLECTOR_TRANSACTIONS_DROPPED,
+        TRANSACTIONS_DROPPED,
         Unit::Count,
-        "The number of transactions dropped by the geth collector before bundling it labelled by \
-         rollup"
+        "The number of transactions dropped by the collectors before bundling it labelled by \
+         rollup and collector type"
     );
     describe_counter!(
-        GETH_COLLECTOR_TRANSACTIONS_FORWARDED,
+        TRANSACTIONS_FORWARDED,
         Unit::Count,
-        "The number of transactions successfully sent by the geth collector to be bundled \
-         labelled by rollup"
-    );
-    describe_histogram!(
-        GETH_COLLECTOR_CONNECTION_LATENCY,
-        Unit::Milliseconds,
-        "The time taken to connect to geth"
-    );
-
-    // grpc collector metrics
-    describe_counter!(
-        GRPC_COLLECTOR_TRANSACTIONS_COLLECTED,
-        Unit::Count,
-        "The number of transactions received by the grpc collector"
-    );
-    describe_counter!(
-        GRPC_COLLECTOR_TRANSACTIONS_DROPPED,
-        Unit::Count,
-        "The number of transactions dropped by the grpc collector before sending it to be bundled"
-    );
-    describe_counter!(
-        GRPC_COLLECTOR_TRANSACTIONS_FORWARDED,
-        Unit::Count,
-        "The number of transactions successfully sent by the grpc collector before sending it to \
-         be bundled"
+        "The number of transactions successfully sent by the collectors to be bundled labelled by \
+         rollup and collector type"
     );
 
     // executor metrics
@@ -86,12 +65,12 @@ pub fn register() {
     );
     describe_gauge!(CURRENT_NONCE, Unit::Count, "The current nonce");
     describe_histogram!(
-        TRANSACTION_SUBMISSION_LATENCY,
+        SEQUENCER_SUBMISSION_LATENCY,
         Unit::Milliseconds,
         "The latency of submitting a transaction to the sequencer"
     );
     describe_counter!(
-        TRANSACTION_SUBMISSION_FAILURE_COUNT,
+        SEQUENCER_SUBMISSION_FAILURE_COUNT,
         Unit::Count,
         "The number of failed transaction submissions to the sequencer"
     );
@@ -106,24 +85,14 @@ pub fn register() {
         "The number of failed bundle submissions to the sequencer"
     );
     describe_histogram!(
-        BUNDLES_OUTGOING_TRANSACTIONS_COUNT,
+        BUNDLES_SUBMITTED_TRANSACTIONS_COUNT,
         Unit::Count,
         "The number of outgoing transactions to the sequencer"
     );
     describe_histogram!(
-        BUNDLES_OUTGOING_BYTES,
+        BUNDLES_SUBMITTED_BYTES,
         Unit::Bytes,
         "The size of bundles in the outgoing bundle"
-    );
-    describe_counter!(
-        BUNDLES_NOT_DRAINED,
-        Unit::Count,
-        "The number of bundles not drained during shutdown"
-    );
-    describe_counter!(
-        BUNDLES_DRAINED,
-        Unit::Count,
-        "The number of bundles drained successfully during shutdown"
     );
 
     // bundle factory metrics
@@ -145,40 +114,13 @@ pub fn register() {
     );
 }
 
-pub const GETH_COLLECTOR_TRANSACTIONS_COLLECTED: &str = concat!(
-    env!("CARGO_CRATE_NAME"),
-    "_geth_collector_transactions_collected"
-);
+pub const TRANSACTIONS_COLLECTED: &str =
+    concat!(env!("CARGO_CRATE_NAME"), "_transactions_collected");
 
-pub const GETH_COLLECTOR_TRANSACTIONS_DROPPED: &str = concat!(
-    env!("CARGO_CRATE_NAME"),
-    "_geth_collector_transactions_dropped"
-);
+pub const TRANSACTIONS_DROPPED: &str = concat!(env!("CARGO_CRATE_NAME"), "_transactions_dropped");
 
-pub const GETH_COLLECTOR_TRANSACTIONS_FORWARDED: &str = concat!(
-    env!("CARGO_CRATE_NAME"),
-    "_geth_collector_transactions_forwarded"
-);
-
-pub const GETH_COLLECTOR_CONNECTION_LATENCY: &str = concat!(
-    env!("CARGO_CRATE_NAME"),
-    "_geth_collector_connection_latency"
-);
-
-pub const GRPC_COLLECTOR_TRANSACTIONS_COLLECTED: &str = concat!(
-    env!("CARGO_CRATE_NAME"),
-    "_grpc_collector_transactions_collected"
-);
-
-pub const GRPC_COLLECTOR_TRANSACTIONS_DROPPED: &str = concat!(
-    env!("CARGO_CRATE_NAME"),
-    "_grpc_collector_transactions_dropped"
-);
-
-pub const GRPC_COLLECTOR_TRANSACTIONS_FORWARDED: &str = concat!(
-    env!("CARGO_CRATE_NAME"),
-    "_grpc_collector_transactions_forwarded"
-);
+pub const TRANSACTIONS_FORWARDED: &str =
+    concat!(env!("CARGO_CRATE_NAME"), "_transactions_forwarded");
 
 pub const TRANSACTIONS_RECEIVED: &str = concat!(env!("CARGO_CRATE_NAME"), "_transactions_received");
 
@@ -194,12 +136,12 @@ pub const NONCE_FETCH_LATENCY: &str = concat!(env!("CARGO_CRATE_NAME"), "_nonce_
 
 pub const CURRENT_NONCE: &str = concat!(env!("CARGO_CRATE_NAME"), "_current_nonce");
 
-pub const TRANSACTION_SUBMISSION_LATENCY: &str =
-    concat!(env!("CARGO_CRATE_NAME"), "_transaction_submission_latency");
+pub const SEQUENCER_SUBMISSION_LATENCY: &str =
+    concat!(env!("CARGO_CRATE_NAME"), "_sequencer_submission_latency");
 
-pub const TRANSACTION_SUBMISSION_FAILURE_COUNT: &str = concat!(
+pub const SEQUENCER_SUBMISSION_FAILURE_COUNT: &str = concat!(
     env!("CARGO_CRATE_NAME"),
-    "_transaction_submission_failure_count"
+    "_sequencer_submission_failure_count"
 );
 
 pub const BUNDLES_SUBMISSION_SUCCESS_COUNT: &str = concat!(
@@ -212,17 +154,13 @@ pub const BUNDLES_SUBMISSION_FAILURE_COUNT: &str = concat!(
     "_bundles_submission_failure_count"
 );
 
-pub const BUNDLES_OUTGOING_TRANSACTIONS_COUNT: &str = concat!(
+pub const BUNDLES_SUBMITTED_TRANSACTIONS_COUNT: &str = concat!(
     env!("CARGO_CRATE_NAME"),
-    "_bundles_outgoing_transactions_count"
+    "_bundles_submitted_transactions_count"
 );
 
-pub const BUNDLES_OUTGOING_BYTES: &str =
-    concat!(env!("CARGO_CRATE_NAME"), "_bundles_outgoing_bytes");
-
-pub const BUNDLES_NOT_DRAINED: &str = concat!(env!("CARGO_CRATE_NAME"), "_bundles_not_drained");
-
-pub const BUNDLES_DRAINED: &str = concat!(env!("CARGO_CRATE_NAME"), "_bundles_drained");
+pub const BUNDLES_SUBMITTED_BYTES: &str =
+    concat!(env!("CARGO_CRATE_NAME"), "_bundles_submitted_bytes");
 
 pub const BUNDLES_TOTAL_COUNT: &str = concat!(env!("CARGO_CRATE_NAME"), "_bundles_total_count");
 

--- a/crates/astria-composer/src/metrics_init.rs
+++ b/crates/astria-composer/src/metrics_init.rs
@@ -14,6 +14,7 @@ pub(crate) const ROLLUP_ID_LABEL: &str = "rollup_id";
 pub(crate) const COLLECTOR_TYPE_LABEL: &str = "collector_type";
 
 /// Registers all metrics used by this crate.
+// allow: refactor this. being tracked in https://github.com/astriaorg/astria/issues/1027
 #[allow(clippy::too_many_lines)]
 pub fn register() {
     describe_counter!(

--- a/crates/astria-composer/src/metrics_init.rs
+++ b/crates/astria-composer/src/metrics_init.rs
@@ -1,0 +1,239 @@
+//! Crate-specific metrics functionality.
+//!
+//! Registers metrics & lists constants to be used as metric names throughout crate.
+
+use metrics::{
+    describe_counter,
+    describe_gauge,
+    describe_histogram,
+    Unit,
+};
+
+/// Labels
+pub(crate) const ROLLUP_ID_LABEL: &str = "rollup_id";
+
+/// Registers all metrics used by this crate.
+#[allow(clippy::too_many_lines)]
+pub fn register() {
+    // geth collectors metrics
+    describe_counter!(
+        GETH_COLLECTOR_TRANSACTIONS_COLLECTED,
+        Unit::Count,
+        "The number of transactions received by the geth collector labelled by rollup"
+    );
+    describe_counter!(
+        GETH_COLLECTOR_TRANSACTIONS_DROPPED,
+        Unit::Count,
+        "The number of transactions dropped by the geth collector before bundling it labelled by \
+         rollup"
+    );
+    describe_counter!(
+        GETH_COLLECTOR_TRANSACTIONS_FORWARDED,
+        Unit::Count,
+        "The number of transactions successfully sent by the geth collector to be bundled \
+         labelled by rollup"
+    );
+    describe_histogram!(
+        GETH_COLLECTOR_CONNECTION_LATENCY,
+        Unit::Milliseconds,
+        "The time taken to connect to geth"
+    );
+
+    // grpc collector metrics
+    describe_counter!(
+        GRPC_COLLECTOR_TRANSACTIONS_COLLECTED,
+        Unit::Count,
+        "The number of transactions received by the grpc collector"
+    );
+    describe_counter!(
+        GRPC_COLLECTOR_TRANSACTIONS_DROPPED,
+        Unit::Count,
+        "The number of transactions dropped by the grpc collector before sending it to be bundled"
+    );
+    describe_counter!(
+        GRPC_COLLECTOR_TRANSACTIONS_FORWARDED,
+        Unit::Count,
+        "The number of transactions successfully sent by the grpc collector before sending it to \
+         be bundled"
+    );
+
+    // executor metrics
+    describe_counter!(
+        TRANSACTIONS_RECEIVED,
+        Unit::Count,
+        "The number of transactions successfully received from collectors and bundled labelled by \
+         rollup"
+    );
+    describe_counter!(
+        TRANSACTIONS_DROPPED_TOO_LARGE,
+        Unit::Count,
+        "The number of transactions dropped because they were too large"
+    );
+    describe_counter!(
+        NONCE_FETCH_COUNT,
+        Unit::Count,
+        "The number of times we have attempted to fetch the nonce"
+    );
+    describe_counter!(
+        NONCE_FETCH_FAILURE_COUNT,
+        Unit::Count,
+        "The number of times we have failed to fetch the nonce"
+    );
+    describe_histogram!(
+        NONCE_FETCH_LATENCY,
+        Unit::Milliseconds,
+        "The latency of nonce fetch"
+    );
+    describe_gauge!(CURRENT_NONCE, Unit::Count, "The current nonce");
+    describe_histogram!(
+        TRANSACTION_SUBMISSION_LATENCY,
+        Unit::Milliseconds,
+        "The latency of submitting a transaction to the sequencer"
+    );
+    describe_counter!(
+        TRANSACTION_SUBMISSION_FAILURE_COUNT,
+        Unit::Count,
+        "The number of failed transaction submissions to the sequencer"
+    );
+    describe_counter!(
+        BUNDLES_SUBMISSION_SUCCESS_COUNT,
+        Unit::Count,
+        "The number of successful bundle submissions to the sequencer"
+    );
+    describe_counter!(
+        BUNDLES_SUBMISSION_FAILURE_COUNT,
+        Unit::Count,
+        "The number of failed bundle submissions to the sequencer"
+    );
+    describe_histogram!(
+        BUNDLES_OUTGOING_TRANSACTIONS_COUNT,
+        Unit::Count,
+        "The number of outgoing transactions to the sequencer"
+    );
+    describe_histogram!(
+        BUNDLES_OUTGOING_BYTES,
+        Unit::Bytes,
+        "The size of bundles in the outgoing bundle"
+    );
+    describe_counter!(
+        BUNDLES_NOT_DRAINED,
+        Unit::Count,
+        "The number of bundles not drained during shutdown"
+    );
+    describe_counter!(
+        BUNDLES_DRAINED,
+        Unit::Count,
+        "The number of bundles drained successfully during shutdown"
+    );
+
+    // bundle factory metrics
+    describe_counter!(
+        BUNDLES_TOTAL_COUNT,
+        Unit::Count,
+        "The total number of finished bundles constructed over the composer's lifetime"
+    );
+    describe_histogram!(
+        BUNDLES_TOTAL_BYTES,
+        Unit::Bytes,
+        "The distribution of sizes of finished bundles constructed over the composer's lifetime"
+    );
+    describe_histogram!(
+        BUNDLES_TOTAL_TRANSACTIONS_COUNT,
+        Unit::Count,
+        "The total number of transactions in finished bundles constructed over the composer's \
+         lifetime"
+    );
+}
+
+// We configure buckets for manually, in order to ensure Prometheus metrics are structured as a
+// Histogram, rather than as a Summary. These values are loosely based on the initial Summary
+// output, and may need to be updated over time.
+pub const HISTOGRAM_BUCKETS: &[f64; 5] = &[0.00001, 0.0001, 0.001, 0.01, 0.1];
+
+pub const GETH_COLLECTOR_TRANSACTIONS_COLLECTED: &str = concat!(
+    env!("CARGO_CRATE_NAME"),
+    "_geth_collector_transactions_collected"
+);
+
+pub const GETH_COLLECTOR_TRANSACTIONS_DROPPED: &str = concat!(
+    env!("CARGO_CRATE_NAME"),
+    "_geth_collector_transactions_dropped"
+);
+
+pub const GETH_COLLECTOR_TRANSACTIONS_FORWARDED: &str = concat!(
+    env!("CARGO_CRATE_NAME"),
+    "_geth_collector_transactions_forwarded"
+);
+
+pub const GETH_COLLECTOR_CONNECTION_LATENCY: &str = concat!(
+    env!("CARGO_CRATE_NAME"),
+    "_geth_collector_connection_latency"
+);
+
+pub const GRPC_COLLECTOR_TRANSACTIONS_COLLECTED: &str = concat!(
+    env!("CARGO_CRATE_NAME"),
+    "_grpc_collector_transactions_collected"
+);
+
+pub const GRPC_COLLECTOR_TRANSACTIONS_DROPPED: &str = concat!(
+    env!("CARGO_CRATE_NAME"),
+    "_grpc_collector_transactions_dropped"
+);
+
+pub const GRPC_COLLECTOR_TRANSACTIONS_FORWARDED: &str = concat!(
+    env!("CARGO_CRATE_NAME"),
+    "_grpc_collector_transactions_forwarded"
+);
+
+pub const TRANSACTIONS_RECEIVED: &str = concat!(env!("CARGO_CRATE_NAME"), "_transactions_received");
+
+pub const TRANSACTIONS_DROPPED_TOO_LARGE: &str =
+    concat!(env!("CARGO_CRATE_NAME"), "_transactions_dropped_too_large");
+
+pub const NONCE_FETCH_COUNT: &str = concat!(env!("CARGO_CRATE_NAME"), "_nonce_fetch_count");
+
+pub const NONCE_FETCH_FAILURE_COUNT: &str =
+    concat!(env!("CARGO_CRATE_NAME"), "_nonce_fetch_failure_count");
+
+pub const NONCE_FETCH_LATENCY: &str = concat!(env!("CARGO_CRATE_NAME"), "_nonce_fetch_latency");
+
+pub const CURRENT_NONCE: &str = concat!(env!("CARGO_CRATE_NAME"), "_current_nonce");
+
+pub const TRANSACTION_SUBMISSION_LATENCY: &str =
+    concat!(env!("CARGO_CRATE_NAME"), "_transaction_submission_latency");
+
+pub const TRANSACTION_SUBMISSION_FAILURE_COUNT: &str = concat!(
+    env!("CARGO_CRATE_NAME"),
+    "_transaction_submission_failure_count"
+);
+
+pub const BUNDLES_SUBMISSION_SUCCESS_COUNT: &str = concat!(
+    env!("CARGO_CRATE_NAME"),
+    "_bundles_submission_success_count"
+);
+
+pub const BUNDLES_SUBMISSION_FAILURE_COUNT: &str = concat!(
+    env!("CARGO_CRATE_NAME"),
+    "_bundles_submission_failure_count"
+);
+
+pub const BUNDLES_OUTGOING_TRANSACTIONS_COUNT: &str = concat!(
+    env!("CARGO_CRATE_NAME"),
+    "_bundles_outgoing_transactions_count"
+);
+
+pub const BUNDLES_OUTGOING_BYTES: &str =
+    concat!(env!("CARGO_CRATE_NAME"), "_bundles_outgoing_bytes");
+
+pub const BUNDLES_NOT_DRAINED: &str = concat!(env!("CARGO_CRATE_NAME"), "_bundles_not_drained");
+
+pub const BUNDLES_DRAINED: &str = concat!(env!("CARGO_CRATE_NAME"), "_bundles_drained");
+
+pub const BUNDLES_TOTAL_COUNT: &str = concat!(env!("CARGO_CRATE_NAME"), "_bundles_total_count");
+
+pub const BUNDLES_TOTAL_BYTES: &str = concat!(env!("CARGO_CRATE_NAME"), "_bundles_total_bytes");
+
+pub const BUNDLES_TOTAL_TRANSACTIONS_COUNT: &str = concat!(
+    env!("CARGO_CRATE_NAME"),
+    "_bundles_total_transactions_count"
+);

--- a/crates/astria-composer/src/metrics_init.rs
+++ b/crates/astria-composer/src/metrics_init.rs
@@ -16,32 +16,17 @@ pub(crate) const COLLECTOR_TYPE_LABEL: &str = "collector_type";
 /// Registers all metrics used by this crate.
 #[allow(clippy::too_many_lines)]
 pub fn register() {
-    // collectors metrics
     describe_counter!(
-        TRANSACTIONS_COLLECTED,
+        TRANSACTIONS_RECEIVED,
         Unit::Count,
-        "The number of transactions received by the collectors labelled by rollup and collector \
-         type"
+        "The number of transactions successfully received from collectors and bundled labelled by \
+         rollup"
     );
     describe_counter!(
         TRANSACTIONS_DROPPED,
         Unit::Count,
         "The number of transactions dropped by the collectors before bundling it labelled by \
          rollup and collector type"
-    );
-    describe_counter!(
-        TRANSACTIONS_FORWARDED,
-        Unit::Count,
-        "The number of transactions successfully sent by the collectors to be bundled labelled by \
-         rollup and collector type"
-    );
-
-    // executor metrics
-    describe_counter!(
-        TRANSACTIONS_RECEIVED,
-        Unit::Count,
-        "The number of transactions successfully received from collectors and bundled labelled by \
-         rollup"
     );
     describe_counter!(
         TRANSACTIONS_DROPPED_TOO_LARGE,
@@ -74,55 +59,22 @@ pub fn register() {
         Unit::Count,
         "The number of failed transaction submissions to the sequencer"
     );
-    describe_counter!(
-        BUNDLES_SUBMISSION_SUCCESS_COUNT,
+    describe_histogram!(
+        TRANSACTIONS_PER_SUBMISSION,
         Unit::Count,
-        "The number of successful bundle submissions to the sequencer"
-    );
-    describe_counter!(
-        BUNDLES_SUBMISSION_FAILURE_COUNT,
-        Unit::Count,
-        "The number of failed bundle submissions to the sequencer"
+        "The number of rollup transactions successfully sent to the sequencer in a single \
+         submission"
     );
     describe_histogram!(
-        BUNDLES_SUBMITTED_TRANSACTIONS_COUNT,
-        Unit::Count,
-        "The number of outgoing transactions to the sequencer"
-    );
-    describe_histogram!(
-        BUNDLES_SUBMITTED_BYTES,
+        BYTES_PER_SUBMISSION,
         Unit::Bytes,
-        "The size of bundles in the outgoing bundle"
-    );
-
-    // bundle factory metrics
-    describe_counter!(
-        BUNDLES_TOTAL_COUNT,
-        Unit::Count,
-        "The total number of finished bundles constructed over the composer's lifetime"
-    );
-    describe_histogram!(
-        BUNDLES_TOTAL_BYTES,
-        Unit::Bytes,
-        "The distribution of sizes of finished bundles constructed over the composer's lifetime"
-    );
-    describe_histogram!(
-        BUNDLES_TOTAL_TRANSACTIONS_COUNT,
-        Unit::Count,
-        "The total number of transactions in finished bundles constructed over the composer's \
-         lifetime"
+        "The total bytes successfully sent to the sequencer in a single submission"
     );
 }
 
-pub const TRANSACTIONS_COLLECTED: &str =
-    concat!(env!("CARGO_CRATE_NAME"), "_transactions_collected");
+pub const TRANSACTIONS_RECEIVED: &str = concat!(env!("CARGO_CRATE_NAME"), "_transactions_received");
 
 pub const TRANSACTIONS_DROPPED: &str = concat!(env!("CARGO_CRATE_NAME"), "_transactions_dropped");
-
-pub const TRANSACTIONS_FORWARDED: &str =
-    concat!(env!("CARGO_CRATE_NAME"), "_transactions_forwarded");
-
-pub const TRANSACTIONS_RECEIVED: &str = concat!(env!("CARGO_CRATE_NAME"), "_transactions_received");
 
 pub const TRANSACTIONS_DROPPED_TOO_LARGE: &str =
     concat!(env!("CARGO_CRATE_NAME"), "_transactions_dropped_too_large");
@@ -144,29 +96,7 @@ pub const SEQUENCER_SUBMISSION_FAILURE_COUNT: &str = concat!(
     "_sequencer_submission_failure_count"
 );
 
-pub const BUNDLES_SUBMISSION_SUCCESS_COUNT: &str = concat!(
-    env!("CARGO_CRATE_NAME"),
-    "_bundles_submission_success_count"
-);
+pub const TRANSACTIONS_PER_SUBMISSION: &str =
+    concat!(env!("CARGO_CRATE_NAME"), "_transaction_per_submission");
 
-pub const BUNDLES_SUBMISSION_FAILURE_COUNT: &str = concat!(
-    env!("CARGO_CRATE_NAME"),
-    "_bundles_submission_failure_count"
-);
-
-pub const BUNDLES_SUBMITTED_TRANSACTIONS_COUNT: &str = concat!(
-    env!("CARGO_CRATE_NAME"),
-    "_bundles_submitted_transactions_count"
-);
-
-pub const BUNDLES_SUBMITTED_BYTES: &str =
-    concat!(env!("CARGO_CRATE_NAME"), "_bundles_submitted_bytes");
-
-pub const BUNDLES_TOTAL_COUNT: &str = concat!(env!("CARGO_CRATE_NAME"), "_bundles_total_count");
-
-pub const BUNDLES_TOTAL_BYTES: &str = concat!(env!("CARGO_CRATE_NAME"), "_bundles_total_bytes");
-
-pub const BUNDLES_TOTAL_TRANSACTIONS_COUNT: &str = concat!(
-    env!("CARGO_CRATE_NAME"),
-    "_bundles_total_transactions_count"
-);
+pub const BYTES_PER_SUBMISSION: &str = concat!(env!("CARGO_CRATE_NAME"), "_bytes_per_submission");

--- a/crates/astria-composer/src/metrics_init.rs
+++ b/crates/astria-composer/src/metrics_init.rs
@@ -145,11 +145,6 @@ pub fn register() {
     );
 }
 
-// We configure buckets for manually, in order to ensure Prometheus metrics are structured as a
-// Histogram, rather than as a Summary. These values are loosely based on the initial Summary
-// output, and may need to be updated over time.
-pub const HISTOGRAM_BUCKETS: &[f64; 5] = &[0.00001, 0.0001, 0.001, 0.01, 0.1];
-
 pub const GETH_COLLECTOR_TRANSACTIONS_COLLECTED: &str = concat!(
     env!("CARGO_CRATE_NAME"),
     "_geth_collector_transactions_collected"


### PR DESCRIPTION
## Summary
This PR setups and instruments metrics with Composer.

## Background
Composer currently doesn't track any metrics. We require metrics in production for observability and alerting.

## Changes
- Metrics setup for Composer crate

More changes detailed in the `Metrics` section

## Testing
Tested these changes by launching composer against messenger rollup and bombarding messenger rollup with txs. The metrics were accurate w.r.t to the load composer received.

## Metrics
- `transactions_dropped`: A counter of the  transactions dropped by the Collectors labelled per rollup id and collector type. This can be due to the Executor channel being closed or the channel has timed out.
- `transactions_received`: A counter of transactions received by the collectors labelled by rollup id and collector type
- `transactions_dropped_too_large`: A counter of transactions dropped because they were too large to fit in a bundle
- `nonce_fetch_count`: A counter of the number of times we have attempted to fetch the nonce
- `nonce_fetch_failure_count`: A counter of the number of times we have failed to fetch the nonce
- `nonce_fetch_latency`: A histogram of the latency of the nonce fetch call
- `current_nonce`: A gauge of the current nonce
- `sequencer_submission_latency`: A histogram of the latency of submitting a transaction to the sequencer
- `sequencer_submission_failure_count`: A counter of the number of failed transaction submission to the sequencer
- `transactions_per_submission`: A histogram of the number of rollup transactions successfully sent to the sequencer per submission
- `bytes_per_submission`: A histogram of the number of bytes successfully sent to the sequencer per submission
