### PR TITLE
chore(ci): CODEOWNERS updates

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,23 +1,29 @@
 * @joroshiba @SuperFluffy @noot
 
-/.github/  @astriaorg/infra
-/containerfiles/  @astriaorg/infra
-/charts/  @astriaorg/infra
-/dev/  @astriaorg/infra
-.dockerignore  @astriaorg/infra
+specs/ @astriaorg/engineering
+justfile @astriaorg/engineering
+README.md @astriaorg/engineering
+taplo.toml @astriaorg/engineering
+.gitattributes @astriaorg/engineering
+.gitignore @astriaorg/engineering
 
-*.rs  @astriaorg/rust-reviewers
-Cargo.toml  @astriaorg/rust-reviewers
-Cargo.lock  @astriaorg/rust-reviewers
-rust-toolchain  @astriaorg/rust-reviewers
-.cargo/  @astriaorg/rust-reviewers
-nextest.toml  @astriaorg/rust-reviewers
-rusfmt.toml  @astriaorg/rust-reviewers
+/.github/ @astriaorg/infra
+/containerfiles/ @astriaorg/infra
+/charts/ @astriaorg/infra
+/dev/ @astriaorg/infra
+.dockerignore @astriaorg/infra
+*.env.example @astriaorg/infra
 
 *.proto @astriaorg/api-reviewers
+proto/*/LICENSE @astriaorg/api-reviewers
 buf.lock @astriaorg/api-reviewers
 buf.yaml @astriaorg/api-reviewers
 buf.work.yaml @astriaorg/api-reviewers
 
-specs/  @astriaorg/engineering
-justfile  @astriaorg/engineering
+*.rs @astriaorg/rust-reviewers
+Cargo.toml @astriaorg/rust-reviewers
+Cargo.lock @astriaorg/rust-reviewers
+rust-toolchain @astriaorg/rust-reviewers
+.cargo/ @astriaorg/rust-reviewers
+nextest.toml @astriaorg/rust-reviewers
+rusfmt.toml @astriaorg/rust-reviewers


### PR DESCRIPTION
## Summary
Changed order since the bottom of codeowners takes precendence, added some files which were defaulting to top level owners to specific groups.
