### PR TITLE
release: chart upgrades for new releases

### DIFF
--- a/charts/celestia-local/Chart.yaml
+++ b/charts/celestia-local/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.7
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.6.0"
+appVersion: "1.8.0"
 
 maintainers:
   - name: wafflesvonmaple

--- a/charts/celestia-local/templates/deployment.yaml
+++ b/charts/celestia-local/templates/deployment.yaml
@@ -92,22 +92,6 @@ spec:
             limits:
               cpu: 2
               memory: 8Gi
-        - name: token-server
-          image: {{ .Values.tokenServerImage }}
-          command: [ "/bin/httpd", "-v", "-f", "-p", "5353", "-h", "/home/celestia/token-server/" ]
-          ports:
-            - containerPort: {{ .Values.ports.celestiaTokenService }}
-              name: token-svc
-          volumeMounts:
-            - mountPath: /home/celestia
-              name: celestia-home-vol
-              readOnly: true
-          startupProbe:
-            httpGet:
-              path: /
-              port: token-svc
-            failureThreshold: 30
-            periodSeconds: 5
       volumes:
         - name: bridge-scripts-volume
           configMap:

--- a/charts/celestia-local/templates/service.yaml
+++ b/charts/celestia-local/templates/service.yaml
@@ -13,9 +13,6 @@ spec:
     - name: bridge-jsonrpc
       port: {{ .Values.ports.bridgeRPC }}
       targetPort: bridge-jsonrpc
-    - name: token-svc
-      port: {{ .Values.ports.celestiaTokenService }}
-      targetPort: token-svc
 ---
 apiVersion: v1
 kind: Service

--- a/charts/celestia-local/values.yaml
+++ b/charts/celestia-local/values.yaml
@@ -16,8 +16,7 @@ storage:
       path: "/data/celestia-data"
 
 celestiaAppImage: "ghcr.io/celestiaorg/celestia-app:v1.8.0"
-celestiaNodeImage: "ghcr.io/celestiaorg/celestia-node:v0.12.4"
-tokenServerImage: "busybox:1.35.0-musl"
+celestiaNodeImage: "ghcr.io/celestiaorg/celestia-node:v0.13.4"
 
 podSecurityContext:
   runAsUser: 10001
@@ -43,6 +42,5 @@ validatorStake: "5000000000utia"
 ports:
   celestiaAppHostPort: 26657
   celestiaAppGrpcPort: 9090
-  celestiaTokenService: 5353
   bridgeRPC: 26658
   bridgeHTTP: 26659

--- a/charts/celestia-node/Chart.yaml
+++ b/charts/celestia-node/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.12.4"
+appVersion: "0.13.4"
 
 maintainers:
   - name: wafflesvonmaple

--- a/charts/celestia-node/files/scripts/start-node.sh
+++ b/charts/celestia-node/files/scripts/start-node.sh
@@ -3,28 +3,13 @@
 set -o errexit -o nounset -o pipefail
 {{- $isCustomNetwork := eq .Values.config.network "custom" }}
 
-{{- if .Values.config.tokenAuthLevel }}
-function set_token() {
-  # NOTE - this is a hack to get the token to the token-server directory.
-  TOKEN=$(/bin/celestia {{ .Values.config.type }} auth {{ .Values.config.tokenAuthLevel }} --node.store "/celestia")
-
-  # Busybox's httpd doesn't support url rewriting, so it's not simple to server another file.
-  # To support an ingress rule path of `/`, we write the token to index.html, which httpd serves by default.
-  mkdir -p /celestia/token-server
-  echo "$TOKEN" > /celestia/token-server/index.html
-}
-
-if [ ! -f /celestia/token-server/index.html ]; then
-  set_token
-fi
-{{- end }}
-
 {{- if $isCustomNetwork }}
 export CELESTIA_CUSTOM=$CELESTIA_CUSTOM_TO_BE
 {{- end }}
 
 exec /bin/celestia {{ .Values.config.type }} start \
   --node.store /celestia \
+  --rpc.skip-auth \
   {{- if not $isCustomNetwork }}
   --core.ip {{ .Values.config.coreIp }} \
   --core.grpc.port "{{ .Values.config.coreGrpcPort }}" \

--- a/charts/celestia-node/files/scripts/start-node.sh
+++ b/charts/celestia-node/files/scripts/start-node.sh
@@ -3,13 +3,29 @@
 set -o errexit -o nounset -o pipefail
 {{- $isCustomNetwork := eq .Values.config.network "custom" }}
 
+{{- if .Values.config.tokenAuthLevel }}
+function set_token() {
+  # NOTE - this is a hack to give access to a token generated on startup to people with ssh access
+  TOKEN=$(/bin/celestia {{ .Values.config.type }} auth {{ .Values.config.tokenAuthLevel }} --node.store "/celestia")
+
+  mkdir -p /celestia/token
+  echo "$TOKEN" > /celestia/token/token.key
+}
+
+if [ ! -f /celestia/token/token.key ]; then
+  set_token
+fi
+{{- end }}
+
 {{- if $isCustomNetwork }}
 export CELESTIA_CUSTOM=$CELESTIA_CUSTOM_TO_BE
 {{- end }}
 
 exec /bin/celestia {{ .Values.config.type }} start \
   --node.store /celestia \
