### PR TITLE
feat(core): generate Bytes and serde traits for new sequencerblock API

### DIFF
--- a/crates/astria-core/src/generated/astria.sequencerblock.v1alpha1.rs
+++ b/crates/astria-core/src/generated/astria.sequencerblock.v1alpha1.rs
@@ -3,8 +3,8 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Proof {
     /// A sequence of 32 byte hashes used to reconstruct a Merkle Tree Hash.
-    #[prost(bytes = "vec", tag = "1")]
-    pub audit_path: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "bytes", tag = "1")]
+    pub audit_path: ::prost::bytes::Bytes,
     /// The index of the leaf this proof applies to.
     #[prost(uint64, tag = "2")]
     pub leaf_index: u64,
@@ -28,12 +28,12 @@ impl ::prost::Name for Proof {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RollupTransactions {
     /// The 32 bytes identifying a rollup. Usually the sha256 hash of a plain rollup name.
-    #[prost(bytes = "vec", tag = "1")]
-    pub rollup_id: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "bytes", tag = "1")]
+    pub rollup_id: ::prost::bytes::Bytes,
     /// The serialized bytes of the rollup data.
     /// Each entry is a protobuf-encoded `RollupData` message.
-    #[prost(bytes = "vec", repeated, tag = "2")]
-    pub transactions: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+    #[prost(bytes = "bytes", repeated, tag = "2")]
+    pub transactions: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
     /// The proof that these rollup transactions are included in sequencer block.
     /// `astria.sequencer.v1alpha.SequencerBlock.rollup_transactions_proof`.
     #[prost(message, optional, tag = "3")]
@@ -76,8 +76,8 @@ pub struct SequencerBlock {
     #[prost(message, optional, tag = "4")]
     pub rollup_ids_proof: ::core::option::Option<Proof>,
     /// / The block hash of the cometbft block that corresponds to this sequencer block.
-    #[prost(bytes = "vec", tag = "5")]
-    pub block_hash: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "bytes", tag = "5")]
+    pub block_hash: ::prost::bytes::Bytes,
 }
 impl ::prost::Name for SequencerBlock {
     const NAME: &'static str = "SequencerBlock";
@@ -99,15 +99,15 @@ pub struct SequencerBlockHeader {
     #[prost(message, optional, tag = "3")]
     pub time: ::core::option::Option<::pbjson_types::Timestamp>,
     /// the data_hash of the sequencer block (merkle root of all transaction hashes)
-    #[prost(bytes = "vec", tag = "4")]
-    pub data_hash: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "bytes", tag = "4")]
+    pub data_hash: ::prost::bytes::Bytes,
     /// the cometbft proposer address of the sequencer block
-    #[prost(bytes = "vec", tag = "5")]
-    pub proposer_address: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "bytes", tag = "5")]
+    pub proposer_address: ::prost::bytes::Bytes,
     /// The 32-byte merkle root of all the rollup transactions in the block,
     /// Corresponds to `MHT(astria.sequencer.v1alpha.SequencerBlock.rollup_transactions)`,
-    #[prost(bytes = "vec", tag = "6")]
-    pub rollup_transactions_root: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "bytes", tag = "6")]
+    pub rollup_transactions_root: ::prost::bytes::Bytes,
 }
 impl ::prost::Name for SequencerBlockHeader {
     const NAME: &'static str = "SequencerBlockHeader";
@@ -132,15 +132,15 @@ pub struct Deposit {
     /// this is required as initializing an account as a bridge account
     /// is permissionless, so the rollup consensus needs to know and enshrine
     /// which accounts it accepts as valid bridge accounts.
-    #[prost(bytes = "vec", tag = "1")]
-    pub bridge_address: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "bytes", tag = "1")]
+    pub bridge_address: ::prost::bytes::Bytes,
     /// the rollup_id which the funds are being deposited to
-    #[prost(bytes = "vec", tag = "2")]
-    pub rollup_id: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "bytes", tag = "2")]
+    pub rollup_id: ::prost::bytes::Bytes,
     #[prost(message, optional, tag = "3")]
     pub amount: ::core::option::Option<super::super::primitive::v1::Uint128>,
