### PR TITLE
refactor(conductor): fetch missing blocks as necessary

### DIFF
--- a/crates/astria-conductor/src/config.rs
+++ b/crates/astria-conductor/src/config.rs
@@ -13,10 +13,6 @@ pub enum CommitLevel {
 }
 
 impl CommitLevel {
-    pub(crate) fn is_soft_and_firm(self) -> bool {
-        matches!(self, Self::SoftAndFirm)
-    }
-
     pub(crate) fn is_with_firm(self) -> bool {
         matches!(self, Self::FirmOnly | Self::SoftAndFirm)
     }
@@ -110,10 +106,6 @@ mod tests {
             SoftAndFirm,
             SoftOnly,
         };
-
-        assert!(!FirmOnly.is_soft_and_firm());
-        assert!(!SoftOnly.is_soft_and_firm());
-        assert!(SoftAndFirm.is_soft_and_firm());
 
         assert!(FirmOnly.is_with_firm());
         assert!(!FirmOnly.is_with_soft());

--- a/crates/astria-conductor/src/executor/client.rs
+++ b/crates/astria-conductor/src/executor/client.rs
@@ -1,6 +1,3 @@
-use std::ops::RangeInclusive;
-
-use ::astria_core::generated::execution::v1alpha2::Block as RawBlock;
 use astria_core::{
     execution::v1alpha2::{
         Block,
@@ -46,44 +43,7 @@ impl Client {
         })
     }
 
-    /// Issues the `astria.execution.v1alpha2.BatchGetBlocks` RPC for `block_numbers`.
-    ///
-    /// Returns a sequence of blocks sorted by block number and without duplicates,
-    /// holes in the requested range, or blocks outside the requested range.
-    ///
-    /// Returns an error if duplicates, holes, or extra blocks are found.
-    #[instrument(skip_all, fields(
-        uri = %self.uri,
-        from = block_numbers.start(),
-        to = block_numbers.end(),
-    ))]
-    pub(crate) async fn batch_get_blocks(
-        &mut self,
-        block_numbers: RangeInclusive<u32>,
-    ) -> eyre::Result<Vec<Block>> {
-        let request = raw::BatchGetBlocksRequest {
-            identifiers: block_numbers.clone().map(block_identifier).collect(),
-        };
-        let raw_blocks = self
-            .inner
-            .batch_get_blocks(request)
-            .await
-            .wrap_err("failed to execute batch get blocks RPC")?
-            .into_inner()
-            .blocks;
-        ensure_batch_get_blocks_is_correct(&raw_blocks, block_numbers).wrap_err(
-            "received an incorrect response; did the rollup execution service violate the \
-             batch-get-blocks contract?",
-        )?;
-        let blocks = raw_blocks
-            .into_iter()
-            .map(Block::try_from_raw)
-            .collect::<Result<_, _>>()
-            .wrap_err("failed validating received blocks")?;
-        Ok(blocks)
-    }
-
-    #[instrument(skip_all, fields(uri = %self.uri), err)]
+    #[instrument(skip_all, fields(block_number, uri = %self.uri), err)]
     pub(crate) async fn get_block(&mut self, block_number: u32) -> eyre::Result<Block> {
         let request = raw::GetBlockRequest {
             identifier: Some(block_identifier(block_number)),
@@ -156,7 +116,7 @@ impl Client {
     }
 
     /// Calls remote procedure `astria.execution.v1alpha2.GetCommitmentState`
-    #[instrument(skip_all, fields(uri = %self.uri))]
+    #[instrument(skip_all, fields(uri = %self.uri), err)]
     pub(crate) async fn get_commitment_state(&mut self) -> eyre::Result<CommitmentState> {
         let request = raw::GetCommitmentStateRequest {};
         let response = self
@@ -196,171 +156,10 @@ impl Client {
     }
 }
 
-#[derive(Debug, thiserror::Error, PartialEq)]
-enum BatchGetBlocksError {
-    #[error(
-        "number of returned blocks does not match requested; requested: `{expected}`, received: \
-         `{actual}`"
-    )]
-    LengthOfResponse { expected: u32, actual: u32 },
-    #[error(
-        "returned blocks did not match in the sequence they were requested at: [{}]",
-        itertools::join(.0, ", ")
-    )]
-    MismatchedBlocks(Vec<MismatchedBlock>),
-}
-
-#[derive(Clone, Copy, Debug, PartialEq)]
-struct MismatchedBlock {
-    index: usize,
-    requested: u32,
-    got: u32,
-}
-
-impl std::fmt::Display for MismatchedBlock {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let Self {
-            index,
-            requested,
-            got,
-        } = self;
-        f.write_fmt(format_args!(
-            "{{\"index\": {index}, \"requested\": {requested}, \"got\": {got}}}"
-        ))
-    }
-}
-
-fn ensure_batch_get_blocks_is_correct(
-    blocks: &[RawBlock],
-    requested_numbers: RangeInclusive<u32>,
-) -> Result<(), BatchGetBlocksError> {
-    let expected = requested_numbers
-        .end()
-        .saturating_sub(*requested_numbers.start())
-        .saturating_add(1);
-    // allow: the calling function can only fetch up to u32::MAX blocks, which itself
-    // is unrealistic. If the next check passes due to a u64 being truncated to u32::MAX
-    // then something is going very wrong and will be caught at the latest in the next step.
-    #[allow(clippy::cast_possible_truncation)]
-    let actual = blocks.len() as u32;
-    if expected != actual {
-        return Err(BatchGetBlocksError::LengthOfResponse {
-            expected,
-            actual,
-        });
-    }
-    let mut mismatched = Vec::with_capacity(blocks.len());
-    for (index, (requested, got)) in requested_numbers
-        .zip(blocks.iter().map(|block| block.number))
-        .enumerate()
-    {
-        if requested != got {
-            mismatched.push(MismatchedBlock {
-                index,
-                requested,
-                got,
-            });
-        }
-    }
-    if !mismatched.is_empty() {
-        return Err(BatchGetBlocksError::MismatchedBlocks(mismatched));
-    }
-    Ok(())
-}
-
 /// Utility function to construct a `astria.execution.v1alpha2.BlockIdentifier` from `number`
 /// to use in RPC requests.
 fn block_identifier(number: u32) -> raw::BlockIdentifier {
     raw::BlockIdentifier {
         identifier: Some(raw::block_identifier::Identifier::BlockNumber(number)),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{
-        ensure_batch_get_blocks_is_correct,
-        MismatchedBlock,
-        RawBlock,
-    };
-    use crate::executor::client::BatchGetBlocksError;
-
-    fn block(number: u32) -> RawBlock {
-        RawBlock {
-            number,
-            ..RawBlock::default()
-        }
-    }
-
-    #[test]
-    fn mismatched_block_is_formatted_as_expected() {
-        let block = MismatchedBlock {
-            index: 1,
-            requested: 2,
-            got: 3,
-        };
-
-        assert_eq!(
-            r#"{"index": 1, "requested": 2, "got": 3}"#,
-            block.to_string()
-        );
-    }
-
-    #[test]
-    fn expected_batch_response_passes() {
-        let range = 2..=7;
-        let blocks: Vec<_> = range.clone().map(block).collect();
-        ensure_batch_get_blocks_is_correct(&blocks, range).unwrap();
-    }
-
-    #[test]
-    fn too_long_batch_response_is_caught() {
-        let range = 2..=7;
-        let mut blocks: Vec<_> = range.clone().map(block).collect();
-        blocks.push(block(8));
-        assert_eq!(
-            Err(BatchGetBlocksError::LengthOfResponse {
-                expected: 6,
-                actual: 7,
-            }),
-            ensure_batch_get_blocks_is_correct(&blocks, range),
-        );
-    }
-
-    #[test]
-    fn too_short_batch_response_is_caught() {
-        let range = 2..=7;
-        let mut blocks: Vec<_> = range.clone().map(block).collect();
-        blocks.pop();
-        assert_eq!(
-            Err(BatchGetBlocksError::LengthOfResponse {
-                expected: 6,
-                actual: 5,
-            }),
-            ensure_batch_get_blocks_is_correct(&blocks, range),
-        );
-    }
-
-    #[test]
-    fn mismatched_batch_response_is_caught() {
-        let range = 2..=7;
-        let mut blocks: Vec<_> = range.clone().map(block).collect();
-        blocks[2].number = 8;
-        blocks[4].number = 9;
-        assert_eq!(
-            Err(BatchGetBlocksError::MismatchedBlocks(vec![
-                MismatchedBlock {
-                    index: 2,
-                    requested: 4,
-                    got: 8
-                },
-                MismatchedBlock {
-                    index: 4,
-                    requested: 6,
-                    got: 9
-                },
-            ])),
-            ensure_batch_get_blocks_is_correct(&blocks, range),
-        );
     }
 }

--- a/crates/astria-conductor/tests/blackbox/helpers/macros.rs
+++ b/crates/astria-conductor/tests/blackbox/helpers/macros.rs
@@ -318,35 +318,27 @@ macro_rules! mount_sequencer_genesis {
 }
 
 #[macro_export]
-macro_rules! mount_pending_blocks {
+macro_rules! mount_get_block {
     (
         $test_env:ident,
-        [$(
-            (
-            number: $number:expr,
-            hash: $hash:expr,
-            parent: $parent:expr $(,)?
-            )
-        ),+ $(,)?
-        ]
-        $(,)?
+        number: $number:expr,
+        hash: $hash:expr,
+        parent: $parent:expr $(,)?
     ) => {{
-        let blocks = vec![$(
-            $crate::block!(
-                number: $number,
-                hash: $hash,
-                parent: $parent,
-            )),*
-        ];
-        let identifiers: Vec<_> = blocks.iter().map(
-            |block| ::astria_core::generated::execution::v1alpha2::BlockIdentifier {
-                identifier: Some(::astria_core::generated::execution::v1alpha2::block_identifier::Identifier::BlockNumber(block.number)),
-        }).collect();
-        $test_env.mount_batch_get_blocks(
-            ::astria_core::generated::execution::v1alpha2::BatchGetBlocksRequest {
-                identifiers,
+        let block = $crate::block!(
+            number: $number,
+            hash: $hash,
+            parent: $parent,
+        );
+        let identifier = ::astria_core::generated::execution::v1alpha2::BlockIdentifier {
+            identifier: Some(
+                ::astria_core::generated::execution::v1alpha2::block_identifier::Identifier::BlockNumber(block.number)
+        )};
+        $test_env.mount_get_block(
+            ::astria_core::generated::execution::v1alpha2::GetBlockRequest {
+                identifier: Some(identifier),
             },
-            blocks,
+            block,
         )
         .await
     }};

--- a/crates/astria-conductor/tests/blackbox/helpers/mod.rs
+++ b/crates/astria-conductor/tests/blackbox/helpers/mod.rs
@@ -130,21 +130,18 @@ impl TestConductor {
         .await;
     }
 
-    pub async fn mount_batch_get_blocks<S: serde::Serialize>(
+    pub async fn mount_get_block<S: serde::Serialize>(
         &self,
         expected_pbjson: S,
-        blocks: Vec<astria_core::generated::execution::v1alpha2::Block>,
+        block: astria_core::generated::execution::v1alpha2::Block,
     ) {
-        use astria_core::generated::execution::v1alpha2::BatchGetBlocksResponse;
         use astria_grpc_mock::{
             matcher::message_partial_pbjson,
             response::constant_response,
             Mock,
         };
-        Mock::for_rpc_given("batch_get_blocks", message_partial_pbjson(&expected_pbjson))
-            .respond_with(constant_response(BatchGetBlocksResponse {
-                blocks,
-            }))
+        Mock::for_rpc_given("get_block", message_partial_pbjson(&expected_pbjson))
+            .respond_with(constant_response(block))
             .expect(1..)
             .mount(&self.mock_grpc.mock_server)
             .await;

--- a/crates/astria-conductor/tests/blackbox/soft_and_firm.rs
+++ b/crates/astria-conductor/tests/blackbox/soft_and_firm.rs
@@ -13,10 +13,10 @@ use crate::{
     mount_celestia_blobs,
     mount_celestia_header_network_head,
     mount_executed_block,
+    mount_get_block,
     mount_get_commitment_state,
     mount_get_filtered_sequencer_block,
     mount_get_genesis_info,
-    mount_pending_blocks,
     mount_sequencer_commit,
     mount_sequencer_genesis,
     mount_sequencer_validator_set,
@@ -142,7 +142,7 @@ async fn simple() {
 }
 
 #[tokio::test]
-async fn pending_blocks_are_fetched() {
+async fn missing_block_is_fetched_for_updating_firm_commitment() {
     let test_conductor = spawn_conductor(CommitLevel::SoftAndFirm).await;
 
     mount_get_genesis_info!(
@@ -173,16 +173,12 @@ async fn pending_blocks_are_fetched() {
 
     mount_sequencer_genesis!(test_conductor);
 
-    mount_pending_blocks!(test_conductor,
-        [(
-            number: 2,
-            hash: [2; 64],
-            parent: [1; 64],
-        )],
+    mount_get_block!(
+        test_conductor,
+        number: 2,
+        hash: [2; 64],
+        parent: [1; 64],
     );
-
-    // mount the Celestia blob containing the pending block to force the confirmation,
-    // but don't mount the filtered sequencer block request yet
 
     mount_celestia_header_network_head!(
         test_conductor,


### PR DESCRIPTION
## Summary
Conductor fetches blocks from the rollup node if they are not in its cache.

## Background
During initialization and when set to firm-and-soft commitment mode, Conductor issued a `BatchGetBlocks` RPC to the rollup. When the delta between firm and soft commitments was too large, this could be a request for 50k and more elements, putting a lot of pressure on the rollup node or failing outright because the request exceeded the default 4MB limit for gRPC requests.

This patch replaces this pre-fetch in favor of an already existing fallback logic: if conductor finds a Celestia block with the next desired firm-number, it either looks up the corresponding rollup block in its cache, or requests it from the rollup. It then updates the rollup's commitment state.

## Changes
- Remove `BatchGetBlocks` logic from conductor

## Testing
Update the conductor test for fetching missing rollup blocks.