### PR TITLE
fix(charts): faucet deployment fix

### DIFF
--- a/charts/evm-rollup/Chart.yaml
+++ b/charts/evm-rollup/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.18.0
+version: 0.18.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/evm-rollup/templates/deployments.yaml
+++ b/charts/evm-rollup/templates/deployments.yaml
@@ -36,7 +36,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: faucet-private-key
-                  key: {{ .Values.secretProvider.secrets.evmPrivateKey.key }}
+                  key: {{ .Values.config.faucet.privateKey.secret.key }}
           {{- end }}
           volumeMounts:
             - mountPath: /home/faucet


### PR DESCRIPTION
Fixes the deployment of the faucet, previously using secret provider had a missing the `token` default value, fix to use updated secret deployment.
* now uses `Values.config.faucet.privateKey.secret.key` as token value when secretProvider is enabled