### PR TITLE
fix(sequencer): do not allow sudo to cause consensus failures

### DIFF
--- a/crates/astria-sequencer/src/authority/action.rs
+++ b/crates/astria-sequencer/src/authority/action.rs
@@ -1,4 +1,5 @@
 use anyhow::{
+    bail,
     ensure,
     Context as _,
     Result,
@@ -7,6 +8,7 @@ use astria_core::{
     primitive::v1::Address,
     protocol::transaction::v1alpha1::action::SudoAddressChangeAction,
 };
+use tendermint::account;
 use tracing::instrument;
 
 use crate::{
@@ -30,6 +32,24 @@ impl ActionHandler for tendermint::validator::Update {
             .await
             .context("failed to get sudo address from state")?;
         ensure!(sudo_address == from, "signer is not the sudo key");
+
+        // ensure that we're not removing the last validator or a validator
+        // that doesn't exist, these both cause issues in cometBFT
+        if self.power.is_zero() {
+            let validator_set = state
+                .get_validator_set()
+                .await
+                .context("failed to get validator set from state")?;
+            // check that validator exists
+            if validator_set
+                .get(&account::Id::from(self.pub_key))
+                .is_none()
+            {
+                bail!("cannot remove a non-existing validator");
+            }
+            // check that this is not the only validator, cannot remove the last one
+            ensure!(validator_set.len() != 1, "cannot remove the last validator");
+        }
         Ok(())
     }
 

--- a/crates/astria-sequencer/src/authority/state_ext.rs
+++ b/crates/astria-sequencer/src/authority/state_ext.rs
@@ -47,12 +47,10 @@ impl ValidatorSet {
         Self(validator_set)
     }
 
-    #[cfg(test)]
     pub(crate) fn len(&self) -> usize {
         self.0.len()
     }
 
-    #[cfg(test)]
     pub(crate) fn get(&self, address: &account::Id) -> Option<&validator::Update> {
         self.0.get(address)
     }


### PR DESCRIPTION
## Summary
Before this PR it was possible for sudo to accidentally cause consensus failures via removing non-existing validators from the validator set. For a single validator setup, sudo could also error by removing the only validator. We need to filter this on the app side because for some reason cometBFT will error/shut down if it receives these bad requests. 

## Changes
- Added to the ActionHandler's stateful checks for validator updates to make sure we don't error.

## Testing
Ran a local testnet with multiple validators and ensured that removing non-existing validators no longer causes consensus failures. 

```
## in /crates/astria-sequencer/ run testnet
just run-testnet

## send this command and see it fail the stateful checks
./target/debug/astria-cli sequencer sudo validator-update \
--validator-public-key c39892c49c819491c3552c1a95337d7324a45b25dd0aa397efb706bae8648dac \
--power 0 \
--private-key 2bd806c97f0e00af1a1fc3328fa763a9269723c8db8fac4f93af71db186d6e90 \
--sequencer-url=http://localhost:27660/ --sequencer.chain-id astria
```

## Related Issues
The failed transaction just gets stuck in the mempool and is a DOS vector as noted in #715. Any transactions that fail the stateful checks get stuck currently. 

closes #967
