### PR TITLE
Relayer secret provider

### DIFF
--- a/charts/sequencer-relayer/Chart.yaml
+++ b/charts/sequencer-relayer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.1
+version: 0.5.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sequencer-relayer/templates/configmaps.yaml
+++ b/charts/sequencer-relayer/templates/configmaps.yaml
@@ -30,7 +30,7 @@ data:
   ASTRIA_SEQUENCER_RELAYER_CELESTIA_BEARER_TOKEN: "{{ .Values.config.relayer.celestiaBearerToken }}"
   {{- else }}
   ASTRIA_SEQUENCER_RELAYER_CELESTIA_APP_GRPC_ENDPOINT: "{{ .Values.config.relayer.celestiaAppGrpc }}"
-  ASTRIA_SEQUENCER_RELAYER_CELESTIA_APP_KEY_FILE: "/celestia-key/{{ .Values.config.celestiaAppPrivateKey.filename }}"
+  ASTRIA_SEQUENCER_RELAYER_CELESTIA_APP_KEY_FILE: "/celestia-key/{{ .Values.config.celestiaAppPrivateKey.secret.filename }}"
   {{- end }}
 ---
 apiVersion: v1
@@ -49,6 +49,6 @@ metadata:
   name: relayer-celestia-key
   namespace: {{ include "sequencer-relayer.namespace" . }}
 data:
-  {{ .Values.config.celestiaAppPrivateKey.filename }}: |
-    {{ .Values.config.celestiaAppPrivateKey.content }}
+  {{ .Values.config.celestiaAppPrivateKey.secret.filename }}: |
+    {{ .Values.config.celestiaAppPrivateKey.devContent }}
 ---

--- a/charts/sequencer-relayer/templates/secretproviderclass.yaml
+++ b/charts/sequencer-relayer/templates/secretproviderclass.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.secretProvider.enabled }}
+---
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: relayer-private-key-celestia
+spec:
+  provider: gcp
+  secretObjects:
+  - secretName: relayer-private-key-celestia
+    type: Opaque
+    data:
+    - objectName: {{ .Values.config.celestiaAppPrivateKey.secret.filename }}
+      key: {{ .Values.config.celestiaAppPrivateKey.secret.key }}
+  parameters:
+    {{- $_ := set $ "key" .Values.config.celestiaAppPrivateKey.secret }}
+    {{- tpl $.Values.secretProvider.parametersTemplate $ | nindent 4 }}
+{{- end }}

--- a/charts/sequencer-relayer/templates/statefulset.yaml
+++ b/charts/sequencer-relayer/templates/statefulset.yaml
@@ -59,4 +59,3 @@ spec:
           configMap:
             name: relayer-celestia-key
           {{- end }}
-        {{- end}}

--- a/charts/sequencer-relayer/templates/statefulset.yaml
+++ b/charts/sequencer-relayer/templates/statefulset.yaml
@@ -54,7 +54,7 @@ spec:
             driver: secrets-store.csi.k8s.io
             readOnly: true
             volumeAttributes:
-              secretProviderClass: relayer-celestia-secrets-store
+              secretProviderClass: relayer-private-key-celestia
           {{- else }}
           configMap:
             name: relayer-celestia-key

--- a/charts/sequencer-relayer/templates/statefulset.yaml
+++ b/charts/sequencer-relayer/templates/statefulset.yaml
@@ -49,5 +49,14 @@ spec:
           emptyDir: {}
           {{- end }}
         - name: relayer-celestia-key-volume
+          {{- if $.Values.secretProvider.enabled }}
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: relayer-celestia-secrets-store
+          {{- else }}
           configMap:
             name: relayer-celestia-key
+          {{- end }}
+        {{- end}}

--- a/charts/sequencer-relayer/values.yaml
+++ b/charts/sequencer-relayer/values.yaml
@@ -42,7 +42,6 @@ config:
     secret:
       filename: "key.hex"
       resourceName: "projects/$PROJECT_ID/secrets/celestiaPrivateKey/versions/latest"
-      key: token
 ports:
   relayerRPC: 2450
   metrics: 9000

--- a/charts/sequencer-relayer/values.yaml
+++ b/charts/sequencer-relayer/values.yaml
@@ -42,6 +42,7 @@ config:
     secret: 
       filename: "key.hex"
       resourceName: "projects/$PROJECT_ID/secrets/celestiaPrivateKey/versions/latest"
