### PR TITLE
fix(sequencer): stateful check now ensures balance for total tx

### DIFF
--- a/crates/astria-sequencer/src/app.rs
+++ b/crates/astria-sequencer/src/app.rs
@@ -1495,7 +1495,7 @@ mod test {
 
         transaction::check_stateful(&signed_tx_pass, &app.state)
             .await
-            .unwrap();
+            .expect("stateful check should pass since we transferred enough to cover fee");
     }
 
     #[tokio::test]

--- a/crates/astria-sequencer/src/transaction/mod.rs
+++ b/crates/astria-sequencer/src/transaction/mod.rs
@@ -71,11 +71,20 @@ pub(crate) async fn check_balance_mempool<S: StateReadExt + 'static>(
     tx: &SignedTransaction,
     state: &S,
 ) -> anyhow::Result<()> {
+    let signer_address = Address::from_verification_key(tx.verification_key());
+    check_balance(tx.unsigned_transaction(), signer_address, state).await?;
+    Ok(())
+}
+
+pub(crate) async fn check_balance<S: StateReadExt + 'static>(
+    tx: &UnsignedTransaction,
+    from: Address,
+    state: &S,
+) -> anyhow::Result<()> {
     use std::collections::HashMap;
 
-    let signer_address = Address::from_verification_key(tx.verification_key());
     let mut fees_by_asset = HashMap::new();
-    for action in tx.actions() {
+    for action in &tx.actions {
         match action {
             Action::Transfer(act) => {
                 fees_by_asset
@@ -133,7 +142,7 @@ pub(crate) async fn check_balance_mempool<S: StateReadExt + 'static>(
     }
     for (asset, total_fee) in fees_by_asset {
         let balance = state
-            .get_account_balance(signer_address, asset)
+            .get_account_balance(from, asset)
             .await
             .context("failed to get account balance")?;
         ensure!(
@@ -286,6 +295,9 @@ impl ActionHandler for UnsignedTransaction {
             curr_nonce == self.params.nonce,
             InvalidNonce(self.params.nonce)
         );
+
+        // Should have enough balance to cover all actions.
+        check_balance(self, from, state).await?;
 
         for action in &self.actions {
             match action {

--- a/crates/astria-sequencer/src/transaction/mod.rs
+++ b/crates/astria-sequencer/src/transaction/mod.rs
@@ -72,11 +72,13 @@ pub(crate) async fn check_balance_mempool<S: StateReadExt + 'static>(
     state: &S,
 ) -> anyhow::Result<()> {
     let signer_address = Address::from_verification_key(tx.verification_key());
-    check_balance(tx.unsigned_transaction(), signer_address, state).await?;
+    check_balance_for_total_fees(tx.unsigned_transaction(), signer_address, state).await?;
     Ok(())
 }
 
-pub(crate) async fn check_balance<S: StateReadExt + 'static>(
+// Checks that the account has enough balance to cover the total fees for all actions in the
+// transaction.
+pub(crate) async fn check_balance_for_total_fees<S: StateReadExt + 'static>(
     tx: &UnsignedTransaction,
     from: Address,
     state: &S,
@@ -297,7 +299,7 @@ impl ActionHandler for UnsignedTransaction {
         );
 
         // Should have enough balance to cover all actions.
-        check_balance(self, from, state).await?;
+        check_balance_for_total_fees(self, from, state).await?;
 
         for action in &self.actions {
             match action {


### PR DESCRIPTION
## Summary
Sequencer's stateful check wasn't ensuring that a transaction's entire fee consumption was covered by the balance, it was only checking per individual action. Now the stateful check will err if there aren't enough funds for the whole transaction.

## Background
We were checking this already in the mempool, but this check will cover the edge case of an account's earlier transaction consuming funds in the same block. 

## Testing
Added unit test.

## Related Issues
closes #786 
