### PR TITLE
check sequencer_chain_id against sequencer client chain id

### DIFF
--- a/crates/astria-composer/src/executor/builder.rs
+++ b/crates/astria-composer/src/executor/builder.rs
@@ -48,6 +48,7 @@ impl Builder {
         } = self;
         let sequencer_client = sequencer_client::HttpClient::new(sequencer_url.as_str())
             .wrap_err("failed constructing sequencer client")?;
+        if sequencer_chain_id != sequencer_client.genesis().chain_id.await() {WrapErr::wrap_err("configured sequencer chain id and sequencer client chain id mismatched");}
         let (status, _) = watch::channel(Status::new());
         let mut private_key_bytes: [u8; 32] = hex::decode(private_key.expose_secret())
             .wrap_err("failed to decode private key bytes from hex string")?


### PR DESCRIPTION
## Summary
Added check to ensure configured sequencer chain id is equal to sequencer client chain id.

## Background
This is to prevent building composer when expected chain id and RPC chain id are misaligned, preventing composer from communicating with the incorrect network.

## Changes
Added comparison statement in the builder for the composer, wrapping an error if the two are not equal

## Testing
Untested

## Related Issues
Part of #986 

closes <!-- list any issues closed here -->
