### PR TITLE
feat(conductor, proto)!: celestia base heights in commitment state

### DIFF
--- a/charts/evm-rollup/Chart.yaml
+++ b/charts/evm-rollup/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.18.4
+version: 0.18.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/evm-rollup/values.yaml
+++ b/charts/evm-rollup/values.yaml
@@ -10,7 +10,7 @@ images:
   geth:
     repo: ghcr.io/astriaorg/astria-geth
     tag: 0.10.1
-    devTag: pr-22 # Reset to latest once this PR has been merged
+    devTag: pr-22  # Reset to latest once this PR has been merged
   conductor:
     repo: ghcr.io/astriaorg/conductor
     tag: "0.16.0"

--- a/charts/evm-rollup/values.yaml
+++ b/charts/evm-rollup/values.yaml
@@ -10,7 +10,7 @@ images:
   geth:
     repo: ghcr.io/astriaorg/astria-geth
     tag: 0.10.1
-    devTag: latest
+    devTag: pr-22 # Reset to latest once this PR has been merged
   conductor:
     repo: ghcr.io/astriaorg/conductor
     tag: "0.16.0"

--- a/crates/astria-conductor/src/celestia/mod.rs
+++ b/crates/astria-conductor/src/celestia/mod.rs
@@ -268,7 +268,7 @@ impl RunningReader {
 
         let celestia_next_height = executor.celestia_base_block_height().value();
         let celestia_reference_height = executor.celestia_base_block_height().value();
-        let celestia_variance = executor.celestia_block_variance().into();
+        let celestia_variance = executor.celestia_block_variance();
 
         Ok(Self {
             block_cache,

--- a/crates/astria-conductor/src/celestia/mod.rs
+++ b/crates/astria-conductor/src/celestia/mod.rs
@@ -266,8 +266,8 @@ impl RunningReader {
         let sequencer_namespace =
             astria_core::celestia::namespace_v0_from_sha256_of_bytes(sequencer_chain_id.as_bytes());
 
-        let celestia_next_height = executor.celestia_base_block_height().value();
-        let celestia_reference_height = executor.celestia_base_block_height().value();
+        let celestia_next_height = executor.celestia_base_block_height();
+        let celestia_reference_height = executor.celestia_base_block_height();
         let celestia_variance = executor.celestia_block_variance();
 
         Ok(Self {

--- a/crates/astria-conductor/src/executor/mod.rs
+++ b/crates/astria-conductor/src/executor/mod.rs
@@ -456,11 +456,10 @@ impl Executor {
         block.height = block.sequencer_height().value(),
     ))]
     async fn execute_firm(&mut self, block: ReconstructedBlock) -> eyre::Result<()> {
-        let celestia_height =
-            block.celestia_height.try_into().expect(
-                "block height overflow, this should not happen since tendermint heights are i64 \
-                 and never negative under the hood",
-            );
+        let celestia_height = block.celestia_height.try_into().expect(
+            "block height overflow, this should not happen since tendermint heights are i64 and \
+             never negative under the hood",
+        );
         let executable_block = ExecutableBlock::from_reconstructed(block);
         let expected_height = self.state.next_expected_firm_sequencer_height();
         let block_height = executable_block.height;
@@ -601,7 +600,11 @@ impl Executor {
         };
         let (firm, soft, celestia_height) = match update {
             OnlyFirm(firm, celestia_height) => (firm, self.state.soft(), celestia_height),
-            OnlySoft(soft) => (self.state.firm(), soft, self.state.celestia_base_block_height()),
+            OnlySoft(soft) => (
+                self.state.firm(),
+                soft,
+                self.state.celestia_base_block_height(),
+            ),
             ToSame(block, celestia_height) => (block.clone(), block, celestia_height),
         };
         let commitment_state = CommitmentState::builder()

--- a/crates/astria-conductor/src/executor/mod.rs
+++ b/crates/astria-conductor/src/executor/mod.rs
@@ -209,7 +209,7 @@ impl Handle<StateIsInit> {
         self.state.celestia_base_block_height()
     }
 
-    pub(crate) fn celestia_block_variance(&mut self) -> u32 {
+    pub(crate) fn celestia_block_variance(&mut self) -> u64 {
         self.state.celestia_block_variance()
     }
 }

--- a/crates/astria-conductor/src/executor/mod.rs
+++ b/crates/astria-conductor/src/executor/mod.rs
@@ -18,7 +18,6 @@ use astria_eyre::eyre::{
     WrapErr as _,
 };
 use bytes::Bytes;
-use celestia_types::Height as CelestiaHeight;
 use sequencer_client::tendermint::{
     block::Height as SequencerHeight,
     Time as TendermintTime,
@@ -58,6 +57,8 @@ pub(super) use client::Client;
 use state::StateReceiver;
 
 use self::state::StateSender;
+
+type CelestiaHeight = u64;
 
 #[derive(Clone, Debug)]
 pub(crate) struct StateNotInit;
@@ -456,10 +457,7 @@ impl Executor {
         block.height = block.sequencer_height().value(),
     ))]
     async fn execute_firm(&mut self, block: ReconstructedBlock) -> eyre::Result<()> {
-        let celestia_height = block.celestia_height.try_into().expect(
-            "block height overflow, this should not happen since tendermint heights are i64 and \
-             never negative under the hood",
-        );
+        let celestia_height = block.celestia_height;
         let executable_block = ExecutableBlock::from_reconstructed(block);
         let expected_height = self.state.next_expected_firm_sequencer_height();
         let block_height = executable_block.height;

--- a/crates/astria-conductor/src/executor/state.rs
+++ b/crates/astria-conductor/src/executor/state.rs
@@ -221,6 +221,7 @@ forward_impls!(
     [celestia_block_variance -> u32],
     [rollup_id -> RollupId],
     [sequencer_genesis_block_height -> SequencerHeight],
+    [celestia_base_block_height -> CelestiaHeight],
 );
 
 forward_impls!(
@@ -279,7 +280,7 @@ impl State {
     }
 
     fn celestia_base_block_height(&self) -> CelestiaHeight {
-        self.genesis_info.celestia_base_block_height()
+        self.commitment_state.base_celestia_height()
     }
 
     fn celestia_block_variance(&self) -> u32 {

--- a/crates/astria-conductor/src/executor/state.rs
+++ b/crates/astria-conductor/src/executor/state.rs
@@ -218,7 +218,7 @@ forward_impls!(
     [soft_number -> u32],
     [firm_hash -> Bytes],
     [soft_hash -> Bytes],
-    [celestia_block_variance -> u32],
+    [celestia_block_variance -> u64],
     [rollup_id -> RollupId],
     [sequencer_genesis_block_height -> SequencerHeight],
     [celestia_base_block_height -> CelestiaHeight],
@@ -227,7 +227,7 @@ forward_impls!(
 forward_impls!(
     StateReceiver:
     [celestia_base_block_height -> CelestiaHeight],
-    [celestia_block_variance -> u32],
+    [celestia_block_variance -> u64],
     [rollup_id -> RollupId],
 );
 
@@ -283,7 +283,7 @@ impl State {
         self.commitment_state.base_celestia_height()
     }
 
-    fn celestia_block_variance(&self) -> u32 {
+    fn celestia_block_variance(&self) -> u64 {
         self.genesis_info.celestia_block_variance()
     }
 

--- a/crates/astria-conductor/src/executor/state.rs
+++ b/crates/astria-conductor/src/executor/state.rs
@@ -370,9 +370,11 @@ mod tests {
             }),
         })
         .unwrap();
+        let celestia_base_height = CelestiaHeight::from(1u32);
         CommitmentState::builder()
             .firm(firm)
             .soft(soft)
+            .base_celestia_height(celestia_base_height)
             .build()
             .unwrap()
     }
@@ -381,7 +383,6 @@ mod tests {
         GenesisInfo::try_from_raw(raw::GenesisInfo {
             rollup_id: vec![24; 32].into(),
             sequencer_genesis_block_height: 10,
-            celestia_base_block_height: 1,
             celestia_block_variance: 0,
         })
         .unwrap()

--- a/crates/astria-conductor/src/executor/state.rs
+++ b/crates/astria-conductor/src/executor/state.rs
@@ -15,7 +15,6 @@ use astria_eyre::{
     eyre::WrapErr as _,
 };
 use bytes::Bytes;
-use celestia_types::Height as CelestiaHeight;
 use sequencer_client::tendermint::block::Height as SequencerHeight;
 use tokio::sync::watch::{
     self,
@@ -221,12 +220,12 @@ forward_impls!(
     [celestia_block_variance -> u64],
     [rollup_id -> RollupId],
     [sequencer_genesis_block_height -> SequencerHeight],
-    [celestia_base_block_height -> CelestiaHeight],
+    [celestia_base_block_height -> u64],
 );
 
 forward_impls!(
     StateReceiver:
-    [celestia_base_block_height -> CelestiaHeight],
+    [celestia_base_block_height -> u64],
     [celestia_block_variance -> u64],
     [rollup_id -> RollupId],
 );
@@ -279,7 +278,7 @@ impl State {
         self.soft().hash().clone()
     }
 
-    fn celestia_base_block_height(&self) -> CelestiaHeight {
+    fn celestia_base_block_height(&self) -> u64 {
         self.commitment_state.base_celestia_height()
     }
 
@@ -370,11 +369,10 @@ mod tests {
             }),
         })
         .unwrap();
-        let celestia_base_height = CelestiaHeight::from(1u32);
         CommitmentState::builder()
             .firm(firm)
             .soft(soft)
-            .base_celestia_height(celestia_base_height)
+            .base_celestia_height(1u64)
             .build()
             .unwrap()
     }

--- a/crates/astria-conductor/src/executor/tests.rs
+++ b/crates/astria-conductor/src/executor/tests.rs
@@ -48,13 +48,13 @@ fn make_state(
     let genesis_info = GenesisInfo::try_from_raw(raw::GenesisInfo {
         rollup_id: Bytes::copy_from_slice(ROLLUP_ID.as_ref()),
         sequencer_genesis_block_height: 1,
-        celestia_base_block_height: 1,
         celestia_block_variance: 1,
     })
     .unwrap();
     let commitment_state = CommitmentState::try_from_raw(raw::CommitmentState {
         firm: Some(make_block(firm)),
         soft: Some(make_block(soft)),
+        base_celestia_height: 1,
     })
     .unwrap();
     let (mut tx, rx) = super::state::channel();

--- a/crates/astria-conductor/tests/blackbox/firm_only.rs
+++ b/crates/astria-conductor/tests/blackbox/firm_only.rs
@@ -27,7 +27,6 @@ async fn simple() {
     mount_get_genesis_info!(
         test_conductor,
         sequencer_genesis_block_height: 1,
-        celestia_base_block_height: 1,
         celestia_block_variance: 10,
     );
 
@@ -43,6 +42,7 @@ async fn simple() {
             hash: [1; 64],
             parent: [0; 64],
         ),
+        base_celestia_height: 1,
     );
 
     mount_sequencer_genesis!(test_conductor);
@@ -84,6 +84,7 @@ async fn simple() {
             hash: [2; 64],
             parent: [1; 64],
         ),
+        base_celestia_height: 1,
     );
 
     timeout(
@@ -107,7 +108,6 @@ async fn submits_two_heights_in_succession() {
     mount_get_genesis_info!(
         test_conductor,
         sequencer_genesis_block_height: 1,
-        celestia_base_block_height: 1,
         celestia_block_variance: 10,
     );
 
@@ -123,6 +123,7 @@ async fn submits_two_heights_in_succession() {
             hash: [1; 64],
             parent: [0; 64],
         ),
+        base_celestia_height: 1,
     );
 
     mount_sequencer_genesis!(test_conductor);
@@ -177,6 +178,7 @@ async fn submits_two_heights_in_succession() {
             hash: [2; 64],
             parent: [1; 64],
         ),
+        base_celestia_height: 1,
     );
 
     let execute_block_number_3 = mount_executed_block!(
@@ -198,6 +200,7 @@ async fn submits_two_heights_in_succession() {
             hash: [3; 64],
             parent: [2; 64],
         ),
+        base_celestia_height: 2,
     );
 
     timeout(
@@ -223,7 +226,6 @@ async fn skips_already_executed_heights() {
     mount_get_genesis_info!(
         test_conductor,
         sequencer_genesis_block_height: 1,
-        celestia_base_block_height: 1,
         celestia_block_variance: 10,
     );
 
@@ -239,6 +241,7 @@ async fn skips_already_executed_heights() {
             hash: [1; 64],
             parent: [0; 64],
         ),
+        base_celestia_height: 1,
     );
     mount_sequencer_genesis!(test_conductor);
 
@@ -293,6 +296,7 @@ async fn skips_already_executed_heights() {
             hash: [2; 64],
             parent: [1; 64],
         ),
+        base_celestia_height: 2,
     );
 
     timeout(
@@ -316,7 +320,6 @@ async fn fetch_from_later_celestia_height() {
     mount_get_genesis_info!(
         test_conductor,
         sequencer_genesis_block_height: 1,
-        celestia_base_block_height: 4,
         celestia_block_variance: 10,
     );
 
@@ -332,6 +335,7 @@ async fn fetch_from_later_celestia_height() {
             hash: [1; 64],
             parent: [0; 64],
         ),
+        base_celestia_height: 4,
     );
 
     mount_sequencer_genesis!(test_conductor);
@@ -373,6 +377,7 @@ async fn fetch_from_later_celestia_height() {
             hash: [2; 64],
             parent: [1; 64],
         ),
+        base_celestia_height: 4,
     );
 
     timeout(

--- a/crates/astria-conductor/tests/blackbox/helpers/macros.rs
+++ b/crates/astria-conductor/tests/blackbox/helpers/macros.rs
@@ -53,8 +53,8 @@ macro_rules! celestia_network_head {
 macro_rules! commitment_state {
     (
         firm: (number: $firm_number:expr,hash: $firm_hash:expr,parent: $firm_parent:expr $(,)?),
-        soft: (number: $soft_number:expr,hash: $soft_hash:expr,parent: $soft_parent:expr $(,)?)
-        $(,)?
+        soft: (number: $soft_number:expr,hash: $soft_hash:expr,parent: $soft_parent:expr $(,)?),
+        base_celestia_height: $base_celestia_height:expr $(,)?
     ) => {
        ::astria_core::generated::execution::v1alpha2::CommitmentState {
             firm: Some($crate::block!(
@@ -67,6 +67,7 @@ macro_rules! commitment_state {
                 hash: $soft_hash,
                 parent: $soft_parent,
             )),
+           base_celestia_height: $base_celestia_height,
         }
     };
 }
@@ -90,15 +91,12 @@ macro_rules! filtered_sequencer_block {
 #[macro_export]
 macro_rules! genesis_info {
     (
-        sequencer_genesis_block_height:
-        $sequencer_height:expr,celestia_base_block_height:
-        $celestia_height:expr,celestia_block_variance:
-        $variance:expr $(,)?
+        sequencer_genesis_block_height: $sequencer_height:expr,
+        celestia_block_variance: $variance:expr $(,)?
     ) => {
         ::astria_core::generated::execution::v1alpha2::GenesisInfo {
             rollup_id: ::bytes::Bytes::from($crate::ROLLUP_ID.to_vec()),
             sequencer_genesis_block_height: $sequencer_height,
-            celestia_base_block_height: $celestia_height,
             celestia_block_variance: $variance,
         }
     };
@@ -153,7 +151,8 @@ macro_rules! mount_get_commitment_state {
     (
         $test_env:ident,
         firm: ( number: $firm_number:expr, hash: $firm_hash:expr, parent: $firm_parent:expr$(,)? ),
-        soft: ( number: $soft_number:expr, hash: $soft_hash:expr, parent: $soft_parent:expr$(,)? )
+        soft: ( number: $soft_number:expr, hash: $soft_hash:expr, parent: $soft_parent:expr$(,)? ),
+        base_celestia_height: $base_celestia_height:expr
         $(,)?
     ) => {
         $test_env
@@ -168,6 +167,7 @@ macro_rules! mount_get_commitment_state {
                     hash: $soft_hash,
                     parent: $soft_parent,
                 ),
+                base_celestia_height: $base_celestia_height,
             ))
         .await
     };
@@ -179,7 +179,8 @@ macro_rules! mount_update_commitment_state {
         $test_env:ident,
         mock_name: $mock_name:expr,
         firm: ( number: $firm_number:expr, hash: $firm_hash:expr, parent: $firm_parent:expr$(,)? ),
-        soft: ( number: $soft_number:expr, hash: $soft_hash:expr, parent: $soft_parent:expr$(,)? )
+        soft: ( number: $soft_number:expr, hash: $soft_hash:expr, parent: $soft_parent:expr$(,)? ),
+        base_celestia_height: $base_celestia_height:expr
         $(,)?
     ) => {
         $test_env
@@ -196,6 +197,7 @@ macro_rules! mount_update_commitment_state {
                         hash: $soft_hash,
                         parent: $soft_parent,
                     ),
+                    base_celestia_height: $base_celestia_height,
                 ),
         )
         .await
@@ -203,7 +205,8 @@ macro_rules! mount_update_commitment_state {
     (
         $test_env:ident,
         firm: ( number: $firm_number:expr, hash: $firm_hash:expr, parent: $firm_parent:expr$(,)? ),
-        soft: ( number: $soft_number:expr, hash: $soft_hash:expr, parent: $soft_parent:expr$(,)? )
+        soft: ( number: $soft_number:expr, hash: $soft_hash:expr, parent: $soft_parent:expr$(,)? ),
+        base_celestia_height: $base_celestia_height:expr
         $(,)?
     ) => {
         mount_update_commitment_state!(
@@ -211,6 +214,7 @@ macro_rules! mount_update_commitment_state {
             mock_name: None,
             firm: ( number: $firm_number, hash: $firm_hash, parent: $firm_parent, ),
             soft: ( number: $soft_number, hash: $soft_hash, parent: $soft_parent, ),
+            base_celestia_height: $base_celestia_height,
         )
     };
 }
@@ -282,14 +286,12 @@ macro_rules! mount_get_genesis_info {
     (
         $test_env:ident,
         sequencer_genesis_block_height: $sequencer_height:expr,
-        celestia_base_block_height: $celestia_height:expr,
         celestia_block_variance: $variance:expr
         $(,)?
     ) => {
         $test_env.mount_get_genesis_info(
             $crate::genesis_info!(
                 sequencer_genesis_block_height: $sequencer_height,
-                celestia_base_block_height: $celestia_height,
                 celestia_block_variance: $variance,
             )
         ).await;

--- a/crates/astria-conductor/tests/blackbox/helpers/macros.rs
+++ b/crates/astria-conductor/tests/blackbox/helpers/macros.rs
@@ -91,8 +91,9 @@ macro_rules! filtered_sequencer_block {
 #[macro_export]
 macro_rules! genesis_info {
     (
-        sequencer_genesis_block_height: $sequencer_height:expr,
-        celestia_block_variance: $variance:expr $(,)?
+        sequencer_genesis_block_height:
+        $sequencer_height:expr,celestia_block_variance:
+        $variance:expr $(,)?
     ) => {
         ::astria_core::generated::execution::v1alpha2::GenesisInfo {
             rollup_id: ::bytes::Bytes::from($crate::ROLLUP_ID.to_vec()),

--- a/crates/astria-conductor/tests/blackbox/soft_and_firm.rs
+++ b/crates/astria-conductor/tests/blackbox/soft_and_firm.rs
@@ -143,6 +143,7 @@ async fn simple() {
     );
 }
 
+#[allow(clippy::too_many_lines)] // it's a test, it's fine
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn missing_block_is_fetched_for_updating_firm_commitment() {
     let test_conductor = spawn_conductor(CommitLevel::SoftAndFirm).await;

--- a/crates/astria-conductor/tests/blackbox/soft_and_firm.rs
+++ b/crates/astria-conductor/tests/blackbox/soft_and_firm.rs
@@ -43,7 +43,6 @@ async fn simple() {
     mount_get_genesis_info!(
         test_conductor,
         sequencer_genesis_block_height: 1,
-        celestia_base_block_height: 1,
         celestia_block_variance: 10,
     );
 
@@ -59,6 +58,7 @@ async fn simple() {
             hash: [1; 64],
             parent: [0; 64],
         ),
+        base_celestia_height: 1,
     );
 
     mount_abci_info!(
@@ -110,6 +110,7 @@ async fn simple() {
             hash: [2; 64],
             parent: [1; 64],
         ),
+        base_celestia_height: 1,
     );
 
     let update_commitment_state_firm = mount_update_commitment_state!(
@@ -124,6 +125,7 @@ async fn simple() {
             hash: [2; 64],
             parent: [1; 64],
         ),
+        base_celestia_height: 1,
     );
 
     timeout(
@@ -148,7 +150,6 @@ async fn missing_block_is_fetched_for_updating_firm_commitment() {
     mount_get_genesis_info!(
         test_conductor,
         sequencer_genesis_block_height: 1,
-        celestia_base_block_height: 1,
         celestia_block_variance: 10,
     );
 
@@ -164,6 +165,7 @@ async fn missing_block_is_fetched_for_updating_firm_commitment() {
             hash: [2; 64],
             parent: [1; 64],
         ),
+        base_celestia_height: 1,
     );
 
     mount_abci_info!(
@@ -210,6 +212,7 @@ async fn missing_block_is_fetched_for_updating_firm_commitment() {
             hash: [2; 64],
             parent: [1; 64],
         ),
+        base_celestia_height: 1,
     );
 
     timeout(
@@ -243,6 +246,7 @@ async fn missing_block_is_fetched_for_updating_firm_commitment() {
             hash: [3; 64],
             parent: [2; 64],
         ),
+        base_celestia_height: 1,
     );
 
     timeout(

--- a/crates/astria-conductor/tests/blackbox/soft_only.rs
+++ b/crates/astria-conductor/tests/blackbox/soft_only.rs
@@ -24,7 +24,6 @@ async fn simple() {
     mount_get_genesis_info!(
         test_conductor,
         sequencer_genesis_block_height: 1,
-        celestia_base_block_height: 1,
         celestia_block_variance: 10,
     );
 
@@ -40,6 +39,7 @@ async fn simple() {
             hash: [1; 64],
             parent: [0; 64],
         ),
+        base_celestia_height: 1,
     );
 
     mount_abci_info!(
@@ -71,6 +71,7 @@ async fn simple() {
             hash: [2; 64],
             parent: [1; 64],
         ),
+        base_celestia_height: 1,
     );
 
     timeout(
@@ -94,7 +95,6 @@ async fn submits_two_heights_in_succession() {
     mount_get_genesis_info!(
         test_conductor,
         sequencer_genesis_block_height: 1,
-        celestia_base_block_height: 1,
         celestia_block_variance: 10,
     );
 
@@ -110,6 +110,7 @@ async fn submits_two_heights_in_succession() {
             hash: [1; 64],
             parent: [0; 64],
         ),
+        base_celestia_height: 1,
     );
 
     mount_abci_info!(
@@ -148,6 +149,7 @@ async fn submits_two_heights_in_succession() {
             hash: [2; 64],
             parent: [1; 64],
         ),
+        base_celestia_height: 1,
     );
 
     let execute_block_number_3 = mount_executed_block!(
@@ -171,6 +173,7 @@ async fn submits_two_heights_in_succession() {
             hash: [3; 64],
             parent: [2; 64],
         ),
+        base_celestia_height: 1,
     );
 
     timeout(
@@ -196,7 +199,6 @@ async fn skips_already_executed_heights() {
     mount_get_genesis_info!(
         test_conductor,
         sequencer_genesis_block_height: 1,
-        celestia_base_block_height: 1,
         celestia_block_variance: 10,
     );
 
@@ -212,6 +214,7 @@ async fn skips_already_executed_heights() {
             hash: [1; 64],
             parent: [0; 64],
         ),
+        base_celestia_height: 1,
     );
 
     mount_abci_info!(
@@ -243,6 +246,7 @@ async fn skips_already_executed_heights() {
             hash: [2; 64],
             parent: [1; 64],
         ),
+        base_celestia_height: 1,
     );
 
     timeout(
@@ -266,7 +270,6 @@ async fn requests_from_later_genesis_height() {
     mount_get_genesis_info!(
         test_conductor,
         sequencer_genesis_block_height: 10,
-        celestia_base_block_height: 1,
         celestia_block_variance: 10,
     );
 
@@ -282,6 +285,7 @@ async fn requests_from_later_genesis_height() {
             hash: [1; 64],
             parent: [0; 64],
         ),
+        base_celestia_height: 1,
     );
 
     mount_abci_info!(
@@ -313,6 +317,7 @@ async fn requests_from_later_genesis_height() {
             hash: [2; 64],
             parent: [1; 64],
         ),
+        base_celestia_height: 1
     );
 
     timeout(

--- a/crates/astria-core/src/execution/v1alpha2/mod.rs
+++ b/crates/astria-core/src/execution/v1alpha2/mod.rs
@@ -432,7 +432,7 @@ impl Protobuf for CommitmentState {
             };
             Block::try_from_raw_ref(firm).map_err(Self::Error::firm)
         }?;
-        
+
         Self::builder()
             .firm(firm)
             .soft(soft)

--- a/crates/astria-core/src/execution/v1alpha2/mod.rs
+++ b/crates/astria-core/src/execution/v1alpha2/mod.rs
@@ -272,7 +272,11 @@ pub struct WithFirm(Block);
 pub struct WithSoft(Block);
 pub struct WithCelestiaBaseHeight(celestia_tendermint::block::Height);
 #[derive(Default)]
-pub struct CommitmentStateBuilder<TFirm = NoFirm, TSoft = NoSoft, TBaseCelestiaHeight = NoBaseCelestiaHeight> {
+pub struct CommitmentStateBuilder<
+    TFirm = NoFirm,
+    TSoft = NoSoft,
+    TBaseCelestiaHeight = NoBaseCelestiaHeight,
+> {
     firm: TFirm,
     soft: TSoft,
     base_celestia_height: TBaseCelestiaHeight,
@@ -292,7 +296,8 @@ impl<TFirm, TSoft, TCelestiaBaseHeight> CommitmentStateBuilder<TFirm, TSoft, TCe
     pub fn firm(self, firm: Block) -> CommitmentStateBuilder<WithFirm, TSoft, TCelestiaBaseHeight> {
         let Self {
             soft,
-            base_celestia_height, ..
+            base_celestia_height,
+            ..
         } = self;
         CommitmentStateBuilder {
             firm: WithFirm(firm),
@@ -304,7 +309,8 @@ impl<TFirm, TSoft, TCelestiaBaseHeight> CommitmentStateBuilder<TFirm, TSoft, TCe
     pub fn soft(self, soft: Block) -> CommitmentStateBuilder<TFirm, WithSoft, TCelestiaBaseHeight> {
         let Self {
             firm,
-            base_celestia_height, ..
+            base_celestia_height,
+            ..
         } = self;
         CommitmentStateBuilder {
             firm,
@@ -313,10 +319,14 @@ impl<TFirm, TSoft, TCelestiaBaseHeight> CommitmentStateBuilder<TFirm, TSoft, TCe
         }
     }
 
-    pub fn base_celestia_height(self, base_celestia_height: celestia_tendermint::block::Height) -> CommitmentStateBuilder<TFirm, TSoft, WithCelestiaBaseHeight> {
+    pub fn base_celestia_height(
+        self,
+        base_celestia_height: celestia_tendermint::block::Height,
+    ) -> CommitmentStateBuilder<TFirm, TSoft, WithCelestiaBaseHeight> {
         let Self {
             firm,
-            soft, ..
+            soft,
+            ..
         } = self;
         CommitmentStateBuilder {
             firm,
@@ -388,7 +398,7 @@ impl CommitmentState {
     pub fn soft(&self) -> &Block {
         &self.soft
     }
-    
+
     pub fn base_celestia_height(&self) -> celestia_tendermint::block::Height {
         self.base_celestia_height
     }
@@ -422,7 +432,8 @@ impl Protobuf for CommitmentState {
             };
             Block::try_from_raw_ref(firm).map_err(Self::Error::firm)
         }?;
-        let base_celestia_height: celestia_tendermint::block::Height = (*base_celestia_height).into();
+        let base_celestia_height: celestia_tendermint::block::Height =
+            (*base_celestia_height).into();
         Self::builder()
             .firm(firm)
             .soft(soft)
@@ -439,11 +450,10 @@ impl Protobuf for CommitmentState {
         } = self;
         let soft = soft.to_raw();
         let firm = firm.to_raw();
-        let base_celestia_height: u32 =
-            (*base_celestia_height).value().try_into().expect(
-                "block height overflow, this should not happen since tendermint heights are i64 \
-                 under the hood",
-            );
+        let base_celestia_height: u32 = (*base_celestia_height).value().try_into().expect(
+            "block height overflow, this should not happen since tendermint heights are i64 under \
+             the hood",
+        );
         Self::Raw {
             soft: Some(soft),
             firm: Some(firm),

--- a/crates/astria-core/src/generated/astria.execution.v1alpha2.rs
+++ b/crates/astria-core/src/generated/astria.execution.v1alpha2.rs
@@ -11,9 +11,6 @@ pub struct GenesisInfo {
     /// The first block height of sequencer chain to use for rollup transactions.
     #[prost(uint32, tag = "2")]
     pub sequencer_genesis_block_height: u32,
-    /// The first block height of celestia chain to use for rollup transactions.
-    #[prost(uint32, tag = "3")]
-    pub celestia_base_block_height: u32,
     /// The allowed variance in celestia for sequencer blocks to have been posted.
     #[prost(uint32, tag = "4")]
     pub celestia_block_variance: u32,
@@ -172,6 +169,9 @@ pub struct CommitmentState {
     /// Firm commitment is achieved when data has been seen in DA.
     #[prost(message, optional, tag = "2")]
     pub firm: ::core::option::Option<Block>,
+    /// The lowest block number of celestia chain to be searched for rollup blocks given current state
+    #[prost(uint32, tag = "3")]
+    pub base_celestia_height: u32,
 }
 impl ::prost::Name for CommitmentState {
     const NAME: &'static str = "CommitmentState";

--- a/crates/astria-core/src/generated/astria.execution.v1alpha2.rs
+++ b/crates/astria-core/src/generated/astria.execution.v1alpha2.rs
@@ -12,8 +12,8 @@ pub struct GenesisInfo {
     #[prost(uint32, tag = "2")]
     pub sequencer_genesis_block_height: u32,
     /// The allowed variance in celestia for sequencer blocks to have been posted.
-    #[prost(uint32, tag = "4")]
-    pub celestia_block_variance: u32,
+    #[prost(uint64, tag = "4")]
+    pub celestia_block_variance: u64,
 }
 impl ::prost::Name for GenesisInfo {
     const NAME: &'static str = "GenesisInfo";
@@ -170,8 +170,8 @@ pub struct CommitmentState {
     #[prost(message, optional, tag = "2")]
     pub firm: ::core::option::Option<Block>,
     /// The lowest block number of celestia chain to be searched for rollup blocks given current state
-    #[prost(uint32, tag = "3")]
-    pub base_celestia_height: u32,
+    #[prost(uint64, tag = "3")]
+    pub base_celestia_height: u64,
 }
 impl ::prost::Name for CommitmentState {
     const NAME: &'static str = "CommitmentState";

--- a/crates/astria-core/src/generated/astria.execution.v1alpha2.serde.rs
+++ b/crates/astria-core/src/generated/astria.execution.v1alpha2.serde.rs
@@ -466,7 +466,8 @@ impl serde::Serialize for CommitmentState {
             struct_ser.serialize_field("firm", v)?;
         }
         if self.base_celestia_height != 0 {
-            struct_ser.serialize_field("base_celestia_height", &self.base_celestia_height)?;
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("base_celestia_height", ToString::to_string(&self.base_celestia_height).as_str())?;
         }
         struct_ser.end()
     }
@@ -724,7 +725,8 @@ impl serde::Serialize for GenesisInfo {
             struct_ser.serialize_field("sequencer_genesis_block_height", &self.sequencer_genesis_block_height)?;
         }
         if self.celestia_block_variance != 0 {
-            struct_ser.serialize_field("celestia_block_variance", &self.celestia_block_variance)?;
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("celestia_block_variance", ToString::to_string(&self.celestia_block_variance).as_str())?;
         }
         struct_ser.end()
     }

--- a/crates/astria-core/src/generated/astria.execution.v1alpha2.serde.rs
+++ b/crates/astria-core/src/generated/astria.execution.v1alpha2.serde.rs
@@ -455,12 +455,18 @@ impl serde::Serialize for CommitmentState {
         if self.firm.is_some() {
             len += 1;
         }
+        if self.base_celestia_height != 0 {
+            len += 1;
+        }
         let mut struct_ser = serializer.serialize_struct("astria.execution.v1alpha2.CommitmentState", len)?;
         if let Some(v) = self.soft.as_ref() {
             struct_ser.serialize_field("soft", v)?;
         }
         if let Some(v) = self.firm.as_ref() {
             struct_ser.serialize_field("firm", v)?;
+        }
+        if self.base_celestia_height != 0 {
+            struct_ser.serialize_field("base_celestia_height", &self.base_celestia_height)?;
         }
         struct_ser.end()
     }
@@ -474,12 +480,15 @@ impl<'de> serde::Deserialize<'de> for CommitmentState {
         const FIELDS: &[&str] = &[
             "soft",
             "firm",
+            "base_celestia_height",
+            "baseCelestiaHeight",
         ];
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Soft,
             Firm,
+            BaseCelestiaHeight,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -503,6 +512,7 @@ impl<'de> serde::Deserialize<'de> for CommitmentState {
                         match value {
                             "soft" => Ok(GeneratedField::Soft),
                             "firm" => Ok(GeneratedField::Firm),
+                            "baseCelestiaHeight" | "base_celestia_height" => Ok(GeneratedField::BaseCelestiaHeight),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -524,6 +534,7 @@ impl<'de> serde::Deserialize<'de> for CommitmentState {
             {
                 let mut soft__ = None;
                 let mut firm__ = None;
+                let mut base_celestia_height__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
                         GeneratedField::Soft => {
@@ -538,11 +549,20 @@ impl<'de> serde::Deserialize<'de> for CommitmentState {
                             }
                             firm__ = map_.next_value()?;
                         }
+                        GeneratedField::BaseCelestiaHeight => {
+                            if base_celestia_height__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("baseCelestiaHeight"));
+                            }
+                            base_celestia_height__ = 
+                                Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
                     }
                 }
                 Ok(CommitmentState {
                     soft: soft__,
                     firm: firm__,
+                    base_celestia_height: base_celestia_height__.unwrap_or_default(),
                 })
             }
         }
@@ -692,9 +712,6 @@ impl serde::Serialize for GenesisInfo {
         if self.sequencer_genesis_block_height != 0 {
             len += 1;
         }
-        if self.celestia_base_block_height != 0 {
-            len += 1;
-        }
         if self.celestia_block_variance != 0 {
             len += 1;
         }
@@ -705,9 +722,6 @@ impl serde::Serialize for GenesisInfo {
         }
         if self.sequencer_genesis_block_height != 0 {
             struct_ser.serialize_field("sequencer_genesis_block_height", &self.sequencer_genesis_block_height)?;
-        }
-        if self.celestia_base_block_height != 0 {
-            struct_ser.serialize_field("celestia_base_block_height", &self.celestia_base_block_height)?;
         }
         if self.celestia_block_variance != 0 {
             struct_ser.serialize_field("celestia_block_variance", &self.celestia_block_variance)?;
@@ -726,8 +740,6 @@ impl<'de> serde::Deserialize<'de> for GenesisInfo {
             "rollupId",
             "sequencer_genesis_block_height",
             "sequencerGenesisBlockHeight",
-            "celestia_base_block_height",
-            "celestiaBaseBlockHeight",
             "celestia_block_variance",
             "celestiaBlockVariance",
         ];
@@ -736,7 +748,6 @@ impl<'de> serde::Deserialize<'de> for GenesisInfo {
         enum GeneratedField {
             RollupId,
             SequencerGenesisBlockHeight,
-            CelestiaBaseBlockHeight,
             CelestiaBlockVariance,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
@@ -761,7 +772,6 @@ impl<'de> serde::Deserialize<'de> for GenesisInfo {
                         match value {
                             "rollupId" | "rollup_id" => Ok(GeneratedField::RollupId),
                             "sequencerGenesisBlockHeight" | "sequencer_genesis_block_height" => Ok(GeneratedField::SequencerGenesisBlockHeight),
-                            "celestiaBaseBlockHeight" | "celestia_base_block_height" => Ok(GeneratedField::CelestiaBaseBlockHeight),
                             "celestiaBlockVariance" | "celestia_block_variance" => Ok(GeneratedField::CelestiaBlockVariance),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
@@ -784,7 +794,6 @@ impl<'de> serde::Deserialize<'de> for GenesisInfo {
             {
                 let mut rollup_id__ = None;
                 let mut sequencer_genesis_block_height__ = None;
-                let mut celestia_base_block_height__ = None;
                 let mut celestia_block_variance__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
@@ -804,14 +813,6 @@ impl<'de> serde::Deserialize<'de> for GenesisInfo {
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
                         }
-                        GeneratedField::CelestiaBaseBlockHeight => {
-                            if celestia_base_block_height__.is_some() {
-                                return Err(serde::de::Error::duplicate_field("celestiaBaseBlockHeight"));
-                            }
-                            celestia_base_block_height__ = 
-                                Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
-                            ;
-                        }
                         GeneratedField::CelestiaBlockVariance => {
                             if celestia_block_variance__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("celestiaBlockVariance"));
@@ -825,7 +826,6 @@ impl<'de> serde::Deserialize<'de> for GenesisInfo {
                 Ok(GenesisInfo {
                     rollup_id: rollup_id__.unwrap_or_default(),
                     sequencer_genesis_block_height: sequencer_genesis_block_height__.unwrap_or_default(),
-                    celestia_base_block_height: celestia_base_block_height__.unwrap_or_default(),
                     celestia_block_variance: celestia_block_variance__.unwrap_or_default(),
                 })
             }

--- a/proto/executionapis/astria/execution/v1alpha2/execution.proto
+++ b/proto/executionapis/astria/execution/v1alpha2/execution.proto
@@ -14,8 +14,6 @@ message GenesisInfo {
   bytes rollup_id = 1;
   // The first block height of sequencer chain to use for rollup transactions.
   uint32 sequencer_genesis_block_height = 2;
-  // The first block height of celestia chain to use for rollup transactions.
-  uint32 celestia_base_block_height = 3;
   // The allowed variance in celestia for sequencer blocks to have been posted.
   uint32 celestia_block_variance = 4;
 }
@@ -86,6 +84,8 @@ message CommitmentState {
   Block soft = 1;
   // Firm commitment is achieved when data has been seen in DA.
   Block firm = 2;
+  // The lowest block number of celestia chain to be searched for rollup blocks given current state
+  uint32 base_celestia_height = 3;
 }
 
 // There is only one CommitmentState object, so the request is empty.

--- a/proto/executionapis/astria/execution/v1alpha2/execution.proto
+++ b/proto/executionapis/astria/execution/v1alpha2/execution.proto
@@ -15,7 +15,7 @@ message GenesisInfo {
   // The first block height of sequencer chain to use for rollup transactions.
   uint32 sequencer_genesis_block_height = 2;
   // The allowed variance in celestia for sequencer blocks to have been posted.
-  uint32 celestia_block_variance = 4;
+  uint64 celestia_block_variance = 4;
 }
 
 // The set of information which deterministic driver of block production
@@ -85,7 +85,7 @@ message CommitmentState {
   // Firm commitment is achieved when data has been seen in DA.
   Block firm = 2;
   // The lowest block number of celestia chain to be searched for rollup blocks given current state
-  uint32 base_celestia_height = 3;
+  uint64 base_celestia_height = 3;
 }
 
 // There is only one CommitmentState object, so the request is empty.


### PR DESCRIPTION
## Summary
Updates the execution api to have celestia base height as a part of commitment instead of genesis, requiring rollups to track the base celestia height as it increases. This enables conductor on resync to move much faster.

https://github.com/astriaorg/astria-geth/pull/22 contains an implementation which works with this PR.

## Background
Conductor resync needs to grab all data from genesis for the rollup currently, even if much of that data is previously executed.

## Changes
- Change execution API to have celestia base height on commitment
- Update conductor logic to update celestia base height to that of most recent firm commitment found in.

## Testing
Manually tested running linked PR in dev cluster, updated blackbox tests.

## Breaking Changelist
- Execution API breaking change, rollout will require a new image for any rollup utilizing.
