### PR TITLE
fix: codeowners order

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,5 @@
+* @joroshiba @SuperFluffy @noot
+
 /.github/  @astriaorg/infra
 /containerfiles/  @astriaorg/infra
 /charts/  @astriaorg/infra
@@ -19,5 +21,3 @@ buf.work.yaml @astriaorg/api-reviewers
 
 specs/  @astriaorg/engineering
 justfile  @astriaorg/engineering
-
-* @joroshiba @SuperFluffy @noot


### PR DESCRIPTION
Since codeowners update only people with * have been being added, I believe I needed to reverse order of file
