### PR TITLE
fix(conductor): only execute firm blocks if firm and soft block numbers match

### DIFF
--- a/crates/astria-conductor/src/executor/builder.rs
+++ b/crates/astria-conductor/src/executor/builder.rs
@@ -13,10 +13,10 @@ use super::{
     Handle,
     StateNotInit,
 };
+use crate::config::CommitLevel;
 
 pub(crate) struct Builder {
-    pub(crate) with_firm: bool,
-    pub(crate) with_soft: bool,
+    pub(crate) mode: CommitLevel,
     pub(crate) rollup_address: String,
     pub(crate) shutdown: CancellationToken,
 }
@@ -24,10 +24,9 @@ pub(crate) struct Builder {
 impl Builder {
     pub(crate) fn build(self) -> eyre::Result<(Executor, Handle)> {
         let Self {
+            mode,
             rollup_address,
             shutdown,
-            with_firm,
-            with_soft,
         } = self;
 
         let rollup_address = rollup_address
@@ -36,7 +35,7 @@ impl Builder {
 
         let mut firm_block_tx = None;
         let mut firm_block_rx = None;
-        if with_firm {
+        if mode.is_with_firm() {
             let (tx, rx) = mpsc::channel(16);
             firm_block_tx = Some(tx);
             firm_block_rx = Some(rx);
@@ -44,7 +43,7 @@ impl Builder {
 
         let mut soft_block_tx = None;
         let mut soft_block_rx = None;
-        if with_soft {
+        if mode.is_with_soft() {
             let (tx, rx) = super::soft_block_channel();
             soft_block_tx = Some(tx);
             soft_block_rx = Some(rx);
@@ -53,6 +52,8 @@ impl Builder {
         let (state_tx, state_rx) = state::channel();
 
         let executor = Executor {
+            mode,
+
             firm_blocks: firm_block_rx,
             soft_blocks: soft_block_rx,
 

--- a/crates/astria-conductor/src/executor/mod.rs
+++ b/crates/astria-conductor/src/executor/mod.rs
@@ -38,7 +38,10 @@ use tracing::{
     instrument,
 };
 
-use crate::celestia::ReconstructedBlock;
+use crate::{
+    celestia::ReconstructedBlock,
+    config::CommitLevel,
+};
 
 mod builder;
 pub(crate) mod channel;
@@ -212,7 +215,17 @@ impl Handle<StateIsInit> {
 }
 
 pub(crate) struct Executor {
+    /// The mode under which this executor (and hence conductor) runs.
+    mode: CommitLevel,
+
+    /// The channel of which this executor receives blocks for executing
+    /// firm commitments.
+    /// Only set if `mode` is `FirmOnly` or `SoftAndFirm`.
     firm_blocks: Option<mpsc::Receiver<ReconstructedBlock>>,
+
+    /// The channel of which this executor receives blocks for executing
+    /// soft commitments.
+    /// Only set if `mode` is `SoftOnly` or `SoftAndFirm`.
     soft_blocks: Option<channel::Receiver<FilteredSequencerBlock>>,
 
     /// Token to listen for Conductor being shut down.
@@ -447,29 +460,49 @@ impl Executor {
             )
         };
 
-        let update_type =
-            if let Some(block) = self.blocks_pending_finalization.remove(&block_number) {
-                info!(
-                    block_number,
-                    "found pending block; updating state but not not re-executing it"
-                );
-                Update::OnlyFirm(block)
-            } else {
-                info!(
-                    block_number,
-                    "did not find pending block; executing firm block"
-                );
-                // The parent hash of the next block is the hash of the block at the current head.
-                let parent_hash = self.state.firm_hash();
-                let executed_block = self
-                    .execute_block(client.clone(), parent_hash, executable_block)
-                    .await
-                    .wrap_err("failed to execute block")?;
-                self.does_block_response_fulfill_contract(ExecutionKind::Firm, &executed_block)
-                    .wrap_err("execution API server violated contract")?;
-                Update::ToSame(executed_block)
-            };
-        self.update_commitment_state(client.clone(), update_type)
+        let update = if self.should_execute_firm_block() {
+            let parent_hash = self.state.firm_hash();
+            let executed_block = self
+                .execute_block(client.clone(), parent_hash, executable_block)
+                .await
+                .wrap_err("failed to execute block")?;
+            self.does_block_response_fulfill_contract(ExecutionKind::Firm, &executed_block)
+                .wrap_err("execution API server violated contract")?;
+            Update::ToSame(executed_block)
+        } else if let Some(block) = self.blocks_pending_finalization.remove(&block_number) {
+            info!(
+                block_number,
+                "found pending block; updating state but not not re-executing it"
+            );
+            Update::OnlyFirm(block)
+        } else {
+            // XXX: This case should never be reached because the firm block *must* exist in the
+            // cache - either due to being pre-populated at startup (via
+            // `populate_blocks_pending_finalization`), or during normal operation (as part of
+            // `execute_soft`).
+            // This code is here as a fall-back mechanism in case there is a bug.
+            error!(
+                block_number,
+                "pending block not found for block number in cache. THIS SHOULD NOT HAPPEN. \
+                 Trying to fetch the already-executed block from the rollup before giving up."
+            );
+            match client.clone().get_block(block_number).await {
+                Ok(block) => Update::OnlyFirm(block),
+                Err(error) => {
+                    error!(
+                        block_number,
+                        %error,
+                        "failed to fetch block missing from rollup and will not be able to update \
+                        the firm commitment state. Giving up."
+                    );
+                    return Err(error).wrap_err_with(|| {
+                        format!("failed to get block at number `{block_number}` from rollup")
+                    });
+                }
+            }
+        };
+
+        self.update_commitment_state(client.clone(), update)
             .await
             .wrap_err("failed to setting both commitment states to executed block")?;
         Ok(())
@@ -523,15 +556,12 @@ impl Executor {
         &mut self,
         mut client: Client,
     ) -> eyre::Result<()> {
-        // Uses the presence of the firm/soft channels as a proxy for which mode
-        // executor runs in. soft-and-firm mode corresponds to both channels being set.
-        if self.firm_blocks.is_none() || self.soft_blocks.is_none() {
+        if !self.mode.is_soft_and_firm() {
             debug!(
-                firm = self.firm_blocks.is_some(),
-                soft = self.soft_blocks.is_some(),
-                "configured without firm or soft commitments; ignoring blocks pending \
-                 finalization and not requesting them from the rollup (only activated in \
-                 soft-and-firm mode)"
+                mode = %self.mode,
+                "blocks pending finalization only relevant in `{}` mode; not requesting them from \
+                the rollup and continuing with initialization",
+                CommitLevel::SoftAndFirm,
             );
             return Ok(());
         }
@@ -639,6 +669,19 @@ impl Executor {
         block: &Block,
     ) -> Result<(), ContractViolation> {
         does_block_response_fulfill_contract(&mut self.state, kind, block)
+    }
+
+    /// Returns whether a firm block should be executed.
+    ///
+    /// Firm blocks should be executed if:
+    /// 1. executor runs in firm only mode (blocks are always executed).
+    /// 2. executor runs in soft-and-firm mode and the soft and firm rollup numbers are equal.
+    fn should_execute_firm_block(&self) -> bool {
+        should_execute_firm_block(
+            self.state.next_expected_firm_sequencer_height().value(),
+            self.state.next_expected_soft_sequencer_height().value(),
+            self.mode,
+        )
     }
 }
 
@@ -754,5 +797,17 @@ fn does_block_response_fulfill_contract(
             expected,
             actual,
         })
+    }
+}
+
+fn should_execute_firm_block(
+    firm_sequencer_height: u64,
+    soft_sequencer_height: u64,
+    executor_mode: CommitLevel,
+) -> bool {
+    match executor_mode {
+        CommitLevel::SoftAndFirm if firm_sequencer_height == soft_sequencer_height => true,
+        CommitLevel::SoftOnly | CommitLevel::SoftAndFirm => false,
+        CommitLevel::FirmOnly => true,
     }
 }

--- a/crates/astria-conductor/src/executor/tests.rs
+++ b/crates/astria-conductor/src/executor/tests.rs
@@ -11,12 +11,14 @@ use astria_core::{
 use bytes::Bytes;
 
 use super::{
+    should_execute_firm_block,
     state::{
         StateReceiver,
         StateSender,
     },
     RollupId,
 };
+use crate::config::CommitLevel;
 
 const ROLLUP_ID: RollupId = RollupId::new([42u8; 32]);
 
@@ -79,7 +81,7 @@ state",
 }
 
 #[test]
-fn foo() {
+fn execute_block_contract_violation() {
     use super::ExecutionKind::{
         Firm,
         Soft,
@@ -154,5 +156,53 @@ fn foo() {
             soft: 3,
         },
         5,
+    );
+}
+
+#[test]
+fn should_execute_firm() {
+    use CommitLevel::{
+        FirmOnly,
+        SoftAndFirm,
+        SoftOnly,
+    };
+
+    assert!(
+        should_execute_firm_block(1, 1, FirmOnly),
+        "firm-mode conductors should always execute firm blocks"
+    );
+    assert!(
+        should_execute_firm_block(0, 1, FirmOnly),
+        "firm-mode conductors should always execute firm blocks"
+    );
+    assert!(
+        should_execute_firm_block(1, 0, FirmOnly),
+        "firm-mode conductors should always execute firm blocks"
+    );
+    assert!(
+        !should_execute_firm_block(1, 1, SoftOnly),
+        "soft-mode conductors should never execute firm blocks"
+    );
+    assert!(
+        !should_execute_firm_block(0, 1, SoftOnly),
+        "soft-mode conductors should never execute firm blocks"
+    );
+    assert!(
+        !should_execute_firm_block(1, 0, SoftOnly),
+        "soft-mode conductors should never execute firm blocks"
+    );
+    assert!(
+        should_execute_firm_block(1, 1, SoftAndFirm),
+        "firm-and-soft-mode conductors should execute firm blocks if soft and firm numbers match"
+    );
+    assert!(
+        !should_execute_firm_block(0, 1, SoftAndFirm),
+        "firm-and-soft-mode conductors should not execute firm blocks if soft and firm numbers \
+         don't match"
+    );
+    assert!(
+        !should_execute_firm_block(1, 0, SoftAndFirm),
+        "firm-and-soft-mode conductors should not execute firm blocks if soft and firm numbers \
+         don't match"
     );
 }


### PR DESCRIPTION
## Summary
Ensures that conductor only executes firm blocks if running in soft-and-firm mode, and if the rollup soft and firm block numbers are equal.

## Background
Previously, Conductor used the presence of a block in its cache [1] as the condition for whether it should execute a firm block against a rollup. This should never be observed in practice, but there is a better (less confusing, more maintainable way) of expressing the same condition:

When running in soft-and-firm mode, Conductor:
1. must only execute a block if the rollup's `firm number == soft number`, and then use the rollup response to advance the firm commitment state.
2. must otherwise only advance (without prior execution) the rollup's firm commitment state using the block pending finalization for the corresponding block number stored in its cache.

1: the cache of blocks pending finalization; only relevant in soft-and-firm mode.

## Changes
- Tightened the condition for when Conductor executes a firm bock against the rollup when running in soft-and-firm mode (only execute if soft number equals firm number)
- Makes the absence of a block in its cache a hard error when not executing but only advancing the commitment state
- Tries to fetch the missing block pending finalization from the rollup as a last ditch effort before bailing

## Testing
Added tests for determining if a firm block should be executed. Because the case where Conductor tries refetching the missing block is a fallback for a faulty edge case that should never be observed in practice this cannot be tested using blackbox tests.

## Related Issues

closes https://github.com/astriaorg/astria/issues/1011