### PR TITLE
Update justfile to match CI

### DIFF
--- a/justfile
+++ b/justfile
@@ -70,8 +70,10 @@ _fmt-proto:
 _lint-proto:
   buf lint
   buf format -d --exit-code
+  buf breaking proto/primitives --against 'buf.build/astria/primitives'
   buf breaking proto/executionapis --against 'buf.build/astria/execution-apis'
-  buf breaking proto/sequencerapis --against 'buf.build/astria/astria'
+  buf breaking proto/sequencerblockapis --against 'buf.build/astria/sequencerblock-apis'
+  buf breaking proto/protocolapis --against 'buf.build/astria/protocol-apis'
   buf breaking proto/composerapis --against 'buf.build/astria/composer-apis'
 
 ##############################################


### PR DESCRIPTION
## Summary
Updated justfile to match CI.

## Background
The justfile `_lint-proto` target has fallen out of sync with the actual proto packages.

## Changes
Fixed this to match [the checks performed in CI](https://github.com/astriaorg/astria/blob/cb2a35ecafb46bada1ccbeac9086ff0f48119faf/.github/workflows/lint.yml#L27-L46).

## Testing
Ran `just lint proto` locally.
