### PR TITLE
release(sequencer): sequencer 0.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "astria-sequencer"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "astria-build-info",

--- a/charts/sequencer/Chart.yaml
+++ b/charts/sequencer/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.14.0
+version: 0.15.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.11.0"
+appVersion: "0.13.0"
 
 dependencies:
   - name: sequencer-relayer

--- a/charts/sequencer/values.yaml
+++ b/charts/sequencer/values.yaml
@@ -17,7 +17,7 @@ images:
     devTag: v0.38.6
   sequencer:
     repo: ghcr.io/astriaorg/sequencer
-    tag: "0.12.0"
+    tag: "0.13.0"
     devTag: latest
 
 config:

--- a/crates/astria-sequencer/Cargo.toml
+++ b/crates/astria-sequencer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astria-sequencer"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 rust-version = "1.73"


### PR DESCRIPTION
## Summary
New release of sequencer for dusk-7 with fees going to sudo address, chart updates to support it.