### PR TITLE
fix(ci): only run proto on actual proto changes

### DIFF
--- a/.github/workflows/reusable-run-checker.yml
+++ b/.github/workflows/reusable-run-checker.yml
@@ -82,8 +82,11 @@ jobs:
               - 'Cargo.lock'
               - '.cargo/**'
             proto:
-              - '**/*.proto'
-              - '!proto/vendored/**'
+              - 'proto/composerapis/**'
+              - 'proto/executionapis/**'
+              - 'proto/primitives/**'
+              - 'proto/protocolapis/**'
+              - 'proto/sequencerblockapis/**'
             rust:
               - '**/*.rs'
             toml:


### PR DESCRIPTION
## Summary
Fix CI test which would run anytime there were changes that were not in the vendored  proto directory.
