### PR TITLE
feat(sequencer-relayer): add metric recording highest sequencer block submitted

### DIFF
--- a/crates/astria-sequencer-relayer/src/metrics_init.rs
+++ b/crates/astria-sequencer-relayer/src/metrics_init.rs
@@ -14,19 +14,19 @@ pub fn register() {
     describe_counter!(
         CELESTIA_SUBMISSION_COUNT,
         Unit::Count,
-        "The number of calls made to submit to celestia"
+        "The number of calls made to submit to Celestia"
     );
 
     describe_counter!(
         CELESTIA_SUBMISSION_HEIGHT,
         Unit::Count,
-        "The height of the last blob submitted to Celestia"
+        "The height of the last blob successfully submitted to Celestia"
     );
 
     describe_counter!(
         CELESTIA_SUBMISSION_FAILURE_COUNT,
         Unit::Count,
-        "The number of calls made to submit to celestia which have failed"
+        "The number of calls made to submit to Celestia which have failed"
     );
 
     describe_counter!(
@@ -39,6 +39,12 @@ pub fn register() {
         SEQUENCER_HEIGHT_FETCH_FAILURE_COUNT,
         Unit::Count,
         "The number of calls made to fetch the current height from sequencer which have failed"
+    );
+
+    describe_counter!(
+        SEQUENCER_SUBMISSION_HEIGHT,
+        Unit::Count,
+        "The height of the highest sequencer block successfully submitted to Celestia"
     );
 
     describe_gauge!(
@@ -106,6 +112,9 @@ pub const SEQUENCER_HEIGHT_FETCH_FAILURE_COUNT: &str = concat!(
     env!("CARGO_CRATE_NAME"),
     "_sequencer_height_fetch_failure_count",
 );
+
+pub const SEQUENCER_SUBMISSION_HEIGHT: &str =
+    concat!(env!("CARGO_CRATE_NAME"), "_sequencer_submission_height");
 
 pub const TOTAL_BLOB_DATA_SIZE_FOR_ASTRIA_BLOCK: &str = concat!(
     env!("CARGO_CRATE_NAME"),

--- a/crates/astria-sequencer-relayer/src/relayer/celestia_client/mod.rs
+++ b/crates/astria-sequencer-relayer/src/relayer/celestia_client/mod.rs
@@ -442,7 +442,7 @@ fn block_height_from_response(
                 trace!(?status);
             }
             if status.code() == tonic::Code::NotFound {
-                debug!(msg = status.message(), "transaction still pending");
+                trace!(msg = status.message(), "transaction still pending");
                 return Ok(None);
             }
             return Err(TrySubmitError::FailedToGetTx(GrpcResponseError::from(
@@ -464,7 +464,7 @@ fn block_height_from_response(
         return Err(error);
     }
     if tx_response.height == 0 {
-        debug!(tx_hash = %tx_response.txhash, "transaction still pending");
+        trace!(tx_hash = %tx_response.txhash, "transaction still pending");
         return Ok(None);
     }
 


### PR DESCRIPTION
## Summary
Added a metric to the relayer to give visibility of the current highest sequencer block stored on Celestia.

## Background
It will be useful to avoid having to search the logs for this info.

## Changes
Added the new metric (see below).  Also dropped the log level of a couple of somewhat noisy `debug!` log lines.

## Testing
No formal tests added.  Viewed the metrics of a running relayer to ensure the new metric was as expected.

## Metrics
- Added `astria_sequencer_relayer_sequencer_submission_height`.
