### PR TITLE
fix(sequencer): set revision number from chain id in `init_chain`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,6 +752,7 @@ dependencies = [
  "penumbra-tower-trace",
  "prost",
  "rand 0.8.5",
+ "regex",
  "serde",
  "serde_json",
  "sha2 0.10.8",

--- a/crates/astria-sequencer/Cargo.toml
+++ b/crates/astria-sequencer/Cargo.toml
@@ -44,6 +44,7 @@ penumbra-proto = { workspace = true }
 penumbra-tower-trace = { workspace = true }
 prost = { workspace = true }
 rand = { workspace = true }
+regex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sha2 = { workspace = true }

--- a/crates/astria-sequencer/src/api_state_ext.rs
+++ b/crates/astria-sequencer/src/api_state_ext.rs
@@ -381,17 +381,10 @@ mod test {
 
     use std::collections::HashMap;
 
-    use astria_core::{
-        sequencer::v1::{
-            asset::Id,
-            block::{
-                Deposit,
-                SequencerBlock,
-            },
-            Address,
-            RollupId,
-        },
-        Protobuf,
+    use astria_core::sequencer::v1::{
+        asset::Id,
+        block::Deposit,
+        Address,
     };
     use cnidarium::StateDelta;
     use rand::Rng;

--- a/crates/astria-sequencer/src/app.rs
+++ b/crates/astria-sequencer/src/app.rs
@@ -179,7 +179,7 @@ impl App {
 
         crate::asset::initialize_native_asset(&genesis_state.native_asset_base_denomination);
         state_tx.put_native_asset_denom(&genesis_state.native_asset_base_denomination);
-        state_tx.put_chain_id(chain_id);
+        state_tx.put_chain_id_and_revision_number(chain_id);
         state_tx.put_block_height(0);
 
         for fee_asset in &genesis_state.allowed_fee_assets {

--- a/crates/astria-sequencer/src/state_ext.rs
+++ b/crates/astria-sequencer/src/state_ext.rs
@@ -273,7 +273,7 @@ fn revision_number_from_chain_id(chain_id: &str) -> u64 {
     let re = regex::Regex::new(r".*-([0-9]+)$").unwrap();
 
     if !re.is_match(chain_id) {
-        debug!("no revision number found in chain id; setting to 0");
+        tracing::debug!("no revision number found in chain id; setting to 0");
         return 0;
     }
 

--- a/crates/astria-sequencer/src/state_ext.rs
+++ b/crates/astria-sequencer/src/state_ext.rs
@@ -55,8 +55,12 @@ pub(crate) trait StateReadExt: StateRead {
             bail!("revision number not found in state");
         };
 
-        let bytes = TryInto::<[u8; 8]>::try_into(bytes)
-            .map_err(|b| anyhow::anyhow!("expected 8 revision number bytes but got {}; this is a bug", b.len()))?;
+        let bytes = TryInto::<[u8; 8]>::try_into(bytes).map_err(|b| {
+            anyhow::anyhow!(
+                "expected 8 revision number bytes but got {}; this is a bug",
+                b.len()
+            )
+        })?;
 
         Ok(u64::from_be_bytes(bytes))
     }

--- a/crates/astria-sequencer/src/state_ext.rs
+++ b/crates/astria-sequencer/src/state_ext.rs
@@ -273,6 +273,7 @@ fn revision_number_from_chain_id(chain_id: &str) -> u64 {
     let re = regex::Regex::new(r".*-([0-9]+)$").unwrap();
 
     if !re.is_match(chain_id) {
+        debug!("no revision number found in chain id; setting to 0");
         return 0;
     }
 


### PR DESCRIPTION
## Summary
set revision number from chain id in `init_chain` 

## Background
we need to set the chain's revision number from the last number of the chain id, if applicable. otherwise, it's set to 0. see https://ibc.cosmos.network/main/ibc/overview#ibc-client-heights

## Changes
- set revision number from chain id in `init_chain` by parsing final integer of chain id if it's in the form `name-<revision-number>`

## Testing
unit tests