+      key: token
 ports:
   relayerRPC: 2450
   metrics: 9000

--- a/charts/sequencer-relayer/values.yaml
+++ b/charts/sequencer-relayer/values.yaml
@@ -38,9 +38,10 @@ config:
       traceHeaders:
 
   celestiaAppPrivateKey:
-    filename: "key.hex"
-    content: "8241386890823ca14743e5d4d583f879a5236af29f454ed4da6fe62b8439e2ab"
-
+    devContent: "8241386890823ca14743e5d4d583f879a5236af29f454ed4da6fe62b8439e2ab"
+    secret: 
+      filename: "key.hex"
+      resourceName: "projects/$PROJECT_ID/secrets/celestiaPrivateKey/versions/latest"
 ports:
   relayerRPC: 2450
   metrics: 9000
@@ -59,3 +60,27 @@ storage:
       size: "1Gi"
       persistentVolumeName: "sequencer-relayer-storage"
       path: "/data/sequencer-relayer-data"
+
+# When deploying in a production environment should use a secret provider
+# This is configured for use with GCP, need to set own resource names
+# and keys
+secretProvider:
+  enabled: true
+  provider: gcp
+  # May need to update this template to match the secret provider
+  # it will be passed an object containing:
+  # {
+  #   key: {
+  #     resourceName: <resourceName>,
+  #     filename: <filename>,
+  #     key: <key>
+  #   }
+  # }
+  #
+  # Can update set the source of each chain key at chain.<chain>.key.secret to
+  # match the secret provider's requirements. The default works for GCP.
+  # The secret file must be mapped to the <key.filename>
+  parametersTemplate: |-
+    secrets: |
+      - resourceName: {{ .key.resourceName }}
+        fileName: "{{ .key.filename }}"

--- a/charts/sequencer-relayer/values.yaml
+++ b/charts/sequencer-relayer/values.yaml
@@ -39,7 +39,7 @@ config:
 
   celestiaAppPrivateKey:
     devContent: "8241386890823ca14743e5d4d583f879a5236af29f454ed4da6fe62b8439e2ab"
-    secret: 
+    secret:
       filename: "key.hex"
       resourceName: "projects/$PROJECT_ID/secrets/celestiaPrivateKey/versions/latest"
       key: token

--- a/charts/sequencer-relayer/values.yaml
+++ b/charts/sequencer-relayer/values.yaml
@@ -66,7 +66,7 @@ storage:
 # This is configured for use with GCP, need to set own resource names
 # and keys
 secretProvider:
-  enabled: true
+  enabled: false
   provider: gcp
   # May need to update this template to match the secret provider
   # it will be passed an object containing:

--- a/charts/sequencer/Chart.lock
+++ b/charts/sequencer/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: sequencer-relayer
   repository: file://../sequencer-relayer
-  version: 0.5.1
-digest: sha256:46d32732cd1648481ce8df225cc18d8cdff484df301973b1e61ef077d262e4b7
-generated: "2024-04-25T20:25:46.358937065+01:00"
+  version: 0.5.2
+digest: sha256:7cc96c8209ea8b84ed5ee2493c02ada12a8fb514fc847ca198284264142d6c33
+generated: "2024-04-26T15:51:58.454369-07:00"

--- a/charts/sequencer/Chart.yaml
+++ b/charts/sequencer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.12.1
+version: 0.12.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sequencer/Chart.yaml
+++ b/charts/sequencer/Chart.yaml
@@ -25,7 +25,7 @@ appVersion: "0.10.1"
 
 dependencies:
   - name: sequencer-relayer
-    version: "0.5.1"
+    version: "0.5.2"
     repository: "file://../sequencer-relayer"
     condition: sequencer-relayer.enabled
 


### PR DESCRIPTION
## Summary
Adds support for using a secret provider to the sequencer-relayer chart

## Background
These changes are being made to make this component consistent with others that have already implemented this.

## Changes
- Add `SecretProviderClass`
- Update the `Values.config.celestiaAppPrivateKey` to be in the correct format
- Update ConfigMaps to reference the updated secret
- Update StatefulSet to optionally pull from secretProvider or devContent value

## Testing
- Ensure `helm template` actually renders without error
- Deploy to local dev-cluster with `Values.secretProvider.enabled=false`
- Will need to still coordinate + deploy to dev with `Values.secretProvider.enabled=true` assuming the secrets have been created

