### PR TITLE
Refactor Docker builds to use Depot for zero emulation builds + persistent cache

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -43,6 +43,9 @@ jobs:
     needs: run_checker
     if: needs.run_checker.outputs.run_docker == 'true' || (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'composer')
     uses: "./.github/workflows/reusable-docker-build.yml"
+    permissions:
+      contents: read
+      id-token: write
     with:
       depot-project-id: TODO
       package-name: composer
@@ -54,6 +57,9 @@ jobs:
     needs: run_checker
     if: needs.run_checker.outputs.run_docker == 'true' || (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'conductor')
     uses: "./.github/workflows/reusable-docker-build.yml"
+    permissions:
+      contents: read
+      id-token: write
     with:
       depot-project-id: TODO
       package-name: conductor
@@ -65,6 +71,9 @@ jobs:
     needs: run_checker
     if: needs.run_checker.outputs.run_docker == 'true' || (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'sequencer')
     uses: "./.github/workflows/reusable-docker-build.yml"
+    permissions:
+      contents: read
+      id-token: write
     with:
       depot-project-id: TODO
       package-name: sequencer
@@ -76,6 +85,9 @@ jobs:
     needs: run_checker
     if: needs.run_checker.outputs.run_docker == 'true' || (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'sequencer-relayer')
     uses: "./.github/workflows/reusable-docker-build.yml"
+    permissions:
+      contents: read
+      id-token: write
     with:
       depot-project-id: TODO
       package-name: sequencer-relayer

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -44,6 +44,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      packages: write
     with:
       depot-project-id: mhgvgvsjnx
       package-name: composer
@@ -58,6 +59,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      packages: write
     with:
       depot-project-id: zrh9t1d84s
       package-name: conductor
@@ -72,6 +74,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      packages: write
     with:
       depot-project-id: brzhxfbv9b
       package-name: sequencer
@@ -86,6 +89,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      packages: write
     with:
       depot-project-id: 86q4kz4wfs
       package-name: sequencer-relayer

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -47,7 +47,7 @@ jobs:
       contents: read
       id-token: write
     with:
-      depot-project-id: TODO
+      depot-project-id: mhgvgvsjnx
       package-name: composer
       target-binary: astria-composer
       tag: ${{ inputs.tag }}
@@ -61,7 +61,7 @@ jobs:
       contents: read
       id-token: write
     with:
-      depot-project-id: TODO
+      depot-project-id: zrh9t1d84s
       package-name: conductor
       target-binary: astria-conductor
       tag: ${{ inputs.tag }}
@@ -75,7 +75,7 @@ jobs:
       contents: read
       id-token: write
     with:
-      depot-project-id: TODO
+      depot-project-id: brzhxfbv9b
       package-name: sequencer
       target-binary: astria-sequencer
       tag: ${{ inputs.tag }}
@@ -89,7 +89,7 @@ jobs:
       contents: read
       id-token: write
     with:
-      depot-project-id: TODO
+      depot-project-id: 86q4kz4wfs
       package-name: sequencer-relayer
       target-binary: astria-sequencer-relayer
       tag: ${{ inputs.tag }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -25,7 +25,6 @@ on:
       - "**-v[0-9]+.[0-9]+.[0-9]+-alpha.[0-9]+"
       - "**-v[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+"
       - "**-v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+"
-    
   # trigger on pull request updates when target is `main` branch
   pull_request:
     types:
@@ -43,8 +42,9 @@ jobs:
   composer:
     needs: run_checker
     if: needs.run_checker.outputs.run_docker == 'true' || (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'composer')
-    uses: './.github/workflows/reusable-docker-build.yml'
+    uses: "./.github/workflows/reusable-docker-build.yml"
     with:
+      depot-project-id: TODO
       package-name: composer
       target-binary: astria-composer
       tag: ${{ inputs.tag }}
@@ -53,8 +53,9 @@ jobs:
   conductor:
     needs: run_checker
     if: needs.run_checker.outputs.run_docker == 'true' || (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'conductor')
-    uses: './.github/workflows/reusable-docker-build.yml'
+    uses: "./.github/workflows/reusable-docker-build.yml"
     with:
+      depot-project-id: TODO
       package-name: conductor
       target-binary: astria-conductor
       tag: ${{ inputs.tag }}
@@ -63,8 +64,9 @@ jobs:
   sequencer:
     needs: run_checker
     if: needs.run_checker.outputs.run_docker == 'true' || (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'sequencer')
-    uses: './.github/workflows/reusable-docker-build.yml'
+    uses: "./.github/workflows/reusable-docker-build.yml"
     with:
+      depot-project-id: TODO
       package-name: sequencer
       target-binary: astria-sequencer
       tag: ${{ inputs.tag }}
@@ -73,13 +75,14 @@ jobs:
   sequencer-relayer:
     needs: run_checker
     if: needs.run_checker.outputs.run_docker == 'true' || (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'sequencer-relayer')
-    uses: './.github/workflows/reusable-docker-build.yml'
+    uses: "./.github/workflows/reusable-docker-build.yml"
     with:
+      depot-project-id: TODO
       package-name: sequencer-relayer
       target-binary: astria-sequencer-relayer
       tag: ${{ inputs.tag }}
     secrets: inherit
-  
+
   smoke-test:
     needs: [run_checker, composer, conductor, sequencer, sequencer-relayer]
     if: github.event_name == 'merge_group' || needs.run_checker.outputs.run_docker == 'true'
@@ -89,7 +92,7 @@ jobs:
       - name: Install just
         uses: taiki-e/install-action@just
       - name: Install kind
-        uses: helm/kind-action@v1 
+        uses: helm/kind-action@v1
         with:
           install_only: true
       - name: Log in to GHCR

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -95,7 +95,7 @@ jobs:
 
   smoke-test:
     needs: [run_checker, composer, conductor, sequencer, sequencer-relayer]
-    if: github.repository_owner == 'astriaorg' && (github.event_name == 'merge_group' || needs.run_checker.outputs.run_docker == 'true')
+    if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'astriaorg/astria') && (github.event_name == 'merge_group' || needs.run_checker.outputs.run_docker == 'true')
     runs-on: buildjet-8vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -77,7 +77,7 @@ jobs:
           build-args: |
             TARGETBINARY=${{ inputs.target-binary }}
           platforms: "linux/amd64,linux/arm64"