-  --rpc.skip-auth \
+  {{- if not .Values.config.tokenAuthLevel }}
+  --rpc.skipAuth \
+  {{- end }}
   {{- if not $isCustomNetwork }}
   --core.ip {{ .Values.config.coreIp }} \
   --core.grpc.port "{{ .Values.config.coreGrpcPort }}" \

--- a/charts/celestia-node/templates/statefulset.yaml
+++ b/charts/celestia-node/templates/statefulset.yaml
@@ -72,24 +72,6 @@ spec:
               subPath: {{ $secret.filename }}
             {{- end }}
             {{- end }}
-        {{- if .Values.config.tokenAuthLevel }}
-        - name: token-server
-          image: {{ .Values.images.tokenServer }}
-          command: [ "/bin/httpd", "-v", "-f", "-p", "{{ .Values.ports.tokenServer }}", "-h", "/celestia/token-server/" ]
-          ports:
-            - containerPort: {{ .Values.ports.tokenServer }}
-              name: token-svc
-          volumeMounts:
-            - mountPath: /celestia
-              name: {{ $label }}-vol
-              readOnly: true
-          startupProbe:
-            httpGet:
-              path: /
-              port: token-svc
-            failureThreshold: 30
-            periodSeconds: 5
-        {{- end }}
       volumes:
         # ------------ Startup scripts -------------
         - name: {{ $label }}-scripts-vol

--- a/charts/celestia-node/values.yaml
+++ b/charts/celestia-node/values.yaml
@@ -12,14 +12,11 @@ config:
   coreIp: "full.consensus.mocha-4.celestia-mocha.com"
   type: light
   coreGrpcPort: 9090
-  tokenAuthLevel: 'read'
   customInfo: ''
 
 images:
   pullPolicy: IfNotPresent
-  node: ghcr.io/celestiaorg/celestia-node:v0.12.4
-  tokenServer: "busybox:1.35.0-musl"
-
+  node: ghcr.io/celestiaorg/celestia-node:v0.13.4
 
 ports:
   celestia:

--- a/charts/celestia-node/values.yaml
+++ b/charts/celestia-node/values.yaml
@@ -11,7 +11,7 @@ config:
   chainId: mocha-4
   coreIp: "full.consensus.mocha-4.celestia-mocha.com"
   type: light
-  tokenAuthLevel: read # can set to nil or false to disable rpc auth
+  tokenAuthLevel: read  # can set to nil or false to disable rpc auth
   coreGrpcPort: 9090
   customInfo: ''
 

--- a/charts/celestia-node/values.yaml
+++ b/charts/celestia-node/values.yaml
@@ -11,6 +11,7 @@ config:
   chainId: mocha-4
   coreIp: "full.consensus.mocha-4.celestia-mocha.com"
   type: light
+  tokenAuthLevel: read # can set to nil or false to disable rpc auth
   coreGrpcPort: 9090
   customInfo: ''
 

--- a/charts/evm-rollup/Chart.lock
+++ b/charts/evm-rollup/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: celestia-node
   repository: file://../celestia-node
-  version: 0.2.1
-digest: sha256:42e3beb2b8dac70b3288ba9bea36cf87d1d51357f84197847895f5056aaafef5
-generated: "2024-03-20T15:44:26.418305-04:00"
+  version: 0.3.0
+digest: sha256:11880d5ac9449bd674625fe78e6af327ba9b8fadacbfe2b43d53f849c80a9860
+generated: "2024-04-26T14:51:12.590892-07:00"

--- a/charts/evm-rollup/Chart.yaml
+++ b/charts/evm-rollup/Chart.yaml
@@ -15,8 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-
-version: 0.13.1
+version: 0.14.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -26,7 +25,7 @@ appVersion: "0.9.1"
 
 dependencies:
   - name: celestia-node
-    version: "0.2.1"
+    version: "0.3.0"
     repository: "file://../celestia-node"
     condition: celestia-node.enabled
 

--- a/charts/evm-rollup/templates/configmap.yaml
+++ b/charts/evm-rollup/templates/configmap.yaml
@@ -12,6 +12,7 @@ data:
   TOKEN_SERVER_URL: "{{ .Values.config.celestia.token }}"
   ASTRIA_CONDUCTOR_CELESTIA_NODE_HTTP_URL: "{{ .Values.config.celestia.rpc }}"
   {{- end }}
+  ASTRIA_CONDUCTOR_CELESTIA_BLOCK_TIME_MS: "12000"
   ASTRIA_CONDUCTOR_EXECUTION_RPC_URL: "http://127.0.0.1:{{ .Values.ports.executionGRPC }}"
   ASTRIA_CONDUCTOR_EXECUTION_COMMIT_LEVEL: "{{ .Values.config.rollup.executionCommitLevel }}"
   ASTRIA_CONDUCTOR_INITIAL_SEQUENCER_BLOCK_HEIGHT: "{{ .Values.config.sequencer.initialBlockHeight }}"
@@ -23,6 +24,7 @@ data:
   ASTRIA_CONDUCTOR_FORCE_STDOUT: "{{ .Values.global.useTTY }}"
   ASTRIA_CONDUCTOR_PRETTY_PRINT: "{{ .Values.global.useTTY }}"
   ASTRIA_CONDUCTOR_NO_OTEL: "{{ not .Values.config.rollup.otel.enabled }}"
