### PR TITLE
fix(charts): cometbft support for secrets

### DIFF
--- a/charts/sequencer/Chart.yaml
+++ b/charts/sequencer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.11.2
+version: 0.11.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sequencer/files/cometbft/config/config.toml
+++ b/charts/sequencer/files/cometbft/config/config.toml
@@ -60,8 +60,12 @@ log_format = "plain"
 # Path to the JSON file containing the initial validator set and other meta data
 genesis_file = "config/genesis.json"
 
+{{- if .Values.secretProvider.enabled }}
+priv_validator_key_file = "/secrets/priv-validator-key/{{ .Values.secretProvider.secrets.privValidatorKey.filename }}"
+{{- else }}
 # Path to the JSON file containing the private key to use as a validator in the consensus protocol
 priv_validator_key_file = "config/priv_validator_key.json"
+{{- end }}
 
 # Path to the JSON file containing the last sign state of a validator
 priv_validator_state_file = "data/priv_validator_state.json"
@@ -70,8 +74,12 @@ priv_validator_state_file = "data/priv_validator_state.json"
 # connections from an external PrivValidator process
 priv_validator_laddr = ""
 
+{{- if .Values.secretProvider.enabled }}
+node_key_file = "/secrets/node-key/{{ .Values.secretProvider.secrets.nodeKey.filename }}"
+{{- else }}
 # Path to the JSON file containing the private key to use for node authentication in the p2p protocol
 node_key_file = "config/node_key.json"
+{{- end }}
 
 # Mechanism to connect to the ABCI application: socket | grpc
 abci = "socket"

