### PR TITLE
fix(charts): only use one of annotation and spec for ingress

### DIFF
--- a/charts/evm-rollup/Chart.yaml
+++ b/charts/evm-rollup/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.12.1
+version: 0.12.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/evm-rollup/templates/ingress.yaml
+++ b/charts/evm-rollup/templates/ingress.yaml
@@ -21,7 +21,9 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
   annotations:
+    {{- if not $ingressSupportsIngressClassName }}
     kubernetes.io/ingress.class: {{ $.Values.ingress.className }}
+    {{- end }}
   {{- if $ingressApiIsStable }}
   {{- range $key, $value := $ingress.annotations }}
     {{ $key }}: {{ tpl $value $ | quote }}

--- a/charts/sequencer-faucet/Chart.yaml
+++ b/charts/sequencer-faucet/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sequencer-faucet/templates/ingress.yaml
+++ b/charts/sequencer-faucet/templates/ingress.yaml
@@ -18,7 +18,9 @@ metadata:
     {{- end }}
   {{- with .Values.ingress.annotations }}
   annotations:
+    {{- if not $ingressSupportsIngressClassName }}
     kubernetes.io/ingress.class: {{ $.Values.ingress.className }}
+    {{- end }}
     {{- range $key, $value := . }}
     {{ $key }}: {{ tpl $value $ | quote }}
     {{- end }}

--- a/charts/sequencer/Chart.yaml
+++ b/charts/sequencer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.11.3
+version: 0.11.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
## Summary
Update to only use either the annotation of the spec definition of ingress class name. 

## Background
Dev encountered this error while deploying charts:
```
Error: INSTALLATION FAILED: 2 errors occurred:
        * Ingress.extensions "node0-sequencer-grpc-ingress" is invalid: annotations.kubernetes.io/ingress.class: Invalid value: "nginx": can not be set when the class field is also set
        * Ingress.extensions "node0-sequencer-rpc-ingress" is invalid: annotations.kubernetes.io/ingress.class: Invalid value: "nginx": can not be set when the class field is also set
```
## Testing
Smoke test

