### PR TITLE
release: dusk-6 releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "astria-composer"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "astria-build-info",
  "astria-config",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "astria-conductor"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "astria-build-info",
  "astria-config",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "astria-sequencer"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "astria-build-info",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "astria-sequencer-relayer"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "assert-json-diff",
  "astria-build-info",

--- a/charts/evm-rollup/Chart.yaml
+++ b/charts/evm-rollup/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.16.2
+version: 0.17.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/evm-rollup/templates/configmap.yaml
+++ b/charts/evm-rollup/templates/configmap.yaml
@@ -48,6 +48,9 @@ data:
   ASTRIA_COMPOSER_SEQUENCER_CHAIN_ID: "{{ .Values.config.sequencer.chainId }}"
   ASTRIA_COMPOSER_SEQUENCER_URL: "{{ .Values.config.sequencer.rpc }}"
   ASTRIA_COMPOSER_ROLLUPS: "{{ .Values.config.rollup.name }}::ws://127.0.0.1:{{ .Values.ports.wsRPC }}"
+  {{- if not .Values.secretProvider.enabled }}
+  ASTRIA_COMPOSER_PRIVATE_KEY: "{{ .Values.config.sequencer.privateKey.devContent }}"
+  {{- end }}
   ASTRIA_COMPOSER_MAX_BYTES_PER_BUNDLE: "{{ .Values.config.rollup.maxBytesPerBundle }}"
   ASTRIA_COMPOSER_BUNDLE_QUEUE_CAPACITY: "{{ .Values.config.rollup.bundleQueueCapacity }}"
   ASTRIA_COMPOSER_MAX_SUBMIT_INTERVAL_MS: "{{ .Values.config.rollup.maxSubmitInterval }}"
@@ -64,11 +67,7 @@ data:
   OTEL_EXPORTER_OTLP_TRACE_HEADERS: "{{ .Values.config.rollup.otel.traceHeaders }}"
   OTEL_SERVICE_NAME: "{{ tpl .Values.config.rollup.otel.serviceNamePrefix . }}-composer"
   {{- if not .Values.global.dev }}
-  {{- if not .Values.secretProvider.enabled }}
-  ASTRIA_COMPOSER_PRIVATE_KEY: "{{ .Values.config.sequencer.privateKey.devContent }}"
-  {{- end }}
   {{- else }}
-  ASTRIA_COMPOSER_PRIVATE_KEY_FILE: "/var/secrets/{{ .Values.config.sequencer.privateKey.secret.filename }}"
   {{- end }}
 ---
 apiVersion: v1

--- a/charts/evm-rollup/templates/configmap.yaml
+++ b/charts/evm-rollup/templates/configmap.yaml
@@ -48,9 +48,7 @@ data:
   ASTRIA_COMPOSER_SEQUENCER_CHAIN_ID: "{{ .Values.config.sequencer.chainId }}"
   ASTRIA_COMPOSER_SEQUENCER_URL: "{{ .Values.config.sequencer.rpc }}"
   ASTRIA_COMPOSER_ROLLUPS: "{{ .Values.config.rollup.name }}::ws://127.0.0.1:{{ .Values.ports.wsRPC }}"
-  {{- if not .Values.secretProvider.enabled }}
-  ASTRIA_COMPOSER_PRIVATE_KEY: "{{ .Values.config.sequencer.privateKey.devContent }}"
-  {{- end }}
+  ASTRIA_COMPOSER_PRIVATE_KEY_FILE: "/var/secrets/{{ .Values.config.sequencer.privateKey.secret.filename }}"
   ASTRIA_COMPOSER_MAX_BYTES_PER_BUNDLE: "{{ .Values.config.rollup.maxBytesPerBundle }}"
   ASTRIA_COMPOSER_BUNDLE_QUEUE_CAPACITY: "{{ .Values.config.rollup.bundleQueueCapacity }}"
   ASTRIA_COMPOSER_MAX_SUBMIT_INTERVAL_MS: "{{ .Values.config.rollup.maxSubmitInterval }}"

--- a/charts/evm-rollup/values.yaml
+++ b/charts/evm-rollup/values.yaml
@@ -13,11 +13,11 @@ images:
     devTag: latest
   conductor:
     repo: ghcr.io/astriaorg/conductor
-    tag: "0.15.0"
+    tag: "0.16.0"
     devTag: latest
   composer:
     repo: ghcr.io/astriaorg/composer
-    tag: "0.6.0"
+    tag: "0.7.0"
     devTag: latest
 
   # Rollup faucet

--- a/charts/sequencer-relayer/Chart.yaml
+++ b/charts/sequencer-relayer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.1
+version: 0.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sequencer-relayer/values.yaml
+++ b/charts/sequencer-relayer/values.yaml
@@ -13,7 +13,7 @@ global:
 images:
   sequencerRelayer:
     repo: ghcr.io/astriaorg/sequencer-relayer
-    tag: "0.13.0"
+    tag: "0.14.0"
     devTag: latest
 
 config:

--- a/charts/sequencer/Chart.lock
+++ b/charts/sequencer/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: sequencer-relayer
   repository: file://../sequencer-relayer
-  version: 0.7.1
-digest: sha256:5a0466a5915b0efa3c5789c6f9ad1e083009e8c122b78c5e93248d30036e948a
-generated: "2024-05-14T09:25:59.584035-04:00"
+  version: 0.8.0
+digest: sha256:7ba5131675eb9bc1cb6f73a20fb8a4187658873397183b48aa6d281e4494e3bb
+generated: "2024-05-20T15:16:02.948351-07:00"

--- a/charts/sequencer/Chart.yaml
+++ b/charts/sequencer/Chart.yaml
@@ -25,7 +25,7 @@ appVersion: "0.11.0"
 
 dependencies:
   - name: sequencer-relayer
-    version: "0.7.1"
+    version: "0.8.0"
     repository: "file://../sequencer-relayer"
     condition: sequencer-relayer.enabled
 

--- a/charts/sequencer/Chart.yaml
+++ b/charts/sequencer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.13.7
+version: 0.14.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sequencer/values.yaml
+++ b/charts/sequencer/values.yaml
@@ -17,7 +17,7 @@ images:
     devTag: v0.38.6
   sequencer:
     repo: ghcr.io/astriaorg/sequencer
-    tag: "0.11.0"
+    tag: "0.12.0"
     devTag: latest
 
 config:

--- a/crates/astria-composer/Cargo.toml
+++ b/crates/astria-composer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astria-composer"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 rust-version = "1.73"
 license = "MIT OR Apache-2.0"

--- a/crates/astria-conductor/Cargo.toml
+++ b/crates/astria-conductor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astria-conductor"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 rust-version = "1.73"
 license = "MIT OR Apache-2.0"

--- a/crates/astria-sequencer-relayer/Cargo.toml
+++ b/crates/astria-sequencer-relayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astria-sequencer-relayer"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 rust-version = "1.73"

--- a/crates/astria-sequencer/Cargo.toml
+++ b/crates/astria-sequencer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astria-sequencer"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 rust-version = "1.73"


### PR DESCRIPTION
## Summary
Releases of composer 0.7.0, conductor 0.16.0, sequencer-relayer 0.14.0, and sequencer 0.12.0. These changes all work together, for use of initial dusk-6 network.
