### PR TITLE
fix(ci): disable storage for dev values

### DIFF
--- a/dev/values/validators/single.yml
+++ b/dev/values/validators/single.yml
@@ -10,10 +10,10 @@ sequencer-relayer:
       cometbftRpc: http://node0-sequencer-rpc-service.astria-dev-cluster.svc.cluster.local:26657
       sequencerGrpc: http://node0-sequencer-grpc-service.astria-dev-cluster.svc.cluster.local:8080
   storage:
-    enabled: true
+    enabled: false
 
 storage:
-  enabled: true
+  enabled: false
 
 ingress:
   rpc:


### PR DESCRIPTION
## Summary
I accidentally enabled storage which can cause slowness and test failures. This disables it by default. 