-          push: true
+          push: ${{ env.LOGIN_DOCKER }}
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
           project: ${{ inputs.depot-project-id }}

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -3,6 +3,7 @@ name: Reusable Docker Build && Push Workflow
 permissions:
   contents: read
   id-token: write
+  packages: write
 
 on:
   workflow_call:

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -53,6 +53,7 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: depot/setup-action@v1
       # Generate correct tabs and labels
       - name: Docker metadata
         id: metadata

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -23,12 +23,13 @@ on:
         type: string
     secrets:
       DOCKER_TOKEN:
-        required: true
+        required: false
       DOCKER_USER:
-        required: true
+        required: false
 env:
   REGISTRY: ghcr.io
   FULL_REF: ${{ inputs.tag && format('refs/tags/{0}', inputs.tag) || github.ref }}
+  LOGIN_DOCKER: ${{ secrets.DOCKER_TOKEN && secrets.DOCKER_USER }}
 
 jobs:
   build-and-push:
@@ -41,6 +42,7 @@ jobs:
           ref: ${{ inputs.tag }}
       # https://github.com/docker/setup-qemu-action
       - name: Login to Docker Hub
+        if: env.DOCKER_LOGIN
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USER }}

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -29,7 +29,6 @@ on:
 env:
   REGISTRY: ghcr.io
   FULL_REF: ${{ inputs.tag && format('refs/tags/{0}', inputs.tag) || github.ref }}
-  LOGIN_DOCKER: ${{ secrets.DOCKER_TOKEN && secrets.DOCKER_USER }}
 
 jobs:
   build-and-push:
@@ -42,7 +41,7 @@ jobs:
           ref: ${{ inputs.tag }}
       # https://github.com/docker/setup-qemu-action
       - name: Login to Docker Hub
-        if: github.repository_owner == 'astriaorg'
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'astriaorg/astria'
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USER }}
@@ -77,7 +76,7 @@ jobs:
           build-args: |
             TARGETBINARY=${{ inputs.target-binary }}
           platforms: "linux/amd64,linux/arm64"
-          push: ${{ github.repository_owner == 'astriaorg'}}
+          push: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'astriaorg/astria'
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
           project: ${{ inputs.depot-project-id }}

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.tag }}
-      # https://github.com/docker/setup-qemu-action
+      - uses: depot/setup-action@v1
       - name: Login to Docker Hub
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'astriaorg/astria'
         uses: docker/login-action@v2
@@ -50,7 +50,6 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: depot/setup-action@v1
       # Generate correct tabs and labels
       - name: Docker metadata
         id: metadata

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -1,8 +1,17 @@
 name: Reusable Docker Build && Push Workflow
 
+# TODO: Add a trust relationship for each Depot project
+permissions:
+  contents: read
+  id-token: write
+
 on:
   workflow_call:
     inputs:
+      # TODO: Create a Depot project for each image to build
+      depot-project-id:
+        required: true
+        type: string
       package-name:
         required: true
         type: string
@@ -23,7 +32,7 @@ env:
 
 jobs:
   build-and-push:
