### PR TITLE
Revert "release(sequencer): sequencer 0.11.1"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "astria-sequencer"
-version = "0.11.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "astria-build-info",

--- a/charts/sequencer/Chart.yaml
+++ b/charts/sequencer/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.13.3
+version: 0.13.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.11.1"
+appVersion: "0.11.0"
 
 dependencies:
   - name: sequencer-relayer

--- a/charts/sequencer/values.yaml
+++ b/charts/sequencer/values.yaml
@@ -17,7 +17,7 @@ images:
     devTag: v0.38.6
   sequencer:
     repo: ghcr.io/astriaorg/sequencer
-    tag: "0.11.1"
+    tag: "0.11.0"
     devTag: latest
 
 config:

--- a/crates/astria-sequencer/Cargo.toml
+++ b/crates/astria-sequencer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astria-sequencer"
-version = "0.11.1"
+version = "0.11.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 rust-version = "1.73"


### PR DESCRIPTION
Reverts astriaorg/astria#1032

https://github.com/astriaorg/astria/pull/1017 was incorrectly labelled as non breaking.