### PR TITLE
fix(sequecer): is_proposer check now considers proposer's address

### DIFF
--- a/crates/astria-sequencer/src/app.rs
+++ b/crates/astria-sequencer/src/app.rs
@@ -105,11 +105,11 @@ pub(crate) struct App {
     // The validator address in cometbft being used to sign votes.
     //
     // Used to avoid executing a block in both `prepare_proposal` and `process_proposal`. It
-    // is set in `prepare_proposal` from information sent in from cometbft and can change.
-    // In `process_proposal` we check if we prepared the proposal, and if so, we clear the
-    // value and we skip re-execution of the block's transactions to avoid failures caused by
-    // re-execution.
-    signing_address: Option<account::Id>,
+    // is set in `prepare_proposal` from information sent in from cometbft and can potentially
+    // change round-to-round. In `process_proposal` we check if we prepared the proposal, and
+    // if so, we clear the value and we skip re-execution of the block's transactions to avoid
+    // failures caused by re-execution.
+    validator_address: Option<account::Id>,
 
     // This is set to the executed hash of the proposal during `process_proposal`
     //
@@ -156,7 +156,7 @@ impl App {
 
         Self {
             state,
-            signing_address: None,
+            validator_address: None,
             executed_proposal_hash: Hash::default(),
             execution_result: HashMap::new(),
             processed_txs: 0,
@@ -234,7 +234,7 @@ impl App {
         prepare_proposal: abci::request::PrepareProposal,
         storage: Storage,
     ) -> anyhow::Result<abci::response::PrepareProposal> {
-        self.signing_address = Some(prepare_proposal.proposer_address);
+        self.validator_address = Some(prepare_proposal.proposer_address);
         self.update_state_for_new_round(&storage);
 
         let (signed_txs, txs_to_include) = self.execute_block_data(prepare_proposal.txs).await;
@@ -266,17 +266,20 @@ impl App {
         // if we proposed this block (ie. prepare_proposal was called directly before this), then
         // we skip execution for this `process_proposal` call.
         //
-        // if we didn't propose this block, `self.signing_address` will be None or a different
+        // if we didn't propose this block, `self.validator_address` will be None or a different
         // value, so we will execute the block as normal.
-        if let Some(id) = self.signing_address {
+        if let Some(id) = self.validator_address {
             if id == process_proposal.proposer_address {
                 debug!("skipping process_proposal as we are the proposer for this block");
-                self.signing_address = None;
+                self.validator_address = None;
                 self.executed_proposal_hash = process_proposal.hash;
                 return Ok(());
             }
-            debug!("signing address was set but we're not the proposer, shouldn't happen");
-            self.signing_address = None;
+            debug!(
+                "our validator address was set but we're not the proposer, so our previous \
+                 proposal was skipped, executing block"
+            );
+            self.validator_address = None;
         }
 
         self.update_state_for_new_round(&storage);

--- a/crates/astria-sequencer/src/app.rs
+++ b/crates/astria-sequencer/src/app.rs
@@ -102,14 +102,14 @@ const MAX_SEQUENCE_DATA_BYTES_PER_BLOCK: usize = 256_000;
 pub(crate) struct App {
     state: InterBlockState,
 
-    // set to true when `prepare_proposal` is called, indicating we are the proposer for this
-    // block. set to false when `process_proposal` is called, as it's called during the prevote
-    // phase for that block.
+    // The validator address in cometbft being used to sign votes.
     //
-    // if true, `process_proposal` is not executed, as this means we are the proposer of that
-    // block, and we have already executed the transactions for the block during
-    // `prepare_proposal`, and re-executing them would cause failure.
-    is_proposer: bool,
+    // Used to avoid executing a block in both `prepare_proposal` and `process_proposal`. It
+    // is set in `prepare_proposal` from information sent in from cometbft and can change.
+    // In `process_proposal` we check if we prepared the proposal, and if so, we clear the
+    // value and we skip re-execution of the block's transactions to avoid failures caused by
+    // re-execution.
+    signing_address: Option<account::Id>,
 
     // This is set to the executed hash of the proposal during `process_proposal`
     //
@@ -156,7 +156,7 @@ impl App {
 
         Self {
             state,
-            is_proposer: false,
+            signing_address: None,
             executed_proposal_hash: Hash::default(),
             execution_result: HashMap::new(),
             processed_txs: 0,
@@ -234,7 +234,7 @@ impl App {
         prepare_proposal: abci::request::PrepareProposal,
         storage: Storage,
     ) -> anyhow::Result<abci::response::PrepareProposal> {
-        self.is_proposer = true;
+        self.signing_address = Some(prepare_proposal.proposer_address);
         self.update_state_for_new_round(&storage);
 
         let (signed_txs, txs_to_include) = self.execute_block_data(prepare_proposal.txs).await;
@@ -266,16 +266,19 @@ impl App {
         // if we proposed this block (ie. prepare_proposal was called directly before this), then
         // we skip execution for this `process_proposal` call.
         //
-        // if we didn't propose this block, `self.is_proposer` will be `false`, so
-        // we will execute the block as normal.
-        if self.is_proposer {
-            debug!("skipping process_proposal as we are the proposer for this block");
-            self.is_proposer = false;
-            self.executed_proposal_hash = process_proposal.hash;
-            return Ok(());
+        // if we didn't propose this block, `self.signing_address` will be None or a differnet
+        // value, so we will execute the block as normal.
+        if let Some(id) = self.signing_address {
+            if id == process_proposal.proposer_address {
+                debug!("skipping process_proposal as we are the proposer for this block");
+                self.signing_address = None;
+                self.executed_proposal_hash = process_proposal.hash;
+                return Ok(());
+            }
+            debug!("signing address was set but we're not the proposer, shouldn't happen");
+            self.signing_address = None;
         }
 
-        self.is_proposer = false;
         self.update_state_for_new_round(&storage);
 
         let mut txs = VecDeque::from(process_proposal.txs);

--- a/crates/astria-sequencer/src/app.rs
+++ b/crates/astria-sequencer/src/app.rs
@@ -266,7 +266,7 @@ impl App {
         // if we proposed this block (ie. prepare_proposal was called directly before this), then
         // we skip execution for this `process_proposal` call.
         //
-        // if we didn't propose this block, `self.signing_address` will be None or a differnet
+        // if we didn't propose this block, `self.signing_address` will be None or a different
         // value, so we will execute the block as normal.
         if let Some(id) = self.signing_address {
             if id == process_proposal.proposer_address {


### PR DESCRIPTION
## Summary

This PR makes the 'did I propose this' check in `process_proposal()` more robust by caching the proposer's address in `prepare_proposal()`. Changed the check from a bool to checking if the cached proposing address matches the proposal's creator.

## Background
The sequencer's app logic shouldn't execute transactions in `process_proposal` if it was the app that proposed the transactions in `prepare_proposal` (as re-executing the transactions will fail due to how we manage state). The previous check was only a `bool` that was set in `process_proposal` and Zellic pointed out that this check could pass incorrectly if the proposed proposal timed out and a new proposal was proposed by someone else.

The proposing address is managed by cometbft and can [change](https://github.com/cometbft/cometbft/blob/c3acea2436f4fc0d2cbbb8b27ada97ab3706892f/internal/consensus/state.go#L277).

This check will fail if there are multiple cometBFT validators running with the same signing key.

I didn't check for proposal height because it seemed redundant; assuming that we're not running multiple validators with the same key, if `process_proposal` is called and we proposed it we must've generated it in `prepare_proposal`.

## Testing
Ran locally and transaction submitting still works.

## Related Issues
closes #920
