### PR TITLE
chore(proto)!: create wrapper types for `RollupId` and `Account`

### DIFF
--- a/crates/astria-conductor/src/sequencer/client.rs
+++ b/crates/astria-conductor/src/sequencer/client.rs
@@ -89,7 +89,7 @@ impl SequencerGrpcClient {
             let mut client = client.clone();
             let req = GetFilteredSequencerBlockRequest {
                 height,
-                rollup_ids: vec![rollup_id.to_vec()],
+                rollup_ids: vec![rollup_id.to_raw()],
             };
             async move { client.get_filtered_sequencer_block(req).await }
         })

--- a/crates/astria-conductor/tests/blackbox/helpers/macros.rs
+++ b/crates/astria-conductor/tests/blackbox/helpers/macros.rs
@@ -238,7 +238,7 @@ macro_rules! mount_get_filtered_sequencer_block {
             .mount_get_filtered_sequencer_block(
                 ::astria_core::generated::sequencerblock::v1alpha1::GetFilteredSequencerBlockRequest {
                     height: $height,
-                    rollup_ids: vec![$crate::ROLLUP_ID.to_vec()],
+                    rollup_ids: vec![$crate::ROLLUP_ID.to_raw()],
                 },
                 $crate::filtered_sequencer_block!(sequencer_height: $height),
             )

--- a/crates/astria-core/src/generated/astria.primitive.v1.rs
+++ b/crates/astria-core/src/generated/astria.primitive.v1.rs
@@ -30,8 +30,8 @@ impl ::prost::Name for Uint128 {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Proof {
     /// A sequence of 32 byte hashes used to reconstruct a Merkle Tree Hash.
-    #[prost(bytes = "vec", tag = "1")]
-    pub audit_path: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "bytes", tag = "1")]
+    pub audit_path: ::prost::bytes::Bytes,
     /// The index of the leaf this proof applies to.
     #[prost(uint64, tag = "2")]
     pub leaf_index: u64,
@@ -51,13 +51,46 @@ impl ::prost::Name for Proof {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Denom {
-    #[prost(bytes = "vec", tag = "1")]
-    pub id: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "bytes", tag = "1")]
+    pub id: ::prost::bytes::Bytes,
     #[prost(string, tag = "2")]
     pub base_denom: ::prost::alloc::string::String,
 }
 impl ::prost::Name for Denom {
     const NAME: &'static str = "Denom";
+    const PACKAGE: &'static str = "astria.primitive.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.primitive.v1.{}", Self::NAME)
+    }
+}
+/// A `RollupId` is a unique identifier for a rollup chain.
+/// It must be 32 bytes long. It can be derived from a string
+/// using a sha256 hash.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RollupId {
+    #[prost(bytes = "bytes", tag = "1")]
+    pub inner: ::prost::bytes::Bytes,
+}
+impl ::prost::Name for RollupId {
+    const NAME: &'static str = "RollupId";
+    const PACKAGE: &'static str = "astria.primitive.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.primitive.v1.{}", Self::NAME)
+    }
+}
+/// An Astria `Address`.
+///
+/// Astria addresses are derived from the ed25519 public key,
+/// using the first 20 bytes of the sha256 hash.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Address {
+    #[prost(bytes = "bytes", tag = "1")]
+    pub inner: ::prost::bytes::Bytes,
+}
+impl ::prost::Name for Address {
+    const NAME: &'static str = "Address";
     const PACKAGE: &'static str = "astria.primitive.v1";
     fn full_name() -> ::prost::alloc::string::String {
         ::prost::alloc::format!("astria.primitive.v1.{}", Self::NAME)

--- a/crates/astria-core/src/generated/astria.primitive.v1.serde.rs
+++ b/crates/astria-core/src/generated/astria.primitive.v1.serde.rs
@@ -1,3 +1,97 @@
+impl serde::Serialize for Address {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.inner.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.primitive.v1.Address", len)?;
+        if !self.inner.is_empty() {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("inner", pbjson::private::base64::encode(&self.inner).as_str())?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for Address {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "inner",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Inner,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "inner" => Ok(GeneratedField::Inner),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = Address;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.primitive.v1.Address")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Address, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut inner__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Inner => {
+                            if inner__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("inner"));
+                            }
+                            inner__ = 
+                                Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
+                            ;
+                        }
+                    }
+                }
+                Ok(Address {
+                    inner: inner__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.primitive.v1.Address", FIELDS, GeneratedVisitor)
+    }
+}
 impl serde::Serialize for Denom {
     #[allow(deprecated)]
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
@@ -245,6 +339,100 @@ impl<'de> serde::Deserialize<'de> for Proof {
             }
         }
         deserializer.deserialize_struct("astria.primitive.v1.Proof", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for RollupId {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.inner.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.primitive.v1.RollupId", len)?;
+        if !self.inner.is_empty() {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("inner", pbjson::private::base64::encode(&self.inner).as_str())?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for RollupId {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "inner",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Inner,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "inner" => Ok(GeneratedField::Inner),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = RollupId;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.primitive.v1.RollupId")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<RollupId, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut inner__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Inner => {
+                            if inner__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("inner"));
+                            }
+                            inner__ = 
+                                Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
+                            ;
+                        }
+                    }
+                }
+                Ok(RollupId {
+                    inner: inner__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.primitive.v1.RollupId", FIELDS, GeneratedVisitor)
     }
 }
 impl serde::Serialize for Uint128 {

--- a/crates/astria-core/src/generated/astria.protocol.transactions.v1alpha1.rs
+++ b/crates/astria-core/src/generated/astria.protocol.transactions.v1alpha1.rs
@@ -90,8 +90,8 @@ impl ::prost::Name for Action {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TransferAction {
-    #[prost(bytes = "vec", tag = "1")]
-    pub to: ::prost::alloc::vec::Vec<u8>,
+    #[prost(message, optional, tag = "1")]
+    pub to: ::core::option::Option<super::super::super::primitive::v1::Address>,
     #[prost(message, optional, tag = "2")]
     pub amount: ::core::option::Option<super::super::super::primitive::v1::Uint128>,
     /// the asset to be transferred
@@ -116,8 +116,8 @@ impl ::prost::Name for TransferAction {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SequenceAction {
-    #[prost(bytes = "vec", tag = "1")]
-    pub rollup_id: ::prost::alloc::vec::Vec<u8>,
+    #[prost(message, optional, tag = "1")]
+    pub rollup_id: ::core::option::Option<super::super::super::primitive::v1::RollupId>,
     #[prost(bytes = "vec", tag = "2")]
     pub data: ::prost::alloc::vec::Vec<u8>,
     /// the asset used to pay the transaction fee
@@ -139,8 +139,8 @@ impl ::prost::Name for SequenceAction {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SudoAddressChangeAction {
-    #[prost(bytes = "vec", tag = "1")]
-    pub new_address: ::prost::alloc::vec::Vec<u8>,
+    #[prost(message, optional, tag = "1")]
+    pub new_address: ::core::option::Option<super::super::super::primitive::v1::Address>,
 }
 impl ::prost::Name for SudoAddressChangeAction {
     const NAME: &'static str = "SudoAddressChangeAction";
@@ -156,8 +156,8 @@ impl ::prost::Name for SudoAddressChangeAction {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MintAction {
-    #[prost(bytes = "vec", tag = "1")]
-    pub to: ::prost::alloc::vec::Vec<u8>,
+    #[prost(message, optional, tag = "1")]
+    pub to: ::core::option::Option<super::super::super::primitive::v1::Address>,
     #[prost(message, optional, tag = "2")]
     pub amount: ::core::option::Option<super::super::super::primitive::v1::Uint128>,
 }
@@ -234,10 +234,10 @@ pub mod ibc_relayer_change_action {
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Value {
-        #[prost(bytes, tag = "1")]
-        Addition(::prost::alloc::vec::Vec<u8>),
-        #[prost(bytes, tag = "2")]
-        Removal(::prost::alloc::vec::Vec<u8>),
+        #[prost(message, tag = "1")]
+        Addition(super::super::super::super::primitive::v1::Address),
+        #[prost(message, tag = "2")]
+        Removal(super::super::super::super::primitive::v1::Address),
     }
 }
 impl ::prost::Name for IbcRelayerChangeAction {
@@ -285,8 +285,8 @@ impl ::prost::Name for FeeAssetChangeAction {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InitBridgeAccountAction {
     /// the rollup ID to register with the bridge account (the tx sender)
-    #[prost(bytes = "vec", tag = "1")]
-    pub rollup_id: ::prost::alloc::vec::Vec<u8>,
+    #[prost(message, optional, tag = "1")]
+    pub rollup_id: ::core::option::Option<super::super::super::primitive::v1::RollupId>,
     /// the asset IDs accepted as an incoming transfer by the bridge account
     #[prost(bytes = "vec", repeated, tag = "2")]
     pub asset_ids: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
@@ -310,8 +310,8 @@ impl ::prost::Name for InitBridgeAccountAction {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BridgeLockAction {
     /// the address of the bridge account to transfer to
-    #[prost(bytes = "vec", tag = "1")]
-    pub to: ::prost::alloc::vec::Vec<u8>,
+    #[prost(message, optional, tag = "1")]
+    pub to: ::core::option::Option<super::super::super::primitive::v1::Address>,
     /// the amount to transfer
     #[prost(message, optional, tag = "2")]
     pub amount: ::core::option::Option<super::super::super::primitive::v1::Uint128>,

--- a/crates/astria-core/src/generated/astria.sequencerblock.v1alpha1.rs
+++ b/crates/astria-core/src/generated/astria.sequencerblock.v1alpha1.rs
@@ -7,8 +7,8 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RollupTransactions {
     /// The 32 bytes identifying a rollup. Usually the sha256 hash of a plain rollup name.
-    #[prost(bytes = "vec", tag = "1")]
-    pub rollup_id: ::prost::alloc::vec::Vec<u8>,
+    #[prost(message, optional, tag = "1")]
+    pub rollup_id: ::core::option::Option<super::super::primitive::v1::RollupId>,
     /// The serialized bytes of the rollup data.
     /// Each entry is a protobuf-encoded `RollupData` message.
     #[prost(bytes = "vec", repeated, tag = "2")]
@@ -113,11 +113,11 @@ pub struct Deposit {
     /// this is required as initializing an account as a bridge account
     /// is permissionless, so the rollup consensus needs to know and enshrine
     /// which accounts it accepts as valid bridge accounts.
-    #[prost(bytes = "vec", tag = "1")]
-    pub bridge_address: ::prost::alloc::vec::Vec<u8>,
+    #[prost(message, optional, tag = "1")]
+    pub bridge_address: ::core::option::Option<super::super::primitive::v1::Address>,
     /// the rollup_id which the funds are being deposited to
-    #[prost(bytes = "vec", tag = "2")]
-    pub rollup_id: ::prost::alloc::vec::Vec<u8>,
+    #[prost(message, optional, tag = "2")]
+    pub rollup_id: ::core::option::Option<super::super::primitive::v1::RollupId>,
     #[prost(message, optional, tag = "3")]
     pub amount: ::core::option::Option<super::super::primitive::v1::Uint128>,
     #[prost(bytes = "vec", tag = "4")]
@@ -226,8 +226,8 @@ pub struct CelestiaRollupBlob {
     pub sequencer_block_hash: ::prost::alloc::vec::Vec<u8>,
     /// The 32 bytes identifying the rollup this blob belongs to. Matches
     /// `astria.sequencer.v1.RollupTransactions.rollup_id`
-    #[prost(bytes = "vec", tag = "2")]
-    pub rollup_id: ::prost::alloc::vec::Vec<u8>,
+    #[prost(message, optional, tag = "2")]
+    pub rollup_id: ::core::option::Option<super::super::primitive::v1::RollupId>,
     /// A list of opaque bytes that are serialized rollup transactions.
     #[prost(bytes = "vec", repeated, tag = "3")]
     pub transactions: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
@@ -263,8 +263,8 @@ pub struct CelestiaSequencerBlob {
     /// The rollup IDs for which `CelestiaRollupBlob`s were submitted to celestia.
     /// Corresponds to the `astria.sequencer.v1.RollupTransactions.rollup_id` field
     /// and is extracted from `astria.SequencerBlock.rollup_transactions`.
-    #[prost(bytes = "vec", repeated, tag = "3")]
-    pub rollup_ids: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+    #[prost(message, repeated, tag = "3")]
+    pub rollup_ids: ::prost::alloc::vec::Vec<super::super::primitive::v1::RollupId>,
     /// The proof that the rollup transactions are included in sequencer block.
     /// Corresponds to `astria.sequencer.v1alpha.SequencerBlock.rollup_transactions_proof`.
     #[prost(message, optional, tag = "4")]
@@ -304,8 +304,8 @@ pub struct GetFilteredSequencerBlockRequest {
     #[prost(uint64, tag = "1")]
     pub height: u64,
     /// The 32 bytes identifying a rollup. Usually the sha256 hash of a plain rollup name.
-    #[prost(bytes = "vec", repeated, tag = "2")]
-    pub rollup_ids: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+    #[prost(message, repeated, tag = "2")]
+    pub rollup_ids: ::prost::alloc::vec::Vec<super::super::primitive::v1::RollupId>,
 }
 impl ::prost::Name for GetFilteredSequencerBlockRequest {
     const NAME: &'static str = "GetFilteredSequencerBlockRequest";

--- a/crates/astria-core/src/generated/astria.sequencerblock.v1alpha1.serde.rs
+++ b/crates/astria-core/src/generated/astria.sequencerblock.v1alpha1.serde.rs
@@ -9,7 +9,7 @@ impl serde::Serialize for CelestiaRollupBlob {
         if !self.sequencer_block_hash.is_empty() {
             len += 1;
         }
-        if !self.rollup_id.is_empty() {
+        if self.rollup_id.is_some() {
             len += 1;
         }
         if !self.transactions.is_empty() {
@@ -23,9 +23,8 @@ impl serde::Serialize for CelestiaRollupBlob {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field("sequencer_block_hash", pbjson::private::base64::encode(&self.sequencer_block_hash).as_str())?;
         }
-        if !self.rollup_id.is_empty() {
-            #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("rollup_id", pbjson::private::base64::encode(&self.rollup_id).as_str())?;
+        if let Some(v) = self.rollup_id.as_ref() {
+            struct_ser.serialize_field("rollup_id", v)?;
         }
         if !self.transactions.is_empty() {
             struct_ser.serialize_field("transactions", &self.transactions.iter().map(pbjson::private::base64::encode).collect::<Vec<_>>())?;
@@ -119,9 +118,7 @@ impl<'de> serde::Deserialize<'de> for CelestiaRollupBlob {
                             if rollup_id__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("rollupId"));
                             }
-                            rollup_id__ = 
-                                Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
-                            ;
+                            rollup_id__ = map_.next_value()?;
                         }
                         GeneratedField::Transactions => {
                             if transactions__.is_some() {
@@ -142,7 +139,7 @@ impl<'de> serde::Deserialize<'de> for CelestiaRollupBlob {
                 }
                 Ok(CelestiaRollupBlob {
                     sequencer_block_hash: sequencer_block_hash__.unwrap_or_default(),
-                    rollup_id: rollup_id__.unwrap_or_default(),
+                    rollup_id: rollup_id__,
                     transactions: transactions__.unwrap_or_default(),
                     proof: proof__,
                 })
@@ -183,7 +180,7 @@ impl serde::Serialize for CelestiaSequencerBlob {
             struct_ser.serialize_field("header", v)?;
         }
         if !self.rollup_ids.is_empty() {
-            struct_ser.serialize_field("rollup_ids", &self.rollup_ids.iter().map(pbjson::private::base64::encode).collect::<Vec<_>>())?;
+            struct_ser.serialize_field("rollup_ids", &self.rollup_ids)?;
         }
         if let Some(v) = self.rollup_transactions_proof.as_ref() {
             struct_ser.serialize_field("rollup_transactions_proof", v)?;
@@ -289,10 +286,7 @@ impl<'de> serde::Deserialize<'de> for CelestiaSequencerBlob {
                             if rollup_ids__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("rollupIds"));
                             }
-                            rollup_ids__ = 
-                                Some(map_.next_value::<Vec<::pbjson::private::BytesDeserialize<_>>>()?
-                                    .into_iter().map(|x| x.0).collect())
-                            ;
+                            rollup_ids__ = Some(map_.next_value()?);
                         }
                         GeneratedField::RollupTransactionsProof => {
                             if rollup_transactions_proof__.is_some() {
@@ -328,10 +322,10 @@ impl serde::Serialize for Deposit {
     {
         use serde::ser::SerializeStruct;
         let mut len = 0;
-        if !self.bridge_address.is_empty() {
+        if self.bridge_address.is_some() {
             len += 1;
         }
-        if !self.rollup_id.is_empty() {
+        if self.rollup_id.is_some() {
             len += 1;
         }
         if self.amount.is_some() {
@@ -344,13 +338,11 @@ impl serde::Serialize for Deposit {
             len += 1;
         }
         let mut struct_ser = serializer.serialize_struct("astria.sequencerblock.v1alpha1.Deposit", len)?;
-        if !self.bridge_address.is_empty() {
-            #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("bridge_address", pbjson::private::base64::encode(&self.bridge_address).as_str())?;
+        if let Some(v) = self.bridge_address.as_ref() {
+            struct_ser.serialize_field("bridge_address", v)?;
         }
-        if !self.rollup_id.is_empty() {
-            #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("rollup_id", pbjson::private::base64::encode(&self.rollup_id).as_str())?;
+        if let Some(v) = self.rollup_id.as_ref() {
+            struct_ser.serialize_field("rollup_id", v)?;
         }
         if let Some(v) = self.amount.as_ref() {
             struct_ser.serialize_field("amount", v)?;
@@ -446,17 +438,13 @@ impl<'de> serde::Deserialize<'de> for Deposit {
                             if bridge_address__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("bridgeAddress"));
                             }
-                            bridge_address__ = 
-                                Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
-                            ;
+                            bridge_address__ = map_.next_value()?;
                         }
                         GeneratedField::RollupId => {
                             if rollup_id__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("rollupId"));
                             }
-                            rollup_id__ = 
-                                Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
-                            ;
+                            rollup_id__ = map_.next_value()?;
                         }
                         GeneratedField::Amount => {
                             if amount__.is_some() {
@@ -481,8 +469,8 @@ impl<'de> serde::Deserialize<'de> for Deposit {
                     }
                 }
                 Ok(Deposit {
-                    bridge_address: bridge_address__.unwrap_or_default(),
-                    rollup_id: rollup_id__.unwrap_or_default(),
+                    bridge_address: bridge_address__,
+                    rollup_id: rollup_id__,
                     amount: amount__,
                     asset_id: asset_id__.unwrap_or_default(),
                     destination_chain_address: destination_chain_address__.unwrap_or_default(),
@@ -699,7 +687,7 @@ impl serde::Serialize for GetFilteredSequencerBlockRequest {
             struct_ser.serialize_field("height", ToString::to_string(&self.height).as_str())?;
         }
         if !self.rollup_ids.is_empty() {
-            struct_ser.serialize_field("rollup_ids", &self.rollup_ids.iter().map(pbjson::private::base64::encode).collect::<Vec<_>>())?;
+            struct_ser.serialize_field("rollup_ids", &self.rollup_ids)?;
         }
         struct_ser.end()
     }
@@ -778,10 +766,7 @@ impl<'de> serde::Deserialize<'de> for GetFilteredSequencerBlockRequest {
                             if rollup_ids__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("rollupIds"));
                             }
-                            rollup_ids__ = 
-                                Some(map_.next_value::<Vec<::pbjson::private::BytesDeserialize<_>>>()?
-                                    .into_iter().map(|x| x.0).collect())
-                            ;
+                            rollup_ids__ = Some(map_.next_value()?);
                         }
                     }
                 }
@@ -1006,7 +991,7 @@ impl serde::Serialize for RollupTransactions {
     {
         use serde::ser::SerializeStruct;
         let mut len = 0;
-        if !self.rollup_id.is_empty() {
+        if self.rollup_id.is_some() {
             len += 1;
         }
         if !self.transactions.is_empty() {
@@ -1016,9 +1001,8 @@ impl serde::Serialize for RollupTransactions {
             len += 1;
         }
         let mut struct_ser = serializer.serialize_struct("astria.sequencerblock.v1alpha1.RollupTransactions", len)?;
-        if !self.rollup_id.is_empty() {
-            #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("rollup_id", pbjson::private::base64::encode(&self.rollup_id).as_str())?;
+        if let Some(v) = self.rollup_id.as_ref() {
+            struct_ser.serialize_field("rollup_id", v)?;
         }
         if !self.transactions.is_empty() {
             struct_ser.serialize_field("transactions", &self.transactions.iter().map(pbjson::private::base64::encode).collect::<Vec<_>>())?;
@@ -1099,9 +1083,7 @@ impl<'de> serde::Deserialize<'de> for RollupTransactions {
                             if rollup_id__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("rollupId"));
                             }
-                            rollup_id__ = 
-                                Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
-                            ;
+                            rollup_id__ = map_.next_value()?;
                         }
                         GeneratedField::Transactions => {
                             if transactions__.is_some() {
@@ -1121,7 +1103,7 @@ impl<'de> serde::Deserialize<'de> for RollupTransactions {
                     }
                 }
                 Ok(RollupTransactions {
-                    rollup_id: rollup_id__.unwrap_or_default(),
+                    rollup_id: rollup_id__,
                     transactions: transactions__.unwrap_or_default(),
                     proof: proof__,
                 })

--- a/crates/astria-core/src/primitive/v1/mod.rs
+++ b/crates/astria-core/src/primitive/v1/mod.rs
@@ -43,7 +43,7 @@ impl Protobuf for merkle::Proof {
              usize",
         );
         Self::unchecked()
-            .audit_path(audit_path)
+            .audit_path(audit_path.to_vec())
             .leaf_index(leaf_index)
             .tree_size(tree_size)
             .try_into_proof()
@@ -62,7 +62,7 @@ impl Protobuf for merkle::Proof {
             tree_size,
         } = self.into_unchecked();
         Self::Raw {
-            audit_path,
+            audit_path: audit_path.into(),
             leaf_index: leaf_index.try_into().expect(
                 "running on a machine with at most 64 bit pointer width and can convert from \
                  usize to u64",
@@ -177,6 +177,29 @@ impl RollupId {
             })?;
         Ok(Self::new(inner))
     }
+
+    #[must_use]
+    pub fn to_raw(&self) -> raw::RollupId {
+        raw::RollupId {
+            inner: self.to_vec().into(),
+        }
+    }
+
+    #[must_use]
+    pub fn into_raw(self) -> raw::RollupId {
+        raw::RollupId {
+            inner: self.to_vec().into(),
+        }
+    }
+
+    /// Converts from protobuf type to rust type for a rollup ID.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the byte slice was not 32 bytes long.
+    pub fn try_from_raw(raw: raw::RollupId) -> Result<Self, IncorrectRollupIdLength> {
+        Self::try_from_slice(&raw.inner)
+    }
 }
 
 impl AsRef<[u8]> for RollupId {
@@ -276,6 +299,29 @@ impl Address {
     #[must_use]
     pub const fn from_array(array: [u8; ADDRESS_LEN]) -> Self {
         Self(array)
+    }
+
+    #[must_use]
+    pub fn to_raw(&self) -> raw::Address {
+        raw::Address {
+            inner: self.to_vec().into(),
+        }
+    }
+
+    #[must_use]
+    pub fn into_raw(self) -> raw::Address {
+        raw::Address {
+            inner: self.to_vec().into(),
+        }
+    }
+
+    /// Convert from protobuf to rust type an address.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the account buffer was not 20 bytes long.
+    pub fn try_from_raw(raw: raw::Address) -> Result<Self, IncorrectAddressLength> {
+        Self::try_from_slice(&raw.inner)
     }
 }
 

--- a/crates/astria-core/src/protocol/transaction/v1alpha1/action.rs
+++ b/crates/astria-core/src/protocol/transaction/v1alpha1/action.rs
@@ -303,8 +303,12 @@ enum ActionErrorKind {
 pub struct SequenceActionError(SequenceActionErrorKind);
 
 impl SequenceActionError {
-    fn rollup_id(inner: IncorrectRollupIdLength) -> Self {
-        Self(SequenceActionErrorKind::RollupId(inner))
+    fn field_not_set(field: &'static str) -> Self {
+        Self(SequenceActionErrorKind::FieldNotSet(field))
+    }
+
+    fn rollup_id_length(inner: IncorrectRollupIdLength) -> Self {
+        Self(SequenceActionErrorKind::RollupIdLength(inner))
     }
 
     fn fee_asset_id(inner: asset::IncorrectAssetIdLength) -> Self {
@@ -314,8 +318,10 @@ impl SequenceActionError {
 
 #[derive(Debug, thiserror::Error)]
 enum SequenceActionErrorKind {
+    #[error("the expected field in the raw source type was not set: `{0}`")]
+    FieldNotSet(&'static str),
     #[error("`rollup_id` field did not contain a valid rollup ID")]
-    RollupId(IncorrectRollupIdLength),
+    RollupIdLength(IncorrectRollupIdLength),
     #[error("`fee_asset_id` field did not contain a valid asset ID")]
     FeeAssetId(asset::IncorrectAssetIdLength),
 }
@@ -338,7 +344,7 @@ impl SequenceAction {
             fee_asset_id,
         } = self;
         raw::SequenceAction {
-            rollup_id: rollup_id.to_vec(),
+            rollup_id: Some(rollup_id.to_raw()),
             data,
             fee_asset_id: fee_asset_id.as_ref().to_vec(),
         }
@@ -352,7 +358,7 @@ impl SequenceAction {
             fee_asset_id,
         } = self;
         raw::SequenceAction {
-            rollup_id: rollup_id.to_vec(),
+            rollup_id: Some(rollup_id.to_raw()),
             data: data.clone(),
             fee_asset_id: fee_asset_id.as_ref().to_vec(),
         }
@@ -368,8 +374,11 @@ impl SequenceAction {
             data,
             fee_asset_id,
         } = proto;
+        let Some(rollup_id) = rollup_id else {
+            return Err(SequenceActionError::field_not_set("rollup_id"));
+        };
         let rollup_id =
-            RollupId::try_from_slice(&rollup_id).map_err(SequenceActionError::rollup_id)?;
+            RollupId::try_from_raw(rollup_id).map_err(SequenceActionError::rollup_id_length)?;
         let fee_asset_id =
             asset::Id::try_from_slice(&fee_asset_id).map_err(SequenceActionError::fee_asset_id)?;
         Ok(Self {
@@ -401,7 +410,7 @@ impl TransferAction {
             fee_asset_id,
         } = self;
         raw::TransferAction {
-            to: to.to_vec(),
+            to: Some(to.to_raw()),
             amount: Some(amount.into()),
             asset_id: asset_id.get().to_vec(),
             fee_asset_id: fee_asset_id.as_ref().to_vec(),
@@ -417,7 +426,7 @@ impl TransferAction {
             fee_asset_id,
         } = self;
         raw::TransferAction {
-            to: to.to_vec(),
+            to: Some(to.to_raw()),
             amount: Some((*amount).into()),
             asset_id: asset_id.get().to_vec(),
             fee_asset_id: fee_asset_id.as_ref().to_vec(),
@@ -437,7 +446,10 @@ impl TransferAction {
             asset_id,
             fee_asset_id,
         } = proto;
-        let to = Address::try_from_slice(&to).map_err(TransferActionError::address)?;
+        let Some(to) = to else {
+            return Err(TransferActionError::field_not_set("to"));
+        };
+        let to = Address::try_from_raw(to).map_err(TransferActionError::address_length)?;
         let amount = amount.map_or(0, Into::into);
         let asset_id =
             asset::Id::try_from_slice(&asset_id).map_err(TransferActionError::asset_id)?;
@@ -458,8 +470,12 @@ impl TransferAction {
 pub struct TransferActionError(TransferActionErrorKind);
 
 impl TransferActionError {
-    fn address(inner: IncorrectAddressLength) -> Self {
-        Self(TransferActionErrorKind::Address(inner))
+    fn field_not_set(field: &'static str) -> Self {
+        Self(TransferActionErrorKind::FieldNotSet(field))
+    }
+
+    fn address_length(inner: IncorrectAddressLength) -> Self {
+        Self(TransferActionErrorKind::AddressLength(inner))
     }
 
     fn asset_id(inner: asset::IncorrectAssetIdLength) -> Self {
@@ -473,8 +489,10 @@ impl TransferActionError {
 
 #[derive(Debug, thiserror::Error)]
 enum TransferActionErrorKind {
+    #[error("the expected field in the raw source type was not set: `{0}`")]
+    FieldNotSet(&'static str),
     #[error("`to` field did not contain a valid address")]
-    Address(#[source] IncorrectAddressLength),
+    AddressLength(#[source] IncorrectAddressLength),
     #[error("`asset_id` field did not contain a valid asset ID")]
     Asset(#[source] asset::IncorrectAssetIdLength),
     #[error("`fee_asset_id` field did not contain a valid asset ID")]
@@ -494,7 +512,7 @@ impl SudoAddressChangeAction {
             new_address,
         } = self;
         raw::SudoAddressChangeAction {
-            new_address: new_address.to_vec(),
+            new_address: Some(new_address.into_raw()),
         }
     }
 
@@ -504,7 +522,7 @@ impl SudoAddressChangeAction {
             new_address,
         } = self;
         raw::SudoAddressChangeAction {
-            new_address: new_address.to_vec(),
+            new_address: Some(new_address.to_raw()),
         }
     }
 
@@ -520,8 +538,11 @@ impl SudoAddressChangeAction {
         let raw::SudoAddressChangeAction {
             new_address,
         } = proto;
+        let Some(new_address) = new_address else {
+            return Err(SudoAddressChangeActionError::field_not_set("new_address"));
+        };
         let new_address =
-            Address::try_from_slice(&new_address).map_err(SudoAddressChangeActionError::address)?;
+            Address::try_from_raw(new_address).map_err(SudoAddressChangeActionError::address)?;
         Ok(Self {
             new_address,
         })
@@ -533,6 +554,9 @@ impl SudoAddressChangeAction {
 pub struct SudoAddressChangeActionError(SudoAddressChangeActionErrorKind);
 
 impl SudoAddressChangeActionError {
+    fn field_not_set(field: &'static str) -> Self {
+        Self(SudoAddressChangeActionErrorKind::FieldNotSet(field))
+    }
     fn address(inner: IncorrectAddressLength) -> Self {
         Self(SudoAddressChangeActionErrorKind::Address(inner))
     }
@@ -540,6 +564,8 @@ impl SudoAddressChangeActionError {
 
 #[derive(Debug, thiserror::Error)]
 enum SudoAddressChangeActionErrorKind {
+    #[error("the expected field in the raw source type was not set: `{0}`")]
+    FieldNotSet(&'static str),
     #[error("`new_address` field did not contain a valid address")]
     Address(#[source] IncorrectAddressLength),
 }
@@ -559,7 +585,7 @@ impl MintAction {
             amount,
         } = self;
         raw::MintAction {
-            to: to.to_vec(),
+            to: Some(to.to_raw()),
             amount: Some(amount.into()),
         }
     }
@@ -571,7 +597,7 @@ impl MintAction {
             amount,
         } = self;
         raw::MintAction {
-            to: to.to_vec(),
+            to: Some(to.to_raw()),
             amount: Some((*amount).into()),
         }
     }
@@ -587,7 +613,10 @@ impl MintAction {
             to,
             amount,
         } = proto;
-        let to = Address::try_from_slice(&to).map_err(MintActionError::address)?;
+        let Some(to) = to else {
+            return Err(MintActionError::field_not_set("to"));
+        };
+        let to = Address::try_from_raw(to).map_err(MintActionError::address_length)?;
         let amount = amount.map_or(0, Into::into);
         Ok(Self {
             to,
@@ -602,15 +631,21 @@ impl MintAction {
 pub struct MintActionError(MintActionErrorKind);
 
 impl MintActionError {
-    fn address(inner: IncorrectAddressLength) -> Self {
-        Self(MintActionErrorKind::Address(inner))
+    fn field_not_set(field: &'static str) -> Self {
+        Self(MintActionErrorKind::FieldNotSet(field))
+    }
+
+    fn address_length(inner: IncorrectAddressLength) -> Self {
+        Self(MintActionErrorKind::AddressLength(inner))
     }
 }
 
 #[derive(Debug, thiserror::Error)]
 enum MintActionErrorKind {
+    #[error("the expected field in the raw source type was not set: `{0}`")]
+    FieldNotSet(&'static str),
     #[error("`to` field did not contain a valid address")]
-    Address(#[source] IncorrectAddressLength),
+    AddressLength(#[source] IncorrectAddressLength),
 }
 
 /// Represents an IBC withdrawal of an asset from a source chain to a destination chain.
@@ -843,12 +878,12 @@ impl IbcRelayerChangeAction {
         match self {
             IbcRelayerChangeAction::Addition(address) => raw::IbcRelayerChangeAction {
                 value: Some(raw::ibc_relayer_change_action::Value::Addition(
-                    address.to_vec(),
+                    address.to_raw(),
                 )),
             },
             IbcRelayerChangeAction::Removal(address) => raw::IbcRelayerChangeAction {
                 value: Some(raw::ibc_relayer_change_action::Value::Removal(
-                    address.to_vec(),
+                    address.to_raw(),
                 )),
             },
         }
@@ -859,12 +894,12 @@ impl IbcRelayerChangeAction {
         match self {
             IbcRelayerChangeAction::Addition(address) => raw::IbcRelayerChangeAction {
                 value: Some(raw::ibc_relayer_change_action::Value::Addition(
-                    address.to_vec(),
+                    address.to_raw(),
                 )),
             },
             IbcRelayerChangeAction::Removal(address) => raw::IbcRelayerChangeAction {
                 value: Some(raw::ibc_relayer_change_action::Value::Removal(
-                    address.to_vec(),
+                    address.to_raw(),
                 )),
             },
         }
@@ -882,14 +917,14 @@ impl IbcRelayerChangeAction {
             raw::IbcRelayerChangeAction {
                 value: Some(raw::ibc_relayer_change_action::Value::Addition(address)),
             } => {
-                let address = Address::try_from_slice(address)
+                let address = Address::try_from_raw(address.clone())
                     .map_err(IbcRelayerChangeActionError::invalid_address)?;
                 Ok(IbcRelayerChangeAction::Addition(address))
             }
             raw::IbcRelayerChangeAction {
                 value: Some(raw::ibc_relayer_change_action::Value::Removal(address)),
             } => {
-                let address = Address::try_from_slice(address)
+                let address = Address::try_from_raw(address.clone())
                     .map_err(IbcRelayerChangeActionError::invalid_address)?;
                 Ok(IbcRelayerChangeAction::Removal(address))
             }
@@ -1029,7 +1064,7 @@ impl InitBridgeAccountAction {
     #[must_use]
     pub fn into_raw(self) -> raw::InitBridgeAccountAction {
         raw::InitBridgeAccountAction {
-            rollup_id: self.rollup_id.to_vec(),
+            rollup_id: Some(self.rollup_id.to_raw()),
             asset_ids: self.asset_ids.iter().map(|id| id.get().to_vec()).collect(),
             fee_asset_id: self.fee_asset_id.get().to_vec(),
         }
@@ -1038,7 +1073,7 @@ impl InitBridgeAccountAction {
     #[must_use]
     pub fn to_raw(&self) -> raw::InitBridgeAccountAction {
         raw::InitBridgeAccountAction {
-            rollup_id: self.rollup_id.to_vec(),
+            rollup_id: Some(self.rollup_id.to_raw()),
             asset_ids: self.asset_ids.iter().map(|id| id.get().to_vec()).collect(),
             fee_asset_id: self.fee_asset_id.get().to_vec(),
         }
@@ -1048,11 +1083,15 @@ impl InitBridgeAccountAction {
     ///
     /// # Errors
     ///
+    /// - if the `rollup_id` field is not set
     /// - if the `rollup_id` field is invalid
     pub fn try_from_raw(
         proto: raw::InitBridgeAccountAction,
     ) -> Result<Self, InitBridgeAccountActionError> {
-        let rollup_id = RollupId::try_from_slice(&proto.rollup_id)
+        let Some(rollup_id) = proto.rollup_id else {
+            return Err(InitBridgeAccountActionError::field_not_set("rollup_id"));
+        };
+        let rollup_id = RollupId::try_from_raw(rollup_id)
             .map_err(InitBridgeAccountActionError::invalid_rollup_id)?;
         let asset_ids = proto
             .asset_ids
@@ -1077,6 +1116,11 @@ pub struct InitBridgeAccountActionError(InitBridgeAccountActionErrorKind);
 
 impl InitBridgeAccountActionError {
     #[must_use]
+    fn field_not_set(field: &'static str) -> Self {
+        Self(InitBridgeAccountActionErrorKind::FieldNotSet(field))
+    }
+
+    #[must_use]
     fn invalid_rollup_id(err: IncorrectRollupIdLength) -> Self {
         Self(InitBridgeAccountActionErrorKind::InvalidRollupId(err))
     }
@@ -1098,6 +1142,8 @@ impl InitBridgeAccountActionError {
 #[derive(Debug, thiserror::Error)]
 #[allow(clippy::enum_variant_names)]
 enum InitBridgeAccountActionErrorKind {
+    #[error("the expected field in the raw source type was not set: `{0}`")]
+    FieldNotSet(&'static str),
     #[error("the `rollup_id` field was invalid")]
     InvalidRollupId(#[source] IncorrectRollupIdLength),
     #[error("an asset ID was invalid")]
@@ -1123,7 +1169,7 @@ impl BridgeLockAction {
     #[must_use]
     pub fn into_raw(self) -> raw::BridgeLockAction {
         raw::BridgeLockAction {
-            to: self.to.to_vec(),
+            to: Some(self.to.to_raw()),
             amount: Some(self.amount.into()),
             asset_id: self.asset_id.get().to_vec(),
             fee_asset_id: self.fee_asset_id.as_ref().to_vec(),
@@ -1134,7 +1180,7 @@ impl BridgeLockAction {
     #[must_use]
     pub fn to_raw(&self) -> raw::BridgeLockAction {
         raw::BridgeLockAction {
-            to: self.to.to_vec(),
+            to: Some(self.to.to_raw()),
             amount: Some(self.amount.into()),
             asset_id: self.asset_id.get().to_vec(),
             fee_asset_id: self.fee_asset_id.as_ref().to_vec(),
@@ -1146,12 +1192,15 @@ impl BridgeLockAction {
     ///
     /// # Errors
     ///
+    /// - if the `to` field is not set
     /// - if the `to` field is invalid
     /// - if the `asset_id` field is invalid
     /// - if the `fee_asset_id` field is invalid
     pub fn try_from_raw(proto: raw::BridgeLockAction) -> Result<Self, BridgeLockActionError> {
-        let to =
-            Address::try_from_slice(&proto.to).map_err(BridgeLockActionError::invalid_address)?;
+        let Some(to) = proto.to else {
+            return Err(BridgeLockActionError::field_not_set("to"));
+        };
+        let to = Address::try_from_raw(to).map_err(BridgeLockActionError::invalid_address)?;
         let amount = proto
             .amount
             .ok_or(BridgeLockActionError::missing_amount())?;
@@ -1175,6 +1224,11 @@ pub struct BridgeLockActionError(BridgeLockActionErrorKind);
 
 impl BridgeLockActionError {
     #[must_use]
+    fn field_not_set(field: &'static str) -> Self {
+        Self(BridgeLockActionErrorKind::FieldNotSet(field))
+    }
+
+    #[must_use]
     fn invalid_address(err: IncorrectAddressLength) -> Self {
         Self(BridgeLockActionErrorKind::InvalidAddress(err))
     }
@@ -1197,7 +1251,9 @@ impl BridgeLockActionError {
 
 #[derive(Debug, thiserror::Error)]
 enum BridgeLockActionErrorKind {
-    #[error("the `address` field was invalid")]
+    #[error("the expected field in the raw source type was not set: `{0}`")]
+    FieldNotSet(&'static str),
+    #[error("the `to` field was invalid")]
     InvalidAddress(#[source] IncorrectAddressLength),
     #[error("the `amount` field was not set")]
     MissingAmount,

--- a/crates/astria-core/src/sequencerblock/v1alpha1/celestia.rs
+++ b/crates/astria-core/src/sequencerblock/v1alpha1/celestia.rs
@@ -237,7 +237,7 @@ impl CelestiaRollupBlob {
         } = self;
         raw::CelestiaRollupBlob {
             sequencer_block_hash: sequencer_block_hash.to_vec(),
-            rollup_id: rollup_id.to_vec(),
+            rollup_id: Some(rollup_id.to_raw()),
             transactions,
             proof: Some(proof.into_raw()),
         }
@@ -254,8 +254,11 @@ impl CelestiaRollupBlob {
             transactions,
             proof,
         } = raw;
+        let Some(rollup_id) = rollup_id else {
+            return Err(CelestiaRollupBlobError::field_not_set("rollup_id"));
+        };
         let rollup_id =
-            RollupId::try_from_vec(rollup_id).map_err(CelestiaRollupBlobError::rollup_id)?;
+            RollupId::try_from_raw(rollup_id).map_err(CelestiaRollupBlobError::rollup_id)?;
         let sequencer_block_hash = sequencer_block_hash
             .try_into()
             .map_err(|bytes: Vec<u8>| CelestiaRollupBlobError::sequencer_block_hash(bytes.len()))?;
@@ -435,7 +438,7 @@ impl UncheckedCelestiaSequencerBlob {
         }?;
         let rollup_ids: Vec<_> = rollup_ids
             .into_iter()
-            .map(RollupId::try_from_vec)
+            .map(RollupId::try_from_raw)
             .collect::<Result<_, _>>()
             .map_err(CelestiaSequencerBlobError::rollup_ids)?;
 
@@ -605,7 +608,7 @@ impl CelestiaSequencerBlob {
         raw::CelestiaSequencerBlob {
             block_hash: block_hash.to_vec(),
             header: Some(header.into_raw()),
-            rollup_ids: rollup_ids.into_iter().map(RollupId::to_vec).collect(),
+            rollup_ids: rollup_ids.into_iter().map(RollupId::into_raw).collect(),
             rollup_transactions_proof: Some(rollup_transactions_proof.into_raw()),
             rollup_ids_proof: Some(rollup_ids_proof.into_raw()),
         }

--- a/crates/astria-sequencer/src/grpc/sequencer.rs
+++ b/crates/astria-sequencer/src/grpc/sequencer.rs
@@ -89,7 +89,7 @@ impl SequencerService for SequencerServer {
         let rollup_ids = request
             .rollup_ids
             .into_iter()
-            .map(RollupId::try_from_vec)
+            .map(RollupId::try_from_raw)
             .collect::<Result<Vec<_>, _>>()
             .map_err(|e| Status::invalid_argument(format!("invalid rollup ID: {e}")))?;
 

--- a/proto/primitives/astria/primitive/v1/types.proto
+++ b/proto/primitives/astria/primitive/v1/types.proto
@@ -34,3 +34,18 @@ message Denom {
   bytes id = 1;
   string base_denom = 2;
 }
+
+// A `RollupId` is a unique identifier for a rollup chain.
+// It must be 32 bytes long. It can be derived from a string
+// using a sha256 hash.
+message RollupId {
+  bytes inner = 1;
+}
+
+// An Astria `Address`.
+//
+// Astria addresses are derived from the ed25519 public key,
+// using the first 20 bytes of the sha256 hash.
+message Address {
+  bytes inner = 1;
+}

--- a/proto/protocolapis/astria/protocol/transactions/v1alpha1/types.proto
+++ b/proto/protocolapis/astria/protocol/transactions/v1alpha1/types.proto
@@ -56,7 +56,7 @@ message Action {
 // Note: all values must be set (ie. not `None`), otherwise it will
 // be considered invalid by the sequencer.
 message TransferAction {
-  bytes to = 1;
+  astria.primitive.v1.Address to = 1;
   astria.primitive.v1.Uint128 amount = 2;
   // the asset to be transferred
   bytes asset_id = 3;
@@ -70,7 +70,7 @@ message TransferAction {
 // It contains the rollup ID of the destination chain, and the
 // opaque transaction data.
 message SequenceAction {
-  bytes rollup_id = 1;
+  astria.primitive.v1.RollupId rollup_id = 1;
   bytes data = 2;
   // the asset used to pay the transaction fee
   bytes fee_asset_id = 3;
@@ -82,7 +82,7 @@ message SequenceAction {
 ///
 /// It contains the new sudo address.
 message SudoAddressChangeAction {
-  bytes new_address = 1;
+  astria.primitive.v1.Address new_address = 1;
 }
 
 // `MintAction` represents a minting transaction.
@@ -90,7 +90,7 @@ message SudoAddressChangeAction {
 //
 // It contains the address to mint to, and the amount to mint.
 message MintAction {
-  bytes to = 1;
+  astria.primitive.v1.Address to = 1;
   astria.primitive.v1.Uint128 amount = 2;
 }
 
@@ -125,8 +125,8 @@ message IbcHeight {
 // The bytes contained in each variant are the address to add or remove.
 message IbcRelayerChangeAction {
   oneof value {
-    bytes addition = 1;
-    bytes removal = 2;
+    astria.primitive.v1.Address addition = 1;
+    astria.primitive.v1.Address removal = 2;
   }
 }
 
@@ -149,7 +149,7 @@ message FeeAssetChangeAction {
 // a `TransferAction`.
 message InitBridgeAccountAction {
   // the rollup ID to register with the bridge account (the tx sender)
-  bytes rollup_id = 1;
+  astria.primitive.v1.RollupId rollup_id = 1;
   // the asset IDs accepted as an incoming transfer by the bridge account
   repeated bytes asset_ids = 2;
   // the asset used to pay the transaction fee
@@ -163,7 +163,7 @@ message InitBridgeAccountAction {
 // `destination_chain_address` field.
 message BridgeLockAction {
   // the address of the bridge account to transfer to
-  bytes to = 1;
+  astria.primitive.v1.Address to = 1;
   // the amount to transfer
   astria.primitive.v1.Uint128 amount = 2;
   // the asset to be transferred

--- a/proto/sequencerblockapis/astria/sequencerblock/v1alpha1/block.proto
+++ b/proto/sequencerblockapis/astria/sequencerblock/v1alpha1/block.proto
@@ -12,7 +12,7 @@ import "google/protobuf/timestamp.proto";
 // services sending and receiving the transactions.
 message RollupTransactions {
   // The 32 bytes identifying a rollup. Usually the sha256 hash of a plain rollup name.
-  bytes rollup_id = 1;
+  astria.primitive.v1.RollupId rollup_id = 1;
   // The serialized bytes of the rollup data.
   // Each entry is a protobuf-encoded `RollupData` message.
   repeated bytes transactions = 2;
@@ -78,9 +78,9 @@ message Deposit {
   // this is required as initializing an account as a bridge account
   // is permissionless, so the rollup consensus needs to know and enshrine
   // which accounts it accepts as valid bridge accounts.
-  bytes bridge_address = 1;
+  astria.primitive.v1.Address bridge_address = 1;
   // the rollup_id which the funds are being deposited to
-  bytes rollup_id = 2;
+  astria.primitive.v1.RollupId rollup_id = 2;
   astria.primitive.v1.Uint128 amount = 3;
   bytes asset_id = 4;
   // the address on the destination chain which

--- a/proto/sequencerblockapis/astria/sequencerblock/v1alpha1/celestia.proto
+++ b/proto/sequencerblockapis/astria/sequencerblock/v1alpha1/celestia.proto
@@ -15,7 +15,7 @@ message CelestiaRollupBlob {
   bytes sequencer_block_hash = 1;
   // The 32 bytes identifying the rollup this blob belongs to. Matches
   // `astria.sequencer.v1.RollupTransactions.rollup_id`
-  bytes rollup_id = 2;
+  astria.primitive.v1.RollupId rollup_id = 2;
   // A list of opaque bytes that are serialized rollup transactions.
   repeated bytes transactions = 3;
   // The proof that these rollup transactions are included in sequencer block.
@@ -39,7 +39,7 @@ message CelestiaSequencerBlob {
   // The rollup IDs for which `CelestiaRollupBlob`s were submitted to celestia.
   // Corresponds to the `astria.sequencer.v1.RollupTransactions.rollup_id` field
   // and is extracted from `astria.SequencerBlock.rollup_transactions`.
-  repeated bytes rollup_ids = 3;
+  repeated astria.primitive.v1.RollupId rollup_ids = 3;
   // The proof that the rollup transactions are included in sequencer block.
   // Corresponds to `astria.sequencer.v1alpha.SequencerBlock.rollup_transactions_proof`.
   astria.primitive.v1.Proof rollup_transactions_proof = 4;

--- a/proto/sequencerblockapis/astria/sequencerblock/v1alpha1/service.proto
+++ b/proto/sequencerblockapis/astria/sequencerblock/v1alpha1/service.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package astria.sequencerblock.v1alpha1;
 
 import "astria/sequencerblock/v1alpha1/block.proto";
+import "astria/primitive/v1/types.proto";
 import "google/api/annotations.proto";
 import "google/api/field_behavior.proto";
 
@@ -15,7 +16,7 @@ message GetFilteredSequencerBlockRequest {
   // The height of the block to retrieve.
   uint64 height = 1 [(google.api.field_behavior) = REQUIRED];
   // The 32 bytes identifying a rollup. Usually the sha256 hash of a plain rollup name.
-  repeated bytes rollup_ids = 2 [(google.api.field_behavior) = REQUIRED];
+  repeated astria.primitive.v1.RollupId rollup_ids = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
 service SequencerService {

--- a/tools/protobuf-compiler/src/main.rs
+++ b/tools/protobuf-compiler/src/main.rs
@@ -63,7 +63,10 @@ fn main() {
         .build_client(true)
         .build_server(true)
         .emit_rerun_if_changed(false)
-        .bytes([".astria.execution.v1alpha2"])
+        .bytes([
+            ".astria.execution.v1alpha2",
+            ".astria.primitive.v1",
+        ])
         .client_mod_attribute(".", "#[cfg(feature=\"client\")]")
         .server_mod_attribute(".", "#[cfg(feature=\"server\")]")
         .extern_path(


### PR DESCRIPTION
## Summary
Creates wrapper proto types for `RollupId` and `Account`, which can allow us to add more representations and acceptable formats for them as non breaking changes in the future.

## Background
We were using `Account` and `RollupId` as simple raw bytes, this means any change would be a breaking change, now we can do non breaking changes such as offering bech32 address versions.

## Changes
- Switched to wrapper types for all references of RollupId and Account

## Testing
CI/CD

## Metrics
- List out metrics added by PR, delete section if none. 

## Breaking Changelist
- Changes core transaction protos
