### PR TITLE
feat(conductor): add retry to execution API gRPCs

### DIFF
--- a/crates/astria-conductor/src/executor/client.rs
+++ b/crates/astria-conductor/src/executor/client.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use astria_core::{
     execution::v1alpha2::{
         Block,
@@ -25,7 +27,12 @@ use tonic::transport::{
     Endpoint,
     Uri,
 };
-use tracing::instrument;
+use tracing::{
+    instrument,
+    warn,
+    Instrument,
+    Span,
+};
 
 /// A newtype wrapper around [`ExecutionServiceClient`] to work with
 /// idiomatic types.
@@ -48,17 +55,24 @@ impl Client {
         })
     }
 
+    /// Calls RPC astria.execution.v1alpha2.GetBlock
     #[instrument(skip_all, fields(block_number, uri = %self.uri), err)]
-    pub(crate) async fn get_block(&mut self, block_number: u32) -> eyre::Result<Block> {
-        let request = raw::GetBlockRequest {
-            identifier: Some(block_identifier(block_number)),
-        };
-        let raw_block = self
-            .inner
-            .get_block(request)
-            .await
-            .wrap_err("failed to execute astria.execution.v1alpha2.GetBlocks RPC")?
-            .into_inner();
+    pub(crate) async fn get_block_with_retry(&mut self, block_number: u32) -> eyre::Result<Block> {
+        let raw_block = tryhard::retry_fn(|| {
+            let mut client = self.inner.clone();
+            let request = raw::GetBlockRequest {
+                identifier: Some(block_identifier(block_number)),
+            };
+            async move { client.get_block(request).await }
+        })
+        .with_config(retry_config())
+        .in_current_span()
+        .await
+        .wrap_err(
+            "failed to execute astria.execution.v1alpha2.GetBlocks RPC after multiple retries; \
+             giving up",
+        )?
+        .into_inner();
         ensure!(
             block_number == raw_block.number,
             "requested block at number `{block_number}`, but received block contained `{}`",
@@ -69,14 +83,20 @@ impl Client {
 
     /// Calls remote procedure `astria.execution.v1alpha2.GetGenesisInfo`
     #[instrument(skip_all, fields(uri = %self.uri))]
-    pub(crate) async fn get_genesis_info(&mut self) -> eyre::Result<GenesisInfo> {
-        let request = raw::GetGenesisInfoRequest {};
-        let response = self
-            .inner
-            .get_genesis_info(request)
-            .await
-            .wrap_err("failed to get genesis_info")?
-            .into_inner();
+    pub(crate) async fn get_genesis_info_with_retry(&mut self) -> eyre::Result<GenesisInfo> {
+        let response = tryhard::retry_fn(|| {
+            let mut client = self.inner.clone();
+            let request = raw::GetGenesisInfoRequest {};
+            async move { client.get_genesis_info(request).await }
+        })
+        .with_config(retry_config())
+        .in_current_span()
+        .await
+        .wrap_err(
+            "failed to execute astria.execution.v1alpha2.GetGenesisInfo RPC after multiple \
+             retries; giving up",
+        )?
+        .into_inner();
         let genesis_info = GenesisInfo::try_from_raw(response)
             .wrap_err("failed converting raw response to validated genesis info")?;
         Ok(genesis_info)
@@ -89,8 +109,8 @@ impl Client {
     /// * `prev_block_hash` - Block hash of the parent block
     /// * `transactions` - List of transactions extracted from the sequencer block
     /// * `timestamp` - Optional timestamp of the sequencer block
-    #[instrument(skip_all, fields(uri = %self.uri))]
-    pub(super) async fn execute_block(
+    #[instrument(skip_all, fields(uri = %self.uri), err)]
+    pub(super) async fn execute_block_with_retry(
         &mut self,
         prev_block_hash: Bytes,
         transactions: Vec<Vec<u8>>,
@@ -109,12 +129,19 @@ impl Client {
             transactions,
             timestamp: Some(timestamp),
         };
-        let response = self
-            .inner
-            .execute_block(request)
-            .await
-            .wrap_err("failed to execute block")?
-            .into_inner();
+        let response = tryhard::retry_fn(|| {
+            let mut client = self.inner.clone();
+            let request = request.clone();
+            async move { client.execute_block(request).await }
+        })
+        .with_config(retry_config())
+        .in_current_span()
+        .await
+        .wrap_err(
+            "failed to execute astria.execution.v1alpha2.ExecuteBlock RPC after multiple retries; \
+             giving up",
+        )?
+        .into_inner();
         let block = Block::try_from_raw(response)
             .wrap_err("failed converting raw response to validated block")?;
         Ok(block)
@@ -122,14 +149,24 @@ impl Client {
 
     /// Calls remote procedure `astria.execution.v1alpha2.GetCommitmentState`
     #[instrument(skip_all, fields(uri = %self.uri), err)]
-    pub(crate) async fn get_commitment_state(&mut self) -> eyre::Result<CommitmentState> {
-        let request = raw::GetCommitmentStateRequest {};
-        let response = self
-            .inner
-            .get_commitment_state(request)
-            .await
-            .wrap_err("failed to get commitment state")?
-            .into_inner();
+    pub(crate) async fn get_commitment_state_with_retry(
+        &mut self,
+    ) -> eyre::Result<CommitmentState> {
+        let response = tryhard::retry_fn(|| {
+            let mut client = self.inner.clone();
+            async move {
+                let request = raw::GetCommitmentStateRequest {};
+                client.get_commitment_state(request).await
+            }
+        })
+        .with_config(retry_config())
+        .in_current_span()
+        .await
+        .wrap_err(
+            "failed to execute astria.execution.v1alpha2.GetCommitmentState RPC after multiple \
+             retries; giving up",
+        )?
+        .into_inner();
         let commitment_state = CommitmentState::try_from_raw(response)
             .wrap_err("failed converting raw response to validated commitment state")?;
         Ok(commitment_state)
@@ -142,19 +179,26 @@ impl Client {
     /// * `firm` - The firm block
     /// * `soft` - The soft block
     #[instrument(skip_all, fields(uri = %self.uri))]
-    pub(super) async fn update_commitment_state(
+    pub(super) async fn update_commitment_state_with_retry(
         &mut self,
         commitment_state: CommitmentState,
     ) -> eyre::Result<CommitmentState> {
         let request = raw::UpdateCommitmentStateRequest {
             commitment_state: Some(commitment_state.into_raw()),
         };
-        let response = self
-            .inner
-            .update_commitment_state(request)
-            .await
-            .wrap_err("failed to update commitment state")?
-            .into_inner();
+        let response = tryhard::retry_fn(|| {
+            let mut client = self.inner.clone();
+            let request = request.clone();
+            async move { client.update_commitment_state(request).await }
+        })
+        .with_config(retry_config())
+        .in_current_span()
+        .await
+        .wrap_err(
+            "failed to execute astria.execution.v1alpha2.UpdateCommitmentState RPC after multiple \
+             retries; giving up",
+        )?
+        .into_inner();
         let commitment_state = CommitmentState::try_from_raw(response)
             .wrap_err("failed converting raw response to validated commitment state")?;
         Ok(commitment_state)
@@ -167,4 +211,42 @@ fn block_identifier(number: u32) -> raw::BlockIdentifier {
     raw::BlockIdentifier {
         identifier: Some(raw::block_identifier::Identifier::BlockNumber(number)),
     }
+}
+
+struct OnRetry {
+    parent: Span,
+}
+
+impl tryhard::OnRetry<tonic::Status> for OnRetry {
+    type Future = futures::future::Ready<()>;
+
+    fn on_retry(
+        &mut self,
+        attempt: u32,
+        next_delay: Option<Duration>,
+        previous_error: &tonic::Status,
+    ) -> Self::Future {
+        let wait_duration = next_delay
+            .map(humantime::format_duration)
+            .map(tracing::field::display);
+        warn!(
+            parent: self.parent.id(),
+            attempt,
+            wait_duration,
+            error = previous_error as &dyn std::error::Error,
+            "failed executing RPC; retrying after after backoff"
+        );
+        futures::future::ready(())
+    }
+}
+
+fn retry_config()
+-> tryhard::RetryFutureConfig<tryhard::backoff_strategies::ExponentialBackoff, OnRetry> {
+    tryhard::RetryFutureConfig::new(u32::MAX)
+        .exponential_backoff(Duration::from_millis(100))
+        // XXX: This should probably be configurable.
+        .max_delay(Duration::from_secs(10))
+        .on_retry(OnRetry {
+            parent: Span::current(),
+        })
 }

--- a/crates/astria-conductor/src/executor/mod.rs
+++ b/crates/astria-conductor/src/executor/mod.rs
@@ -497,7 +497,7 @@ impl Executor {
                 "pending block not found for block number in cache. THIS SHOULD NOT HAPPEN. \
                  Trying to fetch the already-executed block from the rollup before giving up."
             );
-            match self.client.get_block(block_number).await {
+            match self.client.get_block_with_retry(block_number).await {
                 Ok(block) => Update::OnlyFirm(block),
                 Err(error) => {
                     error!(
@@ -542,7 +542,7 @@ impl Executor {
 
         let executed_block = self
             .client
-            .execute_block(parent_hash, transactions, timestamp)
+            .execute_block_with_retry(parent_hash, transactions, timestamp)
             .await
             .wrap_err("failed to run execute_block RPC")?;
 
@@ -561,7 +561,7 @@ impl Executor {
             async {
                 self.client
                     .clone()
-                    .get_genesis_info()
+                    .get_genesis_info_with_retry()
                     .await
                     .wrap_err("failed getting genesis info")
             }
@@ -570,7 +570,7 @@ impl Executor {
             async {
                 self.client
                     .clone()
-                    .get_commitment_state()
+                    .get_commitment_state_with_retry()
                     .await
                     .wrap_err("failed getting commitment state")
             }
@@ -606,7 +606,7 @@ impl Executor {
             .wrap_err("failed constructing commitment state")?;
         let new_state = self
             .client
-            .update_commitment_state(commitment_state)
+            .update_commitment_state_with_retry(commitment_state)
             .await
             .wrap_err("failed updating remote commitment state")?;
         info!(


### PR DESCRIPTION
## Summary
This adds retry logic to all execution API gRPCs from Conductor to the rollup.

## Background
If there was a hickup when communicating with the rollup, conductor would fail immediately. This adds retry logic all execution API calls. Because this cannot yet be done at the transport level due to type-level constraints on tonic and tower, this patch adds retries at the application leve.

## Changes
- Add retry logic to every execution v1alpha2 API call
- Introduce a `ExecutionApiRetryStrategy` implementing `tryhard::BackoffStrategy`
- The following gRPC tonic status codes will be retried:
    - Cancelled
    - Unknown
    - DeadlineExceeded
    - NotFound
    - ResourceExhausted
    - Aborted
    - Unavailable
    - DataLoss


## Testing
Add unit tests for the all codes. The happy-path blackbox tests are unaffected.


## Related Issues

closes https://github.com/astriaorg/astria/issues/624
