### PR TITLE
feat(charts): add otel service names

### DIFF
--- a/charts/evm-rollup/Chart.yaml
+++ b/charts/evm-rollup/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.15.0
+version: 0.15.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/evm-rollup/templates/configmap.yaml
+++ b/charts/evm-rollup/templates/configmap.yaml
@@ -31,6 +31,8 @@ data:
   OTEL_EXPORTER_OTLP_TRACES_COMPRESSION: "{{ .Values.config.rollup.otel.tracesCompression }}"
   OTEL_EXPORTER_OTLP_HEADERS: "{{ .Values.config.rollup.otel.otlpHeaders }}"
   OTEL_EXPORTER_OTLP_TRACE_HEADERS: "{{ .Values.config.rollup.otel.traceHeaders }}"
+  OTEL_SERVICE_NAME: "{{ .Values.config.rollup.otel.serviceNamePrefix }}-conductor"
+  {{- if not .Values.secretProvider.enabled
   {{- if not .Values.global.dev }}
   {{- else }}
   {{- end }}
@@ -61,6 +63,7 @@ data:
   OTEL_EXPORTER_OTLP_TRACES_COMPRESSION: "{{ .Values.config.rollup.otel.tracesCompression }}"
   OTEL_EXPORTER_OTLP_HEADERS: "{{ .Values.config.rollup.otel.otlpHeaders }}"
   OTEL_EXPORTER_OTLP_TRACE_HEADERS: "{{ .Values.config.rollup.otel.traceHeaders }}"
+  OTEL_SERVICE_NAME: "{{ .Values.config.rollup.otel.serviceNamePrefix }}-composer"
   {{- if not .Values.secretProvider.enabled }}
   ASTRIA_COMPOSER_PRIVATE_KEY: "{{ .Values.config.sequencer.privateKey }}"
   {{- end }}

--- a/charts/evm-rollup/templates/configmap.yaml
+++ b/charts/evm-rollup/templates/configmap.yaml
@@ -31,8 +31,7 @@ data:
   OTEL_EXPORTER_OTLP_TRACES_COMPRESSION: "{{ .Values.config.rollup.otel.tracesCompression }}"
   OTEL_EXPORTER_OTLP_HEADERS: "{{ .Values.config.rollup.otel.otlpHeaders }}"
   OTEL_EXPORTER_OTLP_TRACE_HEADERS: "{{ .Values.config.rollup.otel.traceHeaders }}"
-  OTEL_SERVICE_NAME: "{{ .Values.config.rollup.otel.serviceNamePrefix }}-conductor"
-  {{- if not .Values.secretProvider.enabled
+  OTEL_SERVICE_NAME: "{{ tpl .Values.config.rollup.otel.serviceNamePrefix . }}-conductor"
   {{- if not .Values.global.dev }}
   {{- else }}
   {{- end }}
@@ -63,7 +62,7 @@ data:
   OTEL_EXPORTER_OTLP_TRACES_COMPRESSION: "{{ .Values.config.rollup.otel.tracesCompression }}"
   OTEL_EXPORTER_OTLP_HEADERS: "{{ .Values.config.rollup.otel.otlpHeaders }}"
   OTEL_EXPORTER_OTLP_TRACE_HEADERS: "{{ .Values.config.rollup.otel.traceHeaders }}"
-  OTEL_SERVICE_NAME: "{{ .Values.config.rollup.otel.serviceNamePrefix }}-composer"
+  OTEL_SERVICE_NAME: "{{ tpl .Values.config.rollup.otel.serviceNamePrefix . }}-composer"
   {{- if not .Values.secretProvider.enabled }}
   ASTRIA_COMPOSER_PRIVATE_KEY: "{{ .Values.config.sequencer.privateKey }}"
   {{- end }}

--- a/charts/evm-rollup/values.yaml
+++ b/charts/evm-rollup/values.yaml
@@ -112,6 +112,7 @@ config:
       enabled: false
     otel:
       enabled: false
+      serviceNamePrefix: "{{ .Values.config.rollup.name }}"
       endpoint:
       tracesEndpoint:
       tracesCompression: gzip

--- a/charts/sequencer-relayer/Chart.yaml
+++ b/charts/sequencer-relayer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.2
+version: 0.6.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sequencer-relayer/templates/configmaps.yaml
+++ b/charts/sequencer-relayer/templates/configmaps.yaml
@@ -26,6 +26,7 @@ data:
   OTEL_EXPORTER_OTLP_TRACES_COMPRESSION: "{{ .Values.config.relayer.otel.tracesCompression }}"
   OTEL_EXPORTER_OTLP_HEADERS: "{{ .Values.config.relayer.otel.otlpHeaders }}"
   OTEL_EXPORTER_OTLP_TRACE_HEADERS: "{{ .Values.config.relayer.otel.traceHeaders }}"
+  OTEL_SERVICE_NAME: "{{ tpl .Values.config.relayer.otel.serviceName . }}"
   {{- if not .Values.global.dev }}
   {{- else }}
   ASTRIA_SEQUENCER_RELAYER_ONLY_INCLUDE_ROLLUPS: "{{ .Values.config.relayer.onlyIncludeRollups }}"

--- a/charts/sequencer-relayer/values.yaml
+++ b/charts/sequencer-relayer/values.yaml
@@ -28,6 +28,7 @@ config:
 
     otel:
       enabled: false
+      serviceName: "astria-sequencer-relayer"
       endpoint:
       tracesEndpoint:
       tracesCompression: gzip

--- a/charts/sequencer/Chart.lock
+++ b/charts/sequencer/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: sequencer-relayer
   repository: file://../sequencer-relayer
-  version: 0.6.2
-digest: sha256:110f636ecf0e6a06be1ca6e3834ceabec8047494056bbbef1c7e16c6913c82eb
-generated: "2024-04-30T13:28:28.64181968+01:00"
+  version: 0.6.3
+digest: sha256:3bcedb383bf008451bf8689bd9ef844f77bbf4862521212a9c6991b40090104c
+generated: "2024-05-01T09:00:22.402791-07:00"

--- a/charts/sequencer/Chart.yaml
+++ b/charts/sequencer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.13.2
+version: 0.13.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,7 +25,7 @@ appVersion: "0.11.0"
 
 dependencies:
   - name: sequencer-relayer
-    version: "0.6.2"
+    version: "0.6.3"
     repository: "file://../sequencer-relayer"
     condition: sequencer-relayer.enabled
 

--- a/charts/sequencer/templates/configmaps.yaml
+++ b/charts/sequencer/templates/configmaps.yaml
@@ -71,6 +71,7 @@ data:
   OTEL_EXPORTER_OTLP_TRACES_COMPRESSION: "{{ .Values.config.sequencer.otel.tracesCompression }}"
   OTEL_EXPORTER_OTLP_HEADERS: "{{ .Values.config.sequencer.otel.otlpHeaders }}"
   OTEL_EXPORTER_OTLP_TRACE_HEADERS: "{{ .Values.config.sequencer.otel.traceHeaders }}"
+  OTEL_SERVICE_NAME: "{{ tpl .Values.config.sequencer.otel.serviceName . }}"
   {{- if not .Values.global.dev }}
   {{- else }}
   {{- end }}

--- a/charts/sequencer/values.yaml
+++ b/charts/sequencer/values.yaml
@@ -52,6 +52,7 @@ config:
 
     otel:
       enabled: false
+      serviceName: "{{ include 'sequencer.name' . }}"
       endpoint:
       tracesEndpoint:
       tracesCompression: gzip

--- a/charts/sequencer/values.yaml
+++ b/charts/sequencer/values.yaml
@@ -52,7 +52,8 @@ config:
 
     otel:
       enabled: false
-      serviceName: "{{ include 'sequencer.name' . }}"
+      serviceName: |-
+        {{ include "sequencer.name" . }}
       endpoint:
       tracesEndpoint:
       tracesCompression: gzip


### PR DESCRIPTION
## Summary
Adds service name to OTEL data.

## Background
By default service name is `unnamed` this can be configured via env var but wasn't done previously.

## Changes
- Adds `OTEL_SERVICE_NAME` to astria chart configs.
