### PR TITLE
fix(ci): docker runs should pass for external prs

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -26,15 +26,12 @@ on:
       - "**-v[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+"
       - "**-v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+"
     
-  # trigger on pull request updates when target is `main` branch
   pull_request:
     types:
       - opened
       - synchronize
       - reopened
       - labeled
-    branches:
-      - "main"
 
 jobs:
   run_checker:
@@ -82,7 +79,7 @@ jobs:
   
   smoke-test:
     needs: [run_checker, composer, conductor, sequencer, sequencer-relayer]
-    if: github.event_name == 'merge_group' || needs.run_checker.outputs.run_docker == 'true'
+    if: github.repository_owner == 'astriaorg' && (github.event_name == 'merge_group' || needs.run_checker.outputs.run_docker == 'true')
     runs-on: buildjet-8vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -14,9 +14,9 @@ on:
         type: string
     secrets:
       DOCKER_TOKEN:
-        required: true
+        required: false
       DOCKER_USER:
-        required: true
+        required: false
 env:
   REGISTRY: ghcr.io
   FULL_REF: ${{ inputs.tag && format('refs/tags/{0}', inputs.tag) || github.ref }}
@@ -32,6 +32,7 @@ jobs:
           ref: ${{ inputs.tag }}
       # https://github.com/docker/setup-qemu-action
       - name: Login to Docker Hub
+        if: github.repository_owner == 'astriaorg'
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USER }}
@@ -71,7 +72,7 @@ jobs:
           build-args: |
             TARGETBINARY=${{ inputs.target-binary }}
           platforms: 'linux/amd64,linux/arm64'
-          push: true
+          push: ${{ github.repository_owner == 'astriaorg'}}
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
           cache-from: type=registry,ref=${{ format('ghcr.io/astriaorg/{0}:buildcache', inputs.package-name) }}


### PR DESCRIPTION
## Summary
Updating so that external PRs can pass, and to allow docker builds to be specified on non-main builds

## Background
External PR improving docker builds couldn't pass CI, this is a fix for that and for some PRs which we might want to run docker builds on which are merges into other PRs.
