### PR TITLE
feat(sequencer)!: add fees to genesis state

### DIFF
--- a/charts/sequencer/Chart.yaml
+++ b/charts/sequencer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.13.5
+version: 0.13.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sequencer/files/cometbft/config/genesis.json
+++ b/charts/sequencer/files/cometbft/config/genesis.json
@@ -12,6 +12,14 @@
     ],
     "authority_sudo_address": "{{ .Values.config.sequencer.authoritySudoAddress }}",
     "native_asset_base_denomination": "{{ .Values.config.sequencer.nativeAssetBaseDenomination }}",
+    "fees": {
+      "transfer_base_fee": 12,
+      "sequence_base_fee": 32,
+      "sequence_byte_cost_multiplier": 1,
+      "init_bridge_account_base_fee": 48,
+      "bridge_lock_byte_cost_multiplier": 1,
+      "ics20_withdrawal_base_fee": 24
+    },
     "allowed_fee_assets": [
       {{- range $index, $value := .Values.config.sequencer.allowedFeeAssets }}
       {{- if $index }},{{- end }}

--- a/crates/astria-sequencer/src/accounts/component.rs
+++ b/crates/astria-sequencer/src/accounts/component.rs
@@ -14,12 +14,11 @@ use super::state_ext::StateWriteExt;
 use crate::{
     asset::get_native_asset,
     component::Component,
-    genesis::GenesisState,
+    genesis::{
+        GenesisState,
+        TRANSFER_BASE_FEE_FIELD_NAME,
+    },
 };
-
-/// Default transfer base fee.
-/// TODO: put in app genesis state
-pub(crate) const DEFAULT_TRANSFER_BASE_FEE: u128 = 12;
 
 #[derive(Default)]
 pub(crate) struct AccountsComponent;
@@ -38,7 +37,10 @@ impl Component for AccountsComponent {
         }
 
         state
-            .put_transfer_base_fee(DEFAULT_TRANSFER_BASE_FEE)
+            .put_transfer_base_fee(*app_state.fees.get(TRANSFER_BASE_FEE_FIELD_NAME).expect(
+                "genesis `fees` must contain `transfer_base_fee`, as it was validated during \
+                 construction",
+            ))
             .context("failed to put transfer base fee")?;
         Ok(())
     }

--- a/crates/astria-sequencer/src/accounts/component.rs
+++ b/crates/astria-sequencer/src/accounts/component.rs
@@ -14,10 +14,7 @@ use super::state_ext::StateWriteExt;
 use crate::{
     asset::get_native_asset,
     component::Component,
-    genesis::{
-        GenesisState,
-        TRANSFER_BASE_FEE_FIELD_NAME,
-    },
+    genesis::GenesisState,
 };
 
 #[derive(Default)]
@@ -37,10 +34,7 @@ impl Component for AccountsComponent {
         }
 
         state
-            .put_transfer_base_fee(*app_state.fees.get(TRANSFER_BASE_FEE_FIELD_NAME).expect(
-                "genesis `fees` must contain `transfer_base_fee`, as it was validated during \
-                 construction",
-            ))
+            .put_transfer_base_fee(app_state.fees.transfer_base_fee)
             .context("failed to put transfer base fee")?;
         Ok(())
     }

