### PR TITLE
feat(composer): Track the total bundle submission latency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,6 +561,7 @@ dependencies = [
  "hyper",
  "insta",
  "itertools 0.11.0",
+ "metrics",
  "once_cell",
  "pin-project-lite",
  "prost",

--- a/crates/astria-composer/Cargo.toml
+++ b/crates/astria-composer/Cargo.toml
@@ -55,6 +55,7 @@ tracing = { workspace = true, features = ["attributes"] }
 tryhard = { workspace = true }
 tonic = { workspace = true }
 tokio-stream = { workspace = true, features = ["net"] }
+metrics = { workspace = true }
 
 [dependencies.sequencer-client]
 package = "astria-sequencer-client"

--- a/crates/astria-composer/src/collectors/geth.rs
+++ b/crates/astria-composer/src/collectors/geth.rs
@@ -50,7 +50,9 @@ use tracing::{
 use crate::{
     collectors::EXECUTOR_SEND_TIMEOUT,
     executor,
+    metrics_init::ROLLUP_ID_LABEL,
 };
+
 type StdError = dyn std::error::Error;
 
 const WSS_UNSUBSCRIBE_TIMEOUT: Duration = Duration::from_secs(2);
@@ -148,7 +150,7 @@ impl Geth {
             status,
             url,
             shutdown_token,
-            ..
+            chain_name,
         } = self;
 
         let retry_config = tryhard::RetryFutureConfig::new(1024)
@@ -169,6 +171,7 @@ impl Geth {
                 },
             );
 
+        let start = std::time::Instant::now();
         let client = tryhard::retry_fn(|| {
             let url = url.clone();
             async move {
@@ -184,6 +187,10 @@ impl Geth {
             .subscribe_full_pending_txs()
             .await
             .wrap_err("failed to subscribe eth client to full pending transactions")?;
+
+        metrics::histogram!(crate::metrics_init::GETH_COLLECTOR_CONNECTION_LATENCY,
+            ROLLUP_ID_LABEL => chain_name.clone())
+        .record(start.elapsed());
 
         status.send_modify(|status| status.is_connected = true);
 
@@ -204,17 +211,25 @@ impl Geth {
                             fee_asset_id: default_native_asset_id(),
                         };
 
+                        metrics::counter!(crate::metrics_init::GETH_COLLECTOR_TRANSACTIONS_COLLECTED,
+                            ROLLUP_ID_LABEL => chain_name.clone()).increment(1);
+
                         match executor_handle
                             .send_timeout(seq_action, EXECUTOR_SEND_TIMEOUT)
                             .await
                         {
-                            Ok(()) => {}
+                            Ok(()) => {
+                                metrics::counter!(crate::metrics_init::GETH_COLLECTOR_TRANSACTIONS_FORWARDED,
+                                    ROLLUP_ID_LABEL => chain_name.clone()).increment(1);
+                            },
                             Err(SendTimeoutError::Timeout(_seq_action)) => {
                                 warn!(
                                     transaction.hash = %tx_hash,
                                     timeout_ms = EXECUTOR_SEND_TIMEOUT.as_millis(),
                                     "timed out sending new transaction to executor; dropping tx",
                                 );
+                                metrics::counter!(crate::metrics_init::GETH_COLLECTOR_TRANSACTIONS_DROPPED,
+                                    ROLLUP_ID_LABEL => chain_name.clone()).increment(1);
                             }
                             Err(SendTimeoutError::Closed(_seq_action)) => {
                                 warn!(
@@ -222,6 +237,8 @@ impl Geth {
                                     "executor channel closed while sending transaction; dropping transaction \
                                      and exiting event loop"
                                 );
+                                metrics::counter!(crate::metrics_init::GETH_COLLECTOR_TRANSACTIONS_DROPPED,
+                                    ROLLUP_ID_LABEL => chain_name.clone()).increment(1);
                                 break Err(eyre!("executor channel closed while sending transaction"));
                             }
                         }

--- a/crates/astria-composer/src/executor/bundle_factory/mod.rs
+++ b/crates/astria-composer/src/executor/bundle_factory/mod.rs
@@ -22,6 +22,8 @@ use serde::ser::{
 };
 use tracing::trace;
 
+use crate::metrics_init::ROLLUP_ID_LABEL;
+
 mod tests;
 
 #[derive(Debug, thiserror::Error)]
@@ -79,6 +81,9 @@ impl SizedBundle {
         let seq_action_size = estimate_size_of_sequence_action(&seq_action);
 
         if seq_action_size > self.max_size {
+            metrics::gauge!(crate::metrics_init::TRANSACTIONS_DROPPED_TOO_LARGE,
+                ROLLUP_ID_LABEL => seq_action.rollup_id.to_string())
+            .increment(1);
             return Err(SizedBundleError::SequenceActionTooLarge(seq_action));
         }
 
@@ -100,9 +105,19 @@ impl SizedBundle {
         mem::replace(self, Self::new(self.max_size))
     }
 
+    /// Returns the current size of the bundle.
+    pub(super) fn get_size(&self) -> usize {
+        self.curr_size
+    }
+
     /// Consume self and return the underlying buffer of actions.
     pub(super) fn into_actions(self) -> Vec<Action> {
         self.buffer
+    }
+
+    /// Returns the number of sequence actions in the bundle.
+    pub(super) fn no_of_seq_actions(&self) -> usize {
+        self.buffer.len()
     }
 
     /// Returns true if the bundle is empty.
@@ -143,6 +158,11 @@ impl BundleFactory {
         seq_action: SequenceAction,
     ) -> Result<(), BundleFactoryError> {
         let seq_action_size = estimate_size_of_sequence_action(&seq_action);
+        let rollup_id = seq_action.rollup_id;
+
+        metrics::counter!(crate::metrics_init::TRANSACTIONS_RECEIVED,
+                        ROLLUP_ID_LABEL => rollup_id.to_string())
+        .increment(1);
 
         match self.curr_bundle.push(seq_action) {
             Err(SizedBundleError::SequenceActionTooLarge(_seq_action)) => {
@@ -154,6 +174,16 @@ impl BundleFactory {
             }
             Err(SizedBundleError::NotEnoughSpace(seq_action)) => {
                 // if the bundle is full, flush it and start a new one
+                metrics::counter!(crate::metrics_init::BUNDLES_TOTAL_COUNT).increment(1);
+
+                #[allow(clippy::cast_precision_loss)]
+                metrics::histogram!(crate::metrics_init::BUNDLES_TOTAL_BYTES)
+                    .record(self.curr_bundle.get_size() as f64);
+
+                #[allow(clippy::cast_precision_loss)]
+                metrics::histogram!(crate::metrics_init::BUNDLES_TOTAL_TRANSACTIONS_COUNT)
+                    .record(self.curr_bundle.no_of_seq_actions() as f64);
+
                 self.finished.push_back(self.curr_bundle.flush());
                 self.curr_bundle
                     .push(seq_action)
@@ -189,10 +219,25 @@ impl BundleFactory {
     ///
     /// Returns an empty bundle if there are no bundled transactions.
     pub(super) fn pop_now(&mut self) -> SizedBundle {
-        self.finished
+        let bundle = self
+            .finished
             .pop_front()
             .or_else(|| Some(self.curr_bundle.flush()))
-            .unwrap_or(SizedBundle::new(self.curr_bundle.max_size))
+            .unwrap_or(SizedBundle::new(self.curr_bundle.max_size));
+
+        if !bundle.is_empty() {
+            metrics::counter!(crate::metrics_init::BUNDLES_TOTAL_COUNT).increment(1);
+
+            #[allow(clippy::cast_precision_loss)]
+            metrics::histogram!(crate::metrics_init::BUNDLES_TOTAL_BYTES)
+                .record(bundle.get_size() as f64);
+
+            #[allow(clippy::cast_precision_loss)]
+            metrics::histogram!(crate::metrics_init::BUNDLES_TOTAL_TRANSACTIONS_COUNT)
+                .record(bundle.no_of_seq_actions() as f64);
+        }
+
+        bundle
     }
 }
 

--- a/crates/astria-composer/src/executor/mod.rs
+++ b/crates/astria-composer/src/executor/mod.rs
@@ -220,9 +220,7 @@ impl Executor {
                 // process submission result and update nonce
                 rsp = &mut submission_fut, if !submission_fut.is_terminated() => {
                     match rsp {
-                        Ok(new_nonce) => nonce = {
-                            new_nonce
-                        },
+                        Ok(new_nonce) => nonce = new_nonce,
                         Err(error) => {
                             error!(%error, "failed submitting bundle to sequencer; aborting executor");
                             break Err(error).wrap_err("failed submitting bundle to sequencer");
@@ -420,6 +418,8 @@ async fn get_latest_nonce(
             |attempt,
              next_delay: Option<Duration>,
              err: &sequencer_client::extension_trait::Error| {
+                metrics::counter!(crate::metrics_init::NONCE_FETCH_FAILURE_COUNT).increment(1);
+
                 let wait_duration = next_delay
                     .map(humantime::format_duration)
                     .map(tracing::field::display);
@@ -441,10 +441,6 @@ async fn get_latest_nonce(
     .with_config(retry_config)
     .await
     .wrap_err("failed getting latest nonce from sequencer after 1024 attempts");
-
-    if res.is_err() {
-        metrics::counter!(crate::metrics_init::NONCE_FETCH_FAILURE_COUNT).increment(1);
-    }
 
     metrics::histogram!(crate::metrics_init::NONCE_FETCH_LATENCY).record(start.elapsed());
 
@@ -475,6 +471,9 @@ async fn submit_tx(
             |attempt,
              next_delay: Option<Duration>,
              err: &sequencer_client::extension_trait::Error| {
+                metrics::counter!(crate::metrics_init::TRANSACTION_SUBMISSION_FAILURE_COUNT)
+                    .increment(1);
+
                 let wait_duration = next_delay
                     .map(humantime::format_duration)
                     .map(tracing::field::display);
@@ -497,10 +496,6 @@ async fn submit_tx(
     .with_config(retry_config)
     .await
     .wrap_err("failed sending transaction after 1024 attempts");
-
-    if res.is_err() {
-        metrics::counter!(crate::metrics_init::TRANSACTION_SUBMISSION_FAILURE_COUNT).increment(1);
-    }
 
     metrics::histogram!(crate::metrics_init::TRANSACTION_SUBMISSION_LATENCY)
         .record(start.elapsed());

--- a/crates/astria-composer/src/executor/mod.rs
+++ b/crates/astria-composer/src/executor/mod.rs
@@ -172,11 +172,10 @@ impl Executor {
         #[allow(clippy::cast_precision_loss)]
         metrics::histogram!(crate::metrics_init::BUNDLES_OUTGOING_BYTES)
             .record(bundle.get_size() as f64);
-        let no_of_seq_actions = bundle.no_of_seq_actions();
 
         #[allow(clippy::cast_precision_loss)]
         metrics::histogram!(crate::metrics_init::BUNDLES_OUTGOING_TRANSACTIONS_COUNT)
-            .record(no_of_seq_actions as f64);
+            .record(bundle.no_of_seq_actions() as f64);
 
         SubmitFut {
             client: self.sequencer_client.clone(),
@@ -554,6 +553,7 @@ pin_project! {
 impl Future for SubmitFut {
     type Output = eyre::Result<u32>;
 
+    #[allow(clippy::too_many_lines)]
     fn poll(mut self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
         loop {
             let this = self.as_mut().project();

--- a/crates/astria-composer/src/lib.rs
+++ b/crates/astria-composer/src/lib.rs
@@ -45,6 +45,7 @@ mod composer;
 pub mod config;
 mod executor;
 mod grpc;
+pub mod metrics_init;
 mod rollup;
 
 pub use build_info::BUILD_INFO;

--- a/crates/astria-composer/src/main.rs
+++ b/crates/astria-composer/src/main.rs
@@ -1,6 +1,7 @@
 use std::process::ExitCode;
 
 use astria_composer::{
+    metrics_init,
     Composer,
     Config,
     BUILD_INFO,
@@ -40,6 +41,8 @@ async fn main() -> ExitCode {
             .service_name(env!("CARGO_PKG_NAME"));
     }
 
+    metrics_init::register();
+
     if let Err(e) = telemetry_conf
         .try_init()
         .wrap_err("failed to setup telemetry")
@@ -51,7 +54,6 @@ async fn main() -> ExitCode {
     let cfg_ser = serde_json::to_string(&cfg)
         .expect("the json serializer should never fail when serializing to a string");
     eprintln!("config:\n{cfg_ser}");
-
     info!(config = cfg_ser, "initializing composer",);
 
     let composer = match Composer::from_config(&cfg).await {

--- a/crates/astria-composer/src/metrics_init.rs
+++ b/crates/astria-composer/src/metrics_init.rs
@@ -1,0 +1,239 @@
+//! Crate-specific metrics functionality.
+//!
+//! Registers metrics & lists constants to be used as metric names throughout crate.
+
+use metrics::{
+    describe_counter,
+    describe_gauge,
+    describe_histogram,
+    Unit,
+};
+
+/// Labels
+pub(crate) const ROLLUP_ID_LABEL: &str = "rollup_id";
+
+/// Registers all metrics used by this crate.
+#[allow(clippy::too_many_lines)]
+pub fn register() {
+    // geth collectors metrics
+    describe_counter!(
+        GETH_COLLECTOR_TRANSACTIONS_COLLECTED,
+        Unit::Count,
+        "The number of transactions received by the geth collector labelled by rollup"
+    );
+    describe_counter!(
+        GETH_COLLECTOR_TRANSACTIONS_DROPPED,
+        Unit::Count,
+        "The number of transactions dropped by the geth collector before bundling it labelled by \
+         rollup"
+    );
+    describe_counter!(
+        GETH_COLLECTOR_TRANSACTIONS_FORWARDED,
+        Unit::Count,
+        "The number of transactions successfully sent by the geth collector to be bundled \
+         labelled by rollup"
+    );
+    describe_histogram!(
+        GETH_COLLECTOR_CONNECTION_LATENCY,
+        Unit::Milliseconds,
+        "The time taken to connect to geth"
+    );
+
+    // grpc collector metrics
+    describe_counter!(
+        GRPC_COLLECTOR_TRANSACTIONS_COLLECTED,
+        Unit::Count,
+        "The number of transactions received by the grpc collector"
+    );
+    describe_counter!(
+        GRPC_COLLECTOR_TRANSACTIONS_DROPPED,
+        Unit::Count,
+        "The number of transactions dropped by the grpc collector before sending it to be bundled"
+    );
+    describe_counter!(
+        GRPC_COLLECTOR_TRANSACTIONS_FORWARDED,
+        Unit::Count,
+        "The number of transactions successfully sent by the grpc collector before sending it to \
+         be bundled"
+    );
+
+    // executor metrics
+    describe_counter!(
+        TRANSACTIONS_RECEIVED,
+        Unit::Count,
+        "The number of transactions successfully received from collectors and bundled labelled by \
+         rollup"
+    );
+    describe_counter!(
+        TRANSACTIONS_DROPPED_TOO_LARGE,
+        Unit::Count,
+        "The number of transactions dropped because they were too large"
+    );
+    describe_counter!(
+        NONCE_FETCH_COUNT,
+        Unit::Count,
+        "The number of times we have attempted to fetch the nonce"
+    );
+    describe_counter!(
+        NONCE_FETCH_FAILURE_COUNT,
+        Unit::Count,
+        "The number of times we have failed to fetch the nonce"
+    );
+    describe_histogram!(
+        NONCE_FETCH_LATENCY,
+        Unit::Milliseconds,
+        "The latency of nonce fetch"
+    );
+    describe_gauge!(CURRENT_NONCE, Unit::Count, "The current nonce");
+    describe_histogram!(
+        TRANSACTION_SUBMISSION_LATENCY,
+        Unit::Milliseconds,
+        "The latency of submitting a transaction to the sequencer"
+    );
+    describe_counter!(
+        TRANSACTION_SUBMISSION_FAILURE_COUNT,
+        Unit::Count,
+        "The number of failed transaction submissions to the sequencer"
+    );
+    describe_counter!(
+        BUNDLES_SUBMISSION_SUCCESS_COUNT,
+        Unit::Count,
+        "The number of successful bundle submissions to the sequencer"
+    );
+    describe_counter!(
+        BUNDLES_SUBMISSION_FAILURE_COUNT,
+        Unit::Count,
+        "The number of failed bundle submissions to the sequencer"
+    );
+    describe_histogram!(
+        BUNDLES_OUTGOING_TRANSACTIONS_COUNT,
+        Unit::Count,
+        "The number of outgoing transactions to the sequencer"
+    );
+    describe_histogram!(
+        BUNDLES_OUTGOING_BYTES,
+        Unit::Bytes,
+        "The size of bundles in the outgoing bundle"
+    );
+    describe_counter!(
+        BUNDLES_NOT_DRAINED,
+        Unit::Count,
+        "The number of bundles not drained during shutdown"
+    );
+    describe_counter!(
+        BUNDLES_DRAINED,
+        Unit::Count,
+        "The number of bundles drained successfully during shutdown"
+    );
+
+    // bundle factory metrics
+    describe_counter!(
+        BUNDLES_TOTAL_COUNT,
+        Unit::Count,
+        "The total number of finished bundles constructed over the composer's lifetime"
+    );
+    describe_histogram!(
+        BUNDLES_TOTAL_BYTES,
+        Unit::Bytes,
+        "The distribution of sizes of finished bundles constructed over the composer's lifetime"
+    );
+    describe_histogram!(
+        BUNDLES_TOTAL_TRANSACTIONS_COUNT,
+        Unit::Count,
+        "The total number of transactions in finished bundles constructed over the composer's \
+         lifetime"
+    );
+}
+
+// We configure buckets for manually, in order to ensure Prometheus metrics are structured as a
+// Histogram, rather than as a Summary. These values are loosely based on the initial Summary
+// output, and may need to be updated over time.
+pub const HISTOGRAM_BUCKETS: &[f64; 5] = &[0.00001, 0.0001, 0.001, 0.01, 0.1];
+
+pub const GETH_COLLECTOR_TRANSACTIONS_COLLECTED: &str = concat!(
+    env!("CARGO_CRATE_NAME"),
+    "_geth_collector_transactions_collected"
+);
+
+pub const GETH_COLLECTOR_TRANSACTIONS_DROPPED: &str = concat!(
+    env!("CARGO_CRATE_NAME"),
+    "_geth_collector_transactions_dropped"
+);
+
+pub const GETH_COLLECTOR_TRANSACTIONS_FORWARDED: &str = concat!(
+    env!("CARGO_CRATE_NAME"),
+    "_geth_collector_transactions_forwarded"
+);
+
+pub const GETH_COLLECTOR_CONNECTION_LATENCY: &str = concat!(
+    env!("CARGO_CRATE_NAME"),
+    "_geth_collector_connection_latency"
+);
+
+pub const GRPC_COLLECTOR_TRANSACTIONS_COLLECTED: &str = concat!(
+    env!("CARGO_CRATE_NAME"),
+    "_grpc_collector_transactions_collected"
+);
+
+pub const GRPC_COLLECTOR_TRANSACTIONS_DROPPED: &str = concat!(
+    env!("CARGO_CRATE_NAME"),
+    "_grpc_collector_transactions_dropped"
+);
+
+pub const GRPC_COLLECTOR_TRANSACTIONS_FORWARDED: &str = concat!(
+    env!("CARGO_CRATE_NAME"),
+    "_grpc_collector_transactions_forwarded"
+);
+
+pub const TRANSACTIONS_RECEIVED: &str = concat!(env!("CARGO_CRATE_NAME"), "_transactions_received");
+
+pub const TRANSACTIONS_DROPPED_TOO_LARGE: &str =
+    concat!(env!("CARGO_CRATE_NAME"), "_transactions_dropped_too_large");
+
+pub const NONCE_FETCH_COUNT: &str = concat!(env!("CARGO_CRATE_NAME"), "_nonce_fetch_count");
+
+pub const NONCE_FETCH_FAILURE_COUNT: &str =
+    concat!(env!("CARGO_CRATE_NAME"), "_nonce_fetch_failure_count");
+
+pub const NONCE_FETCH_LATENCY: &str = concat!(env!("CARGO_CRATE_NAME"), "_nonce_fetch_latency");
+
+pub const CURRENT_NONCE: &str = concat!(env!("CARGO_CRATE_NAME"), "_current_nonce");
+
+pub const TRANSACTION_SUBMISSION_LATENCY: &str =
+    concat!(env!("CARGO_CRATE_NAME"), "_transaction_submission_latency");
+
+pub const TRANSACTION_SUBMISSION_FAILURE_COUNT: &str = concat!(
+    env!("CARGO_CRATE_NAME"),
+    "_transaction_submission_failure_count"
+);
+
+pub const BUNDLES_SUBMISSION_SUCCESS_COUNT: &str = concat!(
+    env!("CARGO_CRATE_NAME"),
+    "_bundles_submission_success_count"
+);
+
+pub const BUNDLES_SUBMISSION_FAILURE_COUNT: &str = concat!(
+    env!("CARGO_CRATE_NAME"),
+    "_bundles_submission_failure_count"
+);
+
+pub const BUNDLES_OUTGOING_TRANSACTIONS_COUNT: &str = concat!(
+    env!("CARGO_CRATE_NAME"),
+    "_bundles_outgoing_transactions_count"
+);
+
+pub const BUNDLES_OUTGOING_BYTES: &str =
+    concat!(env!("CARGO_CRATE_NAME"), "_bundles_outgoing_bytes");
+
+pub const BUNDLES_NOT_DRAINED: &str = concat!(env!("CARGO_CRATE_NAME"), "_bundles_not_drained");
+
+pub const BUNDLES_DRAINED: &str = concat!(env!("CARGO_CRATE_NAME"), "_bundles_drained");
+
+pub const BUNDLES_TOTAL_COUNT: &str = concat!(env!("CARGO_CRATE_NAME"), "_bundles_total_count");
+
+pub const BUNDLES_TOTAL_BYTES: &str = concat!(env!("CARGO_CRATE_NAME"), "_bundles_total_bytes");
+
+pub const BUNDLES_TOTAL_TRANSACTIONS_COUNT: &str = concat!(
+    env!("CARGO_CRATE_NAME"),
+    "_bundles_total_transactions_count"
+);

--- a/crates/astria-composer/src/metrics_init.rs
+++ b/crates/astria-composer/src/metrics_init.rs
@@ -143,6 +143,12 @@ pub fn register() {
         "The total number of transactions in finished bundles constructed over the composer's \
          lifetime"
     );
+
+    describe_histogram!(
+        TOTAL_BUNDLE_SUBMISSION_LATENCY,
+        Unit::Milliseconds,
+        "The total latency of submitting a bundle to the sequencer including nonce refetches"
+    );
 }
 
 // We configure buckets for manually, in order to ensure Prometheus metrics are structured as a
@@ -237,3 +243,6 @@ pub const BUNDLES_TOTAL_TRANSACTIONS_COUNT: &str = concat!(
     env!("CARGO_CRATE_NAME"),
     "_bundles_total_transactions_count"
 );
+
+pub const TOTAL_BUNDLE_SUBMISSION_LATENCY: &str =
+    concat!(env!("CARGO_CRATE_NAME"), "_total_bundle_submission_latency");


### PR DESCRIPTION
## Summary
Add a metric to track the time taken for the entire bundle submission process including nonce refetches.

## Background
In our previous metrics [PR](https://github.com/astriaorg/astria/pull/932), we are tracking the metrics in Composer. One metric we lacked was tracking the time taken for the entire bundle submission process including nonce-refetches which proved to be non-trivial.

This PR accomplishes this by wrapping the SubmitFut future in an anonymous boxed future which times the passed in SubmitFut future.

## Changes
* Add a type `TrackedSubmitFut` which is Boxed future which returns a `eyre::Result<u32>`.
* Add a method `tracked_submit_bundle` which takes in a `Instrumented<SubmitFut>` and wraps it in an anonymous future.

## Testing
Unit tests and blackbox tests ran successfully. I have tested this against messenger rollup by running a 100TPS load against it.

## Metrics
* `total_bundle_submission_latency` : A histogram of the total time taken to submit a bundle including nonce-refetches.

closes <!-- list any issues closed here -->

