### PR TITLE
feat(proto): update ics20 withdrawal to have a memo field

### DIFF
--- a/crates/astria-core/src/generated/astria.protocol.transactions.v1alpha1.rs
+++ b/crates/astria-core/src/generated/astria.protocol.transactions.v1alpha1.rs
@@ -214,6 +214,9 @@ pub struct Ics20Withdrawal {
     /// the asset used to pay the transaction fee
     #[prost(bytes = "vec", tag = "8")]
     pub fee_asset_id: ::prost::alloc::vec::Vec<u8>,
+    /// a memo to include with the transfer
+    #[prost(string, tag = "9")]
+    pub memo: ::prost::alloc::string::String,
 }
 impl ::prost::Name for Ics20Withdrawal {
     const NAME: &'static str = "Ics20Withdrawal";

--- a/crates/astria-core/src/protocol/transaction/v1alpha1/action.rs
+++ b/crates/astria-core/src/protocol/transaction/v1alpha1/action.rs
@@ -676,6 +676,8 @@ pub struct Ics20Withdrawal {
     source_channel: ChannelId,
     // the asset to use for fee payment.
     fee_asset_id: asset::Id,
+    // a memo to include with the transfer
+    memo: String,
 }
 
 impl Ics20Withdrawal {
@@ -720,13 +722,18 @@ impl Ics20Withdrawal {
     }
 
     #[must_use]
+    pub fn memo(&self) -> &str {
+        &self.memo
+    }
+
+    #[must_use]
     pub fn to_fungible_token_packet_data(&self) -> FungibleTokenPacketData {
         FungibleTokenPacketData {
             amount: self.amount.to_string(),
             denom: self.denom.to_string(),
             sender: self.return_address.to_string(),
             receiver: self.destination_chain_address.clone(),
-            memo: String::new(),
+            memo: self.memo.clone(),
         }
     }
 
@@ -741,6 +748,7 @@ impl Ics20Withdrawal {
             timeout_time: self.timeout_time,
             source_channel: self.source_channel.to_string(),
             fee_asset_id: self.fee_asset_id.get().to_vec(),
+            memo: self.memo.clone(),
         }
     }
 
@@ -755,6 +763,7 @@ impl Ics20Withdrawal {
             timeout_time: self.timeout_time,
             source_channel: self.source_channel.to_string(),
             fee_asset_id: self.fee_asset_id.get().to_vec(),
+            memo: self.memo,
         }
     }
 
@@ -789,6 +798,7 @@ impl Ics20Withdrawal {
                 .map_err(Ics20WithdrawalError::invalid_source_channel)?,
             fee_asset_id: asset::Id::try_from_slice(&proto.fee_asset_id)
                 .map_err(Ics20WithdrawalError::invalid_fee_asset_id)?,
+            memo: proto.memo,
         })
     }
 }

--- a/crates/astria-sequencer/test-genesis-app-state.json
+++ b/crates/astria-sequencer/test-genesis-app-state.json
@@ -21,6 +21,14 @@
     "inbound_ics20_transfers_enabled": true,
     "outbound_ics20_transfers_enabled": true
   },
+  "fees": {
+    "transfer_base_fee": 12,
+    "sequence_base_fee": 32,
+    "sequence_byte_cost_multiplier": 1,
+    "init_bridge_account_base_fee": 48,
+    "bridge_lock_byte_cost_multiplier": 1,
+    "ics20_withdrawal_base_fee": 24
+  },
   "native_asset_base_denomination": "nria",
   "allowed_fee_assets": ["nria"]
 }

--- a/crates/astria-sequencer/test-genesis-app-state.json
+++ b/crates/astria-sequencer/test-genesis-app-state.json
@@ -21,14 +21,6 @@
     "inbound_ics20_transfers_enabled": true,
     "outbound_ics20_transfers_enabled": true
   },
-  "fees": {
-    "transfer_base_fee": 12,
-    "sequence_base_fee": 32,
-    "sequence_byte_cost_multiplier": 1,
-    "init_bridge_account_base_fee": 48,
-    "bridge_lock_byte_cost_multiplier": 1,
-    "ics20_withdrawal_base_fee": 24
-  },
   "native_asset_base_denomination": "nria",
   "allowed_fee_assets": ["nria"]
 }

--- a/proto/protocolapis/astria/protocol/transactions/v1alpha1/types.proto
+++ b/proto/protocolapis/astria/protocol/transactions/v1alpha1/types.proto
@@ -120,6 +120,8 @@ message Ics20Withdrawal {
   string source_channel = 7;
   // the asset used to pay the transaction fee
   bytes fee_asset_id = 8;
+  // a memo to include with the transfer
+  string memo = 9;
 }
 
 message IbcHeight {


### PR DESCRIPTION
## Summary
update ics20 withdrawal to have a memo field as we'll need it for bridging (and good to have in general)

## Changes
- update ics20 withdrawal to have a memo field

## Testing
n/a

## Breaking Changelist
- `Ics20Withdrawal` now contains a `memo` field
