### PR TITLE
refactor(conductor): perform signal handling in binary and test shutdown logic

### DIFF
--- a/crates/astria-conductor/tests/blackbox/firm_only.rs
+++ b/crates/astria-conductor/tests/blackbox/firm_only.rs
@@ -20,7 +20,7 @@ use crate::{
     mount_update_commitment_state,
 };
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn simple() {
     let test_conductor = spawn_conductor(CommitLevel::FirmOnly).await;
 
@@ -100,7 +100,7 @@ async fn simple() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn submits_two_heights_in_succession() {
     let test_conductor = spawn_conductor(CommitLevel::FirmOnly).await;
 
@@ -216,7 +216,7 @@ async fn submits_two_heights_in_succession() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn skips_already_executed_heights() {
     let test_conductor = spawn_conductor(CommitLevel::FirmOnly).await;
 
@@ -309,7 +309,7 @@ async fn skips_already_executed_heights() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn fetch_from_later_celestia_height() {
     let test_conductor = spawn_conductor(CommitLevel::FirmOnly).await;
 

--- a/crates/astria-conductor/tests/blackbox/main.rs
+++ b/crates/astria-conductor/tests/blackbox/main.rs
@@ -2,6 +2,7 @@
 pub mod firm_only;
 #[allow(clippy::missing_panics_doc)]
 pub mod helpers;
+pub mod shutdown;
 pub mod soft_and_firm;
 pub mod soft_only;
 

--- a/crates/astria-conductor/tests/blackbox/shutdown.rs
+++ b/crates/astria-conductor/tests/blackbox/shutdown.rs
@@ -1,0 +1,14 @@
+use astria_conductor::config::CommitLevel;
+
+use crate::helpers::spawn_conductor;
+
+/// Only tests if conductor shuts down during bringup.
+///
+/// No mocks are mounted so that all consituent Conductor tasks
+/// should be stuck in their runtime-initialization phases (if any).
+/// Once `TestConductor`'s `Drop` implementation runs, its shutdown
+/// logic is invoked.
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn shut_down_during_bringup() {
+    spawn_conductor(CommitLevel::SoftAndFirm).await;
+}

--- a/crates/astria-conductor/tests/blackbox/soft_and_firm.rs
+++ b/crates/astria-conductor/tests/blackbox/soft_and_firm.rs
@@ -36,7 +36,7 @@ use crate::{
 /// NOTE: there is a potential race condition in this test in that the information could be first
 /// retrieved from Celestia before Sequencer and executed against the rollup. In that case step 3.
 /// would be skipped (no soft commitment update).
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn simple() {
     let test_conductor = spawn_conductor(CommitLevel::SoftAndFirm).await;
 
@@ -141,7 +141,7 @@ async fn simple() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn missing_block_is_fetched_for_updating_firm_commitment() {
     let test_conductor = spawn_conductor(CommitLevel::SoftAndFirm).await;
 

--- a/crates/astria-conductor/tests/blackbox/soft_only.rs
+++ b/crates/astria-conductor/tests/blackbox/soft_only.rs
@@ -17,7 +17,7 @@ use crate::{
     mount_update_commitment_state,
 };
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn simple() {
     let test_conductor = spawn_conductor(CommitLevel::SoftOnly).await;
 
@@ -87,7 +87,7 @@ async fn simple() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn submits_two_heights_in_succession() {
     let test_conductor = spawn_conductor(CommitLevel::SoftOnly).await;
 
@@ -189,7 +189,7 @@ async fn submits_two_heights_in_succession() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn skips_already_executed_heights() {
     let test_conductor = spawn_conductor(CommitLevel::SoftOnly).await;
 
@@ -259,7 +259,7 @@ async fn skips_already_executed_heights() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn requests_from_later_genesis_height() {
     let test_conductor = spawn_conductor(CommitLevel::SoftOnly).await;
 


### PR DESCRIPTION
## Summary
Removes the signal handler from the `Conductor` type, replacing it with a handler that allows shutting it down explicitly.

## Background
There is no way to test if a service shuts down properly in Rust integration test if the only way to terminate it is to send a SIGTERM. Providing an explicit `shutdown` method allows for testing its shutdown logic independently of OS/runtime specific signal handling.

## Changes
- Introduce a new `Conductor::spawn` method that spawns conductor on the tokio runtime and returns a `Handle` to the running task.
- Add a `Handle::shutdown` method to explicitly shut down conductor.
- Move setup of the unix signal handler from `Conductor::run_until_blocked` into `fn main` and use the new handle.
- Test Conductor shutdown on every blackbox test.

## Testing
All blackbox tests now invoke the Conductor shutdown logic. A single barebones blackbox test is provided to test shutdown logic without any business logic having been performed.