-    #[prost(bytes = "vec", tag = "4")]
-    pub asset_id: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "bytes", tag = "4")]
+    pub asset_id: ::prost::bytes::Bytes,
     /// the address on the destination chain which
     /// will receive the bridged funds
     #[prost(string, tag = "5")]
@@ -159,8 +159,8 @@ impl ::prost::Name for Deposit {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FilteredSequencerBlock {
     /// / The block hash of the cometbft block that corresponds to this sequencer block.
-    #[prost(bytes = "vec", tag = "1")]
-    pub block_hash: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "bytes", tag = "1")]
+    pub block_hash: ::prost::bytes::Bytes,
     /// the block header, which contains sequencer-specific commitments.
     #[prost(message, optional, tag = "2")]
     pub header: ::core::option::Option<SequencerBlockHeader>,
@@ -179,8 +179,8 @@ pub struct FilteredSequencerBlock {
     /// and is extracted from `astria.sequencer.v1alpha.SequencerBlock.rollup_transactions`.
     /// Note that these are all the rollup IDs in the sequencer block, not merely those in
     /// `rollup_transactions` field. This is necessary to prove that no rollup IDs were omitted.
-    #[prost(bytes = "vec", repeated, tag = "5")]
-    pub all_rollup_ids: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+    #[prost(bytes = "bytes", repeated, tag = "5")]
+    pub all_rollup_ids: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
     /// The proof that the `rollup_ids` are included
     /// in the CometBFT block this sequencer block is derived form.
     ///
@@ -218,7 +218,7 @@ pub mod rollup_data {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Value {
         #[prost(bytes, tag = "1")]
-        SequencedData(::prost::alloc::vec::Vec<u8>),
+        SequencedData(::prost::bytes::Bytes),
         #[prost(message, tag = "2")]
         Deposit(super::Deposit),
     }
@@ -239,15 +239,15 @@ impl ::prost::Name for RollupData {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CelestiaRollupBlob {
     /// The hash of the sequencer block. Must be 32 bytes.
-    #[prost(bytes = "vec", tag = "1")]
-    pub sequencer_block_hash: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "bytes", tag = "1")]
+    pub sequencer_block_hash: ::prost::bytes::Bytes,
     /// The 32 bytes identifying the rollup this blob belongs to. Matches
     /// `astria.sequencer.v1.RollupTransactions.rollup_id`
-    #[prost(bytes = "vec", tag = "2")]
-    pub rollup_id: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "bytes", tag = "2")]
+    pub rollup_id: ::prost::bytes::Bytes,
     /// A list of opaque bytes that are serialized rollup transactions.
-    #[prost(bytes = "vec", repeated, tag = "3")]
-    pub transactions: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+    #[prost(bytes = "bytes", repeated, tag = "3")]
+    pub transactions: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
     /// The proof that these rollup transactions are included in sequencer block.
     /// `astria.sequencer.v1alpha.SequencerBlock.rollup_transactions_proof`.
     #[prost(message, optional, tag = "4")]
@@ -272,16 +272,16 @@ impl ::prost::Name for CelestiaRollupBlob {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CelestiaSequencerBlob {
     /// the 32-byte block hash of the sequencer block.
-    #[prost(bytes = "vec", tag = "1")]
-    pub block_hash: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "bytes", tag = "1")]
+    pub block_hash: ::prost::bytes::Bytes,
     /// the block header, which contains sequencer-specific commitments.
     #[prost(message, optional, tag = "2")]
     pub header: ::core::option::Option<SequencerBlockHeader>,
     /// The rollup IDs for which `CelestiaRollupBlob`s were submitted to celestia.
     /// Corresponds to the `astria.sequencer.v1.RollupTransactions.rollup_id` field
     /// and is extracted from `astria.sequencer.v1alpha.SequencerBlock.rollup_transactions`.
-    #[prost(bytes = "vec", repeated, tag = "3")]
-    pub rollup_ids: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+    #[prost(bytes = "bytes", repeated, tag = "3")]
+    pub rollup_ids: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
     /// The proof that the rollup transactions are included in sequencer block.
     /// Corresponds to `astria.sequencer.v1alpha.SequencerBlock.rollup_transactions_proof`.
     #[prost(message, optional, tag = "4")]
