### PR TITLE
metrics(relayer)!: make per submission gauges into histograms

### DIFF
--- a/crates/astria-sequencer-relayer/src/metrics_init.rs
+++ b/crates/astria-sequencer-relayer/src/metrics_init.rs
@@ -47,17 +47,24 @@ pub fn register() {
         "The height of the highest sequencer block successfully submitted to Celestia"
     );
 
-    describe_gauge!(
+    describe_histogram!(
         BLOCKS_PER_CELESTIA_TX,
         Unit::Count,
-        "The number of Astria blocks included in the last Celestia submission"
+        "The number of Astria blocks per Celestia submission"
     );
 
-    describe_gauge!(
+    describe_histogram!(
         BLOBS_PER_CELESTIA_TX,
         Unit::Count,
-        "The number of blobs (Astria blobs converted to Celestia blobs) included in the last \
-         Celestia submission"
+        "The number of blobs (Astria Sequencer blocks converted to Celestia blobs) per Celestia \
+         submission"
+    );
+
+    describe_histogram!(
+        BYTES_PER_CELESTIA_TX,
+        Unit::Bytes,
+        "The total number of payload bytes (Astria Sequencer blocks converted to Celestia blobs) \
+         per Celestia submission"
     );
 
     describe_histogram!(
@@ -71,12 +78,6 @@ pub fn register() {
         Unit::Microseconds,
         "The time it takes to create a new payload for submitting to Celestia (encoding to \
          protobuf, compression, creating blobs)"
-    );
-
-    describe_gauge!(
-        TOTAL_BLOB_DATA_SIZE_FOR_ASTRIA_BLOCK,
-        Unit::Bytes,
-        "The size of all compressed data for all `blob.data`s in an Astria block"
     );
 
     describe_gauge!(
@@ -107,6 +108,8 @@ pub const BLOCKS_PER_CELESTIA_TX: &str =
 
 pub const BLOBS_PER_CELESTIA_TX: &str = concat!(env!("CARGO_CRATE_NAME"), "_blobs_per_celestia_tx");
 
+pub const BYTES_PER_CELESTIA_TX: &str = concat!(env!("CARGO_CRATE_NAME"), "_bytes_per_celestia_tx");
+
 pub const CELESTIA_PAYLOAD_CREATION_LATENCY: &str = concat!(
     env!("CARGO_CRATE_NAME"),
     "_celestia_payload_creation_latency"
@@ -128,10 +131,6 @@ pub const SEQUENCER_HEIGHT_FETCH_FAILURE_COUNT: &str = concat!(
 pub const SEQUENCER_SUBMISSION_HEIGHT: &str =
     concat!(env!("CARGO_CRATE_NAME"), "_sequencer_submission_height");
 
-pub const TOTAL_BLOB_DATA_SIZE_FOR_ASTRIA_BLOCK: &str = concat!(
-    env!("CARGO_CRATE_NAME"),
-    "_total_blob_data_size_for_astria_block"
-);
 pub const COMPRESSION_RATIO_FOR_ASTRIA_BLOCK: &str = concat!(
     env!("CARGO_CRATE_NAME"),
     "_compression_ratio_for_astria_block"

--- a/crates/astria-sequencer-relayer/src/relayer/write/mod.rs
+++ b/crates/astria-sequencer-relayer/src/relayer/write/mod.rs
@@ -286,7 +286,7 @@ async fn submit_blobs(
     // loss
     #[allow(clippy::cast_precision_loss)]
     let compressed_size = data.compressed_size() as f64;
-    metrics::gauge!(metrics_init::TOTAL_BLOB_DATA_SIZE_FOR_ASTRIA_BLOCK).set(compressed_size);
+    metrics::histogram!(metrics_init::BYTES_PER_CELESTIA_TX).record(compressed_size);
 
     metrics::gauge!(metrics_init::COMPRESSION_RATIO_FOR_ASTRIA_BLOCK).set(data.compression_ratio());
 
@@ -297,12 +297,12 @@ async fn submit_blobs(
     // allow: the number of blocks should always be low enough to not cause precision loss
     #[allow(clippy::cast_precision_loss)]
     let blocks_per_celestia_tx = data.num_blocks() as f64;
-    metrics::gauge!(crate::metrics_init::BLOCKS_PER_CELESTIA_TX).set(blocks_per_celestia_tx);
+    metrics::histogram!(crate::metrics_init::BLOCKS_PER_CELESTIA_TX).record(blocks_per_celestia_tx);
 
     // allow: the number of blobs should always be low enough to not cause precision loss
     #[allow(clippy::cast_precision_loss)]
     let blobs_per_celestia_tx = data.num_blobs() as f64;
-    metrics::gauge!(crate::metrics_init::BLOBS_PER_CELESTIA_TX).set(blobs_per_celestia_tx);
+    metrics::histogram!(crate::metrics_init::BLOBS_PER_CELESTIA_TX).record(blobs_per_celestia_tx);
 
     let largest_sequencer_height = data.greatest_sequencer_height();
     let blobs = data.into_blobs();


### PR DESCRIPTION
## Summary
Changes various *per_tx metrics gauges into histograms.

## Background
Making the *per_tx metrics into histograms will allow summing over all Celestia submissions and will give a running total of bytes, blobs, and blocks submitted to Celestia.

## Changes
- Changed `astria_sequencer_relayer_blobs_per_celestia_tx` from `gauge` to `histogram`
- Changed `astria_sequencer_relayer_blocks_per_celestia_tx` from `gauge` to `histogram`
- Removed `astria_sequencer_relayer_total_blob_data_size_for_astria_block`
- Added histogram `astria_sequencer_relayer_bytes_per_celestia_tx`

## Testing
Metrics need to be tested by observing them.

## Metrics
- Added histogram `astria_sequencer_relayer_bytes_per_celestia_tx`

## Breaking Changelist
- Changed metric types, removed a metric, added a metric (see above)