### PR TITLE
fix(composer): account for fee asset id while estimating sequence action size

### DIFF
--- a/crates/astria-composer/src/executor/bundle_factory/mod.rs
+++ b/crates/astria-composer/src/executor/bundle_factory/mod.rs
@@ -214,5 +214,9 @@ impl<'a> NextFinishedBundle<'a> {
 
 /// The size of the `seq_action` in bytes, including the rollup id.
 fn estimate_size_of_sequence_action(seq_action: &SequenceAction) -> usize {
-    seq_action.data.len() + ROLLUP_ID_LEN + FEE_ASSET_ID_LEN
+    seq_action
+        .data
+        .len()
+        .saturating_add(ROLLUP_ID_LEN)
+        .saturating_add(FEE_ASSET_ID_LEN)
 }

--- a/crates/astria-composer/src/executor/bundle_factory/mod.rs
+++ b/crates/astria-composer/src/executor/bundle_factory/mod.rs
@@ -11,6 +11,7 @@ use std::{
 use astria_core::{
     primitive::v1::{
         RollupId,
+        FEE_ASSET_ID_LEN,
         ROLLUP_ID_LEN,
     },
     protocol::transaction::v1alpha1::{
@@ -213,5 +214,5 @@ impl<'a> NextFinishedBundle<'a> {
 
 /// The size of the `seq_action` in bytes, including the rollup id.
 fn estimate_size_of_sequence_action(seq_action: &SequenceAction) -> usize {
-    seq_action.data.len() + ROLLUP_ID_LEN
+    seq_action.data.len() + ROLLUP_ID_LEN + FEE_ASSET_ID_LEN
 }

--- a/crates/astria-composer/src/executor/bundle_factory/tests.rs
+++ b/crates/astria-composer/src/executor/bundle_factory/tests.rs
@@ -4,6 +4,7 @@ mod sized_bundle_tests {
         primitive::v1::{
             asset::default_native_asset_id,
             RollupId,
+            FEE_ASSET_ID_LEN,
             ROLLUP_ID_LEN,
         },
         protocol::transaction::v1alpha1::action::SequenceAction,
@@ -27,7 +28,7 @@ mod sized_bundle_tests {
         // push a sequence action that is 100 bytes total
         let seq_action = SequenceAction {
             rollup_id: RollupId::new([0; ROLLUP_ID_LEN]),
-            data: vec![0; 100 - ROLLUP_ID_LEN],
+            data: vec![0; 100 - ROLLUP_ID_LEN - FEE_ASSET_ID_LEN],
             fee_asset_id: default_native_asset_id(),
         };
 
@@ -43,7 +44,7 @@ mod sized_bundle_tests {
         // push a sequence action that is >100 bytes total
         let seq_action = SequenceAction {
             rollup_id: RollupId::new([0; ROLLUP_ID_LEN]),
-            data: vec![0; 100 - ROLLUP_ID_LEN + 1],
+            data: vec![0; 100 - ROLLUP_ID_LEN - FEE_ASSET_ID_LEN + 1],
             fee_asset_id: default_native_asset_id(),
         };
 
@@ -62,7 +63,7 @@ mod sized_bundle_tests {
         // push a sequence action that is 100 bytes total
         let initial_seq_action = SequenceAction {
             rollup_id: RollupId::new([0; ROLLUP_ID_LEN]),
-            data: vec![0; 100 - ROLLUP_ID_LEN],
+            data: vec![0; 100 - ROLLUP_ID_LEN - FEE_ASSET_ID_LEN],
             fee_asset_id: default_native_asset_id(),
         };
         bundle.push(initial_seq_action).unwrap();
@@ -91,7 +92,7 @@ mod sized_bundle_tests {
         // push a sequence action sucessfully
         let seq_action = SequenceAction {
             rollup_id: RollupId::new([0; ROLLUP_ID_LEN]),
-            data: vec![1; 100 - ROLLUP_ID_LEN],
+            data: vec![1; 100 - ROLLUP_ID_LEN - FEE_ASSET_ID_LEN],
             fee_asset_id: default_native_asset_id(),
         };
         bundle.push(seq_action.clone()).unwrap();
@@ -111,7 +112,7 @@ mod sized_bundle_tests {
     }
 
     fn snapshot_bundle() -> SizedBundle {
-        let mut bundle = SizedBundle::new(200);
+        let mut bundle = SizedBundle::new(264);
         let seq_action1 = SequenceAction {
             rollup_id: RollupId::new([1; ROLLUP_ID_LEN]),
             data: vec![1; 50 - ROLLUP_ID_LEN],
@@ -124,7 +125,7 @@ mod sized_bundle_tests {
         };
         let seq_action2 = SequenceAction {
             rollup_id: RollupId::new([2; ROLLUP_ID_LEN]),
-            data: vec![2; 100 - ROLLUP_ID_LEN],
+            data: vec![2; 100 - ROLLUP_ID_LEN - FEE_ASSET_ID_LEN],
             fee_asset_id: default_native_asset_id(),
         };
         bundle.push(seq_action1).unwrap();
@@ -152,6 +153,7 @@ mod bundle_factory_tests {
         primitive::v1::{
             asset::default_native_asset_id,
             RollupId,
+            FEE_ASSET_ID_LEN,
             ROLLUP_ID_LEN,
         },
         protocol::transaction::v1alpha1::action::SequenceAction,
@@ -171,7 +173,7 @@ mod bundle_factory_tests {
         // push a sequence action that is 100 bytes total
         let seq_action = SequenceAction {
             rollup_id: RollupId::new([0; ROLLUP_ID_LEN]),
-            data: vec![0; 100 - ROLLUP_ID_LEN],
+            data: vec![0; 100 - ROLLUP_ID_LEN - FEE_ASSET_ID_LEN],
             fee_asset_id: default_native_asset_id(),
         };
         bundle_factory.try_push(seq_action).unwrap();
@@ -188,7 +190,7 @@ mod bundle_factory_tests {
         // push a sequence action that is >100 bytes total
         let seq_action = SequenceAction {
             rollup_id: RollupId::new([0; ROLLUP_ID_LEN]),
-            data: vec![0; 100 - ROLLUP_ID_LEN + 1],
+            data: vec![0; 100 - ROLLUP_ID_LEN - FEE_ASSET_ID_LEN + 1],
             fee_asset_id: default_native_asset_id(),
         };
         let actual_size = estimate_size_of_sequence_action(&seq_action);
@@ -210,7 +212,7 @@ mod bundle_factory_tests {
         // push a sequence action that is 100 bytes total
         let seq_action0 = SequenceAction {
             rollup_id: RollupId::new([0; ROLLUP_ID_LEN]),
-            data: vec![0; 100 - ROLLUP_ID_LEN],
+            data: vec![0; 100 - ROLLUP_ID_LEN - FEE_ASSET_ID_LEN],
             fee_asset_id: default_native_asset_id(),
         };
         bundle_factory.try_push(seq_action0.clone()).unwrap();
@@ -219,7 +221,7 @@ mod bundle_factory_tests {
         // flush
         let seq_action1 = SequenceAction {
             rollup_id: RollupId::new([1; ROLLUP_ID_LEN]),
-            data: vec![1; 100 - ROLLUP_ID_LEN],
+            data: vec![1; 100 - ROLLUP_ID_LEN - FEE_ASSET_ID_LEN],
             fee_asset_id: default_native_asset_id(),
         };
         bundle_factory.try_push(seq_action1).unwrap();
@@ -242,7 +244,7 @@ mod bundle_factory_tests {
         // push a sequence action that is 100 bytes total so it doesn't flush
         let seq_action = SequenceAction {
             rollup_id: RollupId::new([0; ROLLUP_ID_LEN]),
-            data: vec![0; 100 - ROLLUP_ID_LEN],
+            data: vec![0; 100 - ROLLUP_ID_LEN - FEE_ASSET_ID_LEN],
             fee_asset_id: default_native_asset_id(),
         };
         bundle_factory.try_push(seq_action.clone()).unwrap();
@@ -262,7 +264,7 @@ mod bundle_factory_tests {
         // push a sequence action that is 100 bytes total so it doesn't flush
         let seq_action = SequenceAction {
             rollup_id: RollupId::new([0; ROLLUP_ID_LEN]),
-            data: vec![0; 100 - ROLLUP_ID_LEN],
+            data: vec![0; 100 - ROLLUP_ID_LEN - FEE_ASSET_ID_LEN],
             fee_asset_id: default_native_asset_id(),
         };
         bundle_factory.try_push(seq_action.clone()).unwrap();
@@ -284,7 +286,7 @@ mod bundle_factory_tests {
         // push a sequence action that is 100 bytes total
         let seq_action0 = SequenceAction {
             rollup_id: RollupId::new([0; ROLLUP_ID_LEN]),
-            data: vec![0; 100 - ROLLUP_ID_LEN],
+            data: vec![0; 100 - ROLLUP_ID_LEN - FEE_ASSET_ID_LEN],
             fee_asset_id: default_native_asset_id(),
         };
         bundle_factory.try_push(seq_action0.clone()).unwrap();
@@ -293,7 +295,7 @@ mod bundle_factory_tests {
         // flush
         let seq_action1 = SequenceAction {
             rollup_id: RollupId::new([1; ROLLUP_ID_LEN]),
-            data: vec![1; 100 - ROLLUP_ID_LEN],
+            data: vec![1; 100 - ROLLUP_ID_LEN - FEE_ASSET_ID_LEN],
             fee_asset_id: default_native_asset_id(),
         };
         bundle_factory.try_push(seq_action1).unwrap();
@@ -327,7 +329,7 @@ mod bundle_factory_tests {
         // push a sequence action that is 100 bytes total
         let seq_action0 = SequenceAction {
             rollup_id: RollupId::new([0; ROLLUP_ID_LEN]),
-            data: vec![0; 100 - ROLLUP_ID_LEN],
+            data: vec![0; 100 - ROLLUP_ID_LEN - FEE_ASSET_ID_LEN],
             fee_asset_id: default_native_asset_id(),
         };
         bundle_factory.try_push(seq_action0.clone()).unwrap();
@@ -336,7 +338,7 @@ mod bundle_factory_tests {
         // flush
         let seq_action1 = SequenceAction {
             rollup_id: RollupId::new([1; ROLLUP_ID_LEN]),
-            data: vec![1; 100 - ROLLUP_ID_LEN],
+            data: vec![1; 100 - ROLLUP_ID_LEN - FEE_ASSET_ID_LEN],
             fee_asset_id: default_native_asset_id(),
         };
         bundle_factory.try_push(seq_action1.clone()).unwrap();

--- a/crates/astria-composer/src/executor/tests.rs
+++ b/crates/astria-composer/src/executor/tests.rs
@@ -4,6 +4,7 @@ use astria_core::{
     primitive::v1::{
         asset::default_native_asset_id,
         RollupId,
+        FEE_ASSET_ID_LEN,
         ROLLUP_ID_LEN,
     },
     protocol::transaction::v1alpha1::action::SequenceAction,
@@ -223,7 +224,7 @@ async fn full_bundle() {
     // order to make space for the second
     let seq0 = SequenceAction {
         rollup_id: RollupId::new([0; ROLLUP_ID_LEN]),
-        data: vec![0u8; cfg.max_bytes_per_bundle - ROLLUP_ID_LEN],
+        data: vec![0u8; cfg.max_bytes_per_bundle - ROLLUP_ID_LEN - FEE_ASSET_ID_LEN],
         fee_asset_id: default_native_asset_id(),
     };
 

--- a/crates/astria-core/src/primitive/v1/mod.rs
+++ b/crates/astria-core/src/primitive/v1/mod.rs
@@ -17,6 +17,7 @@ use crate::{
 
 pub const ADDRESS_LEN: usize = 20;
 pub const ROLLUP_ID_LEN: usize = 32;
+pub const FEE_ASSET_ID_LEN: usize = 32;
 
 impl Protobuf for merkle::Proof {
     type Error = merkle::audit::InvalidProof;


### PR DESCRIPTION
## Summary
Account for the length of fee_asset_id while estimating the sequence action size in composer.

## Background
In Composer, we create bundles with the incoming txs collected from the gRPC and Geth collectors. 
These bundles have to be appropriately sized so that we don't end up sending a tx to the sequencer which is much bigger than the block size or the max tx size accepted by the sequencer. 
To do this, we have a variable `ASTRIA_COMPOSER_MAX_BYTES_PER_BUNDLE` which is the max bytes allowed in a bundle. 
Currently, this was not considering the length of the fee_asset_id field of a SequenceAction. When a large inflow of txs are sent to the composer which causes the bundles to be completely filled, the submission of the bundle to the sequencer fails because the unaccounted fee_asset_id fields cause the tx size to go beyond the accepted tx size by the sequencer. 
It fails with the below error:
`2024-04-19T07:57:14.930902Z  WARN run_until_stopped:submit_bundle: astria_composer::executor: sequencer rejected the transaction; the bundle is likely lost abci.code=5 abci.log="transaction size too large; allowed: 256000 bytes, got 305106" address=Uw2IlR9YdowCe09slJO3kwRg+KQ= nonce.initial=1`

To fix this, we now account for the fee_asset_id len while estimating the sequence action size.

## Changes
- Create a new var `FEE_ASSET_ID_LEN` in astria-core primitives.
- Account for `FEE_ASSET_ID_LEN` in `estimate_size_of_sequence_action` method.

## Testing
We tested this in 2 ways:
1. Unit tests were updated to account for fee_asset_id and they successfully pass
2. Running a load test where a lot of txs were sent to Composer. Before this fix, the txs were being dropped because the tx being sent to the sequencer was too big. 
