### PR TITLE
fix(composer): use tx hash as hex again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -902,6 +902,7 @@ dependencies = [
  "opentelemetry_sdk",
  "serde",
  "serde_json",
+ "serde_with",
  "thiserror",
  "tracing",
  "tracing-opentelemetry",

--- a/crates/astria-composer/src/executor/mod.rs
+++ b/crates/astria-composer/src/executor/mod.rs
@@ -539,7 +539,7 @@ impl Future for SubmitFut {
                     info!(
                         nonce.actual = *this.nonce,
                         bundle = %telemetry::display::json(&SizedBundleReport(this.bundle)),
-                        transaction.hash = %telemetry::display::base64(&tx.sha256_of_proto_encoding()),
+                        transaction.hash = %telemetry::display::hex(&tx.sha256_of_proto_encoding()),
                         "submitting transaction to sequencer",
                     );
                     SubmitState::WaitingForSend {
@@ -601,7 +601,7 @@ impl Future for SubmitFut {
                         info!(
                             nonce.resubmission = *this.nonce,
                             bundle = %telemetry::display::json(&SizedBundleReport(this.bundle)),
-                            transaction.hash = %telemetry::display::base64(&tx.sha256_of_proto_encoding()),
+                            transaction.hash = %telemetry::display::hex(&tx.sha256_of_proto_encoding()),
                             "resubmitting transaction to sequencer with new nonce",
                         );
                         SubmitState::WaitingForSend {

--- a/crates/astria-telemetry/Cargo.toml
+++ b/crates/astria-telemetry/Cargo.toml
@@ -26,6 +26,7 @@ opentelemetry-stdout = { version = "0.3.0", features = ["trace"] }
 opentelemetry_sdk = { version = "0.22.1", features = ["rt-tokio"] }
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
+serde_with = { version = "3.7.0", optional = true }
 thiserror = { workspace = true }
 tracing-opentelemetry = "0.23.0"
 tracing-subscriber = { version = "0.3.17", features = [
@@ -38,4 +39,4 @@ tracing-subscriber = { version = "0.3.17", features = [
 tracing = { workspace = true }
 
 [features]
-display = ["dep:base64", "dep:serde", "dep:serde_json", "dep:base64-serde"]
+display = ["dep:base64", "dep:serde", "dep:serde_json", "dep:base64-serde", "dep:serde_with"]

--- a/crates/astria-telemetry/Cargo.toml
+++ b/crates/astria-telemetry/Cargo.toml
@@ -39,4 +39,10 @@ tracing-subscriber = { version = "0.3.17", features = [
 tracing = { workspace = true }
 
 [features]
-display = ["dep:base64", "dep:serde", "dep:serde_json", "dep:base64-serde", "dep:serde_with"]
+display = [
+  "dep:base64",
+  "dep:serde",
+  "dep:serde_json",
+  "dep:base64-serde",
+  "dep:serde_with",
+]


### PR DESCRIPTION
## Summary
We switched to using base 64 everywhere, but tx hashes for cometbft should be hex.

## Background
When grabbing txs from CometBFT RPCs you need the hex string of the transaction, so logging out base64 is pretty useless unfortunately.

## Changes
- Add telemetry hex back in
- Use hex telemetry encoding for the transaction hash logs in composer.

## Testing
CI
