### PR TITLE
fix(conductor): robust Celestia blob fetch, verify, convert

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8392,7 +8392,7 @@ version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 dependencies = [
- "getrandom 0.2.12",
+ "getrandom 0.2.14",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,11 +613,13 @@ dependencies = [
  "itertools 0.12.1",
  "itoa",
  "jsonrpsee",
+ "moka",
  "once_cell",
  "pbjson-types",
  "pin-project-lite",
  "prost",
  "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "serde",
  "serde_json",
  "sha2 0.10.8",
@@ -1358,6 +1360,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
+name = "bytecount"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e5f035d16fc623ae5f74981db80a439803888314e3a555fd6f04acd51a3205"
+
+[[package]]
 name = "bytemuck"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1415,6 +1423,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24b1f0365a6c6bb4020cd05806fd0d33c44d38046b8bd7f0e40814b9763cabfc"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver 1.0.22",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2393,7 +2414,7 @@ checksum = "4d6259cf4df09300534dcfa6a49918bb442327111e370c656b31f1c10ec08145"
 dependencies = [
  "ansi_term",
  "anyhow",
- "cargo_metadata",
+ "cargo_metadata 0.18.1",
  "dirs",
  "dylint_internal",
  "is-terminal",
@@ -2415,7 +2436,7 @@ dependencies = [
  "ansi_term",
  "anyhow",
  "bitflags 2.5.0",
- "cargo_metadata",
+ "cargo_metadata 0.18.1",
  "git2",
  "home",
  "if_chain",
@@ -2432,7 +2453,7 @@ version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43fc05c7103dfadd497486bbbf941899888f4e19271da70b58f66385247230c2"
 dependencies = [
- "cargo_metadata",
+ "cargo_metadata 0.18.1",
  "dylint_internal",
  "paste",
  "rustversion",
@@ -2448,7 +2469,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "785fa52ac8fe5f1056a71955f4ebda3ca90c269ef28b172ad85a3901752d5fdf"
 dependencies = [
  "anyhow",
- "cargo_metadata",
+ "cargo_metadata 0.18.1",
  "compiletest_rs",
  "dylint",
  "dylint_internal",
@@ -2631,6 +2652,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-chain"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "eth-keystore"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2795,7 +2825,7 @@ checksum = "82d80cc6ad30b14a48ab786523af33b37f28a8623fc06afd55324816ef18fb1f"
 dependencies = [
  "arrayvec 0.7.4",
  "bytes",
- "cargo_metadata",
+ "cargo_metadata 0.18.1",
  "chrono",
  "const-hex",
  "elliptic-curve",
@@ -4688,6 +4718,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
 
 [[package]]
+name = "moka"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1911e88d5831f748a4097a43862d129e3c6fca831eecac9b8db6d01d93c9de2"
+dependencies = [
+ "async-lock",
+ "async-trait",
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "futures-util",
+ "once_cell",
+ "parking_lot",
+ "quanta",
+ "rustc_version 0.4.0",
+ "skeptic",
+ "smallvec",
+ "tagptr",
+ "thiserror",
+ "triomphe",
+ "uuid 1.8.0",
+]
+
+[[package]]
 name = "multiaddr"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6011,6 +6065,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
+dependencies = [
+ "bitflags 2.5.0",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
 name = "quanta"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7037,6 +7102,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "skeptic"
+version = "0.13.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d23b015676c90a0f01c197bfdc786c20342c73a0afdda9025adb0bc42940a8"
+dependencies = [
+ "bytecount",
+ "cargo_metadata 0.14.2",
+ "error-chain",
+ "glob",
+ "pulldown-cmark",
+ "tempfile",
+ "walkdir",
+]
+
+[[package]]
 name = "sketches-ddsketch"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7273,6 +7353,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tap"
@@ -8091,6 +8177,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "triomphe"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859eb650cfee7434994602c3a68b25d77ad9e68c8a6cd491616ef86661382eb3"
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8162,6 +8254,15 @@ name = "uncased"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
+name = "unicase"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
 dependencies = [
  "version_check",
 ]
@@ -8290,6 +8391,9 @@ name = "uuid"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
+dependencies = [
+ "getrandom 0.2.12",
+]
 
 [[package]]
 name = "valuable"
@@ -8310,7 +8414,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e27d6bdd219887a9eadd19e1c34f32e47fa332301184935c6d9bca26f3cca525"
 dependencies = [
  "anyhow",
- "cargo_metadata",
+ "cargo_metadata 0.18.1",
  "cfg-if",
  "git2",
  "regex",

--- a/crates/astria-celestia-client/src/lib.rs
+++ b/crates/astria-celestia-client/src/lib.rs
@@ -56,9 +56,14 @@ pub const fn celestia_namespace_v0_from_rollup_id(
 
 #[must_use = "a celestia namespace must be used in order to be useful"]
 pub fn celestia_namespace_v0_from_str(chain_id: &str) -> Namespace {
+    celestia_namespace_v0_from_bytes(chain_id.as_bytes())
+}
+
+#[must_use = "a celestia namespace must be used in order to be useful"]
+pub fn celestia_namespace_v0_from_bytes(bytes: &[u8]) -> Namespace {
     use sha2::{
         Digest as _,
         Sha256,
     };
-    celestia_namespace_v0_from_array(Sha256::digest(chain_id.as_bytes()).into())
+    celestia_namespace_v0_from_array(Sha256::digest(bytes).into())
 }

--- a/crates/astria-conductor/Cargo.toml
+++ b/crates/astria-conductor/Cargo.toml
@@ -53,6 +53,7 @@ itertools = "0.12.1"
 pin-project-lite = "0.2"
 tokio-stream = "0.1.14"
 tracing-futures = { version = "0.2.5", features = ["futures-03"] }
+moka = { version = "0.12.5", features = ["future"] }
 
 [dev-dependencies]
 astria-core = { path = "../astria-core", features = ["server", "test-utils"] }
@@ -68,6 +69,7 @@ wiremock = { workspace = true }
 
 chrono = "0.4.35"
 tokio-stream = { version = "0.1.15", features = ["net"] }
+rand_chacha = "0.3.1"
 
 [build-dependencies]
 astria-build-info = { path = "../astria-build-info", features = ["build"] }

--- a/crates/astria-conductor/src/block_cache.rs
+++ b/crates/astria-conductor/src/block_cache.rs
@@ -45,9 +45,7 @@ impl<T> BlockCache<T> {
             next_height,
         })
     }
-}
 
-impl<T> BlockCache<T> {
     /// Returns the next sequential block if it exists in the cache.
     pub(crate) fn pop(&mut self) -> Option<T> {
         let block = self.inner.remove(&self.next_height)?;

--- a/crates/astria-conductor/src/celestia/block_verifier.rs
+++ b/crates/astria-conductor/src/celestia/block_verifier.rs
@@ -1,119 +1,74 @@
 use std::collections::HashMap;
 
-use astria_eyre::eyre::{
-    self,
-    bail,
-    ensure,
-    WrapErr as _,
-};
-use celestia_client::CelestiaSequencerBlob;
 use ed25519_consensus::{
     Signature,
     VerificationKey,
 };
 use prost::Message;
 use sequencer_client::{
-    tendermint,
+    tendermint::{
+        self,
+        block::Height,
+    },
     tendermint_rpc,
-    Client as _,
-    HttpClient,
 };
-use tracing::instrument;
 
-/// `BlockVerifier` is verifying blocks received from celestia.
-#[derive(Clone)]
-pub(super) struct BlockVerifier {
-    client: HttpClient,
-}
+#[derive(Debug, thiserror::Error)]
+pub(super) enum QuorumError {
+    #[error("commit height mismatch; expected `{expected_height}`, got `{actual_height}`")]
+    CommitHeightMismatch {
+        expected_height: Height,
+        actual_height: Height,
+    },
 
-impl BlockVerifier {
-    pub(super) fn new(client: HttpClient) -> Self {
-        Self {
-            client,
-        }
-    }
+    #[error(
+        "commit voting power is greater than total voting power: {commit_voting_power} > \
+         {total_voting_power}"
+    )]
+    CommitVotingPowerExceedsTotal {
+        commit_voting_power: u64,
+        total_voting_power: u64,
+    },
 
-    #[instrument(skip_all, fields(
-        height.in_blob = %blob.height(),
-        block_hash.in_blob = %telemetry::display::base64(&blob.block_hash()),
-    ))]
-    pub(super) async fn verify_blob(&self, blob: &CelestiaSequencerBlob) -> eyre::Result<()> {
-        Verify::at_height(self.client.clone(), blob.height())
-            .await
-            .wrap_err("failed getting the required objects to verify blob")?
-            .verify(blob)
-    }
-}
-struct Verify {
-    block_hash: tendermint::Hash,
-    commit_header: tendermint::block::signed_header::SignedHeader,
-}
+    #[error("commit contained an empty signature field for validator `{validator}`")]
+    EmptySignature { validator: tendermint::account::Id },
 
-impl Verify {
-    async fn at_height(
-        client: HttpClient,
-        height: tendermint::block::Height,
-    ) -> eyre::Result<Self> {
-        use futures::TryFutureExt as _;
-        ensure!(
-            height != tendermint::block::Height::from(0u32),
-            "cannot validate sequencer blocks at height 0",
-        );
-        // the validators at height h-1 vote for the block at height h.
-        let prev_height: tendermint::block::Height = (height.value() - 1).try_into().wrap_err(
-            "failed converting decremented height tendermint value to tendermint height type",
-        )?;
-        let (block, commit, validator_set) = tokio::try_join!(
-            client
-                .block(height)
-                .map_err(|e| eyre::Report::new(e).wrap_err("failed fetching sequencer block")),
-            client
-                .commit(height)
-                .map_err(|e| eyre::Report::new(e).wrap_err("failed fetching commit")),
-            client
-                .validators(prev_height, tendermint_rpc::Paging::Default)
-                .map_err(|e| eyre::Report::new(e).wrap_err("failed fetching validator set")),
-        )?;
-        let block_hash = block.block_id.hash;
-        let commit_header = commit.signed_header;
-        Self::new(block_hash, commit_header, &validator_set)
-    }
+    #[error(
+        "commit voting power is less than 2/3 of total voting power: {commit_voting_power} <= 2/3 \
+         {total_voting_power}"
+    )]
+    NoQuorum {
+        commit_voting_power: u64,
+        total_voting_power: u64,
+    },
 
-    fn new(
-        block_hash: tendermint::Hash,
-        commit_header: tendermint::block::signed_header::SignedHeader,
-        validator_set: &tendermint_rpc::endpoint::validators::Response,
-    ) -> eyre::Result<Self> {
-        ensure!(
-            block_hash == commit_header.header.hash(),
-            "block hash stored in commit header does not match block hash of sequencer block",
-        );
-        ensure_commit_has_quorum(
-            &commit_header.commit,
-            validator_set,
-            &commit_header.header.chain_id,
-        )
-        .wrap_err("unable to verify that commit had quorum")?;
-        Ok(Self {
-            block_hash,
-            commit_header,
-        })
-    }
+    #[error("validator `{validator}` was present in commit but not in validator set")]
+    NoSuchValidator { validator: tendermint::account::Id },
 
-    fn verify(&self, blob: &CelestiaSequencerBlob) -> eyre::Result<()> {
-        ensure!(
-            &self.commit_header.header.chain_id == blob.cometbft_chain_id(),
-            "expected cometbft chain ID `{}`, got {}",
-            self.commit_header.header.chain_id,
-            blob.cometbft_chain_id(),
-        );
-        ensure!(
-            blob.block_hash() == self.block_hash.as_bytes(),
-            "block hash in blob does not match block hash of sequencer block",
-        );
+    #[error(
+        "failed to recreate signature for validator from validator set to verify vote signature"
+    )]
+    Signature(#[source] ed25519_consensus::Error),
 
-        Ok(())
-    }
+    #[error("total voting power overflowed u64")]
+    TotalVotingPowerOverflowed,
+
+    #[error(
+        "validator `{expected}` in commit does not address `{actual}` derived from signature in \
+         validator set"
+    )]
+    ValidatorAddressMismatch {
+        expected: tendermint::account::Id,
+        actual: tendermint::account::Id,
+    },
+
+    #[error(
+        "failed to recreate public key for validator from validator set to verify vote signature"
+    )]
+    VerificationKey(#[source] ed25519_consensus::Error),
+
+    #[error("failed to verify vote signature")]
+    VerifyVoteSignature(#[source] ed25519_consensus::Error),
 }
 
 /// This function ensures that the given Commit has quorum, ie that the Commit contains >2/3 voting
@@ -128,26 +83,26 @@ impl Verify {
 /// # Errors
 ///
 /// If any of the above conditions are not satisfied, an error is returned.
-fn ensure_commit_has_quorum(
+pub(super) fn ensure_commit_has_quorum(
     commit: &tendermint::block::Commit,
     validator_set: &tendermint_rpc::endpoint::validators::Response,
     chain_id: &tendermint::chain::Id,
-) -> eyre::Result<()> {
+) -> Result<(), QuorumError> {
     // Validator set at Block N-1 is used for block N
     let expected_height = validator_set.block_height.increment();
     let actual_height = commit.height;
-    ensure!(
-        expected_height == actual_height,
-        "commit height mismatch; expected `{expected_height}`, got `{actual_height}`"
-    );
+    if expected_height != actual_height {
+        return Err(QuorumError::CommitHeightMismatch {
+            expected_height,
+            actual_height,
+        });
+    }
 
-    let Some(total_voting_power) = validator_set
+    let total_voting_power = validator_set
         .validators
         .iter()
         .try_fold(0u64, |acc, validator| acc.checked_add(validator.power()))
-    else {
-        bail!("total voting power exceeded u64:MAX");
-    };
+        .ok_or(QuorumError::TotalVotingPowerOverflowed)?;
 
     let validator_map = validator_set
         .validators
@@ -172,27 +127,27 @@ fn ensure_commit_has_quorum(
         };
 
         let Some(signature) = signature else {
-            bail!(
-                "signature should not be empty for commit with validator {}",
-                validator_address
-            )
+            return Err(QuorumError::EmptySignature {
+                validator: *validator_address,
+            });
         };
 
         // verify validator exists in validator set
         let Some(validator) = validator_map.get(validator_address) else {
-            bail!("validator {} not found in validator set", validator_address);
+            return Err(QuorumError::NoSuchValidator {
+                validator: *validator_address,
+            });
         };
 
         // verify address in signature matches validator pubkey
         let address_from_pubkey = tendermint::account::Id::from(validator.pub_key);
 
-        ensure!(
-            &address_from_pubkey == validator_address,
-            format!(
-                "validator address mismatch: expected {}, got {}",
-                validator_address, address_from_pubkey
-            )
-        );
+        if address_from_pubkey != *validator_address {
+            return Err(QuorumError::ValidatorAddressMismatch {
+                expected: *validator_address,
+                actual: address_from_pubkey,
+            });
+        }
 
         // verify vote signature
         verify_vote_signature(
@@ -201,38 +156,33 @@ fn ensure_commit_has_quorum(
             chain_id,
             &validator.pub_key,
             signature.as_bytes(),
-        )
-        .wrap_err("failed to verify vote signature")?;
+        )?;
 
-        commit_voting_power += validator.power();
+        commit_voting_power = commit_voting_power.saturating_add(validator.power());
     }
 
-    ensure!(
-        commit_voting_power <= total_voting_power,
-        format!(
-            "commit voting power is greater than total voting power: {} > {}",
-            commit_voting_power, total_voting_power
-        )
-    );
-
-    ensure!(
-        does_commit_voting_power_have_quorum(commit_voting_power, total_voting_power),
-        format!(
-            "commit voting power is less than 2/3 of total voting power: {} <= {}",
+    if commit_voting_power > total_voting_power {
+        return Err(QuorumError::CommitVotingPowerExceedsTotal {
             commit_voting_power,
-            total_voting_power * 2 / 3,
-        )
-    );
+            total_voting_power,
+        });
+    }
 
+    if !does_commit_voting_power_have_quorum(commit_voting_power, total_voting_power) {
+        return Err(QuorumError::NoQuorum {
+            commit_voting_power,
+            total_voting_power,
+        });
+    }
     Ok(())
 }
 
 fn does_commit_voting_power_have_quorum(commited: u64, total: u64) -> bool {
     if total < 3 {
-        return commited * 3 > total * 2;
+        commited.saturating_mul(3) > total.saturating_mul(2)
+    } else {
+        commited > total.saturating_div(3).saturating_mul(2)
     }
-
-    commited > total / 3 * 2
 }
 
 // see https://github.com/tendermint/tendermint/blob/35581cf54ec436b8c37fabb43fdaa3f48339a170/types/vote.go#L147
@@ -242,20 +192,16 @@ fn verify_vote_signature(
     chain_id: &tendermint::chain::Id,
     public_key: &tendermint::PublicKey,
     signature_bytes: &[u8],
-) -> eyre::Result<()> {
+) -> Result<(), QuorumError> {
     let public_key = VerificationKey::try_from(public_key.to_bytes().as_slice())
-        .wrap_err("failed to create public key from vote")?;
-    let signature =
-        Signature::try_from(signature_bytes).wrap_err("failed to create signature from vote")?;
+        .map_err(QuorumError::VerificationKey)?;
+    let signature = Signature::try_from(signature_bytes).map_err(QuorumError::Signature)?;
 
     let canonical_vote = tendermint::vote::CanonicalVote {
         vote_type: tendermint::vote::Type::Precommit,
         height: commit.height,
         round: commit.round,
-        block_id: Some(tendermint::block::Id {
-            hash: commit.block_id.hash,
-            part_set_header: commit.block_id.part_set_header,
-        }),
+        block_id: Some(commit.block_id),
         timestamp: Some(timestamp),
         chain_id: chain_id.clone(),
     };
@@ -266,7 +212,7 @@ fn verify_vote_signature(
             &sequencer_client::tendermint_proto::types::CanonicalVote::from(canonical_vote)
                 .encode_length_delimited_to_vec(),
         )
-        .wrap_err("failed to verify vote signature")?;
+        .map_err(QuorumError::VerifyVoteSignature)?;
     Ok(())
 }
 

--- a/crates/astria-conductor/src/celestia/builder.rs
+++ b/crates/astria-conductor/src/celestia/builder.rs
@@ -10,10 +10,7 @@ use celestia_client::jsonrpsee::http_client::HttpClient as CelestiaClient;
 use sequencer_client::HttpClient as SequencerClient;
 use tokio_util::sync::CancellationToken;
 
-use super::{
-    latest_height_stream::stream_latest_heights,
-    Reader,
-};
+use super::Reader;
 use crate::executor;
 
 pub(crate) struct Builder {
@@ -40,12 +37,9 @@ impl Builder {
         let celestia_client = create_celestia_client(celestia_http_endpoint, &celestia_token)
             .wrap_err("failed initializing client for Celestia HTTP RPC")?;
 
-        let latest_celestia_heights =
-            stream_latest_heights(celestia_client.clone(), celestia_block_time);
-
         Ok(Reader {
+            celestia_block_time,
             celestia_client,
-            latest_celestia_heights,
             executor,
             sequencer_cometbft_client,
             shutdown,

--- a/crates/astria-conductor/src/celestia/convert.rs
+++ b/crates/astria-conductor/src/celestia/convert.rs
@@ -1,0 +1,138 @@
+use celestia_client::{
+    celestia_types::{
+        nmt::Namespace,
+        Blob,
+    },
+    CelestiaRollupBlob,
+    CelestiaSequencerBlob,
+};
+use prost::{
+    Message as _,
+    Name as _,
+};
+use telemetry::display::base64;
+use tracing::{
+    info,
+    warn,
+};
+
+use super::fetch::RawBlobs;
+
+type StdError = dyn std::error::Error;
+
+/// Decodes blob bytes into sequencer header or rollup items, returning
+/// them grouped by their block hashes.
+pub(super) fn decode_raw_blobs(
+    raw_blobs: RawBlobs,
+    rollup_namespace: Namespace,
+    sequencer_namespace: Namespace,
+) -> ConvertedBlobs {
+    let mut converted_blobs = ConvertedBlobs::new(raw_blobs.celestia_height);
+    for blob in raw_blobs.header_blobs {
+        if blob.namespace == sequencer_namespace {
+            if let Some(header) = convert_header(&blob) {
+                converted_blobs.push_header(header);
+            }
+        } else {
+            warn!(
+                sequencer_namespace = %base64(sequencer_namespace.as_ref()),
+                namespace_in_blob = %base64(blob.namespace.as_ref()),
+                "blob's namespaces was not the expected sequencer namespace; dropping",
+            );
+        }
+    }
+
+    for blob in raw_blobs.rollup_blobs {
+        if blob.namespace == rollup_namespace {
+            if let Some(rollup) = convert_rollup(&blob) {
+                converted_blobs.push_rollup(rollup);
+            }
+        } else {
+            warn!(
+                rollup_namespace = %base64(rollup_namespace.as_ref()),
+                namespace_in_blob = %base64(blob.namespace.as_ref()),
+                "blob's namespaces was not the expected rollup namespace; dropping",
+            );
+        }
+    }
+    converted_blobs
+}
+
+/// An unsorted [`CelestiaSequencerBlob`] and [`CelestiaRollupBlob`].
+pub(super) struct ConvertedBlobs {
+    celestia_height: u64,
+    header_blobs: Vec<CelestiaSequencerBlob>,
+    rollup_blobs: Vec<CelestiaRollupBlob>,
+}
+
+impl ConvertedBlobs {
+    pub(super) fn len_header_blobs(&self) -> usize {
+        self.header_blobs.len()
+    }
+
+    pub(super) fn len_rollup_blobs(&self) -> usize {
+        self.rollup_blobs.len()
+    }
+
+    pub(super) fn into_parts(self) -> (u64, Vec<CelestiaSequencerBlob>, Vec<CelestiaRollupBlob>) {
+        (self.celestia_height, self.header_blobs, self.rollup_blobs)
+    }
+
+    fn new(celestia_height: u64) -> Self {
+        Self {
+            celestia_height,
+            header_blobs: Vec::new(),
+            rollup_blobs: Vec::new(),
+        }
+    }
+
+    fn push_header(&mut self, header: CelestiaSequencerBlob) {
+        self.header_blobs.push(header);
+    }
+
+    fn push_rollup(&mut self, rollup: CelestiaRollupBlob) {
+        self.rollup_blobs.push(rollup);
+    }
+}
+
+fn convert_header(blob: &Blob) -> Option<CelestiaSequencerBlob> {
+    use astria_core::generated::sequencerblock::v1alpha1::CelestiaSequencerBlob as ProtoType;
+    let raw = ProtoType::decode(&*blob.data)
+        .inspect_err(|err| {
+            info!(
+                error = err as &StdError,
+                target = ProtoType::full_name(),
+                "failed decoding blob bytes as sequencer header; dropping the blob",
+            );
+        })
+        .ok()?;
+    CelestiaSequencerBlob::try_from_raw(raw)
+        .inspect_err(|err| {
+            info!(
+                error = err as &StdError,
+                "failed verifying decoded sequencer header; dropping it"
+            );
+        })
+        .ok()
+}
+
+fn convert_rollup(blob: &Blob) -> Option<CelestiaRollupBlob> {
+    use astria_core::generated::sequencerblock::v1alpha1::CelestiaRollupBlob as ProtoType;
+    let raw_blob = ProtoType::decode(&*blob.data)
+        .inspect_err(|err| {
+            info!(
+                error = err as &StdError,
+                target = ProtoType::full_name(),
+                "failed decoding blob bytes as rollup element; dropping the blob",
+            );
+        })
+        .ok()?;
+    CelestiaRollupBlob::try_from_raw(raw_blob)
+        .inspect_err(|err| {
+            info!(
+                error = err as &StdError,
+                "failed verifying decoded rollup element; dropping it"
+            );
+        })
+        .ok()
+}

--- a/crates/astria-conductor/src/celestia/fetch.rs
+++ b/crates/astria-conductor/src/celestia/fetch.rs
@@ -1,0 +1,159 @@
+use std::{
+    sync::atomic::AtomicU32,
+    time::Duration,
+};
+
+use astria_eyre::{
+    eyre,
+    eyre::WrapErr as _,
+};
+use celestia_client::{
+    celestia_types::{
+        nmt::Namespace,
+        Blob,
+    },
+    jsonrpsee::{
+        self,
+        http_client::HttpClient as CelestiaClient,
+    },
+};
+use telemetry::display::base64;
+use tokio::try_join;
+use tracing::{
+    instrument,
+    warn,
+};
+use tryhard::{
+    backoff_strategies::BackoffStrategy,
+    RetryPolicy,
+};
+
+pub(super) struct RawBlobs {
+    pub(super) celestia_height: u64,
+    pub(super) header_blobs: Vec<Blob>,
+    pub(super) rollup_blobs: Vec<Blob>,
+}
+
+impl RawBlobs {
+    pub(super) fn len_header_blobs(&self) -> usize {
+        self.header_blobs.len()
+    }
+
+    pub(super) fn len_rollup_blobs(&self) -> usize {
+        self.rollup_blobs.len()
+    }
+}
+
+/// Fetch Celestia blobs at `celestia_height` matching `sequencer_namespace` and `rollup_namespace`.
+///
+/// Retries indefinitely if the underlying transport failed. Immediately returns with an error in
+/// all other cases.
+#[instrument(skip_all, fields(
+    celestia_height,
+    sequencer_namespace = %base64(sequencer_namespace.as_ref()),
+    rollup_namespace = %base64(rollup_namespace.as_ref()),
+))]
+pub(super) async fn fetch_new_blobs(
+    client: CelestiaClient,
+    celestia_height: u64,
+    rollup_namespace: Namespace,
+    sequencer_namespace: Namespace,
+) -> eyre::Result<RawBlobs> {
+    let header_blobs = async {
+        fetch_blobs_with_retry(client.clone(), celestia_height, sequencer_namespace)
+            .await
+            .wrap_err("failed to fetch header blobs")
+    };
+    let rollup_blobs = async {
+        fetch_blobs_with_retry(client.clone(), celestia_height, rollup_namespace)
+            .await
+            .wrap_err("failed to fetch rollup blobs")
+    };
+
+    let (header_blobs, rollup_blobs) = try_join!(header_blobs, rollup_blobs)?;
+
+    Ok(RawBlobs {
+        celestia_height,
+        header_blobs,
+        rollup_blobs,
+    })
+}
+
+async fn fetch_blobs_with_retry(
+    client: CelestiaClient,
+    height: u64,
+    namespace: Namespace,
+) -> eyre::Result<Vec<Blob>> {
+    use celestia_client::celestia_rpc::BlobClient as _;
+
+    let number_attempts = AtomicU32::new(0);
+    let retry_config = tryhard::RetryFutureConfig::new(u32::MAX)
+        .custom_backoff(FetchBlobsRetryStrategy::new(Duration::from_millis(100)))
+        .max_delay(Duration::from_secs(20))
+        .on_retry(
+            |attempt: u32, next_delay: Option<Duration>, error: &jsonrpsee::core::Error| {
+                number_attempts.store(attempt, std::sync::atomic::Ordering::Relaxed);
+                let wait_duration = next_delay
+                    .map(humantime::format_duration)
+                    .map(tracing::field::display);
+                warn!(
+                    attempt,
+                    wait_duration,
+                    error = error as &dyn std::error::Error,
+                    "attempt to fetch Celestia Blobs failed; retrying after delay",
+                );
+                futures::future::ready(())
+            },
+        );
+
+    tryhard::retry_fn(move || {
+        let client = client.clone();
+        async move {
+            match client.blob_get_all(height, &[namespace]).await {
+                Ok(blobs) => Ok(blobs),
+                Err(err) if is_blob_not_found(&err) => Ok(vec![]),
+                Err(err) => Err(err),
+            }
+        }
+    })
+    .with_config(retry_config)
+    .await
+    .wrap_err("failed fetching blocks without being able to recover")
+}
+
+struct FetchBlobsRetryStrategy {
+    delay: Duration,
+}
+
+impl FetchBlobsRetryStrategy {
+    fn new(initial_duration: Duration) -> Self {
+        Self {
+            delay: initial_duration,
+        }
+    }
+}
+
+impl<'a> BackoffStrategy<'a, jsonrpsee::core::Error> for FetchBlobsRetryStrategy {
+    type Output = RetryPolicy;
+
+    fn delay(&mut self, _attempt: u32, error: &'a jsonrpsee::core::Error) -> Self::Output {
+        if should_retry(error) {
+            let prev_delay = self.delay;
+            self.delay = self.delay.saturating_mul(2);
+            RetryPolicy::Delay(prev_delay)
+        } else {
+            RetryPolicy::Break
+        }
+    }
+}
+
+fn should_retry(error: &jsonrpsee::core::Error) -> bool {
+    matches!(error, jsonrpsee::core::Error::Transport(_))
+}
+
+fn is_blob_not_found(error: &jsonrpsee::core::Error) -> bool {
+    let jsonrpsee::core::Error::Call(error) = error else {
+        return false;
+    };
+    error.code() == 1 && error.message().contains("blob: not found")
+}

--- a/crates/astria-conductor/src/celestia/mod.rs
+++ b/crates/astria-conductor/src/celestia/mod.rs
@@ -118,8 +118,6 @@ impl GetSequencerHeight for ReconstructedBlock {
 
 pub(super) struct ReconstructedBlocks {
     celestia_height: u64,
-    sequencer_namespace: Namespace,
-    rollup_namespace: Namespace,
     blocks: Vec<ReconstructedBlock>,
 }
 
@@ -532,8 +530,6 @@ impl FetchConvertAndVerify {
 
         let reconstructed_blocks = ReconstructedBlocks {
             celestia_height,
-            sequencer_namespace,
-            rollup_namespace,
             blocks: reconstructed,
         };
 

--- a/crates/astria-conductor/src/celestia/mod.rs
+++ b/crates/astria-conductor/src/celestia/mod.rs
@@ -396,7 +396,7 @@ impl RunningReader {
         while self.can_schedule_blobs() {
             let height = self.celestia_next_height;
             self.celestia_next_height = self.celestia_next_height.saturating_add(1);
-            let task = FetchConvertAndVerify {
+            let task = FetchConvertVerifyAndReconstruct {
                 blob_verifier: self.blob_verifier.clone(),
                 celestia_client: self.celestia_client.clone(),
                 celestia_height: height,
@@ -458,7 +458,7 @@ impl RunningReader {
     }
 }
 
-struct FetchConvertAndVerify {
+struct FetchConvertVerifyAndReconstruct {
     blob_verifier: Arc<BlobVerifier>,
     celestia_client: CelestiaClient,
     celestia_height: u64,
@@ -467,7 +467,7 @@ struct FetchConvertAndVerify {
     sequencer_namespace: Namespace,
 }
 
-impl FetchConvertAndVerify {
+impl FetchConvertVerifyAndReconstruct {
     #[instrument( skip_all, fields(
         celestia_height = self.celestia_height,
         rollup_namespace = %base64(self.rollup_namespace.as_bytes()),

--- a/crates/astria-conductor/src/celestia/mod.rs
+++ b/crates/astria-conductor/src/celestia/mod.rs
@@ -84,7 +84,7 @@ use self::{
     latest_height_stream::stream_latest_heights,
     reconstruct::reconstruct_blocks_from_verified_blobs,
     verify::{
-        verify_and_filter_decoded_blobs,
+        verify_header_blobs,
         BlobVerifier,
     },
 };
@@ -512,7 +512,7 @@ impl FetchConvertAndVerify {
             "decoded Sequencer header and rollup info from raw Celestia blobs",
         );
 
-        let verified_blobs = verify_and_filter_decoded_blobs(blob_verifier, decoded_blobs).await;
+        let verified_blobs = verify_header_blobs(blob_verifier, decoded_blobs).await;
 
         info!(
             number_of_verified_header_blobs = verified_blobs.len_header_blobs(),

--- a/crates/astria-conductor/src/celestia/mod.rs
+++ b/crates/astria-conductor/src/celestia/mod.rs
@@ -1,42 +1,34 @@
 use std::{
-    future::ready,
-    pin::Pin,
-    task::{
-        Context,
-        Poll,
-    },
+    cmp::max,
+    sync::Arc,
     time::Duration,
 };
 
-use astria_core::sequencerblock::v1alpha1::block::SequencerBlockHeader;
+use astria_core::{
+    sequencer::v1::RollupId,
+    sequencerblock::v1alpha1::block::SequencerBlockHeader,
+};
 use astria_eyre::eyre::{
     self,
     bail,
-    ensure,
     WrapErr as _,
 };
 use celestia_client::{
-    celestia_namespace_v0_from_rollup_id,
     celestia_types::nmt::Namespace,
     jsonrpsee::http_client::HttpClient as CelestiaClient,
-    CelestiaClientExt as _,
-    CelestiaSequencerBlob,
 };
 use futures::{
     future::{
-        self,
         BoxFuture,
         Fuse,
         FusedFuture as _,
     },
-    stream::Stream,
     FutureExt as _,
-    StreamExt as _,
 };
-use futures_bounded::FuturesMap;
-use pin_project_lite::pin_project;
 use sequencer_client::{
+    tendermint,
     tendermint::block::Height as SequencerHeight,
+    tendermint_rpc,
     HttpClient as SequencerClient,
 };
 use telemetry::display::{
@@ -49,10 +41,15 @@ use tokio::{
         SendError,
         TrySendError,
     },
+    task::spawn_blocking,
+    try_join,
 };
-use tokio_util::sync::CancellationToken;
+use tokio_stream::StreamExt as _;
+use tokio_util::{
+    sync::CancellationToken,
+    task::JoinMap,
+};
 use tracing::{
-    debug,
     error,
     info,
     info_span,
@@ -61,43 +58,50 @@ use tracing::{
     warn,
 };
 
+use crate::{
+    block_cache::GetSequencerHeight,
+    executor::StateIsInit,
+    utils::flatten,
+};
+
 mod block_verifier;
 mod builder;
+mod convert;
+mod fetch;
 mod latest_height_stream;
+mod reconstruct;
 mod reporting;
+mod verify;
 
-use block_verifier::BlockVerifier;
 pub(crate) use builder::Builder;
 use latest_height_stream::LatestHeightStream;
-use reporting::{
-    ReportReconstructedBlocks,
-    ReportSequencerHeights,
-};
-use tracing_futures::Instrument;
+use reporting::ReportReconstructedBlocks;
 
-use crate::{
-    block_cache::{
-        BlockCache,
-        GetSequencerHeight,
+use self::{
+    block_verifier::ensure_commit_has_quorum,
+    convert::decode_raw_blobs,
+    fetch::fetch_new_blobs,
+    latest_height_stream::stream_latest_heights,
+    reconstruct::reconstruct_blocks_from_verified_blobs,
+    verify::{
+        verify_and_filter_decoded_blobs,
+        BlobVerifier,
     },
+};
+use crate::{
+    block_cache::BlockCache,
     executor,
 };
 
-type StdError = dyn std::error::Error;
-
-struct ReconstructedBlocks {
-    celestia_height: u64,
-    sequencer_namespace: Namespace,
-    rollup_namespace: Namespace,
-    blocks: Vec<ReconstructedBlock>,
-}
-
+/// Sequencer Block information reconstructed from Celestia blobs.
+///
+/// Will be forwarded to the executor as a firm block.
 #[derive(Clone, Debug)]
 pub(crate) struct ReconstructedBlock {
+    pub(crate) celestia_height: u64,
     pub(crate) block_hash: [u8; 32],
     pub(crate) header: SequencerBlockHeader,
     pub(crate) transactions: Vec<Vec<u8>>,
-    pub(crate) celestia_height: u64,
 }
 
 impl ReconstructedBlock {
@@ -112,12 +116,18 @@ impl GetSequencerHeight for ReconstructedBlock {
     }
 }
 
+pub(super) struct ReconstructedBlocks {
+    celestia_height: u64,
+    sequencer_namespace: Namespace,
+    rollup_namespace: Namespace,
+    blocks: Vec<ReconstructedBlock>,
+}
+
 pub(crate) struct Reader {
+    celestia_block_time: Duration,
+
     // Client to fetch heights and blocks from Celestia.
     celestia_client: CelestiaClient,
-
-    // A stream of the latest Celestia heights.
-    latest_celestia_heights: LatestHeightStream,
 
     /// The channel used to send messages to the executor task.
     executor: executor::Handle,
@@ -130,83 +140,135 @@ pub(crate) struct Reader {
 }
 
 impl Reader {
-    #[instrument(skip(self))]
     pub(crate) async fn run_until_stopped(mut self) -> eyre::Result<()> {
-        // Sequencer namespace is defined by the chain id of attached sequencer node
-        // which can be fetched from any block header.
-        let sequencer_namespace = get_sequencer_namespace(self.sequencer_cometbft_client.clone())
+        let (executor, sequencer_chain_id) = self
+            .initialize()
             .await
-            .wrap_err("failed to get sequencer namespace")?;
+            .wrap_err("intialization of runtime information failed")?;
 
-        let mut executor = self
-            .executor
-            .wait_for_init()
+        RunningReader::from_parts(self, executor, sequencer_chain_id)
+            .wrap_err("failed entering run loop")?
+            .run_until_stopped()
             .await
-            .wrap_err("handle to executor failed while waiting for it being initialized")?;
+    }
 
-        let rollup_id = executor.rollup_id();
-        let initial_expected_sequencer_height = executor.next_expected_firm_height();
-        let initial_celestia_height = executor.celestia_base_block_height();
-        let celestia_variance = executor.celestia_block_variance();
-        let rollup_namespace = celestia_namespace_v0_from_rollup_id(rollup_id);
-
-        let block_verifier = BlockVerifier::new(self.sequencer_cometbft_client.clone());
-
-        debug!(
-            %rollup_id,
-            %initial_expected_sequencer_height,
-            %initial_celestia_height,
-            celestia_variance,
-            "setting up celestia reader",
-        );
-
-        let latest_celestia_height = match self.latest_celestia_heights.next().await {
-            Some(Ok(height)) => height,
-            Some(Err(e)) => {
-                return Err(e).wrap_err("subscription to celestia header returned an error");
-            }
-            None => bail!("celestia header subscription was terminated unexpectedly"),
+    async fn initialize(
+        &mut self,
+    ) -> eyre::Result<(executor::Handle<StateIsInit>, tendermint::chain::Id)> {
+        let wait_for_init_executor = async {
+            self.executor
+                .wait_for_init()
+                .await
+                .wrap_err("handle to executor failed while waiting for it being initialized")
         };
 
-        debug!(
-            height = latest_celestia_height,
-            "received latest height from celestia"
+        let get_sequencer_chain_id = async {
+            get_sequencer_chain_id(self.sequencer_cometbft_client.clone())
+                .await
+                .wrap_err("failed to get sequencer chain ID")
+        };
+
+        try_join!(wait_for_init_executor, get_sequencer_chain_id)
+    }
+}
+
+struct RunningReader {
+    block_cache: BlockCache<ReconstructedBlock>,
+
+    blob_verifier: Arc<BlobVerifier>,
+
+    // Client to fetch heights and blocks from Celestia.
+    celestia_client: CelestiaClient,
+
+    /// The channel used to send messages to the executor task.
+    executor: executor::Handle<StateIsInit>,
+
+    /// Token to listen for Conductor being shut down.
+    shutdown: CancellationToken,
+
+    /// Tasks reconstructing Sequencer block information from Celestia blobs.
+    tasks: JoinMap<u64, eyre::Result<ReconstructedBlocks>>,
+
+    latest_heights: LatestHeightStream,
+
+    enqueued_block: Fuse<BoxFuture<'static, Result<u64, SendError<ReconstructedBlock>>>>,
+
+    celestia_head_height: Option<u64>,
+    celestia_next_height: u64,
+    celestia_reference_height: u64,
+    celestia_variance: u64,
+
+    rollup_id: RollupId,
+    rollup_namespace: Namespace,
+
+    sequencer_chain_id: tendermint::chain::Id,
+    sequencer_namespace: Namespace,
+}
+
+impl RunningReader {
+    fn from_parts(
+        exposed_reader: Reader,
+        mut executor: executor::Handle<StateIsInit>,
+        sequencer_chain_id: tendermint::chain::Id,
+    ) -> eyre::Result<Self> {
+        let Reader {
+            celestia_block_time,
+            celestia_client,
+            sequencer_cometbft_client,
+            shutdown,
+            ..
+        } = exposed_reader;
+        let block_cache = BlockCache::with_next_height(executor.next_expected_firm_height())
+            .wrap_err("failed constructing sequential block cache")?;
+
+        let latest_heights = stream_latest_heights(celestia_client.clone(), celestia_block_time);
+        let rollup_id = executor.rollup_id();
+        let rollup_namespace = celestia_client::celestia_namespace_v0_from_rollup_id(rollup_id);
+        let sequencer_namespace =
+            celestia_client::celestia_namespace_v0_from_bytes(sequencer_chain_id.as_bytes());
+
+        let celestia_next_height = executor.celestia_base_block_height().value();
+        let celestia_reference_height = executor.celestia_base_block_height().value();
+        let celestia_variance = executor.celestia_block_variance().into();
+
+        Ok(Self {
+            block_cache,
+            blob_verifier: Arc::new(BlobVerifier::new(sequencer_cometbft_client)),
+            celestia_client,
+            enqueued_block: Fuse::terminated(),
+            executor,
+            latest_heights,
+            shutdown,
+            tasks: JoinMap::new(),
+
+            celestia_head_height: None,
+            celestia_next_height,
+            celestia_reference_height,
+            celestia_variance,
+
+            rollup_id,
+            rollup_namespace,
+            sequencer_chain_id,
+            sequencer_namespace,
+        })
+    }
+
+    #[instrument(skip(self))]
+    async fn run_until_stopped(mut self) -> eyre::Result<()> {
+        info!(
+            initial_celestia_height = self.celestia_next_height,
+            initial_max_celestia_height = self.max_permitted_celestia_height(),
+            celestia_variance = self.celestia_variance,
+            rollup_namespace = %base64(&self.rollup_namespace.as_bytes()),
+            rollup_id = %self.rollup_id,
+            sequencer_chain_id = %self.sequencer_chain_id,
+            sequencer_namespace = %base64(&self.sequencer_namespace.as_bytes()),
+            "starting firm block read loop",
         );
 
-        // XXX: This block cache always starts at height 1, the default value for `Height`.
-        let mut sequential_blocks =
-            BlockCache::<ReconstructedBlock>::with_next_height(initial_expected_sequencer_height)
-                .wrap_err("failed constructing sequential block cache")?;
-
-        let mut block_stream = ReconstructedBlocksStream {
-            track_heights: TrackHeights {
-                reference_height: initial_celestia_height.value(),
-                variance: celestia_variance,
-                last_observed: latest_celestia_height,
-                next_height: initial_celestia_height.value(),
-            },
-            // NOTE: Gives Celestia 600 seconds to respond. This seems reasonable because we need to
-            // 1. fetch all sequencer header blobs, 2. fetch the rollup blobs, 3. verify the rollup
-            // blobs.
-            // XXX: This should probably have explicit retry logic instead of this futures map.
-            in_progress: FuturesMap::new(Duration::from_secs(600), 10),
-            client: self.celestia_client.clone(),
-            verifier: block_verifier.clone(),
-            sequencer_namespace,
-            rollup_namespace,
-        }
-        .instrument(info_span!(
-            "celestia_block_stream",
-            namespace.rollup = %base64(&rollup_namespace.as_bytes()),
-            namespace.sequencer = %base64(&sequencer_namespace.as_bytes()),
-        ));
-
-        // Enqueued block waiting for executor to free up. Set if the executor exhibits
-        // backpressure.
-        let mut enqueued_block: Fuse<BoxFuture<Result<_, SendError<ReconstructedBlock>>>> =
-            future::Fuse::terminated();
-
         let reason = loop {
+            self.schedule_new_blobs();
+
             select!(
                 biased;
 
@@ -214,54 +276,37 @@ impl Reader {
                     break Ok("received shutdown signal");
                 }
 
-                // Process block execution which was enqueued due to executor channel being full
-                res = &mut enqueued_block, if !enqueued_block.is_terminated() => {
+                res = &mut self.enqueued_block, if self.waiting_for_executor_capacity() => {
                     match res {
-                        Ok(celestia_height) => {
-                            block_stream.inner_mut().update_reference_height_if_greater(celestia_height);
-                            debug!("submitted enqueued block to executor, resuming normal operation");
+                        Ok(celestia_height_of_forwarded_block) => {
+                            trace!("submitted enqueued block to executor, resuming normal operation");
+                            self.advance_reference_celestia_height(celestia_height_of_forwarded_block);
                         }
                         Err(err) => break Err(err).wrap_err("failed sending enqueued block to executor"),
                     }
                 }
 
-                // Forward the next block to executor. Enqueue if the executor channel is full.
-                Some(block) = sequential_blocks.next_block(), if enqueued_block.is_terminated() => {
-                    let celestia_height = block.celestia_height;
-                    match executor.try_send_firm_block(block) {
-                        Ok(()) => {
-                            block_stream.inner_mut().update_reference_height_if_greater(celestia_height);
-                        }
-                        Err(TrySendError::Full(block)) => {
-                            trace!("executor channel is full; rescheduling block fetch until the channel opens up");
-                            let executor_clone = executor.clone();
-                            // must return the celestia height to update the reference height upon completion
-                            enqueued_block = async move {
-                                let celestia_height = block.celestia_height;
-                                executor_clone.send_firm_block(block).await?;
-                                Ok(celestia_height)
-                            }.boxed().fuse();
-                        }
-
-                        Err(TrySendError::Closed(_)) => bail!("exiting because executor channel is closed"),
+                Some(block) = self.block_cache.next_block(), if !self.waiting_for_executor_capacity() => {
+                    if let Err(err) = self.forward_block_to_executor(block) {
+                        break Err(err);
                     }
                 }
 
-                // Write the latest Celestia height to the block stream.
-                Some(res) = self.latest_celestia_heights.next() => {
+                Some((celestia_height, res)) = self.tasks.join_next() => {
+                    match flatten(res) {
+                        Ok(blocks) => self.cache_reconstructed_blocks(blocks),
+                        Err(error) => break Err(error).wrap_err_with(|| format!(
+                            "critically failed fetching Celestia block at height \
+                            `{celestia_height}` and reconstructing sequencer block data from it"
+                        )),
+                    }
+                }
+
+                Some(res) = self.latest_heights.next() => {
                     match res {
                         Ok(height) => {
-                            debug!(height, "received height from Celestia");
-                            if block_stream.inner_mut().update_latest_observed_height_if_greater(height)
-                            && block_stream.inner().is_exhausted()
-                            {
-                                info!(
-                                    reference_height = block_stream.inner().track_heights.reference_height(),
-                                    variance = block_stream.inner().track_heights.variance(),
-                                    max_permitted_height = block_stream.inner().track_heights.max_permitted(),
-                                    "updated reference height, but the block stream is exhausted and won't fetch past its permitted window",
-                                );
-                            }
+                            info!(height, "observed latest height from Celestia");
+                            self.record_latest_celestia_height(height);
                         }
                         Err(error) => {
                             warn!(
@@ -272,21 +317,10 @@ impl Reader {
                     }
                 }
 
-                // Pull the the next reconstructed block from the stream reading off of Celestia.
-                Some(reconstructed) = block_stream.next() => {
-                    for block in reconstructed.blocks {
-                        if let Err(e) = sequential_blocks.insert(block) {
-                            warn!(
-                                error = &e as &StdError,
-                                "failed pushing block into cache; dropping",
-                            );
-                        }
-                    }
-                }
             );
         };
 
-        // XXX: explicitly setting the message (usually implicitly set by tracing)
+        // XXX: explicitly setting the event message (usually implicitly set by tracing)
         let message = "shutting down";
         match reason {
             Ok(reason) => {
@@ -299,315 +333,207 @@ impl Reader {
             }
         }
     }
-}
 
-#[derive(Debug)]
-struct TrackHeights {
-    reference_height: u64,
-    variance: u32,
-    last_observed: u64,
-    next_height: u64,
-}
-
-impl TrackHeights {
-    fn reference_height(&self) -> u64 {
-        self.reference_height
-    }
-
-    fn variance(&self) -> u32 {
-        self.variance
-    }
-
-    fn max_permitted(&self) -> u64 {
-        self.reference_height.saturating_add(self.variance.into())
-    }
-
-    fn next_height_to_fetch(&self) -> Option<u64> {
-        if self.next_height <= self.max_permitted() && self.next_height <= self.last_observed {
-            Some(self.next_height)
-        } else {
-            None
-        }
-    }
-
-    fn increment_next_height_to_fetch(&mut self) {
-        self.next_height = self
-            .next_height
-            .checked_add(1)
-            .expect("this value should never reach u64::MAX");
-    }
-
-    fn update_reference_height_if_greater(&mut self, height: u64) -> bool {
-        let updated = self.reference_height < height;
-        if updated {
-            self.reference_height = height;
-        }
-        updated
-    }
-
-    fn update_latest_observed_height_if_greater(&mut self, height: u64) -> bool {
-        let updated = self.last_observed < height;
-        if updated {
-            self.last_observed = height;
-        }
-        updated
-    }
-}
-
-pin_project! {
-    struct ReconstructedBlocksStream {
-        track_heights: TrackHeights,
-
-        in_progress: FuturesMap<u64, eyre::Result<ReconstructedBlocks>>,
-
-        client: CelestiaClient,
-        verifier: BlockVerifier,
-        sequencer_namespace: Namespace,
-        rollup_namespace: Namespace,
-    }
-}
-
-impl ReconstructedBlocksStream {
-    fn is_exhausted(&self) -> bool {
-        self.in_progress.is_empty() && self.track_heights.next_height_to_fetch().is_none()
-    }
-
-    fn update_reference_height_if_greater(&mut self, height: u64) -> bool {
-        self.track_heights
-            .update_reference_height_if_greater(height)
-    }
-
-    fn update_latest_observed_height_if_greater(&mut self, height: u64) -> bool {
-        self.track_heights
-            .update_latest_observed_height_if_greater(height)
-    }
-}
-
-impl Stream for ReconstructedBlocksStream {
-    type Item = ReconstructedBlocks;
-
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        use futures_bounded::PushError;
-
-        let this = self.project();
-        // Try to spawn off as many futures as possible by filling up
-        // our queue of futures.
-        while let Some(height) = this.track_heights.next_height_to_fetch() {
-            match this.in_progress.try_push(
-                height,
-                fetch_blocks_at_celestia_height(
-                    this.client.clone(),
-                    this.verifier.clone(),
-                    height,
-                    *this.sequencer_namespace,
-                    *this.rollup_namespace,
-                ),
-            ) {
-                Err(PushError::BeyondCapacity(_)) => {
-                    break;
-                }
-                Err(PushError::Replaced(_)) => {
-                    error!(
-                        %height,
-                        "scheduled to fetch blocks, but a fetch for the same height was already in-flight",
-                    );
-                }
-                Ok(()) => {
-                    debug!(height = %height, "scheduled fetch of blocks");
-                    this.track_heights.increment_next_height_to_fetch();
-                }
-            }
-        }
-
-        let (height, res) = futures::ready!(this.in_progress.poll_unpin(cx));
-
-        // Ok branch (contains the block or a fetch error): propagate the error up
-        //
-        // Err branch (timeout): a fetch timing out is not a problem: we can just reschedule it.
-        match res {
-            Ok(Ok(blocks)) => return Poll::Ready(Some(blocks)),
-            // XXX: The error is silently dropped as this relies on fetch_blocks_at_celestia_height
-            //      emitting an error event as part of its instrumentation.
-            Ok(Err(_)) => {}
-            Err(timeout) => {
-                warn!(%height, error = %timeout, "request for height timed out, rescheduling",
-                );
-                let res = {
-                    this.in_progress.try_push(
-                        height,
-                        fetch_blocks_at_celestia_height(
-                            this.client.clone(),
-                            this.verifier.clone(),
-                            height,
-                            *this.sequencer_namespace,
-                            *this.rollup_namespace,
-                        ),
-                    )
-                };
-                assert!(
-                    res.is_ok(),
-                    "there must be space in the map after a future timed out"
+    fn cache_reconstructed_blocks(&mut self, reconstructed: ReconstructedBlocks) {
+        for block in reconstructed.blocks {
+            let block_hash = block.block_hash;
+            let celestia_height = block.celestia_height;
+            let sequencer_height = block.sequencer_height().value();
+            if let Err(e) = self.block_cache.insert(block) {
+                warn!(
+                    error = %eyre::Report::new(e),
+                    source_celestia_height = celestia_height,
+                    sequencer_height,
+                    block_hash = %base64(&block_hash),
+                    "failed pushing reconstructed block into sequential cache; dropping it",
                 );
             }
         }
+    }
 
-        // We only reach this part if `futures::ready!` above didn't short circuit and
-        // if no result was ready.
-        if this.track_heights.next_height_to_fetch().is_none() {
-            Poll::Ready(None)
-        } else {
-            Poll::Pending
+    fn can_schedule_blobs(&self) -> bool {
+        let Some(head_height) = self.celestia_head_height else {
+            return false;
+        };
+
+        let is_next_below_head = self.celestia_next_height <= head_height;
+        let is_next_in_window = self.celestia_next_height <= self.max_permitted_celestia_height();
+        let is_capacity_in_task_set = self.tasks.len() < 10;
+
+        is_next_below_head && is_next_in_window && is_capacity_in_task_set
+    }
+
+    fn schedule_new_blobs(&mut self) {
+        let mut scheduled = vec![];
+        while self.can_schedule_blobs() {
+            let height = self.celestia_next_height;
+            self.celestia_next_height = self.celestia_next_height.saturating_add(1);
+            let task = FetchConvertAndVerify {
+                blob_verifier: self.blob_verifier.clone(),
+                celestia_client: self.celestia_client.clone(),
+                celestia_height: height,
+                rollup_id: self.rollup_id,
+                rollup_namespace: self.rollup_namespace,
+                sequencer_namespace: self.sequencer_namespace,
+            };
+            self.tasks.spawn(height, task.execute());
+            scheduled.push(height);
+        }
+        if !scheduled.is_empty() {
+            info!(
+                heights = %json(&scheduled),
+                "scheduled next batch of Celestia heights",
+            );
         }
     }
 
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.in_progress.len(), None)
+    fn advance_reference_celestia_height(&mut self, candidate: u64) {
+        let reference_height = &mut self.celestia_reference_height;
+        *reference_height = max(*reference_height, candidate);
+    }
+
+    fn forward_block_to_executor(&mut self, block: ReconstructedBlock) -> eyre::Result<()> {
+        let celestia_height = block.celestia_height;
+        match self.executor.try_send_firm_block(block) {
+            Ok(()) => self.advance_reference_celestia_height(celestia_height),
+            Err(TrySendError::Full(block)) => {
+                trace!(
+                    "executor channel is full; rescheduling block fetch until the channel opens up"
+                );
+                self.enqueued_block = enqueue_block(self.executor.clone(), block).boxed().fuse();
+            }
+
+            Err(TrySendError::Closed(_)) => bail!("exiting because executor channel is closed"),
+        }
+        Ok(())
+    }
+
+    /// Returns the maximum permitted Celestia height given the current state.
+    ///
+    /// The maximum permitted Celestia height is calculated as `ref_height + 6 * variance`, with:
+    ///
+    /// - `ref_height` the height from which the last expected sequencer block was derived,
+    /// - `variance` the `celestia_block_variance` received from the connected rollup genesis info,
+    /// - and the factor 6 based on the assumption that there are up to 6 sequencer heights stored
+    ///   per Celestia height.
+    fn max_permitted_celestia_height(&self) -> u64 {
+        max_permitted_celestia_height(self.celestia_reference_height, self.celestia_variance)
+    }
+
+    fn record_latest_celestia_height(&mut self, height: u64) {
+        let head_height = self.celestia_head_height.get_or_insert(height);
+        *head_height = max(*head_height, height);
+    }
+
+    fn waiting_for_executor_capacity(&self) -> bool {
+        !self.enqueued_block.is_terminated()
     }
 }
 
-/// Fetches all blob data for the desired rollup at celestia `height`.
-///
-/// Performs the following operations:
-/// 1. retrieves sequencer blobs at `height` matching `sequencer_namespace`;
-/// 2. verifies the sequencer blobs against sequencer, dropping all blobs that failed verification;
-/// 3. retrieves all rollup blobs at `height` matching `rollup_namespace` and the block hash stored
-///    in the sequencer blob.
-#[instrument(
-    skip_all,
-    fields(
-        %celestia_height,
-        namespace.sequencer = %base64(&sequencer_namespace.as_bytes()),
-        namespace.rollup = %base64(&rollup_namespace.as_bytes()),
-    ),
-    err
-)]
-async fn fetch_blocks_at_celestia_height(
-    client: CelestiaClient,
-    verifier: BlockVerifier,
+struct FetchConvertAndVerify {
+    blob_verifier: Arc<BlobVerifier>,
+    celestia_client: CelestiaClient,
     celestia_height: u64,
+    rollup_id: RollupId,
+    rollup_namespace: Namespace,
     sequencer_namespace: Namespace,
-    rollup_namespace: Namespace,
-) -> eyre::Result<ReconstructedBlocks> {
-    use futures::TryStreamExt as _;
-    use tracing_futures::Instrument as _;
-    // XXX: Define the error conditions for which fetching the blob should be rescheduled.
-    // XXX: This object contains information about bad blobs that belonged to the
-    // wrong namespace or had other issues. Consider reporting them.
-    let sequencer_blobs = match client
-        .get_sequencer_blobs(celestia_height, sequencer_namespace)
-        .await
-    {
-        Err(e) if celestia_client::is_blob_not_found(&e) => {
-            info!("no sequencer blobs found");
-            return Ok(ReconstructedBlocks {
-                celestia_height,
-                sequencer_namespace,
-                rollup_namespace,
-                blocks: vec![],
-            });
-        }
-        Err(e) => return Err(e).wrap_err("failed to fetch sequencer data from celestia"),
-        Ok(response) => response.sequencer_blobs,
-    };
-
-    debug!(
-        %celestia_height,
-        sequencer_heights = %json(&ReportSequencerHeights(&sequencer_blobs)),
-        "received sequencer header blobs from Celestia"
-    );
-
-    // FIXME(https://github.com/astriaorg/astria/issues/729): Sequencer blobs can have duplicate block hashes.
-    // We ignore this here and handle that in downstream processing (the sequential cash will reject
-    // the second blob), but we should probably do more reporting on this.
-    let blocks = futures::stream::iter(sequencer_blobs)
-        .then(move |blob| {
-            let client = client.clone();
-            let verifier = verifier.clone();
-            process_sequencer_blob(client, verifier, celestia_height, rollup_namespace, blob)
-        })
-        .inspect_err(|error| {
-            warn!(%error, "failed to reconstruct block from celestia blob");
-        })
-        .filter_map(|x| ready(x.ok()))
-        .in_current_span()
-        .collect()
-        .await;
-    let reconstructed = ReconstructedBlocks {
-        celestia_height,
-        sequencer_namespace,
-        rollup_namespace,
-        blocks,
-    };
-    info!(
-        blocks = %json(&ReportReconstructedBlocks(&reconstructed)),
-        "received and validated reconstructed Sequencer blocks from Celestia",
-    );
-    Ok(reconstructed)
 }
 
-// FIXME: Validation performs a lookup for every sequencer blob at the same height.
-//        That's unnecessary: just get the validation info once for each height and
-//        validate all blocks at the same height in one go.
-#[instrument(
-    skip_all,
-    fields(
-        blob.sequencer_height = sequencer_blob.height().value(),
-        blob.block_hash = %base64(&sequencer_blob.block_hash()),
-        celestia_rollup_namespace = %base64(rollup_namespace.as_bytes()),
-    ),
-    err,
-)]
-async fn process_sequencer_blob(
-    client: CelestiaClient,
-    verifier: BlockVerifier,
-    celestia_height: u64,
-    rollup_namespace: Namespace,
-    sequencer_blob: CelestiaSequencerBlob,
-) -> eyre::Result<ReconstructedBlock> {
-    verifier
-        .verify_blob(&sequencer_blob)
-        .await
-        .wrap_err("failed validating sequencer blob retrieved from celestia")?;
-    let mut rollup_blobs = client
-        .get_rollup_blobs_matching_sequencer_blob(
+impl FetchConvertAndVerify {
+    #[instrument( skip_all, fields(
+        celestia_height = self.celestia_height,
+        rollup_namespace = %base64(self.rollup_namespace.as_bytes()),
+        sequencer_namespace = %base64(self.sequencer_namespace.as_bytes()),
+    ))]
+    async fn execute(self) -> eyre::Result<ReconstructedBlocks> {
+        let Self {
+            blob_verifier,
+            celestia_client,
+            celestia_height,
+            rollup_id,
+            rollup_namespace,
+            sequencer_namespace,
+        } = self;
+
+        let new_blobs = fetch_new_blobs(
+            celestia_client,
             celestia_height,
             rollup_namespace,
-            &sequencer_blob,
+            sequencer_namespace,
         )
         .await
-        .wrap_err("failed fetching rollup blobs from celestia")?;
-    debug!(
-        %celestia_height,
-        number_of_blobs = rollup_blobs.len(),
-        "received rollup blobs from Celestia"
-    );
-    ensure!(
-        rollup_blobs.len() <= 1,
-        "received more than one celestia rollup blob for the given namespace and height"
-    );
-    let transactions = rollup_blobs
-        .pop()
-        .map(|blob| blob.into_unchecked().transactions)
-        .unwrap_or_default();
-    Ok(ReconstructedBlock {
-        celestia_height,
-        block_hash: sequencer_blob.block_hash(),
-        header: sequencer_blob.header().clone(),
-        transactions,
-    })
+        .wrap_err("failed fetching blobs from Celestia")?;
+
+        info!(
+            number_of_header_blobs = new_blobs.len_header_blobs(),
+            number_of_rollup_blobs = new_blobs.len_rollup_blobs(),
+            "received new Celestia blobs"
+        );
+
+        let decode_span = info_span!("decode_blobs");
+        let decoded_blobs = spawn_blocking(move || {
+            decode_span
+                .in_scope(|| decode_raw_blobs(new_blobs, rollup_namespace, sequencer_namespace))
+        })
+        .await
+        .wrap_err("encountered panic while decoding raw Celestia blobs")?;
+
+        info!(
+            number_of_header_blobs = decoded_blobs.len_header_blobs(),
+            number_of_rollup_blobs = decoded_blobs.len_rollup_blobs(),
+            "decoded Sequencer header and rollup info from raw Celestia blobs",
+        );
+
+        let verified_blobs = verify_and_filter_decoded_blobs(blob_verifier, decoded_blobs).await;
+
+        info!(
+            number_of_verified_header_blobs = verified_blobs.len_header_blobs(),
+            number_of_rollup_blobs = verified_blobs.len_rollup_blobs(),
+            "verified header blobs against Sequencer",
+        );
+
+        let reconstruct_span = info_span!("reconstruct_blocks");
+        let reconstructed = spawn_blocking(move || {
+            reconstruct_span
+                .in_scope(|| reconstruct_blocks_from_verified_blobs(verified_blobs, rollup_id))
+        })
+        .await
+        .wrap_err("encountered panic while reconstructing blocks from verified blobs")?;
+
+        let reconstructed_blocks = ReconstructedBlocks {
+            celestia_height,
+            sequencer_namespace,
+            rollup_namespace,
+            blocks: reconstructed,
+        };
+
+        info!(
+            number_of_final_reconstructed_blocks = reconstructed_blocks.blocks.len(),
+            blocks = %json(&ReportReconstructedBlocks(&reconstructed_blocks)),
+            "reconstructed block information by matching verified Sequencer header blobs to rollup blobs",
+        );
+
+        Ok(reconstructed_blocks)
+    }
 }
 
-/// Get the sequencer namespace from the latest sequencer block.
-async fn get_sequencer_namespace(client: SequencerClient) -> eyre::Result<Namespace> {
-    use sequencer_client::SequencerClientExt as _;
+async fn enqueue_block(
+    executor: executor::Handle<StateIsInit>,
+    block: ReconstructedBlock,
+) -> Result<u64, SendError<ReconstructedBlock>> {
+    let celestia_height = block.celestia_height;
+    executor.send_firm_block(block).await?;
+    Ok(celestia_height)
+}
 
-    let retry_config = tryhard::RetryFutureConfig::new(10)
+async fn get_sequencer_chain_id(client: SequencerClient) -> eyre::Result<tendermint::chain::Id> {
+    use sequencer_client::Client as _;
+
+    let retry_config = tryhard::RetryFutureConfig::new(u32::MAX)
         .exponential_backoff(Duration::from_millis(100))
         .max_delay(Duration::from_secs(20))
         .on_retry(
-            |attempt: u32,
-             next_delay: Option<Duration>,
-             error: &sequencer_client::extension_trait::Error| {
+            |attempt: u32, next_delay: Option<Duration>, error: &tendermint_rpc::Error| {
                 let wait_duration = next_delay
                     .map(humantime::format_duration)
                     .map(tracing::field::display);
@@ -615,82 +541,20 @@ async fn get_sequencer_namespace(client: SequencerClient) -> eyre::Result<Namesp
                     attempt,
                     wait_duration,
                     error = error as &dyn std::error::Error,
-                    "attempt to grab sequencer block failed; retrying after backoff",
+                    "attempt to fetch sequencer genesis info; retrying after backoff",
                 );
                 futures::future::ready(())
             },
         );
 
-    let block = tryhard::retry_fn(|| client.latest_sequencer_block())
+    let genesis: tendermint::Genesis = tryhard::retry_fn(|| client.genesis())
         .with_config(retry_config)
         .await
-        .wrap_err("failed to get latest commit from sequencer after 10 attempts")?;
+        .wrap_err("failed to get genesis info from Sequencer after a lot of attempts")?;
 
-    Ok(celestia_client::celestia_namespace_v0_from_str(
-        block.header().chain_id().as_str(),
-    ))
+    Ok(genesis.chain_id)
 }
 
-#[cfg(test)]
-mod tests {
-    use super::TrackHeights;
-
-    #[test]
-    fn next_height_within_allowed_and_observed_is_some() {
-        let tracked = TrackHeights {
-            reference_height: 10,
-            variance: 10,
-            last_observed: 20,
-            next_height: 20,
-        };
-        assert_eq!(Some(20), tracked.next_height_to_fetch());
-    }
-
-    #[test]
-    fn next_height_ahead_of_observed_is_none() {
-        let tracked = TrackHeights {
-            reference_height: 10,
-            variance: 20,
-            last_observed: 20,
-            next_height: 21,
-        };
-        assert_eq!(None, tracked.next_height_to_fetch());
-    }
-
-    #[test]
-    fn next_height_ahead_of_permitted_is_none() {
-        let tracked = TrackHeights {
-            reference_height: 10,
-            variance: 10,
-            last_observed: 30,
-            next_height: 21,
-        };
-        assert_eq!(None, tracked.next_height_to_fetch());
-    }
-
-    #[test]
-    fn incrementing_next_height_past_observed_flips_to_none() {
-        let mut tracked = TrackHeights {
-            reference_height: 10,
-            variance: 20,
-            last_observed: 20,
-            next_height: 20,
-        };
-        assert_eq!(Some(20), tracked.next_height_to_fetch());
-        tracked.increment_next_height_to_fetch();
-        assert_eq!(None, tracked.next_height_to_fetch());
-    }
-
-    #[test]
-    fn incrementing_next_height_past_variance_flips_to_none() {
-        let mut tracked = TrackHeights {
-            reference_height: 10,
-            variance: 10,
-            last_observed: 30,
-            next_height: 20,
-        };
-        assert_eq!(Some(20), tracked.next_height_to_fetch());
-        tracked.increment_next_height_to_fetch();
-        assert_eq!(None, tracked.next_height_to_fetch());
-    }
+fn max_permitted_celestia_height(reference: u64, variance: u64) -> u64 {
+    reference.saturating_add(variance.saturating_mul(6))
 }

--- a/crates/astria-conductor/src/celestia/reconstruct.rs
+++ b/crates/astria-conductor/src/celestia/reconstruct.rs
@@ -24,15 +24,16 @@ use super::{
 /// The `verified_blobs` are guaranteed to have unique Sequencer block hashes.
 ///
 /// This process works in the following way:
-/// 1. Each rollup blob contains a sequencer block hash that is matched against `verified_blocks`
+/// 1. Block execution containing rollup data: each rollup blob contains a sequencer block hash that
+///    is matched against `verified_blocks`
 ///    - The rollup blob's rollup ID, transactions, and proof area used to reconstruct a Merkle Tree
 ///      Hash, which must match the root stored in the Sequencer header blob. If it does, a block is
 ///      reconstructed from the information stored in the header and rollup blobs. The sequencer
 ///      header blob is removed from the map.
 ///    - If no sequencer header blob matches the rollup blob (no matching block hash or the Merkle
 ///      path audit failing), then the rollup blob is dropped.
-/// 2. The remaining Sequencer blobs (i.e. those that had no matching rollup blob) are checked for
-///    `rollup_id`:
+/// 2. Empty block execution (no rollup data): The remaining Sequencer blobs (i.e. those that had no
+///    matching rollup blob) are checked for `rollup_id`:
 ///    - if they contained `rollup_id` they are dropped (as they should have had a matching blob but
 ///      none was found).
 ///    - if they did not contain `rollup_id` a Sequencer block is reconstructed.
@@ -75,7 +76,7 @@ pub(super) fn reconstruct_blocks_from_verified_blobs(
         if header_blob.contains_rollup_id(rollup_id) {
             warn!(
                 block_hash = %base64(&header_blob.block_hash()),
-                "sequencer header blob contains the target rollup ID, but no matching rollup blob was found; the blob",
+                "sequencer header blob contains the target rollup ID, but no matching rollup blob was found; dropping it",
             );
         } else {
             reconstructed_blocks.push(ReconstructedBlock {

--- a/crates/astria-conductor/src/celestia/reconstruct.rs
+++ b/crates/astria-conductor/src/celestia/reconstruct.rs
@@ -5,7 +5,6 @@ use celestia_client::{
     CelestiaRollupBlob,
     CelestiaSequencerBlob,
 };
-use sequencer_client::tendermint::block::Height as SequencerHeight;
 use telemetry::display::base64;
 use tracing::{
     info,
@@ -19,19 +18,20 @@ use super::{
 
 /// Reconstructs block information from verified blocks.
 ///
-/// The reconstructed blocks contain a block hash, tendermint header (both extracted from
-/// sequencer header blobs), and transactions (from rollup blobs, if present).
+/// The reconstructed blocks contain a block hash, Sequencer header and rollup transactions
+/// (from rollup blobs, if present).
+///
+/// The `verified_blobs` are guaranteed to have unique Sequencer block hashes.
 ///
 /// This process works in the following way:
-/// 1. Header blobs are placed in a map using a key `(block_hash, height)`.
-///    - header blobs with the same `(block_hash, height)` are dropped.
-/// 2. Each rollup blob is matched against all header blobs using Merkle proofs and roots.
-///    - A Sequencer block is reconstructed from the the first such match.
-///    - All all other sequencer header blobs with the same block hash but different height are
-///      dropped (it is assumed that sequencer blobs of different height cannot have the same block
-///      hash).
-///    - A rollup blob that has no matching sequencer header blob is dropped.
-/// 3. The remaining Sequencer blobs (i.e. those that had no matching rollup blob) are checked for
+/// 1. Each rollup blob contains a sequencer block hash that is matched against `verified_blocks`
+///    - The rollup blob's rollup ID, transactions, and proof area used to reconstruct a Merkle Tree
+///      Hash, which must match the root stored in the Sequencer header blob. If it does, a block is
+///      reconstructed from the information stored in the header and rollup blobs. The sequencer
+///      header blob is removed from the map.
+///    - If no sequencer header blob matches the rollup blob (no matching block hash or the Merkle
+///      path audit failing), then the rollup blob is dropped.
+/// 2. The remaining Sequencer blobs (i.e. those that had no matching rollup blob) are checked for
 ///    `rollup_id`:
 ///    - if they contained `rollup_id` they are dropped (as they should have had a matching blob but
 ///      none was found).
@@ -40,13 +40,15 @@ pub(super) fn reconstruct_blocks_from_verified_blobs(
     verified_blobs: VerifiedBlobs,
     rollup_id: RollupId,
 ) -> Vec<ReconstructedBlock> {
-    let (celestia_height, header_blobs, rollup_blobs) = verified_blobs.into_parts();
-
-    let mut headers = BlockHashAndHeightToHeader::from_header_blobs(header_blobs);
+    let (celestia_height, mut header_blobs, rollup_blobs) = verified_blobs.into_parts();
 
     let mut reconstructed_blocks = Vec::new();
+
+    // match rollup blobs to header blobs
     for rollup in rollup_blobs {
-        if let Some(header_blob) = headers.remove_header_blob_matching_rollup_blob(&rollup) {
+        if let Some(header_blob) =
+            remove_header_blob_matching_rollup_blob(&mut header_blobs, &rollup)
+        {
             reconstructed_blocks.push(ReconstructedBlock {
                 celestia_height,
                 block_hash: header_blob.block_hash(),
@@ -54,7 +56,7 @@ pub(super) fn reconstruct_blocks_from_verified_blobs(
                 transactions: rollup.into_unchecked().transactions,
             });
         } else {
-            let reason = if headers.any_headers_with_block_hash(rollup.sequencer_block_hash()) {
+            let reason = if header_blobs.contains_key(&rollup.sequencer_block_hash()) {
                 "sequencer header blobs with the same block hash as the rollup blob found, but the \
                  rollup's Merkle proof did not lead any Merkle roots"
             } else {
@@ -68,9 +70,8 @@ pub(super) fn reconstruct_blocks_from_verified_blobs(
         }
     }
 
-    let remaining_headers = headers.map;
-
-    for header_blob in remaining_headers.into_values() {
+    // check left-over header blobs if they expected a rollup blob but none could be found.
+    for header_blob in header_blobs.into_values() {
         if header_blob.contains_rollup_id(rollup_id) {
             warn!(
                 block_hash = %base64(&header_blob.block_hash()),
@@ -88,101 +89,17 @@ pub(super) fn reconstruct_blocks_from_verified_blobs(
     reconstructed_blocks
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-struct Key {
-    block_hash: [u8; 32],
-    height: SequencerHeight,
-}
-
-impl Key {
-    fn from_header_blob(val: &CelestiaSequencerBlob) -> Self {
-        Self {
-            block_hash: val.block_hash(),
-            height: val.height(),
-        }
-    }
-}
-
-struct BlockHashAndHeightToHeader {
-    // The sequencer header blobs grouped by (block_hash, sequencer_height)
-    map: HashMap<Key, CelestiaSequencerBlob>,
-
-    // A reverse index of block_hash -> [(block_hash, sequencer_height)]
-    reverse_index: HashMap<[u8; 32], Vec<Key>>,
-}
-
-impl BlockHashAndHeightToHeader {
-    fn new() -> Self {
-        Self {
-            map: HashMap::new(),
-            reverse_index: HashMap::new(),
-        }
-    }
-
-    fn from_header_blobs(blobs: Vec<CelestiaSequencerBlob>) -> Self {
-        let mut this = Self::new();
-        for blob in blobs {
-            if let Some(dropped) = this.insert(blob) {
-                warn!(
-                    block_hash = %base64(&dropped.block_hash()),
-                    sequencer_height = %dropped.height(),
-                    "more than one sequencer header blob with the same block hash and height passed verification; dropping previous",
-                );
-            }
-        }
-        this
-    }
-
-    fn insert(&mut self, blob: CelestiaSequencerBlob) -> Option<CelestiaSequencerBlob> {
-        let key = Key::from_header_blob(&blob);
-        if let Some(old) = self.map.insert(key, blob) {
-            return Some(old);
-        }
-        self.reverse_index
-            .entry(key.block_hash)
-            .and_modify(|keys| keys.push(key))
-            .or_insert_with(|| vec![key]);
-        None
-    }
-
-    fn any_headers_with_block_hash(&self, block_hash: [u8; 32]) -> bool {
-        self.reverse_index.contains_key(&block_hash)
-    }
-
-    fn remove_header_blob_matching_rollup_blob(
-        &mut self,
-        rollup: &CelestiaRollupBlob,
-    ) -> Option<CelestiaSequencerBlob> {
-        let position_of_matching_key = self
-            .reverse_index
-            .get(&rollup.sequencer_block_hash())?
-            .iter()
-            .position(|key| {
-                let header = self
-                    .map
-                    .get(key)
-                    .expect("keys stored in the reverse index must exist in the map");
-                verify_rollup_blob_against_sequencer_blob(rollup, header)
-            })?;
-
-        let mut all_keys = self
-            .reverse_index
-            .remove(&rollup.sequencer_block_hash())
-            .expect("entry exists, it was just accessed above");
-
-        let target_key = all_keys.swap_remove(position_of_matching_key);
-
-        let target_header = self
-            .map
-            .remove(&target_key)
-            .expect("keys retrieved from the reverse index must exist");
-
-        for key in all_keys {
-            self.map.remove(&key);
-        }
-
-        Some(target_header)
-    }
+fn remove_header_blob_matching_rollup_blob(
+    headers: &mut HashMap<[u8; 32], CelestiaSequencerBlob>,
+    rollup: &CelestiaRollupBlob,
+) -> Option<CelestiaSequencerBlob> {
+    // chaining methods and returning () to use the ? operator and to not bind the value
+    headers
+        .get(&rollup.sequencer_block_hash())
+        .and_then(|header| {
+            verify_rollup_blob_against_sequencer_blob(rollup, header).then_some(())
+        })?;
+    headers.remove(&rollup.sequencer_block_hash())
 }
 
 fn verify_rollup_blob_against_sequencer_blob(

--- a/crates/astria-conductor/src/celestia/reconstruct.rs
+++ b/crates/astria-conductor/src/celestia/reconstruct.rs
@@ -1,0 +1,201 @@
+use std::collections::HashMap;
+
+use astria_core::sequencer::v1::RollupId;
+use celestia_client::{
+    CelestiaRollupBlob,
+    CelestiaSequencerBlob,
+};
+use sequencer_client::tendermint::block::Height as SequencerHeight;
+use telemetry::display::base64;
+use tracing::{
+    info,
+    warn,
+};
+
+use super::{
+    verify::VerifiedBlobs,
+    ReconstructedBlock,
+};
+
+/// Reconstructs block information from verified blocks.
+///
+/// The reconstructed blocks contain a block hash, tendermint header (both extracted from
+/// sequencer header blobs), and transactions (from rollup blobs, if present).
+///
+/// This process works in the following way:
+/// 1. Header blobs are placed in a map using a key `(block_hash, height)`.
+///    - header blobs with the same `(block_hash, height)` are dropped.
+/// 2. Each rollup blob is matched against all header blobs using Merkle proofs and roots.
+///    - A Sequencer block is reconstructed from the the first such match.
+///    - All all other sequencer header blobs with the same block hash but different height are
+///      dropped (it is assumed that sequencer blobs of different height cannot have the same block
+///      hash).
+///    - A rollup blob that has no matching sequencer header blob is dropped.
+/// 3. The remaining Sequencer blobs (i.e. those that had no matching rollup blob) are checked for
+///    `rollup_id`:
+///    - if they contained `rollup_id` they are dropped (as they should have had a matching blob but
+///      none was found).
+///    - if they did not contain `rollup_id` a Sequencer block is reconstructed.
+pub(super) fn reconstruct_blocks_from_verified_blobs(
+    verified_blobs: VerifiedBlobs,
+    rollup_id: RollupId,
+) -> Vec<ReconstructedBlock> {
+    let (celestia_height, header_blobs, rollup_blobs) = verified_blobs.into_parts();
+
+    let mut headers = BlockHashAndHeightToHeader::from_header_blobs(header_blobs);
+
+    let mut reconstructed_blocks = Vec::new();
+    for rollup in rollup_blobs {
+        if let Some(header_blob) = headers.remove_header_blob_matching_rollup_blob(&rollup) {
+            reconstructed_blocks.push(ReconstructedBlock {
+                celestia_height,
+                block_hash: header_blob.block_hash(),
+                header: header_blob.into_unchecked().header,
+                transactions: rollup.into_unchecked().transactions,
+            });
+        } else {
+            let reason = if headers.any_headers_with_block_hash(rollup.sequencer_block_hash()) {
+                "sequencer header blobs with the same block hash as the rollup blob found, but the \
+                 rollup's Merkle proof did not lead any Merkle roots"
+            } else {
+                "no sequencer header blob matching the rollup blob's block hash found"
+            };
+            info!(
+                block_hash = %base64(&rollup.sequencer_block_hash()),
+                reason,
+                "dropping rollup blob",
+            );
+        }
+    }
+
+    let remaining_headers = headers.map;
+
+    for header_blob in remaining_headers.into_values() {
+        if header_blob.contains_rollup_id(rollup_id) {
+            warn!(
+                block_hash = %base64(&header_blob.block_hash()),
+                "sequencer header blob contains the target rollup ID, but no matching rollup blob was found; the blob",
+            );
+        } else {
+            reconstructed_blocks.push(ReconstructedBlock {
+                celestia_height,
+                block_hash: header_blob.block_hash(),
+                header: header_blob.into_unchecked().header,
+                transactions: vec![],
+            });
+        }
+    }
+    reconstructed_blocks
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct Key {
+    block_hash: [u8; 32],
+    height: SequencerHeight,
+}
+
+impl Key {
+    fn from_header_blob(val: &CelestiaSequencerBlob) -> Self {
+        Self {
+            block_hash: val.block_hash(),
+            height: val.height(),
+        }
+    }
+}
+
+struct BlockHashAndHeightToHeader {
+    // The sequencer header blobs grouped by (block_hash, sequencer_height)
+    map: HashMap<Key, CelestiaSequencerBlob>,
+
+    // A reverse index of block_hash -> [(block_hash, sequencer_height)]
+    reverse_index: HashMap<[u8; 32], Vec<Key>>,
+}
+
+impl BlockHashAndHeightToHeader {
+    fn new() -> Self {
+        Self {
+            map: HashMap::new(),
+            reverse_index: HashMap::new(),
+        }
+    }
+
+    fn from_header_blobs(blobs: Vec<CelestiaSequencerBlob>) -> Self {
+        let mut this = Self::new();
+        for blob in blobs {
+            if let Some(dropped) = this.insert(blob) {
+                warn!(
+                    block_hash = %base64(&dropped.block_hash()),
+                    sequencer_height = %dropped.height(),
+                    "more than one sequencer header blob with the same block hash and height passed verification; dropping previous",
+                );
+            }
+        }
+        this
+    }
+
+    fn insert(&mut self, blob: CelestiaSequencerBlob) -> Option<CelestiaSequencerBlob> {
+        let key = Key::from_header_blob(&blob);
+        if let Some(old) = self.map.insert(key, blob) {
+            return Some(old);
+        }
+        self.reverse_index
+            .entry(key.block_hash)
+            .and_modify(|keys| keys.push(key))
+            .or_insert_with(|| vec![key]);
+        None
+    }
+
+    fn any_headers_with_block_hash(&self, block_hash: [u8; 32]) -> bool {
+        self.reverse_index.contains_key(&block_hash)
+    }
+
+    fn remove_header_blob_matching_rollup_blob(
+        &mut self,
+        rollup: &CelestiaRollupBlob,
+    ) -> Option<CelestiaSequencerBlob> {
+        let position_of_matching_key = self
+            .reverse_index
+            .get(&rollup.sequencer_block_hash())?
+            .iter()
+            .position(|key| {
+                let header = self
+                    .map
+                    .get(key)
+                    .expect("keys stored in the reverse index must exist in the map");
+                verify_rollup_blob_against_sequencer_blob(rollup, header)
+            })?;
+
+        let mut all_keys = self
+            .reverse_index
+            .remove(&rollup.sequencer_block_hash())
+            .expect("entry exists, it was just accessed above");
+
+        let target_key = all_keys.swap_remove(position_of_matching_key);
+
+        let target_header = self
+            .map
+            .remove(&target_key)
+            .expect("keys retrieved from the reverse index must exist");
+
+        for key in all_keys {
+            self.map.remove(&key);
+        }
+
+        Some(target_header)
+    }
+}
+
+fn verify_rollup_blob_against_sequencer_blob(
+    rollup_blob: &CelestiaRollupBlob,
+    sequencer_blob: &CelestiaSequencerBlob,
+) -> bool {
+    rollup_blob
+        .proof()
+        .audit()
+        .with_root(sequencer_blob.rollup_transactions_root())
+        .with_leaf_builder()
+        .write(&rollup_blob.rollup_id().get())
+        .write(&merkle::Tree::from_leaves(rollup_blob.transactions()).root())
+        .finish_leaf()
+        .perform()
+}

--- a/crates/astria-conductor/src/celestia/reporting.rs
+++ b/crates/astria-conductor/src/celestia/reporting.rs
@@ -36,17 +36,10 @@ impl<'a> Serialize for ReportReconstructedBlocks<'a> {
     where
         S: serde::Serializer,
     {
-        const FIELDS: [&str; 4] = [
-            "celestia_height",
-            "sequencer_namespace",
-            "rollup_namespace",
-            "reconstructed_blocks",
-        ];
+        const FIELDS: [&str; 2] = ["celestia_height", "reconstructed_blocks"];
         let mut state = serializer.serialize_struct("ReconstructedBlocksInfo", FIELDS.len())?;
         state.serialize_field(FIELDS[0], &self.0.celestia_height)?;
-        state.serialize_field(FIELDS[1], &base64(&self.0.sequencer_namespace.as_bytes()))?;
-        state.serialize_field(FIELDS[2], &base64(self.0.rollup_namespace.as_bytes()))?;
-        state.serialize_field(FIELDS[3], &ReportReconstructedBlocksSeq(&self.0.blocks))?;
+        state.serialize_field(FIELDS[1], &ReportReconstructedBlocksSeq(&self.0.blocks))?;
         state.end()
     }
 }

--- a/crates/astria-conductor/src/celestia/verify.rs
+++ b/crates/astria-conductor/src/celestia/verify.rs
@@ -1,0 +1,342 @@
+use std::{
+    sync::Arc,
+    time::Duration,
+};
+
+use astria_eyre::{
+    eyre,
+    eyre::{
+        ensure,
+        WrapErr as _,
+    },
+};
+use celestia_client::{
+    CelestiaRollupBlob,
+    CelestiaSequencerBlob,
+};
+use moka::future::Cache;
+use sequencer_client::{
+    tendermint::block::{
+        signed_header::SignedHeader,
+        Height as SequencerHeight,
+    },
+    tendermint_rpc,
+    Client as _,
+    HttpClient as SequencerClient,
+};
+use telemetry::display::base64;
+use tokio_util::task::JoinMap;
+use tracing::{
+    info,
+    warn,
+};
+use tryhard::{
+    backoff_strategies::BackoffStrategy,
+    retry_fn,
+    RetryFutureConfig,
+    RetryPolicy,
+};
+
+use super::{
+    block_verifier,
+    convert::ConvertedBlobs,
+};
+use crate::utils::flatten;
+
+pub(super) struct VerifiedBlobs {
+    celestia_height: u64,
+    header_blobs: Vec<CelestiaSequencerBlob>,
+    rollup_blobs: Vec<CelestiaRollupBlob>,
+}
+
+impl VerifiedBlobs {
+    pub(super) fn len_header_blobs(&self) -> usize {
+        self.header_blobs.len()
+    }
+
+    pub(super) fn len_rollup_blobs(&self) -> usize {
+        self.rollup_blobs.len()
+    }
+
+    pub(super) fn into_parts(self) -> (u64, Vec<CelestiaSequencerBlob>, Vec<CelestiaRollupBlob>) {
+        (self.celestia_height, self.header_blobs, self.rollup_blobs)
+    }
+}
+
+/// Task key to track verification of multiple [`CelestiaSequencerBlob`]s.
+///
+/// The index is necessary because two keys might have clashing hashes and heights.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct VerificationTaskKey {
+    index: usize,
+    block_hash: [u8; 32],
+    sequencer_height: SequencerHeight,
+}
+
+/// Returns blobs that could be verified against Sequencer.
+pub(super) async fn verify_and_filter_decoded_blobs(
+    blob_verifier: Arc<BlobVerifier>,
+    converted_blobs: ConvertedBlobs,
+) -> VerifiedBlobs {
+    let (celestia_height, header_blobs, rollup_blobs) = converted_blobs.into_parts();
+
+    let mut verification_tasks = JoinMap::new();
+    let mut verified_header_blobs = Vec::with_capacity(header_blobs.len());
+
+    for (index, blob) in header_blobs.into_iter().enumerate() {
+        verification_tasks.spawn(
+            VerificationTaskKey {
+                index,
+                block_hash: blob.block_hash(),
+                sequencer_height: blob.height(),
+            },
+            blob_verifier.clone().verify_header_blob(blob),
+        );
+    }
+
+    while let Some((key, verification_result)) = verification_tasks.join_next().await {
+        match flatten(verification_result) {
+            Ok(verified_blob) => verified_header_blobs.push(verified_blob),
+            Err(error) => {
+                info!(
+                    block_hash = %base64(&key.block_hash),
+                    sequencer_height = %key.sequencer_height,
+                    %error,
+                    "verification of sequencer blob failed; dropping it"
+                );
+            }
+        }
+    }
+
+    VerifiedBlobs {
+        celestia_height,
+        header_blobs: verified_header_blobs,
+        rollup_blobs,
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum VerificationMetaError {
+    #[error("cannot verify a sequencer height zero")]
+    CantVerifyHeightZero,
+    #[error("failed fetching sequencer block commit for height {height}")]
+    FetchCommit {
+        height: SequencerHeight,
+        source: tendermint_rpc::Error,
+    },
+    #[error(
+        "failed fetching Sequencer validators at height `{prev_height}` (to validate a \
+         Celestia-derived Sequencer block at height `{height}`)"
+    )]
+    FetchValidators {
+        prev_height: SequencerHeight,
+        height: SequencerHeight,
+        source: tendermint_rpc::Error,
+    },
+
+    #[error(
+        "failed ensuring quorum for commit at height `{height_of_commit}` using validator set at \
+         height `{height_of_validator_set}`"
+    )]
+    NoQuorum {
+        height_of_commit: SequencerHeight,
+        height_of_validator_set: SequencerHeight,
+        source: block_verifier::QuorumError,
+    },
+}
+
+/// Data required to verify a
+#[derive(Clone, Debug)]
+struct VerificationMeta {
+    commit_header: SignedHeader,
+}
+
+impl VerificationMeta {
+    async fn fetch(
+        client: SequencerClient,
+        height: SequencerHeight,
+    ) -> Result<Self, VerificationMetaError> {
+        if height.value() == 0 {
+            return Err(VerificationMetaError::CantVerifyHeightZero);
+        }
+        let prev_height = SequencerHeight::try_from(height.value().saturating_sub(1)).expect(
+            "BUG: should always be able to convert a decremented cometbft height back to its \
+             original type; if this is not the case then some fundamentals of cometbft or \
+             tendermint-rs/cometbft-rs no longer hold (or this code has been running several \
+             decades and the chain's height is greater u32::MAX)",
+        );
+        let (commit_response, validators_response) = tokio::try_join!(
+            fetch_commit_with_retry(client.clone(), height),
+            fetch_validators_with_retry(client.clone(), prev_height, height),
+        )?;
+        super::ensure_commit_has_quorum(
+            &commit_response.signed_header.commit,
+            &validators_response,
+            &commit_response.signed_header.header.chain_id,
+        )
+        .map_err(|source| VerificationMetaError::NoQuorum {
+            height_of_commit: height,
+            height_of_validator_set: prev_height,
+            source,
+        })?;
+
+        Ok(Self {
+            commit_header: commit_response.signed_header,
+        })
+    }
+}
+
+pub(super) struct BlobVerifier {
+    cache: Cache<SequencerHeight, VerificationMeta>,
+    sequencer_cometbft_client: SequencerClient,
+}
+
+impl BlobVerifier {
+    pub(super) fn new(sequencer_cometbft_client: SequencerClient) -> Self {
+        Self {
+            // Cache for verifying 1_000 celestia heights, assuming 6 sequencer heights per Celestia
+            // height
+            cache: Cache::new(6_000),
+            sequencer_cometbft_client,
+        }
+    }
+
+    async fn verify_header_blob(
+        self: Arc<Self>,
+        blob: CelestiaSequencerBlob,
+    ) -> eyre::Result<CelestiaSequencerBlob> {
+        use base64::prelude::*;
+        let height = blob.height();
+        let meta = self
+            .cache
+            .try_get_with(
+                height,
+                VerificationMeta::fetch(self.sequencer_cometbft_client.clone(), height),
+            )
+            .await
+            .wrap_err("failed getting data necessary to verify the sequencer header blob")?;
+        ensure!(
+            &meta.commit_header.header.chain_id == blob.cometbft_chain_id(),
+            "expected cometbft chain ID `{}`, got `{}`",
+            meta.commit_header.header.chain_id,
+            blob.cometbft_chain_id(),
+        );
+        ensure!(
+            meta.commit_header.commit.block_id.hash.as_bytes() == blob.block_hash(),
+            "block hash `{}` stored in blob does not match block hash `{}` of sequencer block",
+            BASE64_STANDARD.encode(blob.block_hash()),
+            BASE64_STANDARD.encode(meta.commit_header.commit.block_id.hash.as_bytes()),
+        );
+        Ok(blob)
+    }
+}
+
+async fn fetch_commit_with_retry(
+    client: SequencerClient,
+    height: SequencerHeight,
+) -> Result<tendermint_rpc::endpoint::commit::Response, VerificationMetaError> {
+    let retry_config = RetryFutureConfig::new(u32::MAX)
+        .custom_backoff(CometBftRetryStrategy::new(Duration::from_millis(100)))
+        .max_delay(Duration::from_secs(10))
+        .on_retry(
+            |attempt: u32, next_delay: Option<Duration>, error: &tendermint_rpc::Error| {
+                let wait_duration = next_delay
+                    .map(humantime::format_duration)
+                    .map(tracing::field::display);
+                warn!(
+                    attempt,
+                    wait_duration,
+                    error = error as &dyn std::error::Error,
+                    "attempt to fetch Sequencer validators failed; retrying after delay",
+                );
+                futures::future::ready(())
+            },
+        );
+    retry_fn(move || {
+        let client = client.clone();
+        async move { client.commit(height).await }
+    })
+    .with_config(retry_config)
+    .await
+    .map_err(|source| VerificationMetaError::FetchCommit {
+        height,
+        source,
+    })
+}
+
+async fn fetch_validators_with_retry(
+    client: SequencerClient,
+    prev_height: SequencerHeight,
+    height: SequencerHeight,
+) -> Result<tendermint_rpc::endpoint::validators::Response, VerificationMetaError> {
+    let retry_config = RetryFutureConfig::new(u32::MAX)
+        .custom_backoff(CometBftRetryStrategy::new(Duration::from_millis(100)))
+        .max_delay(Duration::from_secs(10))
+        .on_retry(
+            |attempt: u32, next_delay: Option<Duration>, error: &tendermint_rpc::Error| {
+                let wait_duration = next_delay
+                    .map(humantime::format_duration)
+                    .map(tracing::field::display);
+                warn!(
+                    attempt,
+                    wait_duration,
+                    error = error as &dyn std::error::Error,
+                    "attempt to fetch Sequencer validators failed; retrying after delay",
+                );
+                futures::future::ready(())
+            },
+        );
+    retry_fn(move || {
+        let client = client.clone();
+        async move {
+            client
+                .validators(prev_height, tendermint_rpc::Paging::Default)
+                .await
+        }
+    })
+    .with_config(retry_config)
+    .await
+    .map_err(|source| VerificationMetaError::FetchValidators {
+        height,
+        prev_height,
+        source,
+    })
+}
+
+struct CometBftRetryStrategy {
+    delay: Duration,
+}
+
+impl CometBftRetryStrategy {
+    fn new(initial_duration: Duration) -> Self {
+        Self {
+            delay: initial_duration,
+        }
+    }
+}
+
+impl<'a> BackoffStrategy<'a, tendermint_rpc::Error> for CometBftRetryStrategy {
+    type Output = RetryPolicy;
+
+    fn delay(&mut self, _attempt: u32, error: &'a tendermint_rpc::Error) -> Self::Output {
+        if should_retry(error) {
+            let prev_delay = self.delay;
+            self.delay = self.delay.saturating_mul(2);
+            RetryPolicy::Delay(prev_delay)
+        } else {
+            RetryPolicy::Break
+        }
+    }
+}
+
+fn should_retry(error: &tendermint_rpc::Error) -> bool {
+    use tendermint_rpc::error::ErrorDetail::{
+        Http,
+        HttpRequestFailed,
+        Timeout,
+    };
+    matches!(
+        error.detail(),
+        Http(..) | HttpRequestFailed(..) | Timeout(..)
+    )
+}

--- a/crates/astria-conductor/src/celestia/verify.rs
+++ b/crates/astria-conductor/src/celestia/verify.rs
@@ -73,8 +73,10 @@ struct VerificationTaskKey {
     sequencer_height: SequencerHeight,
 }
 
-/// Returns blobs that could be verified against Sequencer.
-pub(super) async fn verify_and_filter_decoded_blobs(
+/// Verifies Sequencer header blobs against Sequencer commits and validator sets.
+///
+/// Drops blobs that could not be verified.
+pub(super) async fn verify_header_blobs(
     blob_verifier: Arc<BlobVerifier>,
     converted_blobs: ConvertedBlobs,
 ) -> VerifiedBlobs {

--- a/crates/astria-conductor/tests/blackbox/firm_only.rs
+++ b/crates/astria-conductor/tests/blackbox/firm_only.rs
@@ -1,0 +1,390 @@
+use std::time::Duration;
+
+use astria_conductor::config::CommitLevel;
+use futures::future::{
+    join,
+    join4,
+};
+use tokio::time::timeout;
+
+use crate::{
+    helpers::spawn_conductor,
+    mount_celestia_blobs,
+    mount_celestia_header_network_head,
+    mount_executed_block,
+    mount_get_commitment_state,
+    mount_get_genesis_info,
+    mount_sequencer_commit,
+    mount_sequencer_genesis,
+    mount_sequencer_validator_set,
+    mount_update_commitment_state,
+};
+
+#[tokio::test]
+async fn simple() {
+    let test_conductor = spawn_conductor(CommitLevel::FirmOnly).await;
+
+    mount_get_genesis_info!(
+        test_conductor,
+        sequencer_genesis_block_height: 1,
+        celestia_base_block_height: 1,
+        celestia_block_variance: 10,
+    );
+
+    mount_get_commitment_state!(
+        test_conductor,
+        firm: (
+            number: 1,
+            hash: [1; 64],
+            parent: [0; 64],
+        ),
+        soft: (
+            number: 1,
+            hash: [1; 64],
+            parent: [0; 64],
+        ),
+    );
+
+    mount_sequencer_genesis!(test_conductor);
+
+    mount_celestia_header_network_head!(
+        test_conductor,
+        height: 1u32,
+    );
+
+    mount_celestia_blobs!(
+        test_conductor,
+        celestia_height: 1,
+        sequencer_height: 2,
+    );
+
+    mount_sequencer_commit!(
+        test_conductor,
+        height: 2u32,
+    );
+
+    mount_sequencer_validator_set!(test_conductor, height: 1u32);
+
+    let execute_block = mount_executed_block!(
+        test_conductor,
+        number: 2,
+        hash: [2; 64],
+        parent: [1; 64],
+    );
+
+    let update_commitment_state = mount_update_commitment_state!(
+        test_conductor,
+        firm: (
+            number: 2,
+            hash: [2; 64],
+            parent: [1; 64],
+        ),
+        soft: (
+            number: 2,
+            hash: [2; 64],
+            parent: [1; 64],
+        ),
+    );
+
+    timeout(
+        Duration::from_millis(2000),
+        join(
+            execute_block.wait_until_satisfied(),
+            update_commitment_state.wait_until_satisfied(),
+        ),
+    )
+    .await
+    .expect(
+        "conductor should have executed the firm block and updated the firm commitment state \
+         within 1000ms",
+    );
+}
+
+#[tokio::test]
+async fn submits_two_heights_in_sucession() {
+    let test_conductor = spawn_conductor(CommitLevel::FirmOnly).await;
+
+    mount_get_genesis_info!(
+        test_conductor,
+        sequencer_genesis_block_height: 1,
+        celestia_base_block_height: 1,
+        celestia_block_variance: 10,
+    );
+
+    mount_get_commitment_state!(
+        test_conductor,
+        firm: (
+            number: 1,
+            hash: [1; 64],
+            parent: [0; 64],
+        ),
+        soft: (
+            number: 1,
+            hash: [1; 64],
+            parent: [0; 64],
+        ),
+    );
+
+    mount_sequencer_genesis!(test_conductor);
+
+    mount_celestia_header_network_head!(
+        test_conductor,
+        height: 2u32,
+    );
+
+    mount_celestia_blobs!(
+        test_conductor,
+        celestia_height: 1,
+        sequencer_height: 2,
+    );
+
+    mount_celestia_blobs!(
+        test_conductor,
+        celestia_height: 2,
+        sequencer_height: 3,
+    );
+
+    mount_sequencer_commit!(
+        test_conductor,
+        height: 2u32,
+    );
+
+    mount_sequencer_validator_set!(test_conductor, height: 1u32);
+
+    mount_sequencer_commit!(
+        test_conductor,
+        height: 3u32,
+    );
+
+    mount_sequencer_validator_set!(test_conductor, height: 2u32);
+
+    let execute_block_number_2 = mount_executed_block!(
+        test_conductor,
+        number: 2,
+        hash: [2; 64],
+        parent: [1; 64],
+    );
+
+    let update_commitment_state_number_2 = mount_update_commitment_state!(
+        test_conductor,
+        firm: (
+            number: 2,
+            hash: [2; 64],
+            parent: [1; 64],
+        ),
+        soft: (
+            number: 2,
+            hash: [2; 64],
+            parent: [1; 64],
+        ),
+    );
+
+    let execute_block_number_3 = mount_executed_block!(
+        test_conductor,
+        number: 3,
+        hash: [3; 64],
+        parent: [2; 64],
+    );
+
+    let update_commitment_state_number_3 = mount_update_commitment_state!(
+        test_conductor,
+        firm: (
+            number: 3,
+            hash: [3; 64],
+            parent: [2; 64],
+        ),
+        soft: (
+            number: 3,
+            hash: [3; 64],
+            parent: [2; 64],
+        ),
+    );
+
+    timeout(
+        Duration::from_millis(2000),
+        join4(
+            execute_block_number_2.wait_until_satisfied(),
+            update_commitment_state_number_2.wait_until_satisfied(),
+            execute_block_number_3.wait_until_satisfied(),
+            update_commitment_state_number_3.wait_until_satisfied(),
+        ),
+    )
+    .await
+    .expect(
+        "conductor should have executed the soft block and updated the soft commitment state \
+         within 2000ms",
+    );
+}
+
+#[tokio::test]
+async fn skips_already_executed_heights() {
+    let test_conductor = spawn_conductor(CommitLevel::FirmOnly).await;
+
+    mount_get_genesis_info!(
+        test_conductor,
+        sequencer_genesis_block_height: 1,
+        celestia_base_block_height: 1,
+        celestia_block_variance: 10,
+    );
+
+    mount_get_commitment_state!(
+        test_conductor,
+        firm: (
+            number: 5,
+            hash: [1; 64],
+            parent: [0; 64],
+        ),
+        soft: (
+            number: 5,
+            hash: [1; 64],
+            parent: [0; 64],
+        ),
+    );
+    mount_sequencer_genesis!(test_conductor);
+
+    mount_celestia_header_network_head!(
+        test_conductor,
+        height: 2u32,
+    );
+
+    // The blob with sequencer height 5 will be fetched but never forwarded
+    mount_celestia_blobs!(
+        test_conductor,
+        celestia_height: 1,
+        sequencer_height: 5,
+    );
+
+    mount_celestia_blobs!(
+        test_conductor,
+        celestia_height: 2,
+        sequencer_height: 6,
+    );
+
+    mount_sequencer_commit!(
+        test_conductor,
+        height: 5u32,
+    );
+
+    mount_sequencer_validator_set!(test_conductor, height: 4u32);
+
+    mount_sequencer_commit!(
+        test_conductor,
+        height: 6u32,
+    );
+
+    mount_sequencer_validator_set!(test_conductor, height: 5u32);
+
+    let execute_block = mount_executed_block!(
+        test_conductor,
+        number: 6,
+        hash: [2; 64],
+        parent: [1; 64],
+    );
+
+    let update_commitment_state = mount_update_commitment_state!(
+        test_conductor,
+        firm: (
+            number: 6,
+            hash: [2; 64],
+            parent: [1; 64],
+        ),
+        soft: (
+            number: 6,
+            hash: [2; 64],
+            parent: [1; 64],
+        ),
+    );
+
+    timeout(
+        Duration::from_millis(1000),
+        join(
+            execute_block.wait_until_satisfied(),
+            update_commitment_state.wait_until_satisfied(),
+        ),
+    )
+    .await
+    .expect(
+        "conductor should have executed the soft block and updated the soft commitment state \
+         within 1000ms",
+    );
+}
+
+#[tokio::test]
+async fn fetch_from_later_celestia_height() {
+    let test_conductor = spawn_conductor(CommitLevel::FirmOnly).await;
+
+    mount_get_genesis_info!(
+        test_conductor,
+        sequencer_genesis_block_height: 1,
+        celestia_base_block_height: 4,
+        celestia_block_variance: 10,
+    );
+
+    mount_get_commitment_state!(
+        test_conductor,
+        firm: (
+            number: 1,
+            hash: [1; 64],
+            parent: [0; 64],
+        ),
+        soft: (
+            number: 1,
+            hash: [1; 64],
+            parent: [0; 64],
+        ),
+    );
+
+    mount_sequencer_genesis!(test_conductor);
+
+    mount_celestia_header_network_head!(
+        test_conductor,
+        height: 5u32,
+    );
+
+    mount_celestia_blobs!(
+        test_conductor,
+        celestia_height: 4,
+        sequencer_height: 2,
+    );
+
+    mount_sequencer_commit!(
+        test_conductor,
+        height: 2u32,
+    );
+
+    mount_sequencer_validator_set!(test_conductor, height: 1u32);
+
+    let execute_block = mount_executed_block!(
+        test_conductor,
+        number: 2,
+        hash: [2; 64],
+        parent: [1; 64],
+    );
+
+    let update_commitment_state = mount_update_commitment_state!(
+        test_conductor,
+        firm: (
+            number: 2,
+            hash: [2; 64],
+            parent: [1; 64],
+        ),
+        soft: (
+            number: 2,
+            hash: [2; 64],
+            parent: [1; 64],
+        ),
+    );
+
+    timeout(
+        Duration::from_millis(2000),
+        join(
+            execute_block.wait_until_satisfied(),
+            update_commitment_state.wait_until_satisfied(),
+        ),
+    )
+    .await
+    .expect(
+        "conductor should have executed the firm block and updated the firm commitment state \
+         within 1000ms",
+    );
+}

--- a/crates/astria-conductor/tests/blackbox/helpers/macros.rs
+++ b/crates/astria-conductor/tests/blackbox/helpers/macros.rs
@@ -14,6 +14,45 @@ macro_rules! block {
 }
 
 #[macro_export]
+macro_rules! celestia_network_head {
+    (height: $height:expr) => {
+        ::celestia_client::celestia_types::ExtendedHeader {
+            header: ::celestia_client::celestia_tendermint::block::header::Header {
+                height: $height.into(),
+                version: ::celestia_client::celestia_tendermint::block::header::Version {
+                    block: 0,
+                    app: 0,
+                },
+                chain_id: "test_celestia-1000".try_into().unwrap(),
+                time: ::celestia_client::celestia_tendermint::Time::from_unix_timestamp(1, 1)
+                    .unwrap(),
+                last_block_id: None,
+                last_commit_hash: ::celestia_client::celestia_tendermint::Hash::Sha256([0; 32]),
+                data_hash: ::celestia_client::celestia_tendermint::Hash::Sha256([0; 32]),
+                validators_hash: ::celestia_client::celestia_tendermint::Hash::Sha256([0; 32]),
+                next_validators_hash: ::celestia_client::celestia_tendermint::Hash::Sha256([0; 32]),
+                consensus_hash: ::celestia_client::celestia_tendermint::Hash::Sha256([0; 32]),
+                app_hash: vec![0; 32].try_into().unwrap(),
+                last_results_hash: ::celestia_client::celestia_tendermint::Hash::Sha256([0; 32]),
+                evidence_hash: ::celestia_client::celestia_tendermint::Hash::Sha256([0; 32]),
+                proposer_address: vec![0u8; 20].try_into().unwrap(),
+            },
+            commit: ::celestia_client::celestia_tendermint::block::Commit {
+                height: $height.into(),
+                ..Default::default()
+            },
+            validator_set: ::celestia_client::celestia_tendermint::validator::Set::without_proposer(
+                vec![],
+            ),
+            dah: ::celestia_client::celestia_types::DataAvailabilityHeader {
+                row_roots: vec![],
+                column_roots: vec![],
+            },
+        }
+    };
+}
+
+#[macro_export]
 macro_rules! commitment_state {
     (
         firm: (number: $firm_number:expr,hash: $firm_hash:expr,parent: $firm_parent:expr $(,)?),
@@ -40,7 +79,7 @@ macro_rules! filtered_sequencer_block {
     (sequencer_height: $height:expr) => {{
         let block = ::astria_core::sequencer::v1::test_utils::ConfigureCometBftBlock {
             height: $height,
-            rollup_transactions: vec![($crate::ROLLUP_ID, b"hello_world".to_vec())],
+            rollup_transactions: vec![($crate::ROLLUP_ID, $crate::helpers::data())],
             ..Default::default()
         }
         .make();
@@ -69,6 +108,46 @@ macro_rules! genesis_info {
             celestia_block_variance: $variance,
         }
     };
+}
+
+#[macro_export]
+macro_rules! signed_header {
+    (height: $height:expr,block_hash: $block_hash:expr $(,)?) => {};
+}
+
+#[macro_export]
+macro_rules! mount_celestia_blobs {
+    (
+        $test_env:ident,celestia_height:
+        $celestia_height:expr,sequencer_height:
+        $sequencer_height:expr $(,)?
+    ) => {{
+        let blobs = $crate::helpers::make_blobs($sequencer_height);
+        $test_env
+            .mount_celestia_blob_get_all(
+                $celestia_height,
+                $crate::sequencer_namespace(),
+                blobs.header,
+            )
+            .await;
+        $test_env
+            .mount_celestia_blob_get_all($celestia_height, $crate::rollup_namespace(), blobs.rollup)
+            .await
+    }};
+}
+
+#[macro_export]
+macro_rules! mount_celestia_header_network_head {
+    (
+        $test_env:ident,
+        height: $height:expr $(,)?
+    ) => {
+        $test_env
+            .mount_celestia_header_network_head(
+                $crate::celestia_network_head!(height: $height)
+            )
+            .await;
+    }
 }
 
 #[macro_export]
@@ -140,7 +219,7 @@ macro_rules! mount_executed_block {
         $test_env.mount_execute_block(
             ::serde_json::json!({
                 "prev_block_hash": BASE64_STANDARD.encode($parent),
-                "transactions": [{"sequenced_data": BASE64_STANDARD.encode(b"hello_world")}],
+                "transactions": [{"sequenced_data": BASE64_STANDARD.encode($crate::helpers::data())}],
             }),
             $crate::block!(
                 number: $number,
@@ -183,5 +262,30 @@ macro_rules! mount_get_genesis_info {
                 celestia_block_variance: $variance,
             )
         ).await;
+    };
+}
+
+#[macro_export]
+macro_rules! mount_sequencer_commit {
+    ($test_env:ident,height: $height:expr $(,)?) => {
+        $test_env
+            .mount_commit($crate::helpers::make_signed_header($height))
+            .await;
+    };
+}
+
+#[macro_export]
+macro_rules! mount_sequencer_validator_set {
+    ($test_env:ident,height: $height:expr $(,)?) => {
+        $test_env
+            .mount_validator_set($crate::helpers::make_validator_set($height))
+            .await
+    };
+}
+
+#[macro_export]
+macro_rules! mount_sequencer_genesis {
+    ($test_env:ident) => {
+        $test_env.mount_genesis().await;
     };
 }

--- a/crates/astria-conductor/tests/blackbox/helpers/mod.rs
+++ b/crates/astria-conductor/tests/blackbox/helpers/mod.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use astria_conductor::{
     config::CommitLevel,
     Conductor,
@@ -15,7 +17,17 @@ use astria_core::{
     sequencer::v1::RollupId,
 };
 use bytes::Bytes;
+use celestia_client::celestia_types::{
+    nmt::Namespace,
+    Blob,
+};
 use once_cell::sync::Lazy;
+use prost::Message;
+use sequencer_client::{
+    tendermint,
+    tendermint_proto,
+    tendermint_rpc,
+};
 
 #[macro_use]
 mod macros;
@@ -28,6 +40,8 @@ pub const CELESTIA_BEARER_TOKEN: &str = "ABCDEFGH";
 
 pub const ROLLUP_ID: RollupId = RollupId::new([42; 32]);
 pub static ROLLUP_ID_BYTES: Bytes = Bytes::from_static(&RollupId::get(ROLLUP_ID));
+
+pub const SEQUENCER_CHAIN_ID: &str = "test_sequencer-1000";
 
 pub const INITIAL_SOFT_HASH: [u8; 64] = [1; 64];
 pub const INITIAL_FIRM_HASH: [u8; 64] = [1; 64];
@@ -89,12 +103,6 @@ pub struct TestConductor {
 
 impl TestConductor {
     pub async fn mount_abci_info(&self, latest_block_height: u32) {
-        use sequencer_client::{
-            tendermint::abci,
-            tendermint_rpc::{
-                self,
-            },
-        };
         use wiremock::{
             matchers::body_partial_json,
             Mock,
@@ -107,11 +115,172 @@ impl TestConductor {
             tendermint_rpc::response::Wrapper::new_with_id(
                 tendermint_rpc::Id::uuid_v4(),
                 Some(tendermint_rpc::endpoint::abci_info::Response {
-                    response: abci::response::Info {
+                    response: tendermint::abci::response::Info {
                         last_block_height: latest_block_height.into(),
                         ..Default::default()
                     },
                 }),
+                None,
+            ),
+        ))
+        .expect(1..)
+        .mount(&self.mock_http)
+        .await;
+    }
+
+    pub async fn mount_celestia_blob_get_all(
+        &self,
+        celestia_height: u64,
+        namespace: Namespace,
+        blobs: Vec<Blob>,
+    ) {
+        use base64::prelude::*;
+        use wiremock::{
+            matchers::{
+                body_partial_json,
+                header,
+            },
+            Mock,
+            Request,
+            ResponseTemplate,
+        };
+        let namespace_params = BASE64_STANDARD.encode(namespace.as_bytes());
+        Mock::given(body_partial_json(json!({
+            "jsonrpc": "2.0",
+            "method": "blob.GetAll",
+            "params": [celestia_height, [namespace_params]],
+        })))
+        .and(header(
+            "authorization",
+            &*format!("Bearer {CELESTIA_BEARER_TOKEN}"),
+        ))
+        .respond_with(move |request: &Request| {
+            let body: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
+            let id = body.get("id");
+            ResponseTemplate::new(200).set_body_json(json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "result": blobs,
+            }))
+        })
+        .expect(1)
+        .mount(&self.mock_http)
+        .await;
+    }
+
+    pub async fn mount_celestia_header_network_head(
+        &self,
+        extended_header: celestia_client::celestia_types::ExtendedHeader,
+    ) {
+        use wiremock::{
+            matchers::{
+                body_partial_json,
+                header,
+            },
+            Mock,
+            ResponseTemplate,
+        };
+        Mock::given(body_partial_json(
+            json!({"jsonrpc": "2.0", "method": "header.NetworkHead"}),
+        ))
+        .and(header(
+            "authorization",
+            &*format!("Bearer {CELESTIA_BEARER_TOKEN}"),
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jsonrpc": "2.0",
+            "id": 0,
+            "result": extended_header
+        })))
+        .expect(1..)
+        .mount(&self.mock_http)
+        .await;
+    }
+
+    pub async fn mount_commit(
+        &self,
+        signed_header: tendermint::block::signed_header::SignedHeader,
+    ) {
+        use wiremock::{
+            matchers::body_partial_json,
+            Mock,
+            ResponseTemplate,
+        };
+        Mock::given(body_partial_json(json!({
+            "jsonrpc": "2.0",
+            "method": "commit",
+            "params": {
+                "height": signed_header.header.height.to_string(),
+            }
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(
+            tendermint_rpc::response::Wrapper::new_with_id(
+                tendermint_rpc::Id::uuid_v4(),
+                Some(tendermint_rpc::endpoint::commit::Response {
+                    signed_header,
+                    canonical: true,
+                }),
+                None,
+            ),
+        ))
+        .mount(&self.mock_http)
+        .await;
+    }
+
+    pub async fn mount_genesis(&self) {
+        use tendermint::{
+            consensus::{
+                params::{
+                    AbciParams,
+                    ValidatorParams,
+                },
+                Params,
+            },
+            genesis::Genesis,
+            time::Time,
+        };
+        use wiremock::{
+            matchers::body_partial_json,
+            Mock,
+            ResponseTemplate,
+        };
+        Mock::given(body_partial_json(
+            json!({"jsonrpc": "2.0", "method": "genesis", "params": null}),
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(
+            tendermint_rpc::response::Wrapper::new_with_id(
+                tendermint_rpc::Id::uuid_v4(),
+                Some(
+                    tendermint_rpc::endpoint::genesis::Response::<serde_json::Value> {
+                        genesis: Genesis {
+                            genesis_time: Time::from_unix_timestamp(1, 1).unwrap(),
+                            chain_id: SEQUENCER_CHAIN_ID.try_into().unwrap(),
+                            initial_height: 1,
+                            consensus_params: Params {
+                                block: tendermint::block::Size {
+                                    max_bytes: 1024,
+                                    max_gas: 1024,
+                                    time_iota_ms: 1000,
+                                },
+                                evidence: tendermint::evidence::Params {
+                                    max_age_num_blocks: 1000,
+                                    max_age_duration: tendermint::evidence::Duration(
+                                        Duration::from_secs(3600),
+                                    ),
+                                    max_bytes: 1_048_576,
+                                },
+                                validator: ValidatorParams {
+                                    pub_key_types: vec![tendermint::public_key::Algorithm::Ed25519],
+                                },
+                                version: None,
+                                abci: AbciParams::default(),
+                            },
+                            validators: vec![],
+                            app_hash: tendermint::hash::AppHash::default(),
+                            app_state: serde_json::Value::Null,
+                        },
+                    },
+                ),
                 None,
             ),
         ))
@@ -205,6 +374,35 @@ impl TestConductor {
         .mount_as_scoped(&self.mock_grpc.mock_server)
         .await
     }
+
+    pub async fn mount_validator_set(
+        &self,
+        validator_set: tendermint_rpc::endpoint::validators::Response,
+    ) {
+        use wiremock::{
+            matchers::body_partial_json,
+            Mock,
+            ResponseTemplate,
+        };
+        Mock::given(body_partial_json(json!({
+            "jsonrpc": "2.0",
+            "method": "validators",
+            "params": {
+                "height": validator_set.block_height.to_string(),
+                "page": null,
+                "per_page": null
+            }
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(
+            tendermint_rpc::response::Wrapper::new_with_id(
+                tendermint_rpc::Id::uuid_v4(),
+                Some(validator_set),
+                None,
+            ),
+        ))
+        .mount(&self.mock_http)
+        .await;
+    }
 }
 
 fn make_config() -> Config {
@@ -224,4 +422,161 @@ fn make_config() -> Config {
         metrics_http_listener_addr: String::new(),
         pretty_print: false,
     }
+}
+
+#[must_use]
+pub fn make_sequencer_block(height: u32) -> astria_core::sequencerblock::v1alpha1::SequencerBlock {
+    astria_core::sequencerblock::v1alpha1::SequencerBlock::try_from_cometbft(
+        astria_core::sequencer::v1::test_utils::ConfigureCometBftBlock {
+            chain_id: Some(crate::SEQUENCER_CHAIN_ID.to_string()),
+            height,
+            rollup_transactions: vec![(crate::ROLLUP_ID, data())],
+            unix_timestamp: (1i64, 1u32).into(),
+            signing_key: Some(signing_key()),
+            proposer_address: None,
+        }
+        .make(),
+    )
+    .unwrap()
+}
+
+pub struct Blobs {
+    pub header: Vec<Blob>,
+    pub rollup: Vec<Blob>,
+}
+
+#[must_use]
+pub fn make_blobs(height: u32) -> Blobs {
+    let (head, tail) = make_sequencer_block(height).into_celestia_blobs();
+
+    let header = ::celestia_client::celestia_types::Blob::new(
+        ::celestia_client::celestia_namespace_v0_from_bytes(crate::SEQUENCER_CHAIN_ID.as_bytes()),
+        ::prost::Message::encode_to_vec(&head.into_raw()),
+    )
+    .unwrap();
+
+    let mut rollup = Vec::new();
+    for elem in tail {
+        let blob = ::celestia_client::celestia_types::Blob::new(
+            ::celestia_client::celestia_namespace_v0_from_rollup_id(crate::ROLLUP_ID),
+            ::prost::Message::encode_to_vec(&elem.into_raw()),
+        )
+        .unwrap();
+        rollup.push(blob);
+    }
+    Blobs {
+        header: vec![header],
+        rollup,
+    }
+}
+
+fn signing_key() -> ed25519_consensus::SigningKey {
+    use rand_chacha::{
+        rand_core::SeedableRng as _,
+        ChaChaRng,
+    };
+    ed25519_consensus::SigningKey::new(ChaChaRng::seed_from_u64(0))
+}
+
+fn validator() -> tendermint::validator::Info {
+    let signing_key = signing_key();
+    let pub_key = tendermint::public_key::PublicKey::from_raw_ed25519(
+        signing_key.verification_key().as_ref(),
+    )
+    .unwrap();
+    let address = tendermint::account::Id::from(pub_key);
+
+    tendermint::validator::Info {
+        address,
+        pub_key,
+        power: 10u32.into(),
+        proposer_priority: 0.into(),
+        name: None,
+    }
+}
+
+#[must_use]
+pub fn make_commit(height: u32) -> tendermint::block::Commit {
+    let signing_key = signing_key();
+    let validator = validator();
+
+    let block_hash = make_sequencer_block(height).block_hash();
+
+    let timestamp = tendermint::Time::from_unix_timestamp(1, 1).unwrap();
+    let canonical_vote = tendermint::vote::CanonicalVote {
+        vote_type: tendermint::vote::Type::Precommit,
+        height: height.into(),
+        round: 0u16.into(),
+        block_id: Some(tendermint::block::Id {
+            hash: tendermint::Hash::Sha256(block_hash),
+            part_set_header: tendermint::block::parts::Header::default(),
+        }),
+        timestamp: Some(timestamp),
+        chain_id: crate::SEQUENCER_CHAIN_ID.try_into().unwrap(),
+    };
+
+    let message = tendermint_proto::types::CanonicalVote::from(canonical_vote)
+        .encode_length_delimited_to_vec();
+    let signature = signing_key.sign(&message);
+
+    tendermint::block::Commit {
+        height: height.into(),
+        round: 0u16.into(),
+        block_id: tendermint::block::Id {
+            hash: tendermint::Hash::Sha256(block_hash),
+            part_set_header: tendermint::block::parts::Header::default(),
+        },
+        signatures: vec![tendermint::block::CommitSig::BlockIdFlagCommit {
+            validator_address: validator.address,
+            timestamp,
+            signature: Some(signature.into()),
+        }],
+    }
+}
+
+#[must_use]
+pub fn make_signed_header(height: u32) -> tendermint::block::signed_header::SignedHeader {
+    tendermint::block::signed_header::SignedHeader::new(
+        tendermint::block::Header {
+            version: tendermint::block::header::Version {
+                block: 1,
+                app: 1,
+            },
+            chain_id: crate::SEQUENCER_CHAIN_ID.try_into().unwrap(),
+            height: height.into(),
+            time: tendermint::time::Time::from_unix_timestamp(1, 1).unwrap(),
+            last_block_id: None,
+            last_commit_hash: None,
+            data_hash: None,
+            validators_hash: tendermint::Hash::Sha256([0; 32]),
+            next_validators_hash: tendermint::Hash::Sha256([0; 32]),
+            consensus_hash: tendermint::Hash::Sha256([0; 32]),
+            app_hash: tendermint::AppHash::default(),
+            last_results_hash: None,
+            evidence_hash: None,
+            proposer_address: validator().address,
+        },
+        make_commit(height),
+    )
+    .unwrap()
+}
+
+#[must_use]
+pub fn data() -> Vec<u8> {
+    b"hello_world".to_vec()
+}
+
+#[must_use]
+pub fn make_validator_set(height: u32) -> tendermint_rpc::endpoint::validators::Response {
+    tendermint_rpc::endpoint::validators::Response::new(height.into(), vec![validator()], 1)
+}
+
+#[must_use]
+pub fn rollup_namespace() -> Namespace {
+    celestia_client::celestia_namespace_v0_from_rollup_id(ROLLUP_ID)
+}
+
+#[must_use]
+pub fn sequencer_namespace() -> Namespace {
+    celestia_client::celestia_namespace_v0_from_bytes(SEQUENCER_CHAIN_ID.as_bytes())
 }

--- a/crates/astria-conductor/tests/blackbox/main.rs
+++ b/crates/astria-conductor/tests/blackbox/main.rs
@@ -1,6 +1,12 @@
 // allow: clippy lints that are not ok in production code but acceptable or wanted in tests
+pub mod firm_only;
 #[allow(clippy::missing_panics_doc)]
 pub mod helpers;
 pub mod soft_only;
 
-use helpers::ROLLUP_ID;
+use helpers::{
+    rollup_namespace,
+    sequencer_namespace,
+    ROLLUP_ID,
+    SEQUENCER_CHAIN_ID,
+};

--- a/crates/astria-core/src/sequencerblock/v1alpha1/celestia.rs
+++ b/crates/astria-core/src/sequencerblock/v1alpha1/celestia.rs
@@ -524,6 +524,18 @@ impl CelestiaSequencerBlob {
         &self.header
     }
 
+    /// Returns the Merkle Tree Hash constructed from the rollup transactions of the original
+    /// [`SequencerBlock`] this blob was derived from.
+    #[must_use]
+    pub fn rollup_transactions_root(&self) -> [u8; 32] {
+        self.header.rollup_transactions_root()
+    }
+
+    #[must_use]
+    pub fn contains_rollup_id(&self, rollup_id: RollupId) -> bool {
+        self.rollup_ids.contains(&rollup_id)
+    }
+
     /// Converts into the unchecked representation fo this type.
     #[must_use]
     pub fn into_unchecked(self) -> UncheckedCelestiaSequencerBlob {


### PR DESCRIPTION
## Summary
Fixes conductor so it works in the presence of duplicate sequencer blobs or rollup blobs fetched from Celestia.

## Background
Duplicate sequencer block information can end up on Celestia. If a single Sequencer block ends up as a duplicate at the same Celestia height (for example, because two Sequencer nodes both relayed to Celestia), then Conductor can potentially stop functioning correctly because of code present as of commit [`cd38d1d5458fd561696590417b647f1844d328f2`](https://github.com/astriaorg/astria/blob/cd38d1d5458fd561696590417b647f1844d328f2/crates/astria-conductor/src/celestia/mod.rs#L586-L589):
```rust
    ensure!(
        rollup_blobs.len() <= 1,
        "received more than one celestia rollup blob for the given namespace and height"
    );
```
This causes Conductor to drop reconstruction of a Sequencer block information from blobs fetched from Celestia, even though it would be perfectly acceptable to go on.

## Changes
- Split the celestia `Reader` object into a crate-public exposed Reader and an internal `RunningReader`. `Reader::run_until_stopped` itself initializes the `RunningReader` with information it has to await at runtime before delegating to it.
- Determine the Sequencer chain ID (required to get its namespace) form the `/genesis` endpoint (instead of `/latest_block`).
- Remove the stream of new blocks reconstructed from Celestia blobs
- Replace the stream with a `JoinMap` (one task per Celestia height)
- Each task performs the following steps
    1. fetch Celestia blobs for a given height, sequencer namespace, rollup namespace
    2. decode the blobs according to their namespace (sequencer header or rollup item)
    3. verify all sequencer headers blobs against sequencer
    4. reconstruct rollup information by matching the verified sequencer blobs to the rollup item blobs

## Testing
Blackbox tests are implemented for the following cases (more will be implemented in a followup):

1. conductor fetches a block with sequencer height 2 from celestia height 1 and executes it
2. conductor fetches blocks with sequencer height 2 from celestia height 1, sequencer height 3 from celestia height 2, and executes both in succession
3. the remote rollup starts at block number 5. Conductor fetches sequencer heights 5 and 6 from celestia heights 1 and 2, but only forwards sequencer height 6.
4. the remote rollup has celestia height 4 in its genesis. Conductor starts fetching at that block number.

## Related Issues
closes https://github.com/astriaorg/astria/issues/94
closes https://github.com/astriaorg/astria/issues/184 (together with work done in https://github.com/astriaorg/astria/pull/769)
closes https://github.com/astriaorg/astria/issues/884
closes https://github.com/astriaorg/astria/issues/947
closes https://github.com/astriaorg/astria/issues/948