### PR TITLE
release: sequencer 0.11, conductor 0.14, composer 0.6, relayer 0.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -557,7 +557,7 @@ dependencies = [
 
 [[package]]
 name = "astria-composer"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "astria-build-info",
  "astria-config",
@@ -602,7 +602,7 @@ dependencies = [
 
 [[package]]
 name = "astria-conductor"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "astria-build-info",
  "astria-celestia-client",
@@ -753,7 +753,7 @@ dependencies = [
 
 [[package]]
 name = "astria-sequencer"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "astria-build-info",
@@ -821,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "astria-sequencer-relayer"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "assert-json-diff",
  "astria-build-info",

--- a/crates/astria-composer/Cargo.toml
+++ b/crates/astria-composer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astria-composer"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.73"
 license = "MIT OR Apache-2.0"

--- a/crates/astria-conductor/Cargo.toml
+++ b/crates/astria-conductor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astria-conductor"
-version = "0.13.1"
+version = "0.14.0"
 edition = "2021"
 rust-version = "1.73"
 license = "MIT OR Apache-2.0"

--- a/crates/astria-sequencer-relayer/Cargo.toml
+++ b/crates/astria-sequencer-relayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astria-sequencer-relayer"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 rust-version = "1.73"

--- a/crates/astria-sequencer/Cargo.toml
+++ b/crates/astria-sequencer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astria-sequencer"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 rust-version = "1.73"


### PR DESCRIPTION
## Summary
Cut releases of the core components for initial dusk-5 release. Note that sequencer-relayer is not required and can catch up after further testing of new changes.