-    runs-on: buildjet-8vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     if: startsWith(inputs.tag, inputs.package-name) || !inputs.tag && (startsWith(github.ref, format('refs/tags/{0}-v', inputs.package-name)) || github.ref == 'refs/heads/main' || github.event_name == 'pull_request' || github.event_name == 'merge_group')
     steps:
       # Checking out the repo
@@ -42,12 +51,6 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      # https://github.com/docker/setup-buildx-action
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v2
       # Generate correct tabs and labels
       - name: Docker metadata
         id: metadata
@@ -61,7 +64,7 @@ jobs:
             # set latest tag for `main` branch
             type=raw,value=latest,enable=${{ env.FULL_REF == format('refs/heads/{0}', 'main') }}
       - name: Build and push
-        uses: docker/build-push-action@v4
+        uses: depot/build-push-action@v1
         with:
           # this gets rid of the unknown/unknown image that is created without this setting
           # https://github.com/docker/build-push-action/issues/820#issuecomment-1455687416
@@ -70,10 +73,8 @@ jobs:
           file: containerfiles/Dockerfile
           build-args: |
             TARGETBINARY=${{ inputs.target-binary }}
-          platforms: 'linux/amd64,linux/arm64'
+          platforms: "linux/amd64,linux/arm64"
           push: true
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
-          cache-from: type=registry,ref=${{ format('ghcr.io/astriaorg/{0}:buildcache', inputs.package-name) }}
-          cache-to: type=registry,ref=${{ format('ghcr.io/astriaorg/{0}:buildcache', inputs.package-name) }},mode=max
-        
+          project: ${{ inputs.depot-project-id }}

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -1,6 +1,5 @@
 name: Reusable Docker Build && Push Workflow
 
-# TODO: Add a trust relationship for each Depot project
 permissions:
   contents: read
   id-token: write
@@ -8,7 +7,6 @@ permissions:
 on:
   workflow_call:
     inputs:
-      # TODO: Create a Depot project for each image to build
       depot-project-id:
         required: true
         type: string
@@ -76,7 +74,7 @@ jobs:
           build-args: |
             TARGETBINARY=${{ inputs.target-binary }}
           platforms: "linux/amd64,linux/arm64"
-          push: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'astriaorg/astria'
+          push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'astriaorg/astria' }}
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
           project: ${{ inputs.depot-project-id }}

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -1,10 +1,5 @@
 name: Reusable Docker Build && Push Workflow
 
-permissions:
-  contents: read
-  id-token: write
-  packages: write
-
 on:
   workflow_call:
     inputs:
@@ -32,6 +27,10 @@ env:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
     if: startsWith(inputs.tag, inputs.package-name) || !inputs.tag && (startsWith(github.ref, format('refs/tags/{0}-v', inputs.package-name)) || github.ref == 'refs/heads/main' || github.event_name == 'pull_request' || github.event_name == 'merge_group')
     steps:
       # Checking out the repo

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -77,7 +77,7 @@ jobs:
           build-args: |
             TARGETBINARY=${{ inputs.target-binary }}
           platforms: "linux/amd64,linux/arm64"
-          push: ${{ env.LOGIN_DOCKER }}
+          push: ${{ env.LOGIN_DOCKER || 'false' }}
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
           project: ${{ inputs.depot-project-id }}


### PR DESCRIPTION
## Summary
This moves the Docker image builds to [Depot](https://depot.dev), where they can be done on native Intel and Arm CPUs with persistent layer cache across builds.

## Background
I sent our [benchmark-astria results](https://github.com/depot/benchmark-astria/actions/runs/8647400279/job/23708761387) over to @joroshiba that shows how Depot can build all these images in ~46 seconds for a fully cached build. He asked if we could open a PR to help with the cutover.

## Changes
- `reusable-docker-build.yml` is updated to use [`depot/build-push-action`](https://github.com/depot/build-push-action), which takes all the same parameters with the addition of a `project` property to route the image build to a specific project in Depot.
- `reusable-docker-build.yml` contains a new permissions block so that you can authenticate to Depot from a GHA job via an OIDC access token instead of having static tokens in CI (see [trust relationship docs](https://depot.dev/docs/cli/authentication#oidc-trust-relationships))
- Drops `cache-to` and `cache-from` as Depot projects come with persistent caching to real SSDs that are automatically orchestrated across builds.
- `docker-build.yml` is updated to pass in the Depot project ID for each image to build.
- Run the `reusable-docker-build.yml` on a default GHA runner as you no longer need the BuildJet 8 CPU runner because the image build is happening on a Depot image builder with 16 CPUs & 32 GB of RAM & a 50 GB NVMe SSD for each architecture.

## Testing
Tested the basic components of this in the benchmark.