@@ -319,8 +319,8 @@ pub struct GetFilteredSequencerBlockRequest {
     #[prost(uint64, tag = "1")]
     pub height: u64,
     /// The 32 bytes identifying a rollup. Usually the sha256 hash of a plain rollup name.
-    #[prost(bytes = "vec", repeated, tag = "2")]
-    pub rollup_ids: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+    #[prost(bytes = "bytes", repeated, tag = "2")]
+    pub rollup_ids: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
 }
 impl ::prost::Name for GetFilteredSequencerBlockRequest {
     const NAME: &'static str = "GetFilteredSequencerBlockRequest";

--- a/crates/astria-core/src/generated/astria.sequencerblock.v1alpha1.serde.rs
+++ b/crates/astria-core/src/generated/astria.sequencerblock.v1alpha1.serde.rs
@@ -1,3 +1,325 @@
+impl serde::Serialize for CelestiaRollupBlob {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.sequencer_block_hash.is_empty() {
+            len += 1;
+        }
+        if !self.rollup_id.is_empty() {
+            len += 1;
+        }
+        if !self.transactions.is_empty() {
+            len += 1;
+        }
+        if self.proof.is_some() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.sequencerblock.v1alpha1.CelestiaRollupBlob", len)?;
+        if !self.sequencer_block_hash.is_empty() {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("sequencer_block_hash", pbjson::private::base64::encode(&self.sequencer_block_hash).as_str())?;
+        }
+        if !self.rollup_id.is_empty() {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("rollup_id", pbjson::private::base64::encode(&self.rollup_id).as_str())?;
+        }
+        if !self.transactions.is_empty() {
+            struct_ser.serialize_field("transactions", &self.transactions.iter().map(pbjson::private::base64::encode).collect::<Vec<_>>())?;
+        }
+        if let Some(v) = self.proof.as_ref() {
+            struct_ser.serialize_field("proof", v)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for CelestiaRollupBlob {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "sequencer_block_hash",
+            "sequencerBlockHash",
+            "rollup_id",
+            "rollupId",
+            "transactions",
+            "proof",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            SequencerBlockHash,
+            RollupId,
+            Transactions,
+            Proof,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "sequencerBlockHash" | "sequencer_block_hash" => Ok(GeneratedField::SequencerBlockHash),
+                            "rollupId" | "rollup_id" => Ok(GeneratedField::RollupId),
+                            "transactions" => Ok(GeneratedField::Transactions),
+                            "proof" => Ok(GeneratedField::Proof),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = CelestiaRollupBlob;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.sequencerblock.v1alpha1.CelestiaRollupBlob")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<CelestiaRollupBlob, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut sequencer_block_hash__ = None;
+                let mut rollup_id__ = None;
+                let mut transactions__ = None;
+                let mut proof__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::SequencerBlockHash => {
+                            if sequencer_block_hash__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("sequencerBlockHash"));
+                            }
+                            sequencer_block_hash__ = 
+                                Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::RollupId => {
+                            if rollup_id__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("rollupId"));
+                            }
+                            rollup_id__ = 
+                                Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::Transactions => {
+                            if transactions__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("transactions"));
+                            }
+                            transactions__ = 
+                                Some(map_.next_value::<Vec<::pbjson::private::BytesDeserialize<_>>>()?
+                                    .into_iter().map(|x| x.0).collect())
+                            ;
+                        }
+                        GeneratedField::Proof => {
+                            if proof__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("proof"));
+                            }
+                            proof__ = map_.next_value()?;
+                        }
+                    }
+                }
+                Ok(CelestiaRollupBlob {
+                    sequencer_block_hash: sequencer_block_hash__.unwrap_or_default(),
+                    rollup_id: rollup_id__.unwrap_or_default(),
+                    transactions: transactions__.unwrap_or_default(),
+                    proof: proof__,
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.sequencerblock.v1alpha1.CelestiaRollupBlob", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for CelestiaSequencerBlob {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.block_hash.is_empty() {
+            len += 1;
+        }
+        if self.header.is_some() {
+            len += 1;
+        }
+        if !self.rollup_ids.is_empty() {
+            len += 1;
+        }
+        if self.rollup_transactions_proof.is_some() {
+            len += 1;
+        }
+        if self.rollup_ids_proof.is_some() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.sequencerblock.v1alpha1.CelestiaSequencerBlob", len)?;
+        if !self.block_hash.is_empty() {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("block_hash", pbjson::private::base64::encode(&self.block_hash).as_str())?;
+        }
+        if let Some(v) = self.header.as_ref() {
+            struct_ser.serialize_field("header", v)?;
+        }
+        if !self.rollup_ids.is_empty() {
+            struct_ser.serialize_field("rollup_ids", &self.rollup_ids.iter().map(pbjson::private::base64::encode).collect::<Vec<_>>())?;
+        }
+        if let Some(v) = self.rollup_transactions_proof.as_ref() {
+            struct_ser.serialize_field("rollup_transactions_proof", v)?;
+        }
+        if let Some(v) = self.rollup_ids_proof.as_ref() {
+            struct_ser.serialize_field("rollup_ids_proof", v)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for CelestiaSequencerBlob {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "block_hash",
+            "blockHash",
+            "header",
+            "rollup_ids",
+            "rollupIds",
+            "rollup_transactions_proof",
+            "rollupTransactionsProof",
+            "rollup_ids_proof",
+            "rollupIdsProof",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            BlockHash,
+            Header,
+            RollupIds,
+            RollupTransactionsProof,
+            RollupIdsProof,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "blockHash" | "block_hash" => Ok(GeneratedField::BlockHash),
+                            "header" => Ok(GeneratedField::Header),
+                            "rollupIds" | "rollup_ids" => Ok(GeneratedField::RollupIds),
+                            "rollupTransactionsProof" | "rollup_transactions_proof" => Ok(GeneratedField::RollupTransactionsProof),
+                            "rollupIdsProof" | "rollup_ids_proof" => Ok(GeneratedField::RollupIdsProof),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = CelestiaSequencerBlob;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.sequencerblock.v1alpha1.CelestiaSequencerBlob")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<CelestiaSequencerBlob, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut block_hash__ = None;
+                let mut header__ = None;
+                let mut rollup_ids__ = None;
+                let mut rollup_transactions_proof__ = None;
+                let mut rollup_ids_proof__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::BlockHash => {
+                            if block_hash__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("blockHash"));
+                            }
+                            block_hash__ = 
+                                Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::Header => {
+                            if header__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("header"));
+                            }
+                            header__ = map_.next_value()?;
+                        }
+                        GeneratedField::RollupIds => {
+                            if rollup_ids__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("rollupIds"));
+                            }
+                            rollup_ids__ = 
+                                Some(map_.next_value::<Vec<::pbjson::private::BytesDeserialize<_>>>()?
+                                    .into_iter().map(|x| x.0).collect())
+                            ;
+                        }
+                        GeneratedField::RollupTransactionsProof => {
+                            if rollup_transactions_proof__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("rollupTransactionsProof"));
+                            }
+                            rollup_transactions_proof__ = map_.next_value()?;
+                        }
+                        GeneratedField::RollupIdsProof => {
+                            if rollup_ids_proof__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("rollupIdsProof"));
+                            }
+                            rollup_ids_proof__ = map_.next_value()?;
+                        }
+                    }
+                }
+                Ok(CelestiaSequencerBlob {
+                    block_hash: block_hash__.unwrap_or_default(),
+                    header: header__,
+                    rollup_ids: rollup_ids__.unwrap_or_default(),
+                    rollup_transactions_proof: rollup_transactions_proof__,
+                    rollup_ids_proof: rollup_ids_proof__,
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.sequencerblock.v1alpha1.CelestiaSequencerBlob", FIELDS, GeneratedVisitor)
+    }
+}
 impl serde::Serialize for Deposit {
     #[allow(deprecated)]
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
@@ -472,6 +794,237 @@ impl<'de> serde::Deserialize<'de> for GetFilteredSequencerBlockRequest {
         deserializer.deserialize_struct("astria.sequencerblock.v1alpha1.GetFilteredSequencerBlockRequest", FIELDS, GeneratedVisitor)
     }
 }
