### PR TITLE
feat(sequencer): add cache to cometbft mempool

### DIFF
--- a/crates/astria-core/src/protocol/abci.rs
+++ b/crates/astria-core/src/protocol/abci.rs
@@ -18,6 +18,7 @@ impl AbciErrorCode {
     pub const INSUFFICIENT_FUNDS: Self = Self(6);
     pub const INVALID_CHAIN_ID: Self = Self(7);
     pub const VALUE_NOT_FOUND: Self = Self(8);
+    pub const ALREADY_PROCESSED: Self = Self(9);
 }
 
 impl AbciErrorCode {
@@ -33,6 +34,7 @@ impl AbciErrorCode {
             6 => "insufficient funds".into(),
             7 => "the provided chain id was invalid".into(),
             8 => "the requested value was not found".into(),
+            9 => "the transaction has already been processed".into(),
             other => format!("unknown non-zero abci error code: {other}").into(),
         }
     }
@@ -61,6 +63,7 @@ impl From<NonZeroU32> for AbciErrorCode {
             6 => Self::INSUFFICIENT_FUNDS,
             7 => Self::INVALID_CHAIN_ID,
             8 => Self::VALUE_NOT_FOUND,
+            9 => Self::ALREADY_PROCESSED,
             other => Self(other),
         }
     }

--- a/crates/astria-sequencer/src/app/mod.rs
+++ b/crates/astria-sequencer/src/app/mod.rs
@@ -538,7 +538,7 @@ impl App {
                 }
                 Err(e) => {
                     metrics::counter!(
-                        metrics_init::PREPARE_PROPOSAL_EXCLUDED_TRANSACTIONS_DECODE_FAILURE
+                        metrics_init::PREPARE_PROPOSAL_EXCLUDED_TRANSACTIONS_FAILED_EXECUTION
                     )
                     .increment(1);
                     debug!(

--- a/crates/astria-sequencer/src/service/mempool.rs
+++ b/crates/astria-sequencer/src/service/mempool.rs
@@ -124,6 +124,7 @@ impl TxCache {
 /// It performs a stateless check of the given transaction,
 /// returning a [`tendermint::v0_38::abci::response::CheckTx`].
 #[derive(Clone)]
+#[allow(clippy::struct_field_names)]
 pub(crate) struct Mempool {
     storage: Storage,
     mempool: AppMempool,

--- a/crates/astria-sequencer/src/service/mempool.rs
+++ b/crates/astria-sequencer/src/service/mempool.rs
@@ -48,7 +48,7 @@ use crate::{
 
 // TODO make these config configurable
 const MAX_TX_SIZE: usize = 256_000; // 256 KB
-const CACHE_SIZE: usize = 4600;
+const CACHE_SIZE: usize = 16384;
 const CACHE_TTL: i64 = 60; // 60 seconds 
 
 /// `TxCache` provides for keeping `CometBFT`'s mempool clean.
@@ -82,7 +82,6 @@ impl TxCache {
         }
     }
 
-    // returns
     fn cached(&self, tx_hash: [u8; 32]) -> bool {
         // the tx is known and entry hasn't expired
         self.cache.contains(&tx_hash)
@@ -95,8 +94,7 @@ impl TxCache {
     fn add(&mut self, tx_hash: [u8; 32]) {
         if self.cache.contains(&tx_hash) {
             // update time to live if already exists
-            // note: this doesn't change the tx's position in the remove vector,
-            // this should be fine as correct remove ordering isn't a security matter
+            // note: this doesn't change the tx's position in the remove vector
             self.time_added
                 .insert(tx_hash, Time::now().unix_timestamp());
             return;

--- a/crates/astria-sequencer/src/service/mempool.rs
+++ b/crates/astria-sequencer/src/service/mempool.rs
@@ -51,7 +51,7 @@ const MAX_TX_SIZE: usize = 256_000; // 256 KB
 const CACHE_SIZE: usize = 4600;
 const CACHE_TTL: i64 = 60; // 60 seconds 
 
-/// `TxCache`` provides for keeping `CometBFT`'s mempool clean.
+/// `TxCache` provides for keeping `CometBFT`'s mempool clean.
 //
 /// Since we're now using an app side mempool, we can remove
 /// transactions from this mempool once we've placed them there.
@@ -304,10 +304,10 @@ async fn handle_check_tx<S: StateReadExt + 'static>(
     response::CheckTx::default()
 }
 
+#[cfg(test)]
 mod test {
     use std::time::Duration;
 
-    use tendermint::Time;
     use tokio::time;
 
     use crate::service::mempool::TxCache;


### PR DESCRIPTION
## Summary
Currently, transactions that fail to execute (but pass stateless checks) get stuck inside of the CometBFT mempool. This is caused by the cycle of:
- transaction gets added to CometBFT mempool and passes checks
- transaction gets fed to `prepare_proposal()`, fails to execute, gets removed from app's mempool, but doesn't get removed from CometBFT's mempool
- transaction gets re-fed to app's mempool during `handle_check_tx()` and repeats process

## Changes
Added a simple transaction cache to the CometBFT's `handle_check_tx()` service. The cache has a max size and applies a TTL to the entries, allowing for users to eventually be able to have transactions re-added to the app's mempool if desired.

Note: the TTL for this PR doesn't affect the transactions stored in the app's mempool.

## Testing
Running failing-to-execute transactions locally and watching them not get stuck in the mempool anymore. 
