### PR TITLE
fix(conductor): retry blob fetch on request timeout

### DIFF
--- a/crates/astria-conductor/src/celestia/fetch.rs
+++ b/crates/astria-conductor/src/celestia/fetch.rs
@@ -146,7 +146,10 @@ impl<'a> BackoffStrategy<'a, jsonrpsee::core::Error> for FetchBlobsRetryStrategy
 }
 
 fn should_retry(error: &jsonrpsee::core::Error) -> bool {
-    matches!(error, jsonrpsee::core::Error::Transport(_))
+    matches!(
+        error,
+        jsonrpsee::core::Error::Transport(_) | jsonrpsee::core::Error::RequestTimeout,
+    )
 }
 
 fn is_blob_not_found(error: &jsonrpsee::core::Error) -> bool {


### PR DESCRIPTION
## Summary
Fixes celestia-blob-fetch logic to also retry on request timeout.

## Background
jsonrpsee has a dedicated request timeout error variant that is different from the underlying transport failing. We have to take it into account when determining whether to retry a blob fetch or not.

## Changes
- added `jsonrpsee::core::Error::RequestTimeout` to the list of errors for which conductor retries fetching celestia blob

## Testing
Needs to be tested in a dev environment. Very difficult to reproduce the actual jsonrpsee error. 