### PR TITLE
fix(conductor): don't exit on bad Sequencer connection

### DIFF
--- a/crates/astria-conductor/src/sequencer/block_stream.rs
+++ b/crates/astria-conductor/src/sequencer/block_stream.rs
@@ -72,17 +72,13 @@ impl Heights {
     /// Sets the latest height observed from sequencer if greater than what was previously set.
     ///
     /// Returns `true` is greater, `false` if not.
-    pub(super) fn set_latest_observed_sequencer_height_if_greater(
-        &mut self,
-        candidate: Height,
-    ) -> bool {
-        let candidate = candidate.value();
-        let current = self
+    pub(super) fn set_latest_observed_sequencer_height_if_greater(&mut self, new: Height) -> bool {
+        let new = new.value();
+        let is_greater = self
             .latest_observed_sequencer_height
-            .get_or_insert(candidate);
-        let is_greater = candidate > *current;
+            .map_or(true, |old| new > old);
         if is_greater {
-            *current = candidate;
+            self.latest_observed_sequencer_height.replace(new);
         }
         is_greater
     }

--- a/crates/astria-conductor/src/sequencer/block_stream.rs
+++ b/crates/astria-conductor/src/sequencer/block_stream.rs
@@ -34,20 +34,21 @@ use crate::sequencer::reporting::ReportFilteredSequencerBlock;
 struct Heights {
     rollup_expects: u64,
     greatest_requested_height: Option<u64>,
-    latest_sequencer_height: u64,
+    latest_observed_sequencer_height: Option<u64>,
     max_ahead: u64,
 }
 
 impl Heights {
     /// Returns the next height to fetch, if any.
     fn next_height_to_fetch(&self) -> Option<u64> {
+        let latest_observed_sequencer_height = self.latest_observed_sequencer_height?;
         let potential_height = match self.greatest_requested_height {
             None => self.rollup_expects,
             Some(greatest_requested_height) => greatest_requested_height.saturating_add(1),
         };
         let not_too_far_ahead =
             potential_height < (self.rollup_expects.saturating_add(self.max_ahead));
-        let height_exists_on_sequencer = potential_height <= self.latest_sequencer_height;
+        let height_exists_on_sequencer = potential_height <= latest_observed_sequencer_height;
         if not_too_far_ahead && height_exists_on_sequencer {
             Some(potential_height)
         } else {
@@ -71,13 +72,19 @@ impl Heights {
     /// Sets the latest height observed from sequencer if greater than what was previously set.
     ///
     /// Returns `true` is greater, `false` if not.
-    pub(super) fn set_latest_observed_if_greater(&mut self, height: Height) -> bool {
-        let height = height.value();
-        let greater = height > self.latest_sequencer_height;
-        if greater {
-            self.latest_sequencer_height = height;
+    pub(super) fn set_latest_observed_sequencer_height_if_greater(
+        &mut self,
+        candidate: Height,
+    ) -> bool {
+        let candidate = candidate.value();
+        let current = self
+            .latest_observed_sequencer_height
+            .get_or_insert(candidate);
+        let is_greater = candidate > *current;
+        if is_greater {
+            *current = candidate;
         }
-        greater
+        is_greater
     }
 
     /// Sets the latest height expected by the rollup if greater than what was previously set.
@@ -109,12 +116,15 @@ impl BlocksFromHeightStream {
     #[instrument(
         skip_all,
         fields(
-            latest_height.observed = %height,
-            latest_height.recorded = %self.heights.latest_sequencer_height,
+            latest_height.received = height.value(),
+            latest_height.recorded = self.heights.latest_observed_sequencer_height,
         )
     )]
     pub(super) fn set_latest_observed_height_if_greater(&mut self, height: Height) {
-        if !self.heights.set_latest_observed_if_greater(height) {
+        if !self
+            .heights
+            .set_latest_observed_sequencer_height_if_greater(height)
+        {
             info!("observed latest sequencer height older or the same as previous; ignoring it");
         }
     }
@@ -135,15 +145,18 @@ impl BlocksFromHeightStream {
         }
     }
 
+    /// Returns a stream of Sequencer Blocks for `rollup_id` and starting from `first_height`.
+    ///
+    /// Note that [`BlocksFromHeightStream::set_latest_observed_height_if_greater`] needs to
+    /// be called after the stream is constructed. Otherwise it will not fetch blocks.
     pub(super) fn new(
         rollup_id: RollupId,
-        rollup_expects: Height,
-        latest_sequencer_height: Height,
+        first_height: Height,
         client: SequencerGrpcClient,
     ) -> Self {
         let heights = Heights {
-            rollup_expects: rollup_expects.value(),
-            latest_sequencer_height: latest_sequencer_height.value(),
+            rollup_expects: first_height.value(),
+            latest_observed_sequencer_height: None,
             greatest_requested_height: None,
             max_ahead: 128,
         };
@@ -271,7 +284,7 @@ mod tests {
         let mut heights = Heights {
             rollup_expects: 5,
             greatest_requested_height: None,
-            latest_sequencer_height: 6,
+            latest_observed_sequencer_height: Some(6),
             max_ahead: 3,
         };
         let next = heights.next_height_to_fetch();
@@ -296,7 +309,7 @@ mod tests {
         let heights = Heights {
             rollup_expects: 4,
             greatest_requested_height: Some(5),
-            latest_sequencer_height: 6,
+            latest_observed_sequencer_height: Some(6),
             max_ahead: 2,
         };
         let next = heights.next_height_to_fetch();
@@ -308,8 +321,20 @@ mod tests {
         let heights = Heights {
             rollup_expects: 4,
             greatest_requested_height: Some(5),
-            latest_sequencer_height: 5,
+            latest_observed_sequencer_height: Some(5),
             max_ahead: 2,
+        };
+        let next = heights.next_height_to_fetch();
+        assert_eq!(None, next);
+    }
+
+    #[test]
+    fn next_height_is_none_if_latest_observed_height_not_set() {
+        let mut heights = Heights {
+            rollup_expects: 5,
+            greatest_requested_height: None,
+            latest_observed_sequencer_height: None,
+            max_ahead: 3,
         };
         let next = heights.next_height_to_fetch();
         assert_eq!(None, next);

--- a/crates/astria-conductor/src/sequencer/block_stream.rs
+++ b/crates/astria-conductor/src/sequencer/block_stream.rs
@@ -330,7 +330,7 @@ mod tests {
 
     #[test]
     fn next_height_is_none_if_latest_observed_height_not_set() {
-        let mut heights = Heights {
+        let heights = Heights {
             rollup_expects: 5,
             greatest_requested_height: None,
             latest_observed_sequencer_height: None,

--- a/crates/astria-conductor/src/sequencer/mod.rs
+++ b/crates/astria-conductor/src/sequencer/mod.rs
@@ -80,31 +80,18 @@ impl Reader {
             sequencer_cometbft_client.stream_latest_height(sequencer_block_time)
         };
 
-        let latest_height = match latest_height_stream.next().await {
-            None => bail!("subscription to sequencer for latest heights failed immediately"),
-            Some(Err(e)) => {
-                return Err(e).wrap_err("first latest height from sequencer was bad");
-            }
-            Some(Ok(height)) => height,
-        };
         let mut sequential_blocks = BlockCache::with_next_height(next_expected_height)
             .wrap_err("failed constructing sequential block cache")?;
+
         let mut blocks_from_heights = block_stream::BlocksFromHeightStream::new(
             executor.rollup_id(),
             next_expected_height,
-            latest_height,
             sequencer_grpc_client.clone(),
         );
 
         // Enqueued block waiting for executor to free up. Set if the executor exhibits
         // backpressure.
         let mut enqueued_block: Fuse<BoxFuture<Result<_, _>>> = future::Fuse::terminated();
-
-        info!(
-            next_expected_sequencer_height = next_expected_height.value(),
-            latest_height_of_sequencer = latest_height.value(),
-            "entering Sequencer read loop",
-        );
 
         let reason = loop {
             select! {

--- a/crates/astria-conductor/src/sequencer/mod.rs
+++ b/crates/astria-conductor/src/sequencer/mod.rs
@@ -4,7 +4,6 @@ use std::time::Duration;
 
 use astria_eyre::eyre::{
     self,
-    bail,
     Report,
     WrapErr as _,
 };


### PR DESCRIPTION
## Summary
Conductor no longer exits if it can't observe the initial height of the Sequencer network.

## Background
When having soft commitments enabled, Conductor attempted to read the current height of the Sequencer network during initialization. If this failed, Conductor would immediately exit rather than retry. In the Astria dev environment this would happen repeatedly because Conductor's startup is much faster than Sequencer.

This changes removes this initial height-read entirely because it is not necessary.

## Changes
- Remove reading the current height of the Sequencer network during initialization
- Change the latest observed sequencer height in the internal block stream to be optional: the stream will now only start producing blocks once a height was externally recorded

## Testing
This change should be transparent to all blackbox tests: they still run to completion. A unit test was added to check that the mechanism to return the next height to fetch inside the block-stream returns `None` if no height was recorded.