--- a/crates/astria-sequencer/src/app/test_utils.rs
+++ b/crates/astria-sequencer/src/app/test_utils.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use astria_core::{
     primitive::v1::{
         asset::DEFAULT_NATIVE_ASSET_DENOM,
@@ -65,6 +67,17 @@ pub(crate) fn default_genesis_accounts() -> Vec<Account> {
     ]
 }
 
+pub(crate) fn default_fees() -> HashMap<String, u128> {
+    let mut fees = HashMap::new();
+    fees.insert("transfer_base_fee".to_string(), 12);
+    fees.insert("sequence_base_fee".to_string(), 32);
+    fees.insert("sequence_byte_cost_multiplier".to_string(), 1);
+    fees.insert("init_bridge_account_base_fee".to_string(), 48);
+    fees.insert("bridge_lock_byte_cost_multiplier".to_string(), 1);
+    fees.insert("ics20_withdrawal_base_fee".to_string(), 24);
+    fees
+}
+
 pub(crate) async fn initialize_app_with_storage(
     genesis_state: Option<GenesisState>,
     genesis_validators: Vec<tendermint::validator::Update>,
@@ -84,6 +97,7 @@ pub(crate) async fn initialize_app_with_storage(
         native_asset_base_denomination: DEFAULT_NATIVE_ASSET_DENOM.to_string(),
         ibc_params: IBCParameters::default(),
         allowed_fee_assets: vec![DEFAULT_NATIVE_ASSET_DENOM.to_owned().into()],
+        fees: default_fees(),
     });
 
     app.init_chain(

--- a/crates/astria-sequencer/src/app/test_utils.rs
+++ b/crates/astria-sequencer/src/app/test_utils.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use astria_core::{
     primitive::v1::{
         asset::DEFAULT_NATIVE_ASSET_DENOM,
@@ -21,6 +19,7 @@ use penumbra_ibc::params::IBCParameters;
 use crate::{
     app::App,
     genesis::{
+        self,
         Account,
         GenesisState,
     },
@@ -67,15 +66,15 @@ pub(crate) fn default_genesis_accounts() -> Vec<Account> {
     ]
 }
 
-pub(crate) fn default_fees() -> HashMap<String, u128> {
-    let mut fees = HashMap::new();
-    fees.insert("transfer_base_fee".to_string(), 12);
-    fees.insert("sequence_base_fee".to_string(), 32);
-    fees.insert("sequence_byte_cost_multiplier".to_string(), 1);
-    fees.insert("init_bridge_account_base_fee".to_string(), 48);
-    fees.insert("bridge_lock_byte_cost_multiplier".to_string(), 1);
-    fees.insert("ics20_withdrawal_base_fee".to_string(), 24);
-    fees
+pub(crate) fn default_fees() -> genesis::Fees {
+    genesis::Fees {
+        transfer_base_fee: 12,
+        sequence_base_fee: 32,
+        sequence_byte_cost_multiplier: 1,
+        init_bridge_account_base_fee: 48,
+        bridge_lock_byte_cost_multiplier: 1,
+        ics20_withdrawal_base_fee: 24,
+    }
 }
 
 pub(crate) async fn initialize_app_with_storage(

--- a/crates/astria-sequencer/src/app/tests_app.rs
+++ b/crates/astria-sequencer/src/app/tests_app.rs
@@ -199,6 +199,7 @@ async fn app_commit() {
         native_asset_base_denomination: DEFAULT_NATIVE_ASSET_DENOM.to_string(),
         ibc_params: IBCParameters::default(),
         allowed_fee_assets: vec![DEFAULT_NATIVE_ASSET_DENOM.to_owned().into()],
+        fees: default_fees(),
     };
 
     let (mut app, storage) = initialize_app_with_storage(Some(genesis_state), vec![]).await;

--- a/crates/astria-sequencer/src/app/tests_execute_transaction.rs
+++ b/crates/astria-sequencer/src/app/tests_execute_transaction.rs
@@ -283,6 +283,7 @@ async fn app_execute_transaction_validator_update() {
         native_asset_base_denomination: DEFAULT_NATIVE_ASSET_DENOM.to_string(),
         ibc_params: IBCParameters::default(),
         allowed_fee_assets: vec![DEFAULT_NATIVE_ASSET_DENOM.to_owned().into()],
+        fees: default_fees(),
     };
     let mut app = initialize_app(Some(genesis_state), vec![]).await;
 
@@ -321,6 +322,7 @@ async fn app_execute_transaction_ibc_relayer_change_addition() {
         native_asset_base_denomination: DEFAULT_NATIVE_ASSET_DENOM.to_string(),
         allowed_fee_assets: vec![DEFAULT_NATIVE_ASSET_DENOM.to_owned().into()],
         ibc_params: IBCParameters::default(),
+        fees: default_fees(),
     };
     let mut app = initialize_app(Some(genesis_state), vec![]).await;
 
@@ -350,6 +352,7 @@ async fn app_execute_transaction_ibc_relayer_change_deletion() {
         native_asset_base_denomination: DEFAULT_NATIVE_ASSET_DENOM.to_string(),
         allowed_fee_assets: vec![DEFAULT_NATIVE_ASSET_DENOM.to_owned().into()],
         ibc_params: IBCParameters::default(),
+        fees: default_fees(),
     };
     let mut app = initialize_app(Some(genesis_state), vec![]).await;
 
@@ -379,6 +382,7 @@ async fn app_execute_transaction_ibc_relayer_change_invalid() {
         native_asset_base_denomination: DEFAULT_NATIVE_ASSET_DENOM.to_string(),
         allowed_fee_assets: vec![DEFAULT_NATIVE_ASSET_DENOM.to_owned().into()],
         ibc_params: IBCParameters::default(),
+        fees: default_fees(),
     };
     let mut app = initialize_app(Some(genesis_state), vec![]).await;
 
@@ -406,6 +410,7 @@ async fn app_execute_transaction_sudo_address_change() {
         native_asset_base_denomination: DEFAULT_NATIVE_ASSET_DENOM.to_string(),
         ibc_params: IBCParameters::default(),
         allowed_fee_assets: vec![DEFAULT_NATIVE_ASSET_DENOM.to_owned().into()],
+        fees: default_fees(),
     };
     let mut app = initialize_app(Some(genesis_state), vec![]).await;
 
@@ -442,6 +447,7 @@ async fn app_execute_transaction_sudo_address_change_error() {
         native_asset_base_denomination: DEFAULT_NATIVE_ASSET_DENOM.to_string(),
         ibc_params: IBCParameters::default(),
         allowed_fee_assets: vec![DEFAULT_NATIVE_ASSET_DENOM.to_owned().into()],
+        fees: default_fees(),
     };
     let mut app = initialize_app(Some(genesis_state), vec![]).await;
 
@@ -479,6 +485,7 @@ async fn app_execute_transaction_fee_asset_change_addition() {
         native_asset_base_denomination: DEFAULT_NATIVE_ASSET_DENOM.to_string(),
         ibc_params: IBCParameters::default(),
         allowed_fee_assets: vec![DEFAULT_NATIVE_ASSET_DENOM.to_owned().into()],
+        fees: default_fees(),
     };
     let mut app = initialize_app(Some(genesis_state), vec![]).await;
 
@@ -519,6 +526,7 @@ async fn app_execute_transaction_fee_asset_change_removal() {
             DEFAULT_NATIVE_ASSET_DENOM.to_owned().into(),
             test_asset.clone(),
         ],
+        fees: default_fees(),
     };
     let mut app = initialize_app(Some(genesis_state), vec![]).await;
 
@@ -558,6 +566,7 @@ async fn app_execute_transaction_fee_asset_change_invalid() {
         native_asset_base_denomination: DEFAULT_NATIVE_ASSET_DENOM.to_string(),
         ibc_params: IBCParameters::default(),
         allowed_fee_assets: vec![DEFAULT_NATIVE_ASSET_DENOM.to_owned().into()],
+        fees: default_fees(),
     };
     let mut app = initialize_app(Some(genesis_state), vec![]).await;
 
@@ -844,6 +853,7 @@ async fn app_execute_transaction_mint() {
         native_asset_base_denomination: DEFAULT_NATIVE_ASSET_DENOM.to_string(),
         ibc_params: IBCParameters::default(),
         allowed_fee_assets: vec![DEFAULT_NATIVE_ASSET_DENOM.to_owned().into()],
+        fees: default_fees(),
     };
     let mut app = initialize_app(Some(genesis_state), vec![]).await;
 

--- a/crates/astria-sequencer/src/bridge/component.rs
+++ b/crates/astria-sequencer/src/bridge/component.rs
@@ -10,11 +10,7 @@ use tracing::instrument;
 use super::state_ext::StateWriteExt;
 use crate::{
     component::Component,
-    genesis::{
-        GenesisState,
-        BRIDGE_LOCK_BYTE_COST_MULTIPLIER_FIELD_NAME,
-        INIT_BRIDGE_ACCOUNT_BASE_FEE_FIELD_NAME,
-    },
+    genesis::GenesisState,
 };
 
 #[derive(Default)]
@@ -26,24 +22,8 @@ impl Component for BridgeComponent {
 
     #[instrument(name = "BridgeComponent::init_chain", skip(state))]
     async fn init_chain<S: StateWriteExt>(mut state: S, app_state: &Self::AppState) -> Result<()> {
-        state.put_init_bridge_account_base_fee(
-            *app_state
-                .fees
-                .get(INIT_BRIDGE_ACCOUNT_BASE_FEE_FIELD_NAME)
-                .expect(
-                    "genesis `fees` must contain `init_bridge_account_base_fee`, as it was \
-                     validated during construction",
-                ),
-        );
-        state.put_bridge_lock_byte_cost_multiplier(
-            *app_state
-                .fees
-                .get(BRIDGE_LOCK_BYTE_COST_MULTIPLIER_FIELD_NAME)
-                .expect(
-                    "genesis `fees` must contain `bridge_lock_byte_cost_multiplier`, as it was \
-                     validated during construction",
-                ),
-        );
+        state.put_init_bridge_account_base_fee(app_state.fees.init_bridge_account_base_fee);
+        state.put_bridge_lock_byte_cost_multiplier(app_state.fees.bridge_lock_byte_cost_multiplier);
         Ok(())
     }
 

--- a/crates/astria-sequencer/src/bridge/component.rs
+++ b/crates/astria-sequencer/src/bridge/component.rs
@@ -10,17 +10,12 @@ use tracing::instrument;
 use super::state_ext::StateWriteExt;
 use crate::{
     component::Component,
-    genesis::GenesisState,
+    genesis::{
+        GenesisState,
+        BRIDGE_LOCK_BYTE_COST_MULTIPLIER_FIELD_NAME,
+        INIT_BRIDGE_ACCOUNT_BASE_FEE_FIELD_NAME,
+    },
 };
-
-/// Default base fee for a [`InitBridgeAccountAction`].
-const DEFAULT_INIT_BRIDGE_ACCOUNT_BASE_FEE: u128 = 48;
-
-/// Default multiplier for the cost of a byte in a [`BridgeLockAction`].
-///
-/// Note that the base fee for a [`BridgeLockAction`] is the same as the
-/// base fee for a [`TransferAction`].
-const DEFAULT_BRIDGE_LOCK_BYTE_COST_MULTIPLIER: u128 = 1;
 
 #[derive(Default)]
 pub(crate) struct BridgeComponent;
@@ -31,8 +26,24 @@ impl Component for BridgeComponent {
 
     #[instrument(name = "BridgeComponent::init_chain", skip(state))]
     async fn init_chain<S: StateWriteExt>(mut state: S, app_state: &Self::AppState) -> Result<()> {
-        state.put_init_bridge_account_base_fee(DEFAULT_INIT_BRIDGE_ACCOUNT_BASE_FEE);
-        state.put_bridge_lock_byte_cost_multiplier(DEFAULT_BRIDGE_LOCK_BYTE_COST_MULTIPLIER);
+        state.put_init_bridge_account_base_fee(
+            *app_state
+                .fees
+                .get(INIT_BRIDGE_ACCOUNT_BASE_FEE_FIELD_NAME)
+                .expect(
+                    "genesis `fees` must contain `init_bridge_account_base_fee`, as it was \
+                     validated during construction",
+                ),
+        );
+        state.put_bridge_lock_byte_cost_multiplier(
+            *app_state
+                .fees
+                .get(BRIDGE_LOCK_BYTE_COST_MULTIPLIER_FIELD_NAME)
+                .expect(
+                    "genesis `fees` must contain `bridge_lock_byte_cost_multiplier`, as it was \
+                     validated during construction",
+                ),
+        );
         Ok(())
     }
 

--- a/crates/astria-sequencer/src/genesis.rs
+++ b/crates/astria-sequencer/src/genesis.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use astria_core::primitive::v1::{
     asset,
     Address,
@@ -24,8 +22,17 @@ pub(crate) struct GenesisState {
     pub(crate) ibc_params: IBCParameters,
     #[serde(deserialize_with = "deserialize_assets")]
     pub(crate) allowed_fee_assets: Vec<asset::Denom>,
-    #[serde(deserialize_with = "deserialize_fees")]
-    pub(crate) fees: HashMap<String, u128>,
+    pub(crate) fees: Fees,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct Fees {
+    pub(crate) transfer_base_fee: u128,
+    pub(crate) sequence_base_fee: u128,
+    pub(crate) sequence_byte_cost_multiplier: u128,
+    pub(crate) init_bridge_account_base_fee: u128,
+    pub(crate) bridge_lock_byte_cost_multiplier: u128,
+    pub(crate) ics20_withdrawal_base_fee: u128,
 }
 
 #[derive(Debug, Deserialize)]
@@ -76,40 +83,6 @@ where
     Ok(strings.into_iter().map(asset::Denom::from).collect())
 }
 
-pub(crate) const TRANSFER_BASE_FEE_FIELD_NAME: &str = "transfer_base_fee";
-pub(crate) const SEQUENCE_BASE_FEE_FIELD_NAME: &str = "sequence_base_fee";
-pub(crate) const SEQUENCE_BYTE_COST_MULTIPLIER_FIELD_NAME: &str = "sequence_byte_cost_multiplier";
-pub(crate) const INIT_BRIDGE_ACCOUNT_BASE_FEE_FIELD_NAME: &str = "init_bridge_account_base_fee";
-pub(crate) const BRIDGE_LOCK_BYTE_COST_MULTIPLIER_FIELD_NAME: &str =
-    "bridge_lock_byte_cost_multiplier";
-pub(crate) const ICS20_WITHDRAWAL_BASE_FEE_FIELD_NAME: &str = "ics20_withdrawal_base_fee";
-
-fn deserialize_fees<'de, D>(deserializer: D) -> Result<HashMap<String, u128>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let fees: HashMap<String, u128> = serde::Deserialize::deserialize(deserializer)?;
-
-    let expected_fees = [
-        TRANSFER_BASE_FEE_FIELD_NAME,
-        SEQUENCE_BASE_FEE_FIELD_NAME,
-        SEQUENCE_BYTE_COST_MULTIPLIER_FIELD_NAME,
-        INIT_BRIDGE_ACCOUNT_BASE_FEE_FIELD_NAME,
-        BRIDGE_LOCK_BYTE_COST_MULTIPLIER_FIELD_NAME,
-        ICS20_WITHDRAWAL_BASE_FEE_FIELD_NAME,
-    ];
-
-    for fee in expected_fees {
-        if !fees.contains_key(fee) {
-            return Err(serde::de::Error::custom(format!(
-                "genesis `fees` field missing the following expected key: {fee}"
-            )));
-        }
-    }
-
-    Ok(fees)
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
@@ -153,48 +126,5 @@ mod test {
           "#;
         let genesis: GenesisState = serde_json::from_str(genesis_str).unwrap();
         assert_eq!(genesis.ibc_relayer_addresses.len(), 2);
-    }
-
-    #[test]
-    fn genesis_deserialize_fees_invalid() {
-        let genesis_str: &str = r#"{
-            "accounts": [
-              {
-                "address": "1c0c490f1b5528d8173c5de46d131160e4b2c0c3",
-                "balance": 1000000000000000000
-              },
-              {
-                "address": "34fec43c7fcab9aef3b3cf8aba855e41ee69ca3a",
-                "balance": 1000000000000000000
-              },
-              {
-                "address": "60709e2d391864b732b4f0f51e387abb76743871",
-                "balance": 1000000000000000000
-              }
-            ],
-            "authority_sudo_address": "1c0c490f1b5528d8173c5de46d131160e4b2c0c3",
-            "ibc_sudo_address": "1c0c490f1b5528d8173c5de46d131160e4b2c0c3",
-            "ibc_relayer_addresses": ["1c0c490f1b5528d8173c5de46d131160e4b2c0c3", "34fec43c7fcab9aef3b3cf8aba855e41ee69ca3a"],
-            "ibc_params": {
-                "ibc_enabled": true,
-                "inbound_ics20_transfers_enabled": true,
-                "outbound_ics20_transfers_enabled": true
-            },
-            "fees": {
-                "transfer_base_fee": 12,
-                "sequence_base_fee": 32,
-                "sequence_byte_cost_multiplier": 1,
-                "init_bridge_account_base_fee": 48,
-                "bridge_lock_byte_cost_multiplier": 1
-            },
-            "native_asset_base_denomination": "nria",
-            "allowed_fee_assets": ["nria"]
-          }
-          "#;
-        let err = serde_json::from_str::<GenesisState>(genesis_str).unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("missing the following expected key: ics20_withdrawal_base_fee")
-        );
     }
 }

--- a/crates/astria-sequencer/src/ibc/component.rs
+++ b/crates/astria-sequencer/src/ibc/component.rs
@@ -16,14 +16,15 @@ use tracing::instrument;
 
 use crate::{
     component::Component,
-    genesis::GenesisState,
+    genesis::{
+        GenesisState,
+        ICS20_WITHDRAWAL_BASE_FEE_FIELD_NAME,
+    },
     ibc::{
         host_interface::AstriaHost,
         state_ext::StateWriteExt,
     },
 };
-
-pub(crate) const DEFAULT_ICS20_WITHDRAWAL_FEE: u128 = 24;
 
 #[derive(Default)]
 pub(crate) struct IbcComponent;
@@ -51,7 +52,15 @@ impl Component for IbcComponent {
         }
 
         state
-            .put_ics20_withdrawal_base_fee(DEFAULT_ICS20_WITHDRAWAL_FEE)
+            .put_ics20_withdrawal_base_fee(
+                *app_state
+                    .fees
+                    .get(ICS20_WITHDRAWAL_BASE_FEE_FIELD_NAME)
+                    .expect(
+                        "genesis `fees` must contain `ics20_withdrawal_base_fee`, as it was \
+                         validated during construction",
+                    ),
+            )
             .context("failed to put ics20 withdrawal base fee")?;
         Ok(())
     }

--- a/crates/astria-sequencer/src/ibc/component.rs
+++ b/crates/astria-sequencer/src/ibc/component.rs
@@ -16,10 +16,7 @@ use tracing::instrument;
 
 use crate::{
     component::Component,
-    genesis::{
-        GenesisState,
-        ICS20_WITHDRAWAL_BASE_FEE_FIELD_NAME,
-    },
+    genesis::GenesisState,
     ibc::{
         host_interface::AstriaHost,
         state_ext::StateWriteExt,
@@ -52,15 +49,7 @@ impl Component for IbcComponent {
         }
 
         state
-            .put_ics20_withdrawal_base_fee(
-                *app_state
-                    .fees
-                    .get(ICS20_WITHDRAWAL_BASE_FEE_FIELD_NAME)
-                    .expect(
-                        "genesis `fees` must contain `ics20_withdrawal_base_fee`, as it was \
-                         validated during construction",
-                    ),
-            )
+            .put_ics20_withdrawal_base_fee(app_state.fees.ics20_withdrawal_base_fee)
             .context("failed to put ics20 withdrawal base fee")?;
         Ok(())
     }

--- a/crates/astria-sequencer/src/sequence/component.rs
+++ b/crates/astria-sequencer/src/sequence/component.rs
@@ -10,11 +10,7 @@ use tracing::instrument;
 use super::state_ext::StateWriteExt;
 use crate::{
     component::Component,
-    genesis::{
-        GenesisState,
-        SEQUENCE_BASE_FEE_FIELD_NAME,
-        SEQUENCE_BYTE_COST_MULTIPLIER_FIELD_NAME,
-    },
+    genesis::GenesisState,
 };
 
 #[derive(Default)]
@@ -26,21 +22,9 @@ impl Component for SequenceComponent {
 
     #[instrument(name = "SequenceComponent::init_chain", skip(state))]
     async fn init_chain<S: StateWriteExt>(mut state: S, app_state: &Self::AppState) -> Result<()> {
-        state.put_sequence_action_base_fee(
-            *app_state.fees.get(SEQUENCE_BASE_FEE_FIELD_NAME).expect(
-                "genesis `fees` must contain `sequence_base_fee`, as it was validated during \
-                 construction",
-            ),
-        );
-        state.put_sequence_action_byte_cost_multiplier(
-            *app_state
-                .fees
-                .get(SEQUENCE_BYTE_COST_MULTIPLIER_FIELD_NAME)
-                .expect(
-                    "genesis `fees` must contain `sequence_byte_cost_multiplier`, as it was \
-                     validated during construction",
-                ),
-        );
+        state.put_sequence_action_base_fee(app_state.fees.sequence_base_fee);
+        state
+            .put_sequence_action_byte_cost_multiplier(app_state.fees.sequence_byte_cost_multiplier);
         Ok(())
     }
 

--- a/crates/astria-sequencer/src/sequence/component.rs
+++ b/crates/astria-sequencer/src/sequence/component.rs
@@ -10,14 +10,12 @@ use tracing::instrument;
 use super::state_ext::StateWriteExt;
 use crate::{
     component::Component,
-    genesis::GenesisState,
+    genesis::{
+        GenesisState,
+        SEQUENCE_BASE_FEE_FIELD_NAME,
+        SEQUENCE_BYTE_COST_MULTIPLIER_FIELD_NAME,
+    },
 };
-
-/// Default base fee for a [`SequenceAction`].
-const DEFAULT_SEQUENCE_ACTION_BASE_FEE: u128 = 32;
-
-/// Default multiplier for the cost of a byte in a [`SequenceAction`].
-const DEFAULT_SEQUENCE_ACTION_BYTE_COST_MULTIPLIER: u128 = 1;
 
 #[derive(Default)]
 pub(crate) struct SequenceComponent;
@@ -28,9 +26,21 @@ impl Component for SequenceComponent {
 
     #[instrument(name = "SequenceComponent::init_chain", skip(state))]
     async fn init_chain<S: StateWriteExt>(mut state: S, app_state: &Self::AppState) -> Result<()> {
-        state.put_sequence_action_base_fee(DEFAULT_SEQUENCE_ACTION_BASE_FEE);
-        state
-            .put_sequence_action_byte_cost_multiplier(DEFAULT_SEQUENCE_ACTION_BYTE_COST_MULTIPLIER);
+        state.put_sequence_action_base_fee(
+            *app_state.fees.get(SEQUENCE_BASE_FEE_FIELD_NAME).expect(
+                "genesis `fees` must contain `sequence_base_fee`, as it was validated during \
+                 construction",
+            ),
+        );
+        state.put_sequence_action_byte_cost_multiplier(
+            *app_state
+                .fees
+                .get(SEQUENCE_BYTE_COST_MULTIPLIER_FIELD_NAME)
+                .expect(
+                    "genesis `fees` must contain `sequence_byte_cost_multiplier`, as it was \
+                     validated during construction",
+                ),
+        );
         Ok(())
     }
 

--- a/crates/astria-sequencer/src/service/consensus.rs
+++ b/crates/astria-sequencer/src/service/consensus.rs
@@ -245,6 +245,7 @@ mod test {
 
     use super::*;
     use crate::{
+        app::test_utils::default_fees,
         asset::get_native_asset,
         mempool::{
             Mempool,
@@ -470,6 +471,7 @@ mod test {
                 native_asset_base_denomination: DEFAULT_NATIVE_ASSET_DENOM.to_string(),
                 ibc_params: penumbra_ibc::params::IBCParameters::default(),
                 allowed_fee_assets: vec![DEFAULT_NATIVE_ASSET_DENOM.to_owned().into()],
+                fees: default_fees(),
             }
         }
     }

--- a/crates/astria-sequencer/src/transaction/mod.rs
+++ b/crates/astria-sequencer/src/transaction/mod.rs
@@ -497,9 +497,7 @@ mod test {
         let snapshot = storage.latest_snapshot();
         let mut state_tx = StateDelta::new(snapshot);
 
-        state_tx
-            .put_transfer_base_fee(crate::accounts::component::DEFAULT_TRANSFER_BASE_FEE)
-            .unwrap();
+        state_tx.put_transfer_base_fee(12).unwrap();
         state_tx.put_sequence_action_base_fee(0);
         state_tx.put_sequence_action_byte_cost_multiplier(1);
         state_tx.put_ics20_withdrawal_base_fee(1).unwrap();
@@ -565,9 +563,7 @@ mod test {
         let snapshot = storage.latest_snapshot();
         let mut state_tx = StateDelta::new(snapshot);
 
-        state_tx
-            .put_transfer_base_fee(crate::accounts::component::DEFAULT_TRANSFER_BASE_FEE)
-            .unwrap();
+        state_tx.put_transfer_base_fee(12).unwrap();
         state_tx.put_sequence_action_base_fee(0);
         state_tx.put_sequence_action_byte_cost_multiplier(1);
         state_tx.put_ics20_withdrawal_base_fee(1).unwrap();

--- a/crates/astria-sequencer/test-genesis-app-state.json
+++ b/crates/astria-sequencer/test-genesis-app-state.json
@@ -21,6 +21,14 @@
     "inbound_ics20_transfers_enabled": true,
     "outbound_ics20_transfers_enabled": true
   },
+  "fees": {
+    "transfer_base_fee": 12,
+    "sequence_base_fee": 32,
+    "sequence_byte_cost_multiplier": 1,
+    "init_bridge_account_base_fee": 48,
+    "bridge_lock_byte_cost_multiplier": 1,
+    "ics20_withdrawal_base_fee": 24
+  },
   "native_asset_base_denomination": "nria",
   "allowed_fee_assets": ["nria"]
 }


### PR DESCRIPTION
## Summary
instead of having hard coded default fee values, the fees now must be set in the genesis file. this makes it more explicit as to how the network is configured.

## Background
related to https://github.com/astriaorg/astria/issues/1003

## Changes
- update genesis app state to contain required fees
- set these fees in state in `init_chain`

## Testing
unit tests

## Breaking Changelist
- genesis app state must now contain fees

## Related Issues

related to https://github.com/astriaorg/astria/issues/1003
