### PR TITLE
chore: update codeowners w/ teams

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,23 @@
-*	@joroshiba @noot @SuperFluffy @Fraser999
+/.github/  @astriaorg/infra
+/containerfiles/  @astriaorg/infra
+/charts/  @astriaorg/infra
+/dev/  @astriaorg/infra
+.dockerignore  @astriaorg/infra
 
-/.github/	@astriaorg/infra
-/containerfiles/	@astriaorg/infra
-/charts/ @astriaorg/infra
-/dev/ @astriaorg/infra
+*.rs  @astriaorg/rust-reviewers
+Cargo.toml  @astriaorg/rust-reviewers
+Cargo.lock  @astriaorg/rust-reviewers
+rust-toolchain  @astriaorg/rust-reviewers
+.cargo/  @astriaorg/rust-reviewers
+nextest.toml  @astriaorg/rust-reviewers
+rusfmt.toml  @astriaorg/rust-reviewers
+
+*.proto @astriaorg/api-reviewers
+buf.lock @astriaorg/api-reviewers
+buf.yaml @astriaorg/api-reviewers
+buf.work.yaml @astriaorg/api-reviewers
+
+specs/  @astriaorg/engineering
+justfile  @astriaorg/engineering
+
+* @joroshiba @SuperFluffy @noot


### PR DESCRIPTION
## Summary
Updating the split up into more groups. I have updated the groups within github to autoassign a member from the group when added in a round robin fashion. So this will auto assign, and if one person is in multiple assigned groups selected that will count for all. I've also removed myself from the assignment pool queue for rust reviewers.

## Background
We want to declutter inbox and more more concrete assignment. 

## Changes
- More granular code ownership settings, pushing most to groups. 
