### PR TITLE
feat(conductor): skip outdated block metadata

### DIFF
--- a/crates/astria-conductor/src/celestia/mod.rs
+++ b/crates/astria-conductor/src/celestia/mod.rs
@@ -427,6 +427,7 @@ impl RunningReader {
                 rollup_id: self.rollup_id,
                 rollup_namespace: self.rollup_namespace,
                 sequencer_namespace: self.sequencer_namespace,
+                executor: self.executor.clone(),
             };
             self.reconstruction_tasks.spawn(height, task.execute());
             scheduled.push(height);
@@ -498,6 +499,7 @@ struct FetchConvertVerifyAndReconstruct {
     rollup_id: RollupId,
     rollup_namespace: Namespace,
     sequencer_namespace: Namespace,
+    executor: executor::Handle<StateIsInit>,
 }
 
 impl FetchConvertVerifyAndReconstruct {
@@ -514,6 +516,7 @@ impl FetchConvertVerifyAndReconstruct {
             rollup_id,
             rollup_namespace,
             sequencer_namespace,
+            executor,
         } = self;
 
         let new_blobs = fetch_new_blobs(
@@ -585,7 +588,7 @@ impl FetchConvertVerifyAndReconstruct {
             "decoded Sequencer header and rollup info from raw Celestia blobs",
         );
 
-        let verified_blobs = verify_metadata(blob_verifier, decoded_blobs).await;
+        let verified_blobs = verify_metadata(blob_verifier, decoded_blobs, executor).await;
 
         {
             // allow: histograms require f64; precision loss would be no problem

--- a/crates/astria-conductor/tests/blackbox/firm_only.rs
+++ b/crates/astria-conductor/tests/blackbox/firm_only.rs
@@ -194,7 +194,7 @@ async fn submits_two_heights_in_succession() {
             hash: [3; 64],
             parent: [2; 64],
         ),
-        base_celestia_height: 2,
+        base_celestia_height: 1,
     );
 
     timeout(
@@ -280,7 +280,7 @@ async fn skips_already_executed_heights() {
             hash: [2; 64],
             parent: [1; 64],
         ),
-        base_celestia_height: 2,
+        base_celestia_height: 1,
     );
 
     timeout(

--- a/crates/astria-conductor/tests/blackbox/firm_only.rs
+++ b/crates/astria-conductor/tests/blackbox/firm_only.rs
@@ -55,7 +55,7 @@ async fn simple() {
     mount_celestia_blobs!(
         test_conductor,
         celestia_height: 1,
-        sequencer_height: 3,
+        sequencer_heights: [3],
     );
 
     mount_sequencer_commit!(
@@ -136,13 +136,7 @@ async fn submits_two_heights_in_succession() {
     mount_celestia_blobs!(
         test_conductor,
         celestia_height: 1,
-        sequencer_height: 3,
-    );
-
-    mount_celestia_blobs!(
-        test_conductor,
-        celestia_height: 2,
-        sequencer_height: 4,
+        sequencer_heights: [3, 4],
     );
 
     mount_sequencer_commit!(
@@ -250,25 +244,15 @@ async fn skips_already_executed_heights() {
         height: 2u32,
     );
 
-    // The blob with sequencer height 5 will be fetched but never forwarded
+    // The blob contains sequencer heights 6 and 7, but no commits or validator sets are mounted.
+    // XXX: A non-fetch cannot be tested for programmatically right now. Running the test with
+    // tracing enabled should show that the sequencer metadata at height 6 is explicitly
+    // skipped.
     mount_celestia_blobs!(
         test_conductor,
         celestia_height: 1,
-        sequencer_height: 6,
+        sequencer_heights: [6, 7],
     );
-
-    mount_celestia_blobs!(
-        test_conductor,
-        celestia_height: 2,
-        sequencer_height: 7,
-    );
-
-    mount_sequencer_commit!(
-        test_conductor,
-        height: 6u32,
-    );
-
-    mount_sequencer_validator_set!(test_conductor, height: 5u32);
 
     mount_sequencer_commit!(
         test_conductor,
@@ -348,7 +332,7 @@ async fn fetch_from_later_celestia_height() {
     mount_celestia_blobs!(
         test_conductor,
         celestia_height: 4,
-        sequencer_height: 3,
+        sequencer_heights: [3],
     );
 
     mount_sequencer_commit!(

--- a/crates/astria-conductor/tests/blackbox/helpers/macros.rs
+++ b/crates/astria-conductor/tests/blackbox/helpers/macros.rs
@@ -111,11 +111,12 @@ macro_rules! signed_header {
 #[macro_export]
 macro_rules! mount_celestia_blobs {
     (
-        $test_env:ident,celestia_height:
-        $celestia_height:expr,sequencer_height:
-        $sequencer_height:expr $(,)?
+        $test_env:ident,
+        celestia_height: $celestia_height:expr,
+        sequencer_heights: [ $($sequencer_height:expr),+ ]
+        $(,)?
     ) => {{
-        let blobs = $crate::helpers::make_blobs(&[$sequencer_height]);
+        let blobs = $crate::helpers::make_blobs(&[ $( $sequencer_height ),+ ]);
         $test_env
             .mount_celestia_blob_get_all(
                 $celestia_height,

--- a/crates/astria-conductor/tests/blackbox/helpers/mod.rs
+++ b/crates/astria-conductor/tests/blackbox/helpers/mod.rs
@@ -473,7 +473,18 @@ fn make_config() -> Config {
 
 #[must_use]
 pub fn make_sequencer_block(height: u32) -> astria_core::sequencerblock::v1alpha1::SequencerBlock {
+    fn repeat_bytes_of_u32_as_array(val: u32) -> [u8; 32] {
+        let repr = val.to_le_bytes();
+        [
+            repr[0], repr[1], repr[2], repr[3], repr[0], repr[1], repr[2], repr[3], repr[0],
+            repr[1], repr[2], repr[3], repr[0], repr[1], repr[2], repr[3], repr[0], repr[1],
+            repr[2], repr[3], repr[0], repr[1], repr[2], repr[3], repr[0], repr[1], repr[2],
+            repr[3], repr[0], repr[1], repr[2], repr[3],
+        ]
+    }
+
     astria_core::protocol::test_utils::ConfigureSequencerBlock {
+        block_hash: Some(repeat_bytes_of_u32_as_array(height)),
         chain_id: Some(crate::SEQUENCER_CHAIN_ID.to_string()),
         height,
         sequence_data: vec![(crate::ROLLUP_ID, data())],

--- a/crates/astria-conductor/tests/blackbox/soft_and_firm.rs
+++ b/crates/astria-conductor/tests/blackbox/soft_and_firm.rs
@@ -76,7 +76,7 @@ async fn simple() {
     mount_celestia_blobs!(
         test_conductor,
         celestia_height: 1,
-        sequencer_height: 3,
+        sequencer_heights: [3],
     );
 
     mount_sequencer_commit!(
@@ -191,7 +191,7 @@ async fn missing_block_is_fetched_for_updating_firm_commitment() {
     mount_celestia_blobs!(
         test_conductor,
         celestia_height: 1,
-        sequencer_height: 3,
+        sequencer_heights: [3],
     );
 
     mount_sequencer_commit!(


### PR DESCRIPTION
## Summary
Conductor drops sequencer metadata items retrieved from Celestia if their height has already been executed/committed.

## Background
Conductor would try and unnecessarily verify Sequencer metadata retrieved from Celestia, putting a lot of pressure on the Sequencer node. Because Conductor is stateless, it fetches all Celestia blobs for the sequencer and rollup namespaces starting from the `celestia_base_block_height` configured the rollup. It would then verify all sequencer metadata items retrieved in this way against the Sequencer, even if the metadata was for old blocks (meaning blocks with a height below the next firm height expected by the rollup).

## Changes
- Check the Sequencer height of each sequencer metadata item received from Celestia against the next expected firm height; drop the item without verification if its less than the expected height

## Testing
- Cannot yet be tested programatically, but the blackbox tests have been updated to contain several sequencer blocks per Celestia blob. Running the following one can observe a specific line indicating that the logic works:
```
TEST_LOG=1 RUST_LOG=debug cargo test firm_only::skips_already_executed_heights
...
2024-05-29T13:00:48.704019Z  INFO execute:verify_metadata: astria_conductor::celestia::verify: dropping Sequencer metadata item without verifying against Sequencer because its height is below the next expected firm height next_expected_firm_sequencer_height=7 sequencer_height_in_metadata=6 celestia_height=1 rollup_namespace=AAAAAAAAAAAAAAAAAAAAAAAAACoqKioqKioqKio= sequencer_namespace=AAAAAAAAAAAAAAAAAAAAAAAAAKDcd7eO77LbDQs=
```