--- a/charts/sequencer/files/scripts/init-cometbft.sh
+++ b/charts/sequencer/files/scripts/init-cometbft.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -o errexit -o nounset
+
+# Only need to configure cometbft data if not already initialized
+if [ -z "$(ls -A /cometbft/data)" ]; then
+  cp -LR /data/ /cometbft/data
+fi
+
+# Don't replace the config directory if it already exists
+if [ -z "$(ls -A /cometbft/config)" ]; then
+  cp -LR /config/ /cometbft/config
+else
+  cp /config/* /cometbft/config/
+fi
+
+chmod -R 0777 /cometbft

--- a/charts/sequencer/templates/configmaps.yaml
+++ b/charts/sequencer/templates/configmaps.yaml
@@ -6,12 +6,23 @@ metadata:
 data:
   genesis.json: |
     {{- tpl (.Files.Get "files/cometbft/config/genesis.json") $ | nindent 4 }}
+  config.toml: |
+    {{- tpl (.Files.Get "files/cometbft/config/config.toml") $ | nindent 4 }}
+  {{- if not .Values.secretProvider.enabled }}
   node_key.json: |
     {{- tpl (.Files.Get "files/cometbft/config/node_key.json") $ | nindent 4 }}
   priv_validator_key.json: |
     {{- tpl (.Files.Get "files/cometbft/config/priv_validator_key.json") $ | nindent 4 }}
-  config.toml: |
-    {{- tpl (.Files.Get "files/cometbft/config/config.toml") $ | nindent 4 }}
+  {{- end }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.config.moniker }}-cometbft-init-scripts
+  namespace: {{ include "sequencer.namespace" . }}
+data:
+  init-cometbft.sh: |
+    {{- tpl (.Files.Get "files/scripts/init-cometbft.sh") $ | nindent 4 }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/charts/sequencer/templates/secretproviderclass.yaml
+++ b/charts/sequencer/templates/secretproviderclass.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.secretProvider.enabled }}
+  
+---
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: sequencer-keys-provider
+spec:
+  provider: gcp
+  secretObjects:
+  {{- range $key, $value := .Values.secretProvider.secrets }}
+  - secretName: {{ kebabcase $key }}
+    type: Opaque
+    data:
+    - objectName: {{ $value.filename }}
+      key: {{ $value.key }}
+  {{- end }}
+  parameters:
+    secrets: |
+      {{- range $key, $value := .Values.secretProvider.secrets }}
+      - resourceName: {{ $value.resourceName }}
+        fileName: "{{ $value.filename }}"
+      {{- end }}
+{{- end }}

--- a/charts/sequencer/templates/statefulsets.yaml
+++ b/charts/sequencer/templates/statefulsets.yaml
@@ -17,16 +17,16 @@ spec:
         app: {{ .Values.config.moniker }}-sequencer
     spec:
       initContainers:
-        - command: [ "/bin/sh", "-c" ]
-          args:
-            - cp -LR /data/ /cometbft/data && cp -LR /config /cometbft/config && chmod -R 0777 /cometbft
+        - command: [ "/scripts/init-cometbft.sh" ]
           name: config-cometbft
           image: "ghcr.io/tomwright/dasel:alpine"
           volumeMounts:
-            - mountPath: /config/
+            - mountPath: /config
               name: cometbft-config-volume
-            - mountPath: /data/
+            - mountPath: /data
               name: cometbft-data-volume
+            - mountPath: /scripts
+              name: cometbft-init-scripts-volume
             - mountPath: /cometbft
               name: sequencer-shared-storage-vol
               subPath: {{ .Values.config.moniker }}/cometbft
@@ -66,6 +66,10 @@ spec:
             - mountPath: /cometbft
               name: sequencer-shared-storage-vol
               subPath: {{ .Values.config.moniker }}/cometbft
+            {{- if .Values.secretProvider.enabled }}
+            - mountPath: "/secrets"
+              name: sequencer-keys-provider
+            {{- end }}
           ports:
             - containerPort: {{ .Values.ports.cometBFTP2P }}
               name: cometbft-p2p
@@ -84,6 +88,10 @@ spec:
           configMap:
             name: {{ .Values.config.moniker }}-cometbft-data
             defaultMode: 0700
+        - name: cometbft-init-scripts-volume
+          configMap:
+            name: {{ .Values.config.moniker }}-cometbft-init-scripts
+            defaultMode: 0777
         - name: sequencer-shared-storage-vol
           {{- if .Values.storage.enabled }}
           persistentVolumeClaim:
@@ -91,3 +99,11 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
+        {{- if .Values.secretProvider.enabled }}
+        - name: sequencer-secret-keys-vol
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: sequencer-keys-provider
+        {{- end }}

--- a/charts/sequencer/values.yaml
+++ b/charts/sequencer/values.yaml
@@ -107,6 +107,23 @@ config:
 sequencer-relayer:
   enabled: false
 
+# When deploying in a production environment should use a secret provider
+# This is configured for use with GCP, need to set own resource names
+# and keys
+secretProvider:
+  enabled: false
+  provider: gcp
+  secrets:
+    # Used in place of config.fundingPrivateKey value when provider enabled
+    privValidatorKey:
+      filename: privValidatorKey.json
+      resourceName: "projects/$PROJECT_ID/secrets/privValidatorKey/versions/latest"
+      key: token
+    nodeKey:
+      filename: nodeKey.json
+      resourceName: "projects/$PROJECT_ID/secrets/privValidatorKey/versions/latest"
+      key: token
+
 ports:
   cometBFTP2P: 26656
   cometBFTRPC: 26657

--- a/dev/values/validators/single.yml
+++ b/dev/values/validators/single.yml
@@ -10,7 +10,10 @@ sequencer-relayer:
       cometbftRpc: http://node0-sequencer-rpc-service.astria-dev-cluster.svc.cluster.local:26657
       sequencerGrpc: http://node0-sequencer-grpc-service.astria-dev-cluster.svc.cluster.local:8080
   storage:
-    enabled: false
+    enabled: true
+
+storage:
+  enabled: true
 
 ingress:
   rpc:


### PR DESCRIPTION
## Summary
Adds SecretProvider to CometBFT, and configures for use for private key files. Additionally updates such that config updates will propograte through on update, without overriding the data directory.

## Background
Way back when I had trouble getting this all to work, and once I found something that copied I stopped touching. This resulted in a bad configuration where private keys had to be in values files. Also required manual inteverention on node to update config.toml files. This fixes those.

## Changes
- Secret providers for private keys
- config file changes propogate at update.

## Testing
Run locally with storage enabled, ensured directories outside /cometbft can work for private keys, still need to test on cluster for secret provider.
