### PR TITLE
chore(charts): update evm chart to have better default request limits

### DIFF
--- a/charts/evm-rollup/Chart.yaml
+++ b/charts/evm-rollup/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.18.1
+version: 0.18.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.10.0"
+appVersion: "0.10.1"
 
 dependencies:
   - name: celestia-node

--- a/charts/evm-rollup/Chart.yaml
+++ b/charts/evm-rollup/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.18.2
+version: 0.18.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/evm-rollup/values.yaml
+++ b/charts/evm-rollup/values.yaml
@@ -9,7 +9,7 @@ global:
 images:
   geth:
     repo: ghcr.io/astriaorg/astria-geth
-    tag: 0.10.0
+    tag: 0.10.1
     devTag: latest
   conductor:
     repo: ghcr.io/astriaorg/conductor
@@ -311,17 +311,17 @@ resources:
   conductor:
     requests:
       cpu: 0.1
-      memory: 20Mi
+      memory: 200Mi
     limits:
       cpu: 1
-      memory: 200Mi
+      memory: 2Gi
   composer:
     requests:
       cpu: 0.1
-      memory: 20Mi
+      memory: 100Mi
     limits:
       cpu: 1
-      memory: 200Mi
+      memory: 1Gi
   geth:
     requests:
       cpu: 4


### PR DESCRIPTION
## Summary
Chart limits for conductor & composer were too low, and we have a new geth image with less noisy logs