### PR TITLE
chore(sequencer): update justfile and testnet script

### DIFF
--- a/crates/astria-sequencer/justfile
+++ b/crates/astria-sequencer/justfile
@@ -19,7 +19,7 @@ run-cometbft:
 
 run-testnet: 
   cargo build
-  ${OUT_DIR} ${NUM_VALIDATORS} ./scripts/testnet.sh
+  ./scripts/testnet.sh
 
 cometbft-logs-testnet NODE="node0":
   tail -f sequencer_testnet/{{ NODE }}/cometbft.log
@@ -28,7 +28,9 @@ sequencer-logs-testnet NODE="node0":
   tail -f sequencer_testnet/{{ NODE }}/sequencer.log
 
 stop-testnet:
-  pkill cometbft && pkill astria-sequencer
+  pkill cometbft || true
+  pkill astria-sequencer || true
 
 clean-testnet DIR="sequencer_testnet": stop-testnet
-  rm -r {{ DIR }}
+  rm -r {{ DIR }} || true
+  rm -r /tmp/astria_db_* || true

--- a/crates/astria-sequencer/justfile
+++ b/crates/astria-sequencer/justfile
@@ -17,19 +17,28 @@ run-cometbft:
   sed -i'.bak' 's/timeout_commit = "1s"/timeout_commit = "2s"/g' ~/.cometbft/config/config.toml
   cometbft node
 
+[macos]
+stop-testnet:
+  pkill cometbft || true
+  pkill astria-sequencer || true
+[macos]
 run-testnet: 
   cargo build
   ./scripts/testnet.sh
+
+[linux]
+stop-testnet:
+  pkill cometbft && pkill astria-sequencer
+[linux] 
+run-testnet: 
+  cargo build
+  ${OUT_DIR} ${NUM_VALIDATORS} ./scripts/testnet.sh
 
 cometbft-logs-testnet NODE="node0":
   tail -f sequencer_testnet/{{ NODE }}/cometbft.log
 
 sequencer-logs-testnet NODE="node0":
   tail -f sequencer_testnet/{{ NODE }}/sequencer.log
-
-stop-testnet:
-  pkill cometbft || true
-  pkill astria-sequencer || true
 
 clean-testnet DIR="sequencer_testnet": stop-testnet
   rm -r {{ DIR }} || true

--- a/crates/astria-sequencer/scripts/testnet.sh
+++ b/crates/astria-sequencer/scripts/testnet.sh
@@ -3,6 +3,15 @@
 set -o errexit -o nounset
 set -x
 
+# Function to perform sed in-place editing in a cross-platform way
+edit_in_place() {
+    case "$(uname)" in
+        Linux*) sed -i "$@" ;;
+        Darwin*) sed -i '' "$@" ;;
+        *) echo "Unsupported OS" >&2; exit 1 ;;
+    esac
+}
+
 : "${OUT_DIR:=sequencer_testnet}"
 : "${NUM_VALIDATORS:=3}"
 
@@ -16,27 +25,38 @@ for i in $(seq 0 "$((NUM_VALIDATORS - 1))"); do
     COMETBFT_P2P_PORT=$((28660 + $i))
 
     # update sequencer app port
-    sed -i "s/proxy_app = \"tcp:\/\/127.0.0.1:26658\"/proxy_app = \"tcp:\/\/127.0.0.1:$APP_PORT\"/g" $OUT_DIR/node$i/config/config.toml
+    edit_in_place "s/proxy_app = \"tcp:\/\/127.0.0.1:26658\"/proxy_app = \"tcp:\/\/127.0.0.1:$APP_PORT\"/g" $OUT_DIR/node$i/config/config.toml
     # RPC laddr