+impl serde::Serialize for GetSequencerBlockRequest {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.height != 0 {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.sequencerblock.v1alpha1.GetSequencerBlockRequest", len)?;
+        if self.height != 0 {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("height", ToString::to_string(&self.height).as_str())?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for GetSequencerBlockRequest {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "height",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Height,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "height" => Ok(GeneratedField::Height),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = GetSequencerBlockRequest;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.sequencerblock.v1alpha1.GetSequencerBlockRequest")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<GetSequencerBlockRequest, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut height__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Height => {
+                            if height__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("height"));
+                            }
+                            height__ = 
+                                Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                    }
+                }
+                Ok(GetSequencerBlockRequest {
+                    height: height__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.sequencerblock.v1alpha1.GetSequencerBlockRequest", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for Proof {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.audit_path.is_empty() {
+            len += 1;
+        }
+        if self.leaf_index != 0 {
+            len += 1;
+        }
+        if self.tree_size != 0 {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.sequencerblock.v1alpha1.Proof", len)?;
+        if !self.audit_path.is_empty() {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("audit_path", pbjson::private::base64::encode(&self.audit_path).as_str())?;
+        }
+        if self.leaf_index != 0 {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("leaf_index", ToString::to_string(&self.leaf_index).as_str())?;
+        }
+        if self.tree_size != 0 {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("tree_size", ToString::to_string(&self.tree_size).as_str())?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for Proof {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "audit_path",
+            "auditPath",
+            "leaf_index",
+            "leafIndex",
+            "tree_size",
+            "treeSize",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            AuditPath,
+            LeafIndex,
+            TreeSize,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "auditPath" | "audit_path" => Ok(GeneratedField::AuditPath),
+                            "leafIndex" | "leaf_index" => Ok(GeneratedField::LeafIndex),
+                            "treeSize" | "tree_size" => Ok(GeneratedField::TreeSize),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = Proof;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.sequencerblock.v1alpha1.Proof")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Proof, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut audit_path__ = None;
+                let mut leaf_index__ = None;
+                let mut tree_size__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::AuditPath => {
+                            if audit_path__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("auditPath"));
+                            }
+                            audit_path__ = 
+                                Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::LeafIndex => {
+                            if leaf_index__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("leafIndex"));
+                            }
+                            leaf_index__ = 
+                                Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::TreeSize => {
+                            if tree_size__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("treeSize"));
+                            }
+                            tree_size__ = 
+                                Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                    }
+                }
+                Ok(Proof {
+                    audit_path: audit_path__.unwrap_or_default(),
+                    leaf_index: leaf_index__.unwrap_or_default(),
+                    tree_size: tree_size__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.sequencerblock.v1alpha1.Proof", FIELDS, GeneratedVisitor)
+    }
+}
 impl serde::Serialize for RollupData {
     #[allow(deprecated)]
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
@@ -712,6 +1265,172 @@ impl<'de> serde::Deserialize<'de> for RollupTransactions {
             }
         }
         deserializer.deserialize_struct("astria.sequencerblock.v1alpha1.RollupTransactions", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for SequencerBlock {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.header.is_some() {
+            len += 1;
+        }
+        if !self.rollup_transactions.is_empty() {
+            len += 1;
+        }
+        if self.rollup_transactions_proof.is_some() {
+            len += 1;
+        }
+        if self.rollup_ids_proof.is_some() {
+            len += 1;
+        }
+        if !self.block_hash.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.sequencerblock.v1alpha1.SequencerBlock", len)?;
+        if let Some(v) = self.header.as_ref() {
+            struct_ser.serialize_field("header", v)?;
+        }
+        if !self.rollup_transactions.is_empty() {
+            struct_ser.serialize_field("rollup_transactions", &self.rollup_transactions)?;
+        }
+        if let Some(v) = self.rollup_transactions_proof.as_ref() {
+            struct_ser.serialize_field("rollup_transactions_proof", v)?;
+        }
+        if let Some(v) = self.rollup_ids_proof.as_ref() {
+            struct_ser.serialize_field("rollup_ids_proof", v)?;
+        }
+        if !self.block_hash.is_empty() {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("block_hash", pbjson::private::base64::encode(&self.block_hash).as_str())?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for SequencerBlock {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "header",
+            "rollup_transactions",
+            "rollupTransactions",
+            "rollup_transactions_proof",
+            "rollupTransactionsProof",
+            "rollup_ids_proof",
+            "rollupIdsProof",
+            "block_hash",
+            "blockHash",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Header,
+            RollupTransactions,
+            RollupTransactionsProof,
+            RollupIdsProof,
+            BlockHash,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "header" => Ok(GeneratedField::Header),
+                            "rollupTransactions" | "rollup_transactions" => Ok(GeneratedField::RollupTransactions),
+                            "rollupTransactionsProof" | "rollup_transactions_proof" => Ok(GeneratedField::RollupTransactionsProof),
+                            "rollupIdsProof" | "rollup_ids_proof" => Ok(GeneratedField::RollupIdsProof),
+                            "blockHash" | "block_hash" => Ok(GeneratedField::BlockHash),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = SequencerBlock;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.sequencerblock.v1alpha1.SequencerBlock")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<SequencerBlock, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut header__ = None;
+                let mut rollup_transactions__ = None;
+                let mut rollup_transactions_proof__ = None;
+                let mut rollup_ids_proof__ = None;
+                let mut block_hash__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Header => {
+                            if header__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("header"));
+                            }
+                            header__ = map_.next_value()?;
+                        }
+                        GeneratedField::RollupTransactions => {
+                            if rollup_transactions__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("rollupTransactions"));
+                            }
+                            rollup_transactions__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::RollupTransactionsProof => {
+                            if rollup_transactions_proof__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("rollupTransactionsProof"));
+                            }
+                            rollup_transactions_proof__ = map_.next_value()?;
+                        }
+                        GeneratedField::RollupIdsProof => {
+                            if rollup_ids_proof__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("rollupIdsProof"));
+                            }
+                            rollup_ids_proof__ = map_.next_value()?;
+                        }
+                        GeneratedField::BlockHash => {
+                            if block_hash__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("blockHash"));
+                            }
+                            block_hash__ = 
+                                Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
+                            ;
+                        }
+                    }
+                }
+                Ok(SequencerBlock {
+                    header: header__,
+                    rollup_transactions: rollup_transactions__.unwrap_or_default(),
+                    rollup_transactions_proof: rollup_transactions_proof__,
+                    rollup_ids_proof: rollup_ids_proof__,
+                    block_hash: block_hash__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.sequencerblock.v1alpha1.SequencerBlock", FIELDS, GeneratedVisitor)
     }
 }
 impl serde::Serialize for SequencerBlockHeader {

--- a/tools/protobuf-compiler/src/main.rs
+++ b/tools/protobuf-compiler/src/main.rs
@@ -63,7 +63,10 @@ fn main() {
         .build_client(true)
         .build_server(true)
         .emit_rerun_if_changed(false)
-        .bytes([".astria.execution.v1alpha2"])
+        .bytes([
+            ".astria.execution.v1alpha2",
+            ".astria.sequencerblock.v1alpha1",
+        ])
         .client_mod_attribute(".", "#[cfg(feature=\"client\")]")
         .server_mod_attribute(".", "#[cfg(feature=\"server\")]")
         .extern_path(
@@ -112,12 +115,7 @@ fn main() {
             ".astria.sequencer.v1.RollupData",
             ".astria.sequencer.v1.RollupTransactions",
             ".astria.primitive.v1.Uint128",
-            ".astria.sequencerblock.v1alpha1.Deposit",
-            ".astria.sequencerblock.v1alpha1.SequencerBlockHeader",
-            ".astria.sequencerblock.v1alpha1.FilteredSequencerBlock",
-            ".astria.sequencerblock.v1alpha1.GetFilteredSequencerBlockRequest",
-            ".astria.sequencerblock.v1alpha1.RollupData",
-            ".astria.sequencerblock.v1alpha1.RollupTransactions",
+            ".astria.sequencerblock.v1alpha1",
         ])
         .unwrap();
 


### PR DESCRIPTION
## Summary
Generate `Bytes` for protobuf `bytes` fields and all serde `Deserialize` and `Serialize` for all new protobuf types.

## Background
It's a long-standing goal to prefer `Bytes` over `Vec<u8>` (for performance/zero-copy reasons). Using the protobuf <> json mapping for our protobuf specs also provides for common standard across all our API (and is required when macking mock tests using `astria-grpc-mock).

## Changes
- add all of `.astria.sequenceblock.v1alpha1` to `prost_build::Config::bytes` and `pbjson_build::Config::new`

## Testing
N/A, just generated code.