### PR TITLE
fix(sequencer): move begin_block ibc stuff to end_block

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,6 +738,7 @@ dependencies = [
  "astria-merkle",
  "astria-telemetry",
  "async-trait",
+ "base64 0.21.7",
  "borsh 1.4.0",
  "bytes",
  "cnidarium",

--- a/crates/astria-sequencer/Cargo.toml
+++ b/crates/astria-sequencer/Cargo.toml
@@ -60,6 +60,7 @@ tower-http = { version = "0.4", features = ["cors"] }
 config = { package = "astria-config", path = "../astria-config", features = [
   "tests",
 ] }
+base64 = { workspace = true }
 
 [build-dependencies]
 astria-build-info = { path = "../astria-build-info", features = ["build"] }

--- a/crates/astria-sequencer/src/transaction/mod.rs
+++ b/crates/astria-sequencer/src/transaction/mod.rs
@@ -511,4 +511,17 @@ mod test {
             .expect_err("insufficient funds for `other` asset");
         assert!(err.to_string().contains(&other_asset.to_string()));
     }
+
+    #[test]
+    fn tx_ibc_relay() {
+        use base64::prelude::*;
+        use prost::Message as _;
+
+        let str = "Cq0BCisvaWJjLmxpZ2h0Y2xpZW50cy50ZW5kZXJtaW50LnYxLkNsaWVudFN0YXRlEn4KB21vY2hhLTQSBAgBEAMaBAiA6kkiBAiA324qAgg3MgA6BggEENWcXkIZCgkIARgBIAEqAQASDAoCAAEQIRgEIAwwAUIZCgkIARgBIAEqAQASDAoCAAEQIBgBIAEwAUoHdXBncmFkZUoQdXBncmFkZWRJQkNTdGF0ZVABWAEShgEKLi9pYmMubGlnaHRjbGllbnRzLnRlbmRlcm1pbnQudjEuQ29uc2Vuc3VzU3RhdGUSVAoMCIiYwrAGEIzI9KwBEiIKIIQ/VOM6GD9ErLRNlgQlJhxlNxRXXyJDtqYz3LjF5JFTGiCJdX646SJuUIgOvm/GFSeegVTpVbVkadI/OVq03Bs5AhooOWRmNzhiY2QwMDc4NWRhODM0Y2ZhMDJjZDhlMDQ4MWY1OTRhMzMzNg==";
+        let tx = penumbra_proto::penumbra::core::component::ibc::v1::IbcRelay::decode(
+            BASE64_STANDARD.decode(str).unwrap().as_slice(),
+        )
+        .unwrap();
+        println!("{:?}", tx);
+    }
 }

--- a/crates/astria-sequencer/src/transaction/mod.rs
+++ b/crates/astria-sequencer/src/transaction/mod.rs
@@ -518,10 +518,9 @@ mod test {
         use prost::Message as _;
 
         let str = "Cq0BCisvaWJjLmxpZ2h0Y2xpZW50cy50ZW5kZXJtaW50LnYxLkNsaWVudFN0YXRlEn4KB21vY2hhLTQSBAgBEAMaBAiA6kkiBAiA324qAgg3MgA6BggEENWcXkIZCgkIARgBIAEqAQASDAoCAAEQIRgEIAwwAUIZCgkIARgBIAEqAQASDAoCAAEQIBgBIAEwAUoHdXBncmFkZUoQdXBncmFkZWRJQkNTdGF0ZVABWAEShgEKLi9pYmMubGlnaHRjbGllbnRzLnRlbmRlcm1pbnQudjEuQ29uc2Vuc3VzU3RhdGUSVAoMCIiYwrAGEIzI9KwBEiIKIIQ/VOM6GD9ErLRNlgQlJhxlNxRXXyJDtqYz3LjF5JFTGiCJdX646SJuUIgOvm/GFSeegVTpVbVkadI/OVq03Bs5AhooOWRmNzhiY2QwMDc4NWRhODM0Y2ZhMDJjZDhlMDQ4MWY1OTRhMzMzNg==";
-        let tx = penumbra_proto::penumbra::core::component::ibc::v1::IbcRelay::decode(
+        let _tx = penumbra_proto::penumbra::core::component::ibc::v1::IbcRelay::decode(
             BASE64_STANDARD.decode(str).unwrap().as_slice(),
         )
         .unwrap();
-        println!("{:?}", tx);
     }
 }


### PR DESCRIPTION
don't review yet!! this is a hack fix.

## Summary
maybe fix running a full node - during proposal phase tx execution, we haven't called begin_block before executing the txs, so the state is different. this is not the proper fix, but might fix full nodes on dusk 4. the actual fix is to call the begin_block stuff inside prepare/process_proposal before tx execution.

## Changes
-  move begin_block ibc stuff to end_block

## Testing
dusk 4 full node ?

