### PR TITLE
fix(sequencer): fix ibc prefix conversion

### DIFF
--- a/crates/astria-sequencer/src/ibc/ics20_transfer.rs
+++ b/crates/astria-sequencer/src/ibc/ics20_transfer.rs
@@ -244,7 +244,13 @@ impl AppHandlerExecute for Ics20Transfer {
         .await
         {
             Ok(()) => TokenTransferAcknowledgement::success(),
-            Err(e) => TokenTransferAcknowledgement::Error(e.to_string()),
+            Err(e) => {
+                tracing::debug!(
+                    error = AsRef::<dyn std::error::Error>::as_ref(&e),
+                    "failed to execute ics20 transfer"
+                );
+                TokenTransferAcknowledgement::Error(e.to_string())
+            }
         };
 
         let ack_bytes: Vec<u8> = ack.into();

--- a/crates/astria-sequencer/src/ibc/ics20_transfer.rs
+++ b/crates/astria-sequencer/src/ibc/ics20_transfer.rs
@@ -379,12 +379,9 @@ async fn execute_ics20_transfer_bridge_lock<S: StateWriteExt>(
     Ok(())
 }
 
-async fn convert_denomination<S: StateReadExt>(
+async fn convert_denomination_if_ibc_prefixed<S: StateReadExt>(
     state: &mut S,
     packet_denom: Denom,
-    dest_port: &PortId,
-    dest_channel: &ChannelId,
-    is_refund: bool,
 ) -> Result<Denom> {
     // if the asset is prefixed with `ibc`, the rest of the denomination string is the asset ID,
     // so we need to look up the full trace from storage.
@@ -402,16 +399,20 @@ async fn convert_denomination<S: StateReadExt>(
         packet_denom
     };
 
-    let prefixed_denomination = if is_refund {
-        // we're refunding a token we issued and tried to bridge, but failed
-        denom
-    } else {
-        // we're receiving a token from another chain
-        // create a token with additional prefix and mint it to the recipient
-        format!("{dest_port}/{dest_channel}/{denom}").into()
-    };
+    Ok(denom)
+}
 
-    Ok(prefixed_denomination)
+fn prefix_denomination(
+    packet_denom: Denom,
+    dest_port: &PortId,
+    dest_channel: &ChannelId,
+    is_refund: bool,
+) -> Denom {
+    if is_refund {
+        packet_denom
+    } else {
+        format!("{dest_port}/{dest_channel}/{packet_denom}").into()
+    }
 }
 
 async fn execute_ics20_transfer<S: StateWriteExt>(
@@ -441,26 +442,13 @@ async fn execute_ics20_transfer<S: StateWriteExt>(
     .context("invalid recipient address")?;
     let packet_denom: Denom = packet_data.denom.clone().into();
 
-    // convert denomination from packet form to the correct prefixed or unprefixed form,
-    // depending on whether this is a refund or not
-    let denom = convert_denomination(state, packet_denom, dest_port, dest_channel, is_refund)
+    // convert denomination if it's prefixed with `ibc/`
+    // note: this denomination might have a prefix, but it wasn't prefixed by us right now.
+    let unprefixed_denom = convert_denomination_if_ibc_prefixed(state, packet_denom)
         .await
-        .context("failed to convert denomination")?;
+        .context("failed to convert denomination if ibc/ prefixed")?;
 
-    // check if this is a transfer to a bridge account and
-    // execute relevant state changes if it is
-    execute_ics20_transfer_bridge_lock(
-        state,
-        &recipient,
-        &denom,
-        packet_amount,
-        packet_data.memo.clone(),
-        is_refund,
-    )
-    .await
-    .context("failed to execute ics20 transfer to bridge account")?;
-
-    let is_prefixed = is_prefixed(source_port, source_channel, &denom);
+    let is_prefixed = is_prefixed(source_port, source_channel, &unprefixed_denom);
     let is_source = if is_refund {
         // we are the source if the denom is not prefixed by source_port/source_channel
         !is_prefixed
@@ -469,13 +457,30 @@ async fn execute_ics20_transfer<S: StateWriteExt>(
         is_prefixed
     };
 
+    // prefix the denomination with the destination port and channel if not a refund
+    let prefixed_denomination =
+        prefix_denomination(unprefixed_denom.clone(), dest_port, dest_channel, is_refund);
+
+    // check if this is a transfer to a bridge account and
+    // execute relevant state changes if it is
+    execute_ics20_transfer_bridge_lock(
+        state,
+        &recipient,
+        &prefixed_denomination,
+        packet_amount,
+        packet_data.memo.clone(),
+        is_refund,
+    )
+    .await
+    .context("failed to execute ics20 transfer to bridge account")?;
+
     if is_source {
         // the asset being transferred in is an asset that originated from astria
         // subtract balance from escrow account and transfer to user
 
         // strip the prefix from the denom, as we're back on the source chain
         // note: if this is a refund, this is a no-op.
-        let denom = denom.to_base_denom();
+        let denom = unprefixed_denom.to_base_denom();
 
         let escrow_channel = if is_refund {
             source_channel
@@ -507,17 +512,17 @@ async fn execute_ics20_transfer<S: StateWriteExt>(
     } else {
         // register denomination in global ID -> denom map if it's not already there
         if !state
-            .has_ibc_asset(denom.id())
+            .has_ibc_asset(prefixed_denomination.id())
             .await
             .context("failed to check if ibc asset exists in state")?
         {
             state
-                .put_ibc_asset(denom.id(), &denom)
+                .put_ibc_asset(prefixed_denomination.id(), &prefixed_denomination)
                 .context("failed to put IBC asset in storage")?;
         }
 
         state
-            .increase_balance(recipient, denom.id(), packet_amount)
+            .increase_balance(recipient, prefixed_denomination.id(), packet_amount)
             .await
             .context("failed to update user account balance in execute_ics20_transfer")?;
     }
@@ -548,57 +553,32 @@ mod test {
     }
 
     #[tokio::test]
-    async fn convert_denomination_not_ibc_prefixed_not_refund() {
-        let storage = cnidarium::TempStorage::new().await.unwrap();
-        let snapshot = storage.latest_snapshot();
-        let mut state_tx = StateDelta::new(snapshot.clone());
-
+    async fn prefix_denomination_not_refund() {
         let packet_denom = Denom::from("asset".to_string());
         let dest_port = "transfer".to_string().parse().unwrap();
         let dest_channel = "channel-99".to_string().parse().unwrap();
         let is_refund = false;
 
-        let denom = convert_denomination(
-            &mut state_tx,
-            packet_denom,
-            &dest_port,
-            &dest_channel,
-            is_refund,
-        )
-        .await
-        .expect("valid convert_denomination call");
+        let denom = prefix_denomination(packet_denom, &dest_port, &dest_channel, is_refund);
         let expected = Denom::from("transfer/channel-99/asset".to_string());
 
         assert_eq!(denom, expected);
     }
 
     #[tokio::test]
-    async fn convert_denomination_not_ibc_prefixed_refund() {
-        let storage = cnidarium::TempStorage::new().await.unwrap();
-        let snapshot = storage.latest_snapshot();
-        let mut state_tx = StateDelta::new(snapshot.clone());
-
+    async fn prefix_denomination_refund() {
         let packet_denom = Denom::from("asset".to_string());
         let dest_port = "transfer".to_string().parse().unwrap();
         let dest_channel = "channel-99".to_string().parse().unwrap();
         let is_refund = true;
 
         let expected = packet_denom.clone();
-        let denom = convert_denomination(
-            &mut state_tx,
-            packet_denom,
-            &dest_port,
-            &dest_channel,
-            is_refund,
-        )
-        .await
-        .expect("valid convert_denomination call");
-
+        let denom = prefix_denomination(packet_denom, &dest_port, &dest_channel, is_refund);
         assert_eq!(denom, expected);
     }
 
     #[tokio::test]
-    async fn convert_denomination_ibc_prefixed_not_refund() {
+    async fn convert_denomination_if_ibc_prefixed_with_prefix() {
         let storage = cnidarium::TempStorage::new().await.unwrap();
         let snapshot = storage.latest_snapshot();
         let mut state_tx = StateDelta::new(snapshot.clone());
@@ -607,52 +587,26 @@ mod test {
         state_tx
             .put_ibc_asset(denom_trace.id(), &denom_trace)
             .unwrap();
-
-        let packet_denom = format!("ibc/{}", hex::encode(denom_trace.id().as_ref())).into();
-        let dest_port = "transfer".to_string().parse().unwrap();
-        let dest_channel = "channel-99".to_string().parse().unwrap();
-        let is_refund = false;
-
-        let denom = convert_denomination(
-            &mut state_tx,
-            packet_denom,
-            &dest_port,
-            &dest_channel,
-            is_refund,
-        )
-        .await
-        .expect("valid convert_denomination call");
-        let expected = Denom::from("transfer/channel-99/asset".to_string());
-
-        assert_eq!(denom, expected);
-    }
-
-    #[tokio::test]
-    async fn convert_denomination_ibc_prefixed_refund() {
-        let storage = cnidarium::TempStorage::new().await.unwrap();
-        let snapshot = storage.latest_snapshot();
-        let mut state_tx = StateDelta::new(snapshot.clone());
-
-        let denom_trace = Denom::from("asset".to_string());
-        state_tx
-            .put_ibc_asset(denom_trace.id(), &denom_trace)
-            .unwrap();
-
-        let packet_denom = format!("ibc/{}", hex::encode(denom_trace.id().as_ref())).into();
-        let dest_port = "transfer".to_string().parse().unwrap();
-        let dest_channel = "channel-99".to_string().parse().unwrap();
-        let is_refund = true;
 
         let expected = denom_trace.clone();
-        let denom = convert_denomination(
-            &mut state_tx,
-            packet_denom,
-            &dest_port,
-            &dest_channel,
-            is_refund,
-        )
-        .await
-        .expect("valid convert_denomination call");
+        let packet_denom = format!("ibc/{}", hex::encode(denom_trace.id().as_ref())).into();
+        let denom = convert_denomination_if_ibc_prefixed(&mut state_tx, packet_denom)
+            .await
+            .unwrap();
+        assert_eq!(denom, expected);
+    }
+
+    #[tokio::test]
+    async fn convert_denomination_if_ibc_prefixed_without_prefix() {
+        let storage = cnidarium::TempStorage::new().await.unwrap();
+        let snapshot = storage.latest_snapshot();
+        let mut state_tx = StateDelta::new(snapshot.clone());
+
+        let packet_denom = Denom::from("asset".to_string());
+        let expected = packet_denom.clone();
+        let denom = convert_denomination_if_ibc_prefixed(&mut state_tx, packet_denom)
+            .await
+            .unwrap();
         assert_eq!(denom, expected);
     }
 
@@ -706,7 +660,7 @@ mod test {
 
         let bridge_address = Address::from([99; 20]);
         let rollup_id = RollupId::from_unhashed_bytes(b"testchainid");
-        let denom: Denom = "nootasset".to_string().into();
+        let denom: Denom = "dest_port/dest_channel/nootasset".to_string().into();
 
         state_tx.put_bridge_account_rollup_id(&bridge_address, &rollup_id);
         state_tx
@@ -759,7 +713,7 @@ mod test {
 
         let bridge_address = Address::from([99; 20]);
         let rollup_id = RollupId::from_unhashed_bytes(b"testchainid");
-        let denom: Denom = "nootasset".to_string().into();
+        let denom: Denom = "dest_port/dest_channel/nootasset".to_string().into();
 
         state_tx.put_bridge_account_rollup_id(&bridge_address, &rollup_id);
         state_tx
@@ -797,7 +751,7 @@ mod test {
 
         let bridge_address = Address::from([99; 20]);
         let rollup_id = RollupId::from_unhashed_bytes(b"testchainid");
-        let denom: Denom = "nootasset".to_string().into();
+        let denom: Denom = "dest_port/dest_channel/nootasset".to_string().into();
 
         state_tx.put_bridge_account_rollup_id(&bridge_address, &rollup_id);
         state_tx

--- a/crates/astria-sequencer/src/ibc/ics20_transfer.rs
+++ b/crates/astria-sequencer/src/ibc/ics20_transfer.rs
@@ -394,11 +394,10 @@ async fn convert_denomination<S: StateReadExt>(
             .context("failed to decode ibc/ prefixed id as hex")?
             .try_into()
             .map_err(|_| anyhow::anyhow!("ibc/ prefixed id was not 32 bytes"))?;
-        let denom = state
+        state
             .get_ibc_asset(id_bytes.into())
             .await
-            .context("failed to get denom trace from asset id")?;
-        denom
+            .context("failed to get denom trace from asset id")?
     } else {
         packet_denom
     };
@@ -409,7 +408,7 @@ async fn convert_denomination<S: StateReadExt>(
     } else {
         // we're receiving a token from another chain
         // create a token with additional prefix and mint it to the recipient
-        format!("{dest_port}/{dest_channel}/{}", denom).into()
+        format!("{dest_port}/{dest_channel}/{denom}").into()
     };
 
     Ok(prefixed_denomination)

--- a/crates/astria-sequencer/src/ibc/ics20_transfer.rs
+++ b/crates/astria-sequencer/src/ibc/ics20_transfer.rs
@@ -460,8 +460,12 @@ async fn execute_ics20_transfer<S: StateWriteExt>(
     };
 
     // prefix the denomination with the destination port and channel if not a refund
-    let prefixed_denomination =
-        prefix_denomination(Cow::Borrowed(&unprefixed_denom), dest_port, dest_channel, is_refund);
+    let prefixed_denomination = prefix_denomination(
+        Cow::Borrowed(&unprefixed_denom),
+        dest_port,
+        dest_channel,
+        is_refund,
+    );
 
     // check if this is a transfer to a bridge account and
     // execute relevant state changes if it is
@@ -561,7 +565,12 @@ mod test {
         let dest_channel = "channel-99".to_string().parse().unwrap();
         let is_refund = false;
 
-        let denom = prefix_denomination(Cow::Owned(packet_denom), &dest_port, &dest_channel, is_refund);
+        let denom = prefix_denomination(
+            Cow::Owned(packet_denom),
+            &dest_port,
+            &dest_channel,
+            is_refund,
+        );
         let expected = Denom::from("transfer/channel-99/asset".to_string());
 
         assert_eq!(denom.into_owned(), expected);
@@ -575,7 +584,12 @@ mod test {
         let is_refund = true;
 
         let expected = packet_denom.clone();
-        let denom = prefix_denomination(Cow::Owned(packet_denom), &dest_port, &dest_channel, is_refund);
+        let denom = prefix_denomination(
+            Cow::Owned(packet_denom),
+            &dest_port,
+            &dest_channel,
+            is_refund,
+        );
         assert_eq!(denom.into_owned(), expected);
     }
 


### PR DESCRIPTION
## Summary
prefixes were not being converted correctly for bridge locks, i refactored the ibc prefix conversion to be in its own function and added unit tests for all cases.

## Background
found while testing incoming ibc transfers to a bridge account, the denom was not being prefixed before being compared to the allowed asset ID for the bridge account.

## Changes
- put all conversion from packet denom -> converted ibc'd denom into its own `convert_denomination` function
- this is now called before everything else in `execute_ics20_transfer`, so the correct converted denom should be used

## Testing
unit tests + tested it with a bridge lock via ibc
