### PR TITLE
fix(sequencer): set current app hash properly when creating app

### DIFF
--- a/crates/astria-sequencer/src/app.rs
+++ b/crates/astria-sequencer/src/app.rs
@@ -146,21 +146,30 @@ pub(crate) struct App {
 }
 
 impl App {
-    pub(crate) fn new(snapshot: Snapshot) -> Self {
+    pub(crate) async fn new(snapshot: Snapshot) -> anyhow::Result<Self> {
         tracing::debug!("initializing App instance");
+
+        let app_hash: AppHash = snapshot
+            .root_hash()
+            .await
+            .context("failed to get current root hash")?
+            .0
+            .to_vec()
+            .try_into()
+            .expect("root hash conversion must succeed; should be 32 bytes");
 
         // We perform the `Arc` wrapping of `State` here to ensure
         // there should be no unexpected copies elsewhere.
         let state = Arc::new(StateDelta::new(snapshot));
 
-        Self {
+        Ok(Self {
             state,
             validator_address: None,
             executed_proposal_hash: Hash::default(),
             execution_results: None,
             write_batch: None,
-            app_hash: AppHash::default(),
-        }
+            app_hash,
+        })
     }
 
     #[instrument(name = "App:init_chain", skip_all)]
@@ -767,12 +776,13 @@ impl App {
             .prepare_commit(state)
             .await
             .context("failed to prepare commit")?;
-        let app_hash = write_batch
+        let app_hash: AppHash = write_batch
             .root_hash()
             .0
             .to_vec()
             .try_into()
             .context("failed to convert app hash")?;
+        info!(app_hash = %telemetry::display::hex(app_hash.as_bytes()), "prepared commit");
         self.write_batch = Some(write_batch);
         Ok(app_hash)
     }
@@ -927,7 +937,7 @@ impl App {
             ))
             .expect("must be able to successfully commit to storage");
         tracing::debug!(
-            app_hash = %telemetry::display::base64(&app_hash),
+            app_hash = %telemetry::display::hex(&app_hash),
             "finished committing state",
         );
         self.app_hash = app_hash
@@ -1114,7 +1124,7 @@ mod test {
             .await
             .expect("failed to create temp storage backing chain state");
         let snapshot = storage.latest_snapshot();
-        let mut app = App::new(snapshot);
+        let mut app = App::new(snapshot).await.unwrap();
 
         let genesis_state = genesis_state.unwrap_or_else(|| GenesisState {
             accounts: default_genesis_accounts(),

--- a/crates/astria-sequencer/src/app.rs
+++ b/crates/astria-sequencer/src/app.rs
@@ -782,7 +782,6 @@ impl App {
             .to_vec()
             .try_into()
             .context("failed to convert app hash")?;
-        info!(app_hash = %telemetry::display::hex(app_hash.as_bytes()), "prepared commit");
         self.write_batch = Some(write_batch);
         Ok(app_hash)
     }

--- a/crates/astria-sequencer/src/sequencer.rs
+++ b/crates/astria-sequencer/src/sequencer.rs
@@ -86,7 +86,9 @@ impl Sequencer {
             crate::asset::initialize_native_asset(&native_asset);
         }
 
-        let app = App::new(snapshot);
+        let app = App::new(snapshot)
+            .await
+            .context("failed to initialize app")?;
 
         let consensus_service = tower::ServiceBuilder::new()
             .layer(request_span::layer(|req: &ConsensusRequest| {

--- a/crates/astria-sequencer/src/service/consensus.rs
+++ b/crates/astria-sequencer/src/service/consensus.rs
@@ -488,7 +488,7 @@ mod test {
 
         let storage = cnidarium::TempStorage::new().await.unwrap();
         let snapshot = storage.latest_snapshot();
-        let mut app = App::new(snapshot);
+        let mut app = App::new(snapshot).await.unwrap();
         app.init_chain(storage.clone(), genesis_state, vec![], "test".to_string())
             .await
             .unwrap();


### PR DESCRIPTION
## Summary
set current app hash properly when creating app

## Background
this was causing issues if the node was restarted as the app hash would be empty, and this is written to state in ibc begin_block, causing an app hash mismatch on the next synced block

## Changes
- set current app hash properly when creating app

## Testing
local testnet with 4 validators and restarting one node, previously failed, now it works