+  ASTRIA_CONDUCTOR_CELESTIA_BEARER_TOKEN: "{{ .Values.config.celestia.token }}"
   OTEL_EXPORTER_OTLP_ENDPOINT: "{{ .Values.config.rollup.otel.endpoint }}"
   OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: "{{ .Values.config.rollup.otel.tracesEndpoint }}"
   OTEL_EXPORTER_OTLP_TRACES_TIMEOUT: "{{ .Values.config.rollup.otel.tracesTimeout }}"
@@ -30,27 +32,8 @@ data:
   OTEL_EXPORTER_OTLP_HEADERS: "{{ .Values.config.rollup.otel.otlpHeaders }}"
   OTEL_EXPORTER_OTLP_TRACE_HEADERS: "{{ .Values.config.rollup.otel.traceHeaders }}"
   {{- if not .Values.global.dev }}
-
-  # This block is for removing `ASTRIA_CONDUCTOR_CELESTIA_NODE_WEBSOCKET_URL`.
-  # 
-  {{- if (index .Values "celestia-node").enabled }}
-  ASTRIA_CONDUCTOR_CELESTIA_NODE_WEBSOCKET_URL: "{{ include "celestiaNode.service.addresses.ws" (index .Subcharts "celestia-node") }}"
   {{- else }}
-  ASTRIA_CONDUCTOR_CELESTIA_NODE_WEBSOCKET_URL: "{{ .Values.config.celestia.ws }}"
   {{- end }}
