### PR TITLE
fix(chart): secretObject when no env var usage

### DIFF
--- a/charts/sequencer-relayer/Chart.yaml
+++ b/charts/sequencer-relayer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.6.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sequencer-relayer/templates/configmaps.yaml
+++ b/charts/sequencer-relayer/templates/configmaps.yaml
@@ -39,7 +39,7 @@ data:
   start-relayer.sh: |
     {{- .Files.Get "files/scripts/start-relayer.sh" | nindent 4 }}
 ---
----
+{{- if not .Values.secretProvider.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -49,3 +49,4 @@ data:
   {{ .Values.config.celestiaAppPrivateKey.secret.filename }}: |
     {{ .Values.config.celestiaAppPrivateKey.devContent }}
 ---
+{{- end }}

--- a/charts/sequencer-relayer/templates/secretproviderclass.yaml
+++ b/charts/sequencer-relayer/templates/secretproviderclass.yaml
@@ -6,12 +6,6 @@ metadata:
   name: relayer-private-key-celestia
 spec:
   provider: gcp
-  secretObjects:
-  - secretName: relayer-private-key-celestia
-    type: Opaque
-    data:
-    - objectName: {{ .Values.config.celestiaAppPrivateKey.secret.filename }}
-      key: {{ .Values.config.celestiaAppPrivateKey.secret.key }}
   parameters:
     {{- $_ := set $ "key" .Values.config.celestiaAppPrivateKey.secret }}
     {{- tpl $.Values.secretProvider.parametersTemplate $ | nindent 4 }}

--- a/charts/sequencer/Chart.lock
+++ b/charts/sequencer/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: sequencer-relayer
   repository: file://../sequencer-relayer
-  version: 0.6.0
-digest: sha256:634e5149be8b93abed2d4db930c45b8ecff7f28a2f1439d263607d5b28290237
-generated: "2024-04-26T13:35:20.77244-07:00"
+  version: 0.6.1
+digest: sha256:0ffd0788c4b51035c971b70a71e926f7d5392ff1b560a5476aca0a52c031b929
+generated: "2024-04-29T13:48:42.89755-07:00"

--- a/charts/sequencer/Chart.yaml
+++ b/charts/sequencer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.13.0
+version: 0.13.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,7 +25,7 @@ appVersion: "0.11.0"
 
 dependencies:
   - name: sequencer-relayer
-    version: "0.6.0"
+    version: "0.6.1"
     repository: "file://../sequencer-relayer"
     condition: sequencer-relayer.enabled
 


### PR DESCRIPTION
## Summary
Removes the unused `secretObjects` in relayer chart, and the `configmap` which is unused when `secretProvider` is enabled

## Background
Secret objects are used for loading into k8s secrets and env vars, this is not something we are doing for the relayer chart as the secret is only accessed directly as a file. 

## Changes
- disable configmap when secret provider enabled
- remove `secretObjects` from the provider.

## Testing
CI/CD, and changes have been manually made to deployments for devnet. 