### PR TITLE
chore(chart): change evm back to latest on dev

### DIFF
--- a/charts/evm-rollup/Chart.yaml
+++ b/charts/evm-rollup/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.18.5
+version: 0.18.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/evm-rollup/values.yaml
+++ b/charts/evm-rollup/values.yaml
@@ -10,7 +10,7 @@ images:
   geth:
     repo: ghcr.io/astriaorg/astria-geth
     tag: 0.10.1
-    devTag: pr-22  # Reset to latest once this PR has been merged
+    devTag: latest
   conductor:
     repo: ghcr.io/astriaorg/conductor
     tag: "0.16.0"


### PR DESCRIPTION
Due to submission order needs, switched dev tag to pr branch, this switches it back to latest.