### PR TITLE
fix(charts): update evm rollup charts for new genesis configs

### DIFF
--- a/charts/evm-rollup/Chart.yaml
+++ b/charts/evm-rollup/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.14.0
+version: 0.15.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.9.1"
+appVersion: "0.10.0"
 
 dependencies:
   - name: celestia-node

--- a/charts/evm-rollup/files/genesis/geth-genesis.json
+++ b/charts/evm-rollup/files/genesis/geth-genesis.json
@@ -34,8 +34,9 @@
         "astriaRollupName": "{{ .Values.config.rollup.name }}",
         "astriaCelestiaInitialHeight": {{ toString .Values.config.celestia.initialBlockHeight | replace "\"" "" }},
         "astriaCelestiaHeightVariance": {{ toString .Values.config.celestia.heightVariance | replace "\"" "" }},
-        "astriaBridgeAddresses": [{{ .Values.config.rollup.genesis.bridgeAddress | quote }}],
-        "astriaBridgeAllowedAssetDenom": {{ .Values.config.rollup.genesis.bridgeAllowedAssetDenom | quote }}
+        "astriaBridgeAddresses": {{ toPrettyJson .Values.config.rollup.genesis.bridgeAddresses | indent 8 | trim }},
+        "astriaFeeCollectors": {{ toPrettyJson .Values.config.rollup.genesis.feeCollectors | indent 8 | trim }},
+        "astriaEIP1559Params": {{ toPrettyJson .Values.config.rollup.genesis.eip1559Params | indent 8 | trim }}
         {{- if not .Values.global.dev }}
         {{- else }}
         {{- end }}

--- a/charts/evm-rollup/values.yaml
+++ b/charts/evm-rollup/values.yaml
@@ -76,10 +76,23 @@ config:
       extraDataOverride: ""
       # If set to true the genesis block will contain extra data
       overrideGenesisExtraData: true
-      # Configure the sequencer bridge address and allowed asset denom if using
+      # Configure the sequencer bridge addresses and allowed assets if using
       # the astria canonical bridge. Recommend removing alloc values if so.
-      bridgeAddress: ""
-      bridgeAllowedAssetDenom: nria
+      bridgeAddresses: []
+        # - address: "684ae50c49a434199199c9c698115391152d7b3f"
+        #   startHeight: 1
+        #   assetDenom: "nria"
+        #   assetPrecision: 9
+      # Configure the fee collector for the evm tx fees, activated at block heights.
+      # If not configured, all tx fees will be burned.
+      feeCollectors:
+        1: "0xaC21B97d35Bf75A7dAb16f35b111a50e78A72F30"
+      # Configure EIP-1559 params, activated at block heights
+      eip1559Params: {}
+        # 1:
+        #   minBaseFee: 0
+        #   elasticityMultiplier: 2
+        #   baseFeeChangeDenominator: 8
       # Can configure the genesis allocs for the chain
       alloc:
         - address: "0xaC21B97d35Bf75A7dAb16f35b111a50e78A72F30"

--- a/charts/evm-rollup/values.yaml
+++ b/charts/evm-rollup/values.yaml
@@ -9,7 +9,7 @@ global:
 images:
   geth:
     repo: ghcr.io/astriaorg/astria-geth
-    tag: 0.9.1
+    tag: 0.10.0
     devTag: latest
   conductor:
     repo: ghcr.io/astriaorg/conductor


### PR DESCRIPTION
## Summary
Latest changes to astria-geth have added/changed genesis configs which breaks the existing charts

## Background
we want charts to work

## Changes
- update `astriaBridgeAddresses` structure.
- remove `astriaBridgeAllowedAssetDenom`
- add `astriaFeeCollectors`
- add `astriaEIP1559Params`

## Testing
using repo smoke tests
