### PR TITLE
fix(sequencer): fix `just run-cometbft` command

### DIFF
--- a/crates/astria-sequencer/justfile
+++ b/crates/astria-sequencer/justfile
@@ -13,7 +13,7 @@ run:
 
 run-cometbft:
   cometbft init
-  ../../target/debug/astria-sequencer-utils --genesis-app-state-file=test-genesis-app-state.json --destination-genesis-file=$HOME/.cometbft/config/genesis.json --chain-id=astria
+  ../../target/debug/astria-sequencer-utils copy-genesis-state --genesis-app-state-file=test-genesis-app-state.json --destination-genesis-file=$HOME/.cometbft/config/genesis.json --chain-id=astria
   sed -i'.bak' 's/timeout_commit = "1s"/timeout_commit = "2s"/g' ~/.cometbft/config/config.toml
   cometbft node
 


### PR DESCRIPTION
## Summary
 fix `just run-cometbft` command in justfile

## Background
astria-sequencer-utils changed with a recent PR

## Changes
-  fix `just run-cometbft` command

## Testing
i ran the command 