-
-  {{- else }}
-  ASTRIA_CONDUCTOR_CELESTIA_BLOCK_TIME_MS: "12000"
-  {{- end }}
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{ .Values.config.rollup.name }}-conductor-scripts
-  namespace: {{ include "rollup.namespace" .  }}
-data:
-  start-conductor.sh: |
-    {{- .Files.Get "files/scripts/start-conductor.sh" | nindent 4 }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -60,6 +43,8 @@ metadata:
 data:
   ASTRIA_COMPOSER_LOG: "astria_composer={{ .Values.config.logLevel }}"
   ASTRIA_COMPOSER_API_LISTEN_ADDR: "0.0.0.0:0"
+  ASTRIA_COMPOSER_GRPC_ADDR: "0.0.0.0:{{ .Values.ports.composerGRPC }}"
+  ASTRIA_COMPOSER_SEQUENCER_CHAIN_ID: "{{ .Values.config.sequencer.chainId }}"
   ASTRIA_COMPOSER_SEQUENCER_URL: "{{ .Values.config.sequencer.rpc }}"
   ASTRIA_COMPOSER_ROLLUPS: "{{ .Values.config.rollup.name }}::ws://127.0.0.1:{{ .Values.ports.wsRPC }}"
   ASTRIA_COMPOSER_MAX_BYTES_PER_BUNDLE: "{{ .Values.config.rollup.maxBytesPerBundle }}"
@@ -81,8 +66,6 @@ data:
   {{- end }}
   {{- if not .Values.global.dev }}
   {{- else }}
-  ASTRIA_COMPOSER_GRPC_ADDR: "0.0.0.0:0"
-  ASTRIA_COMPOSER_SEQUENCER_CHAIN_ID: "{{ .Values.config.sequencer.chainId }}"
   {{- end }}
 ---
 apiVersion: v1

--- a/charts/evm-rollup/templates/statefulsets.yaml
+++ b/charts/evm-rollup/templates/statefulsets.yaml
@@ -115,13 +115,9 @@ spec:
             {{- toYaml .Values.resources.composer | trim | nindent 12 }}
         - name: conductor
           image: {{ include "conductor.image" . }}
-          command: [ "/scripts/start-conductor.sh" ]
+          command: [ "/usr/local/bin/astria-conductor" ]
           stdin: {{ .Values.global.useTTY }}
           tty: {{ .Values.global.useTTY }}
-          volumeMounts:
-            - mountPath: /scripts/
-              name: {{ .Values.config.rollup.name }}-conductor-scripts-volume
-              readOnly: true
           envFrom:
             - configMapRef:
                 name: {{ .Values.config.rollup.name }}-conductor-env
@@ -136,10 +132,6 @@ spec:
         - name: {{ .Values.config.rollup.name }}-executor-scripts-volume
           configMap:
             name: {{ .Values.config.rollup.name }}-executor-scripts
-            defaultMode: 0500
-        - name: {{ .Values.config.rollup.name }}-conductor-scripts-volume
-          configMap:
-            name: {{ .Values.config.rollup.name }}-conductor-scripts
             defaultMode: 0500
         - name: {{ $.Values.config.rollup.name }}-rollup-shared-storage-vol
           {{- if .Values.storage.enabled }}

--- a/charts/evm-rollup/values.yaml
+++ b/charts/evm-rollup/values.yaml
@@ -8,16 +8,16 @@ global:
 
 images:
   geth:
-    repo: ghcr.io/astriaorg/go-ethereum
-    tag: "0.9.1"
+    repo: ghcr.io/astriaorg/astria-geth
+    tag: 0.9.1
     devTag: latest
   conductor:
     repo: ghcr.io/astriaorg/conductor
-    tag: "0.13.1"
+    tag: "0.14.0"
     devTag: latest
   composer:
     repo: ghcr.io/astriaorg/composer
-    tag: "0.5.0"
+    tag: "0.6.0"
     devTag: latest
 
   # Rollup faucet
@@ -165,7 +165,6 @@ config:
     # if config.rollup.executionLevel is NOT 'SoftOnly' AND celestia-node is not enabled
     # the rpc, ws, and token fields must be set to access celestia network.
     rpc: ""
-    ws: ""
     token: ""
     initialBlockHeight: "2"
     heightVariance: "10"
@@ -326,6 +325,7 @@ ports:
   jsonRPC: 8545
   wsRPC: 8546
   executionGRPC: 50051
+  composerGRPC: 50052
   gossipnet: 2451
   faucet: 8080
   blockscout: 4000

--- a/charts/evm-rollup/values.yaml
+++ b/charts/evm-rollup/values.yaml
@@ -179,7 +179,7 @@ celestia-node:
   config:
     labelPrefix: astria
     type: light
-    tokenAuthLevel: read
+    tokenAuthLevel: false # Set to false to disable auth
     # You can deploy on top of a custom celestia network, uncomment below and
     # update fields with notes
     # network: custom

--- a/charts/evm-rollup/values.yaml
+++ b/charts/evm-rollup/values.yaml
@@ -179,7 +179,7 @@ celestia-node:
   config:
     labelPrefix: astria
     type: light
-    tokenAuthLevel: false # Set to false to disable auth
+    tokenAuthLevel: false  # Set to false to disable auth
     # You can deploy on top of a custom celestia network, uncomment below and
     # update fields with notes
     # network: custom

--- a/charts/hermes/Chart.yaml
+++ b/charts/hermes/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hermes/templates/configmaps.yaml
+++ b/charts/hermes/templates/configmaps.yaml
@@ -16,7 +16,7 @@ metadata:
   namespace: {{ include "hermes.namespace" $ }}
 data:
   {{ $chain.key.name }}.json: |
-  {{- toPrettyJson $chain.key.content | nindent 4 }}
+  {{- toPrettyJson $chain.key.devContent | nindent 4 }}
 ---
 {{- end }}
 {{- end }}

--- a/charts/hermes/values.yaml
+++ b/charts/hermes/values.yaml
@@ -16,7 +16,7 @@ createChannel:
   chainA: ''  # For local test is equencer-test-chain-0
   portA: ''   # likely "transfer"
   chainB: ''  # For default local test celestia-local-0
-  portB: ''  # likely "transfer"
+  portB: ''   # likely "transfer"
 
 rest:
   enabled: false
@@ -63,7 +63,7 @@ chains:
   #   storePrefix: ibc_data
   #   key:
   #     name: astria-wallet
-  #     content:
+  #     devContent:
   #       signing_key: [43, 216, 6, 201, 127, 14, 0, 175, 26, 31, 195, 50, 143, 167, 99, 169, 38, 151, 35, 200, 219, 143, 172, 79, 147, 175, 113, 219, 24, 109, 110, 144]
   #       address_type: Astria
   #     secret:
@@ -87,31 +87,10 @@ chains:
   #   accountPrefix: celestia
   #   key:
   #     name: celestia
-  #     content:
+  #     devContent:
   #       private_key: 8241386890823ca14743e5d4d583f879a5236af29f454ed4da6fe62b8439e2ab
   #       public_key: 03b0effa59e7eee365a888b4d2fa4c9be82a4925df255d4443151d61b11ac63714
-  #       address: [
-  #         39,
-  #         166,
-  #         219,
-  #         243,
-  #         73,
-  #         131,
-  #         245,
-  #         143,
-  #         2,
-  #         206,
-  #         64,
-  #         203,
-  #         217,
-  #         165,
-  #         252,
-  #         194,
-  #         189,
-  #         5,
-  #         171,
-  #         220
-  #       ]
+  #       address: [39, 166, 219, 243, 73, 131, 245, 143, 2, 206, 64, 203, 217, 165, 252, 194, 189, 5, 171, 220]
   #       address_type: Cosmos
   #       account: celestia1y7ndhu6fs06c7qkwgr9anf0uc27st27uwdj6vq
   #     secret:
@@ -131,8 +110,9 @@ secretProvider:
   provider: gcp
   # May need to update this template to match the secret provider
   # it will be passed an object of the form:
-  # { key: {
-  #     name: <filename>,
+  # {
+  #   key: {
+  #     name: <name>,
   #     secret: { resourceName: <resourceName> }
   #   }
   # }

--- a/charts/sequencer-relayer/Chart.yaml
+++ b/charts/sequencer-relayer/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.1
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.11.0"
+appVersion: "0.12.0"
 
 maintainers:
   - name: wafflesvonmaple

--- a/charts/sequencer-relayer/templates/configmaps.yaml
+++ b/charts/sequencer-relayer/templates/configmaps.yaml
@@ -8,9 +8,10 @@ data:
   ASTRIA_SEQUENCER_RELAYER_BLOCK_TIME: "1000"
   ASTRIA_SEQUENCER_RELAYER_VALIDATOR_KEY_FILE: /cometbft/config/priv_validator_key.json
   ASTRIA_SEQUENCER_RELAYER_RELAY_ONLY_VALIDATOR_KEY_BLOCKS: "false"
-  TOKEN_SERVER: "{{ .Values.config.relayer.tokenServer }}"
   ASTRIA_SEQUENCER_RELAYER_COMETBFT_ENDPOINT: "{{ .Values.config.relayer.cometbftRpc }}"
   ASTRIA_SEQUENCER_RELAYER_SEQUENCER_GRPC_ENDPOINT: "{{ .Values.config.relayer.sequencerGrpc }}"
+  ASTRIA_SEQUENCER_RELAYER_CELESTIA_APP_GRPC_ENDPOINT: "{{ .Values.config.relayer.celestiaAppGrpc }}"
+  ASTRIA_SEQUENCER_RELAYER_CELESTIA_APP_KEY_FILE: "/celestia-key/{{ .Values.config.celestiaAppPrivateKey.filename }}"
   ASTRIA_SEQUENCER_RELAYER_API_ADDR: "127.0.0.1:{{ .Values.ports.relayerRPC }}"
   ASTRIA_SEQUENCER_RELAYER_PRE_SUBMIT_PATH: "{{ include "sequencer-relayer.storage.preSubmitPath" . }}"
   ASTRIA_SEQUENCER_RELAYER_POST_SUBMIT_PATH: "{{ include "sequencer-relayer.storage.postSubmitPath" . }}"
@@ -26,11 +27,7 @@ data:
   OTEL_EXPORTER_OTLP_HEADERS: "{{ .Values.config.relayer.otel.otlpHeaders }}"
   OTEL_EXPORTER_OTLP_TRACE_HEADERS: "{{ .Values.config.relayer.otel.traceHeaders }}"
   {{- if not .Values.global.dev }}
-  ASTRIA_SEQUENCER_RELAYER_CELESTIA_ENDPOINT: "{{ .Values.config.relayer.celestiaRpc }}"
-  ASTRIA_SEQUENCER_RELAYER_CELESTIA_BEARER_TOKEN: "{{ .Values.config.relayer.celestiaBearerToken }}"
   {{- else }}
-  ASTRIA_SEQUENCER_RELAYER_CELESTIA_APP_GRPC_ENDPOINT: "{{ .Values.config.relayer.celestiaAppGrpc }}"
-  ASTRIA_SEQUENCER_RELAYER_CELESTIA_APP_KEY_FILE: "/celestia-key/{{ .Values.config.celestiaAppPrivateKey.filename }}"
   {{- end }}
 ---
 apiVersion: v1

--- a/charts/sequencer-relayer/values.yaml
+++ b/charts/sequencer-relayer/values.yaml
@@ -36,7 +36,7 @@ config:
 
   celestiaAppPrivateKey:
     filename: "key.hex"
-    content: "8241386890823ca14743e5d4d583f879a5236af29f454ed4da6fe62b8439e2ab"
+    content: ""
 
 ports:
   relayerRPC: 2450

--- a/charts/sequencer-relayer/values.yaml
+++ b/charts/sequencer-relayer/values.yaml
@@ -13,15 +13,12 @@ global:
 images:
   sequencerRelayer:
     repo: ghcr.io/astriaorg/sequencer-relayer
-    tag: "0.11.0"
+    tag: "0.12.0"
     devTag: latest
 
 config:
   relayer:
-    celestiaBearerToken: ""
-    celestiaRpc: http://celestia-service.astria-dev-cluster.svc.cluster.local:26658
-    celestiaAppGrpc: http://celestia-app-service.astria-dev-cluster.svc.cluster.local:9090
-    tokenServer: http://celestia-service.astria-dev-cluster.svc.cluster.local:5353
+    celestiaAppGrpc: ""
     cometbftRpc: ""
     sequencerGrpc: ""
 

--- a/charts/sequencer/Chart.lock
+++ b/charts/sequencer/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: sequencer-relayer
   repository: file://../sequencer-relayer
-  version: 0.5.1
-digest: sha256:46d32732cd1648481ce8df225cc18d8cdff484df301973b1e61ef077d262e4b7
-generated: "2024-04-25T20:25:46.358937065+01:00"
+  version: 0.6.0
+digest: sha256:634e5149be8b93abed2d4db930c45b8ecff7f28a2f1439d263607d5b28290237
+generated: "2024-04-26T13:35:20.77244-07:00"

--- a/charts/sequencer/Chart.yaml
+++ b/charts/sequencer/Chart.yaml
@@ -15,17 +15,17 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.12.1
+version: 0.13.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.10.1"
+appVersion: "0.11.0"
 
 dependencies:
   - name: sequencer-relayer
-    version: "0.5.1"
+    version: "0.6.0"
     repository: "file://../sequencer-relayer"
     condition: sequencer-relayer.enabled
 

--- a/charts/sequencer/values.yaml
+++ b/charts/sequencer/values.yaml
@@ -21,7 +21,7 @@ images:
     devTag: latest
 
 config:
-  moniker: ""
+  moniker: "node"
   sequencer:
     authoritySudoAddress: 1c0c490f1b5528d8173c5de46d131160e4b2c0c3
     nativeAssetBaseDenomination: nria

--- a/charts/sequencer/values.yaml
+++ b/charts/sequencer/values.yaml
@@ -17,11 +17,11 @@ images:
     devTag: v0.38.6
   sequencer:
     repo: ghcr.io/astriaorg/sequencer
-    tag: "0.10.1"
+    tag: "0.11.0"
     devTag: latest
 
 config:
-  moniker: "node0"
+  moniker: ""
   sequencer:
     authoritySudoAddress: 1c0c490f1b5528d8173c5de46d131160e4b2c0c3
     nativeAssetBaseDenomination: nria
@@ -96,30 +96,30 @@ config:
         devContent:
           priv_key:
             type: tendermint/PrivKeyEd25519
-            value: HGWRtLbV8WLGFgbYhaGyaLe++DC+DBoc7O3bri81vs2ZlpR28IFfQScoO1aNOE/ygs8LIPM9UzLzbaab4VMggQ==
+            value: "" # can override with a value for local testing
         secret:
           resourceName: "projects/$PROJECT_ID/secrets/privValidatorKey/versions/latest"
       privValidatorKey:
         filename: privValidatorKey.json
         devContent:
           # Ed25519 address of validator
-          address: 091E47761C58C474534F4D414AF104A6CAF90C22
+          address: "" # can override with a value for local testing
           # public key for the validator address
           pub_key:
             type: tendermint/PubKeyEd25519
-            value: lV57+rGs2vac7mvkGHP1oBFGHPJM3a+WoAzeFDCJDNU=
+            value: "" # can override with a value for local testing
           # private key for the validator address
           # This is a secret key, should use a secret manager for production deployments
           priv_key:
             type: tendermint/PrivKeyEd25519
-            value: dGOTAweQV8Do9P2n+A8m5EnboDrlxgD3dg4vrYpdIRqVXnv6saza9pzua+QYc/WgEUYc8kzdr5agDN4UMIkM1Q==
+            value: "" # can override with a value for local testing
         secret:
           resourceName: "projects/$PROJECT_ID/secrets/privValidatorKey/versions/latest"
-    validators:
-      - name: core
-        power: '1'
-        address: 091E47761C58C474534F4D414AF104A6CAF90C22
-        pubKey: lV57+rGs2vac7mvkGHP1oBFGHPJM3a+WoAzeFDCJDNU=
+    validators: []
+      # - name: core
+      #   power: '1'
+      #   address: 091E47761C58C474534F4D414AF104A6CAF90C22
+      #   pubKey: lV57+rGs2vac7mvkGHP1oBFGHPJM3a+WoAzeFDCJDNU=
 
 sequencer-relayer:
   enabled: false

--- a/charts/sequencer/values.yaml
+++ b/charts/sequencer/values.yaml
@@ -96,23 +96,23 @@ config:
         devContent:
           priv_key:
             type: tendermint/PrivKeyEd25519
-            value: "" # can override with a value for local testing
+            value: ""  # can override with a value for local testing
         secret:
           resourceName: "projects/$PROJECT_ID/secrets/privValidatorKey/versions/latest"
       privValidatorKey:
         filename: privValidatorKey.json
         devContent:
           # Ed25519 address of validator
-          address: "" # can override with a value for local testing
+          address: ""  # can override with a value for local testing
           # public key for the validator address
           pub_key:
             type: tendermint/PubKeyEd25519
-            value: "" # can override with a value for local testing
+            value: ""  # can override with a value for local testing
           # private key for the validator address
           # This is a secret key, should use a secret manager for production deployments
           priv_key:
             type: tendermint/PrivKeyEd25519
-            value: "" # can override with a value for local testing
+            value: ""  # can override with a value for local testing
         secret:
           resourceName: "projects/$PROJECT_ID/secrets/privValidatorKey/versions/latest"
     validators: []

--- a/dev/values/hermes/local.yml
+++ b/dev/values/hermes/local.yml
@@ -15,42 +15,8 @@ chains:
     storePrefix: ibc_data
     key:
       name: astria-wallet
-      content:
-        signing_key:
-          [
-            43,
-            216,
-            6,
-            201,
-            127,
-            14,
-            0,
-            175,
-            26,
-            31,
-            195,
-            50,
-            143,
-            167,
-            99,
-            169,
-            38,
-            151,
-            35,
-            200,
-            219,
-            143,
-            172,
-            79,
-            147,
-            175,
-            113,
-            219,
-            24,
-            109,
-            110,
-            144,
-          ]
+      devContent:
+        signing_key: [43, 216, 6, 201, 127, 14, 0, 175, 26, 31, 195, 50, 143, 167, 99, 169, 38, 151, 35, 200, 219, 143, 172, 79, 147, 175, 113, 219, 24, 109, 110, 144]
         address_type: Astria
       secret:
         resourceName: projects/$PROJECT_ID/secrets/astria-ibc-relay-key/versions/latest
@@ -76,32 +42,10 @@ chains:
     accountPrefix: celestia
     key:
       name: celestia
-      content:
+      devContent:
         private_key: 8241386890823ca14743e5d4d583f879a5236af29f454ed4da6fe62b8439e2ab
         public_key: 03b0effa59e7eee365a888b4d2fa4c9be82a4925df255d4443151d61b11ac63714
-        address:
-          [
-            39,
-            166,
-            219,
-            243,
-            73,
-            131,
-            245,
-            143,
-            2,
-            206,
-            64,
-            203,
-            217,
-            165,
-            252,
-            194,
-            189,
-            5,
-            171,
-            220,
-          ]
+        address: [39, 166, 219, 243, 73, 131, 245, 143, 2, 206, 64, 203, 217, 165, 252, 194, 189, 5, 171, 220]
         address_type: Cosmos
         account: celestia1y7ndhu6fs06c7qkwgr9anf0uc27st27uwdj6vq
       secret:

--- a/dev/values/rollup/dev.yaml
+++ b/dev/values/rollup/dev.yaml
@@ -7,7 +7,6 @@ config:
     chainId: sequencer-test-chain-0
   celestia:
     rpc: "http://celestia-service.astria-dev-cluster.svc.cluster.local:26658"
-    ws: "ws://celestia-service.astria-dev-cluster.svc.cluster.local:26658"
     token: "http://celestia-service.astria-dev-cluster.svc.cluster.local:5353"
 
 resources:

--- a/dev/values/validators/node0.yml
+++ b/dev/values/validators/node0.yml
@@ -61,4 +61,4 @@ sequencer-relayer:
       cometbftRpc: http://node0-sequencer-rpc-service.astria-dev-cluster.svc.cluster.local:26657
       sequencerGrpc: http://node0-sequencer-grpc-service.astria-dev-cluster.svc.cluster.local:8080
     celestiaAppPrivateKey:
-      content: 8241386890823ca14743e5d4d583f879a5236af29f454ed4da6fe62b8439e2ab
+      devContent: 8241386890823ca14743e5d4d583f879a5236af29f454ed4da6fe62b8439e2ab

--- a/dev/values/validators/node0.yml
+++ b/dev/values/validators/node0.yml
@@ -60,3 +60,5 @@ sequencer-relayer:
       celestiaAppGrpc: http://celestia-app-service.astria-dev-cluster.svc.cluster.local:9090
       cometbftRpc: http://node0-sequencer-rpc-service.astria-dev-cluster.svc.cluster.local:26657
       sequencerGrpc: http://node0-sequencer-grpc-service.astria-dev-cluster.svc.cluster.local:8080
+    celestiaAppPrivateKey:
+      content: 8241386890823ca14743e5d4d583f879a5236af29f454ed4da6fe62b8439e2ab

--- a/dev/values/validators/node0.yml
+++ b/dev/values/validators/node0.yml
@@ -9,11 +9,11 @@ config:
   # Values for CometBFT node configuration
   cometBFT:
     secrets:
-      node_key:
+      nodeKey:
         devContent:
           priv_key:
             value: HGWRtLbV8WLGFgbYhaGyaLe++DC+DBoc7O3bri81vs2ZlpR28IFfQScoO1aNOE/ygs8LIPM9UzLzbaab4VMggQ==
-      priv_validator_key:
+      privValidatorKey:
         devContent:
           address: 091E47761C58C474534F4D414AF104A6CAF90C22
           pub_key:
@@ -57,6 +57,6 @@ sequencer-relayer:
   enabled: true
   config:
     relayer:
-      celestiaRpc: http://celestia-service.astria-dev-cluster.svc.cluster.local:26658
+      celestiaAppGrpc: http://celestia-app-service.astria-dev-cluster.svc.cluster.local:9090
       cometbftRpc: http://node0-sequencer-rpc-service.astria-dev-cluster.svc.cluster.local:26657
       sequencerGrpc: http://node0-sequencer-grpc-service.astria-dev-cluster.svc.cluster.local:8080

--- a/dev/values/validators/node1.yml
+++ b/dev/values/validators/node1.yml
@@ -8,11 +8,11 @@ config:
   # Values for CometBFT node configuration
   cometBFT:
     secrets:
-      node_key:
+      nodeKey:
         devContent:
           priv_key:
             value: YhbLhsKYUexcVOPBHUS6nNy7AOjVX0DxvIQW0mZBHwjbGbIgGlfuzuswG+uetk5zhPHYZMMCz77fa5/B/KP0lw==
-      priv_validator_key:
+      privValidatorKey:
         devContent:
           address: E82D827830B163D5179291FB27BB58E605DF2FA2
           pub_key:

--- a/dev/values/validators/node2.yml
+++ b/dev/values/validators/node2.yml
@@ -8,11 +8,11 @@ config:
   # Values for CometBFT node configuration
   cometBFT:
     secrets:
-      node_key:
+      nodeKey:
         devContent:
           priv_key:
             value: 1yh4XrMHn75sSW5cOhGDTVgv5BbqXlhrLduxHcE2t1osbwKQzo7xlvSK1vh5CVDvHESPYK/56uTKXM/1ifqHbw==
-      priv_validator_key:
+      privValidatorKey:
         devContent:
           address: 8C17BBDC7C350C83C550163458FC9B7A5B54A64E
           pub_key:

--- a/dev/values/validators/single.yml
+++ b/dev/values/validators/single.yml
@@ -36,6 +36,8 @@ sequencer-relayer:
       celestiaAppGrpc: http://celestia-app-service.astria-dev-cluster.svc.cluster.local:9090
       cometbftRpc: http://node0-sequencer-rpc-service.astria-dev-cluster.svc.cluster.local:26657
       sequencerGrpc: http://node0-sequencer-grpc-service.astria-dev-cluster.svc.cluster.local:8080
+    celestiaAppPrivateKey:
+      content: 8241386890823ca14743e5d4d583f879a5236af29f454ed4da6fe62b8439e2ab
       
   storage:
     enabled: false

--- a/dev/values/validators/single.yml
+++ b/dev/values/validators/single.yml
@@ -2,13 +2,41 @@ global:
   namespaceOverride: astria-dev-cluster
   dev: true
 
+config:
+  moniker: node0
+  cometBFT:
+    validators:
+      - name: core
+        power: '1'
+        address: 091E47761C58C474534F4D414AF104A6CAF90C22
+        pubKey: lV57+rGs2vac7mvkGHP1oBFGHPJM3a+WoAzeFDCJDNU=
+    secrets:
+      nodeKey:
+        filename: nodeKey.json
+        devContent:
+          priv_key:
+            value: HGWRtLbV8WLGFgbYhaGyaLe++DC+DBoc7O3bri81vs2ZlpR28IFfQScoO1aNOE/ygs8LIPM9UzLzbaab4VMggQ==
+      privValidatorKey:
+        filename: privValidatorKey.json
+        devContent:
+          # Ed25519 address of validator
+          address: 091E47761C58C474534F4D414AF104A6CAF90C22
+          # public key for the validator address
+          pub_key:
+            value: lV57+rGs2vac7mvkGHP1oBFGHPJM3a+WoAzeFDCJDNU=
+          # private key for the validator address
+          # This is a secret key, should use a secret manager for production deployments
+          priv_key:
+            value: dGOTAweQV8Do9P2n+A8m5EnboDrlxgD3dg4vrYpdIRqVXnv6saza9pzua+QYc/WgEUYc8kzdr5agDN4UMIkM1Q==
+
 sequencer-relayer:
   enabled: true
   config:
     relayer:
-      celestiaRpc: http://celestia-service.astria-dev-cluster.svc.cluster.local:26658
+      celestiaAppGrpc: http://celestia-app-service.astria-dev-cluster.svc.cluster.local:9090
       cometbftRpc: http://node0-sequencer-rpc-service.astria-dev-cluster.svc.cluster.local:26657
       sequencerGrpc: http://node0-sequencer-grpc-service.astria-dev-cluster.svc.cluster.local:8080
+      
   storage:
     enabled: false
 

--- a/dev/values/validators/single.yml
+++ b/dev/values/validators/single.yml
@@ -37,7 +37,7 @@ sequencer-relayer:
       cometbftRpc: http://node0-sequencer-rpc-service.astria-dev-cluster.svc.cluster.local:26657
       sequencerGrpc: http://node0-sequencer-grpc-service.astria-dev-cluster.svc.cluster.local:8080
     celestiaAppPrivateKey:
-      content: 8241386890823ca14743e5d4d583f879a5236af29f454ed4da6fe62b8439e2ab
+      devContent: 8241386890823ca14743e5d4d583f879a5236af29f454ed4da6fe62b8439e2ab
       
   storage:
     enabled: false

--- a/justfile
+++ b/justfile
@@ -136,7 +136,7 @@ wait-for-ingress-controller:
 
 validatorName := "single"
 deploy-sequencer name=validatorName:
-  helm dependency build charts/sequencer > /dev/null
+  helm dependency update charts/sequencer > /dev/null
   helm install --debug \
     {{ replace('-f dev/values/validators/#.yml' , '#', name) }} \
     -n astria-validator-{{name}} --create-namespace \
@@ -164,7 +164,7 @@ defaultGenesisAllocAddress := ""
 defaultPrivateKey          := ""
 defaultSequencerStartBlock := ""
 deploy-rollup rollupName=defaultRollupName networkId=defaultNetworkId genesisAllocAddress=defaultGenesisAllocAddress privateKey=defaultPrivateKey sequencerStartBlock=defaultSequencerStartBlock:
-  helm dependency build charts/evm-rollup > /dev/null
+  helm dependency update charts/evm-rollup > /dev/null
   helm install \
     {{ if rollupName          != '' { replace('--set config.rollup.name=# --set celestia-node.config.labelPrefix=#', '#', rollupName) } else { '' } }} \
     {{ if networkId           != '' { replace('--set config.rollup.networkId=#', '#', networkId) } else { '' } }} \
@@ -174,7 +174,7 @@ deploy-rollup rollupName=defaultRollupName networkId=defaultNetworkId genesisAll
     {{rollupName}}-chain-chart ./charts/evm-rollup --namespace astria-dev-cluster
 
 deploy-dev-rollup rollupName=defaultRollupName networkId=defaultNetworkId genesisAllocAddress=defaultGenesisAllocAddress privateKey=defaultPrivateKey sequencerStartBlock=defaultSequencerStartBlock:
-  helm dependency build charts/evm-rollup > /dev/null
+  helm dependency update charts/evm-rollup > /dev/null
   helm install \
     {{ if rollupName          != '' { replace('--set config.rollup.name=# --set celestia-node.config.labelPrefix=#', '#', rollupName) } else { '' } }} \
     {{ if networkId           != '' { replace('--set config.rollup.networkId=#', '#', networkId) } else { '' } }} \
@@ -219,8 +219,8 @@ deploy-smoke-test tag=defaultTag:
   @echo "Deploying ingress controller..." && just deploy-ingress-controller > /dev/null
   @just wait-for-ingress-controller > /dev/null
   @echo "Deploying local celestia instance..." && just deploy celestia-local > /dev/null
-  @helm dependency build charts/sequencer > /dev/null
-  @helm dependency build charts/evm-rollup > /dev/null
+  @helm dependency update charts/sequencer > /dev/null
+  @helm dependency update charts/evm-rollup > /dev/null
   @echo "Setting up single astria sequencer..." && helm install \
     -n astria-validator-single single-sequencer-chart ./charts/sequencer \
     -f dev/values/validators/single.yml \


### PR DESCRIPTION
## Summary
Upgrades all our charts to utilize latest releases, including updates celestia-node. Additionally removes the token server from celestia-node & celestia-local which is not needed now that we submit directly to app. Some secret information has been moved from the core chart into the dev values to avoid someone actually deploying with these values in production. 

## Background
New releases of core services are cut, this upgrades the charts to support those.

## Changes
- List changes which were made.

## Testing
Local testing of setitngs with charts both in dev mode and not. CI smoke test for dev-mode.

## Breaking Changelist
- Charts are upgraded, new releases that are major updates