-    sed -i "s/laddr = \"tcp:\/\/127.0.0.1:26657\"/laddr = \"tcp:\/\/127.0.0.1:$COMETBFT_RPC_PORT\"/g" $OUT_DIR/node$i/config/config.toml
+    edit_in_place "s/laddr = \"tcp:\/\/127.0.0.1:26657\"/laddr = \"tcp:\/\/127.0.0.1:$COMETBFT_RPC_PORT\"/g" $OUT_DIR/node$i/config/config.toml
     # p2p laddr
-    sed -i "s/laddr = \"tcp:\/\/0.0.0.0:26656\"/laddr = \"tcp:\/\/127.0.0.1:$COMETBFT_P2P_PORT\"/g" $OUT_DIR/node$i/config/config.toml
+    edit_in_place "s/laddr = \"tcp:\/\/0.0.0.0:26656\"/laddr = \"tcp:\/\/127.0.0.1:$COMETBFT_P2P_PORT\"/g" $OUT_DIR/node$i/config/config.toml
 
     # update p2p persistent peer ports
     for j in $(seq 0 "$((NUM_VALIDATORS - 1))"); do
         P2P_PORT=$((28660 + $j))
-        sed -i "s/node$j:26656/127.0.0.1:$P2P_PORT/g" $OUT_DIR/node$i/config/config.toml
+        edit_in_place "s/node$j:26656/127.0.0.1:$P2P_PORT/g" $OUT_DIR/node$i/config/config.toml
     done
 
     # allow peers from the same IP
-    sed -i 's/allow_duplicate_ip = false/allow_duplicate_ip = true/' $OUT_DIR/node$i/config/config.toml
-    sed -i 's/addr_book_strict = true/addr_book_strict = false/' $OUT_DIR/node$i/config/config.toml
+    edit_in_place 's/allow_duplicate_ip = false/allow_duplicate_ip = true/' $OUT_DIR/node$i/config/config.toml
+    edit_in_place 's/addr_book_strict = true/addr_book_strict = false/' $OUT_DIR/node$i/config/config.toml
+
+    # update genesis file with app state
+    ../../target/debug/astria-sequencer-utils --genesis-app-state-file=test-genesis-app-state.json --destination-genesis-file=$OUT_DIR/node$i/config//genesis.json --chain-id=astria
+    sed -i'.bak' 's/timeout_commit = "1s"/timeout_commit = "2s"/g' ~/.cometbft/config/config.toml
 done
 
 # start sequencer application for each node
 for i in $(seq 0 "$((NUM_VALIDATORS - 1))"); do
-    APP_PORT=$((26660 + $i))
-    ../../target/debug/astria-sequencer --genesis-file=test-genesis.json --listen-addr=127.0.0.1:$APP_PORT &> $OUT_DIR/node$i/sequencer.log &
+    # edit default .env files for multiple validators 
+    DB_PATH="/tmp/astria_db_$i"
+    ASTRIA_SEQUENCER_LISTEN_ADDR=127.0.0.1:$((26660 + $i))
+    ASTRIA_SEQUENCER_GRPC_ADDR=127.0.0.1:$((8080 + $i))
+
+    export ASTRIA_SEQUENCER_DB_FILEPATH=$DB_PATH \
+    && export ASTRIA_SEQUENCER_LISTEN_ADDR=$ASTRIA_SEQUENCER_LISTEN_ADDR \
+    && export ASTRIA_SEQUENCER_GRPC_ADDR=$ASTRIA_SEQUENCER_GRPC_ADDR \
+    && RUST_LOG=debug RUST_BACKTRACE=1 ../../target/debug/astria-sequencer &> $OUT_DIR/node$i/sequencer.log &
 done
 
 # finally, start cometbft nodes


### PR DESCRIPTION
## Summary
Updated the sequencer's justfile and testnet.sh script to work again with latest version of sequencer.

TODO: have someone test on their linux machine. I had to edit the script to work on a mac and tried to make the commands work on both but I'm unsure if I did it right.

## Testing
`just run-testnet` : to run testnet locally 
`just clean-testnet` : to cleanup testnet
