### PR TITLE
fix(sequencer): unstick wrong sudo signer from mempool

### DIFF
--- a/crates/astria-sequencer/src/app/mod.rs
+++ b/crates/astria-sequencer/src/app/mod.rs
@@ -538,7 +538,7 @@ impl App {
                 }
                 Err(e) => {
                     metrics::counter!(
-                        metrics_init::PREPARE_PROPOSAL_EXCLUDED_TRANSACTIONS_DECODE_FAILURE
+                        metrics_init::PREPARE_PROPOSAL_EXCLUDED_TRANSACTIONS_FAILED_EXECUTION
                     )
                     .increment(1);
                     debug!(

--- a/crates/astria-sequencer/src/transaction/mod.rs
+++ b/crates/astria-sequencer/src/transaction/mod.rs
@@ -23,6 +23,7 @@ pub(crate) use checks::{
     check_balance_mempool,
     check_chain_id_mempool,
     check_nonce_mempool,
+    check_sudo_signer,
 };
 use tracing::instrument;
 


### PR DESCRIPTION
## Summary
Currently authority transactions that have the wrong sudo signer get stuck in the mempool. This is because the incorrectly signed transactions will fail to execute and will be removed from the `prepare_proposal()` block, will not be removed from the cometBFT mempool, and then re-added to the app's mempool during cometBFT's `CheckTx` flow. 

## Changes
- added to `CheckTx` flow verification of correct sudo signer for sudo actions

## Testing
Sending sudo txs via CLI 
