### PR TITLE
chore(sequencer): remove unneeded allow attribute

### DIFF
--- a/crates/astria-sequencer/src/mempool.rs
+++ b/crates/astria-sequencer/src/mempool.rs
@@ -25,7 +25,6 @@ impl TransactionPriority {
 }
 
 impl Ord for TransactionPriority {
-    #[allow(clippy::non_canonical_partial_ord_impl)]
     fn cmp(&self, other: &Self) -> Ordering {
         // we want to execute the lowest nonce first,
         // so lower nonce difference means higher priority


### PR DESCRIPTION
## Summary
Removes an unneeded clippy allow attribute. 

## Background
`#[allow(clippy::non_canonical_partial_ord_impl)]` is not doing anything because `PartialOrd` is in fact implemented in terms of `Ord`.