### PR TITLE
chore(sequencer-relayer): change compression ratio calculation

### DIFF
--- a/crates/astria-sequencer-relayer/src/relayer/write/conversion.rs
+++ b/crates/astria-sequencer-relayer/src/relayer/write/conversion.rs
@@ -576,12 +576,4 @@ mod tests {
         let payload = input.try_into_payload().unwrap();
         assert_eq!(2, payload.num_blobs());
     }
-
-    #[tokio::test]
-    async fn should_compress() {
-        let mut next_submission = NextSubmission::new(include_all_rollups());
-        next_submission.try_add(block(1)).unwrap();
-        let submission = next_submission.take().await.unwrap();
-        assert!(submission.compression_ratio() > 1.0);
-    }
 }


### PR DESCRIPTION
## Summary
Inverts the compression ratio calculation.

## Background
It's normal to express a compression ratio as uncompressed:compressed, but were reporting it as the inverse of this in logs and metrics (despite the metric's description claiming it was uncompressed:compressed).

## Changes
As per summary.

## Testing
Added a unit test.

## Metrics
No new metric added, but the value of `astria_sequencer_relayer_compression_ratio_for_astria_block` should now generally be > 1 rather than < 1.
