### PR TITLE
feat(telemetry): register metrics via callback

### DIFF
--- a/crates/astria-composer/src/main.rs
+++ b/crates/astria-composer/src/main.rs
@@ -38,10 +38,9 @@ async fn main() -> ExitCode {
     if !cfg.no_metrics {
         telemetry_conf = telemetry_conf
             .metrics_addr(&cfg.metrics_http_listener_addr)
-            .service_name(env!("CARGO_PKG_NAME"));
+            .service_name(env!("CARGO_PKG_NAME"))
+            .register_metrics(metrics_init::register);
     }
-
-    metrics_init::register();
 
     if let Err(e) = telemetry_conf
         .try_init()

--- a/crates/astria-conductor/src/main.rs
+++ b/crates/astria-conductor/src/main.rs
@@ -45,7 +45,8 @@ async fn main() -> ExitCode {
     if !cfg.no_metrics {
         telemetry_conf = telemetry_conf
             .metrics_addr(&cfg.metrics_http_listener_addr)
-            .service_name(env!("CARGO_PKG_NAME"));
+            .service_name(env!("CARGO_PKG_NAME"))
+            .register_metrics(|| {}); // conductor currently has no metrics
     }
 
     if let Err(e) = telemetry_conf

--- a/crates/astria-sequencer-relayer/src/main.rs
+++ b/crates/astria-sequencer-relayer/src/main.rs
@@ -35,9 +35,9 @@ async fn main() -> ExitCode {
     if !cfg.no_metrics {
         telemetry_conf = telemetry_conf
             .metrics_addr(&cfg.metrics_http_listener_addr)
-            .service_name(env!("CARGO_PKG_NAME"));
+            .service_name(env!("CARGO_PKG_NAME"))
+            .register_metrics(metrics_init::register);
     }
-    metrics_init::register();
 
     if let Err(e) = telemetry_conf
         .try_init()

--- a/crates/astria-sequencer/src/main.rs
+++ b/crates/astria-sequencer/src/main.rs
@@ -36,9 +36,9 @@ async fn main() -> ExitCode {
     if !cfg.no_metrics {
         telemetry_conf = telemetry_conf
             .metrics_addr(&cfg.metrics_http_listener_addr)
-            .service_name(env!("CARGO_PKG_NAME"));
+            .service_name(env!("CARGO_PKG_NAME"))
+            .register_metrics(metrics_init::register);
     }
-    metrics_init::register();
 
     if let Err(e) = telemetry_conf
         .try_init()


### PR DESCRIPTION
## Summary
Register metrics for a service through a callback on the telemetry builder.

## Background
`astria_telemetry::Config` should be the central entry point to configure telemetry and metrics. Before this patch the metrics provider, buckets, and global labels were set through config, but actual metrics specific outside of it. With this patch this is done in one step.

## Changes
- add `Config::register_metrics` on telemetry builder
- change all services to pass their initialization function to it. 

## Testing
Must be observed in a dev cluster.