### PR TITLE
fix(charts): shorten metric port names

### DIFF
--- a/charts/evm-rollup/Chart.yaml
+++ b/charts/evm-rollup/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.15.2
+version: 0.15.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/evm-rollup/templates/service.yaml
+++ b/charts/evm-rollup/templates/service.yaml
@@ -55,13 +55,13 @@ spec:
   selector:
     app: {{ .Values.config.rollup.name }}-astria-dev-cluster
   ports:
-    - name: geth-metrics
+    - name: geth-metr
       port: {{ .Values.ports.metrics }}
-      targetPort: geth-metrics
-    - name: composer-metrics
+      targetPort: geth-metr
+    - name: composer-metr
       port: {{ .Values.ports.composerMetrics }}
-      targetPort: composer-metrics
-    - name: conductor-metrics
+      targetPort: composer-metr
+    - name: conductor-metr
       port: {{ .Values.ports.conductorMetrics }}
-      targetPort: conductor-metrics
+      targetPort: conductor-metr
 {{- end }}

--- a/charts/evm-rollup/templates/servicemonitor.yaml
+++ b/charts/evm-rollup/templates/servicemonitor.yaml
@@ -17,7 +17,7 @@ spec:
     matchLabels:
       app: {{ .Values.config.rollup.name }}-astria-dev-cluster
   endpoints:
-    - port: geth-metrics
+    - port: geth-metr
       path: /debug/metrics/prometheus
       {{- with .Values.config.rollup.serviceMonitor.interval }}
       interval: {{ . }}
@@ -25,7 +25,7 @@ spec:
       {{- with .Values.config.rollup.serviceMonitor.scrapeTimeout  }}
       scrapeTimeout: {{ . }}
       {{- end }}
-    - port: composer-metrics
+    - port: composer-metr
       path: /
       {{- with .Values.config.rollup.serviceMonitor.interval }}
       interval: {{ . }}
@@ -33,7 +33,7 @@ spec:
       {{- with .Values.config.rollup.serviceMonitor.scrapeTimeout  }}
       scrapeTimeout: {{ . }}
       {{- end }}
-    - port: conductor-metrics
+    - port: conductor-metr
       path: /
       {{- with .Values.config.rollup.serviceMonitor.interval }}
       interval: {{ . }}

--- a/charts/evm-rollup/templates/statefulsets.yaml
+++ b/charts/evm-rollup/templates/statefulsets.yaml
@@ -81,7 +81,7 @@ spec:
               name: execution-grpc
             {{- if .Values.config.rollup.metrics.enabled }} 
             - containerPort: {{ .Values.ports.metrics }}
-              name: geth-metrics
+              name: geth-metr
             {{- end }}
           resources:
             {{- toYaml .Values.resources.geth | trim | nindent 12 }}     
@@ -109,7 +109,7 @@ spec:
           {{- if .Values.config.rollup.metrics.enabled }} 
           ports:
             - containerPort: {{ .Values.ports.composerMetrics }}
-              name: composer-metrics
+              name: composer-metr
           {{- end }}
           resources:
             {{- toYaml .Values.resources.composer | trim | nindent 12 }}
@@ -126,7 +126,7 @@ spec:
           {{- if .Values.config.rollup.metrics.enabled }} 
           ports:
             - containerPort: {{ .Values.ports.conductorMetrics }}
-              name: conductor-metrics
+              name: conductor-metr
           {{- end }}
       volumes:
         - name: {{ .Values.config.rollup.name }}-executor-scripts-volume

--- a/charts/sequencer/Chart.yaml
+++ b/charts/sequencer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.13.3
+version: 0.13.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sequencer/templates/service.yaml
+++ b/charts/sequencer/templates/service.yaml
@@ -61,8 +61,8 @@ spec:
       port: {{ .Values.ports.cometBFTMETRICS }}
       targetPort: cometbft-metric
     {{- if .Values.config.sequencer.metrics.enabled }}
-    - name: sequencer-metric
+    - name: seq-metric
       port: {{ .Values.ports.sequencerMetrics }}
-      targetPort: sequencer-metric
+      targetPort: seq-metric
     {{- end }}
 {{- end }}

--- a/charts/sequencer/templates/servicemonitor.yaml
+++ b/charts/sequencer/templates/servicemonitor.yaml
@@ -45,7 +45,7 @@ spec:
     matchLabels:
       {{- include "sequencer.selectorLabels" . | nindent 6 }}
   endpoints:
-    - port: sequencer-metric
+    - port: seq-metric
       path: /
       {{- with .Values.serviceMonitor.interval }}
       interval: {{ . }}

--- a/charts/sequencer/templates/statefulsets.yaml
+++ b/charts/sequencer/templates/statefulsets.yaml
@@ -50,7 +50,7 @@ spec:
               name: sequencer-grpc
             {{- if .Values.config.sequencer.metrics.enabled }}
             - containerPort: {{ .Values.ports.sequencerMetrics }}
-              name: sequencer-metric
+              name: seq-metric
             {{- end }}
         - name: cometbft
           imagePullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary
Shortens the  port names which were too long, making it impossible to enable metrics.