### PR TITLE
fix(sequencer): panic sequencer instead of cometbft on erroring abci consensus requests

### DIFF
--- a/crates/astria-sequencer/src/service/consensus.rs
+++ b/crates/astria-sequencer/src/service/consensus.rs
@@ -54,11 +54,7 @@ impl Consensus {
             // for some reason -- but that's not our problem.
             let rsp = self.handle_request(req).instrument(span.clone()).await;
             if let Err(e) = rsp.as_ref() {
-                warn!(
-                    parent: &span,
-                    error = e,
-                    "failed processing consensus request; returning error back to sender",
-                );
+                panic!("failed to handle consensus request, this is a bug: {e:?}");
             }
             // `send` returns the sent message if sending fail, so we are dropping it.
             if rsp_sender.send(rsp).is_err() {


### PR DESCRIPTION
## Summary
Zellic suggested that we panic the sequencer on consensus failures instead of silently sending them to cometbft. There isn't any error handling in cometbft so doing this makes sense and gives us more info for debugging.

## Changes
Made the request handler panic in the sequencer on abci requests that shouldn't fail. 

## Testing
Ran the sequencer locally with planned failures. 

## Related Issues

closes #1004
