### PR TITLE
feat(sequencer): add ttl and invalid cache to app mempool

### DIFF
--- a/crates/astria-core/src/protocol/abci.rs
+++ b/crates/astria-core/src/protocol/abci.rs
@@ -18,6 +18,8 @@ impl AbciErrorCode {
     pub const INSUFFICIENT_FUNDS: Self = Self(6);
     pub const INVALID_CHAIN_ID: Self = Self(7);
     pub const VALUE_NOT_FOUND: Self = Self(8);
+    pub const TRANSACTION_EXPIRED: Self = Self(9);
+    pub const TRANSACTION_FAILED: Self = Self(10);
 }
 
 impl AbciErrorCode {
@@ -33,6 +35,8 @@ impl AbciErrorCode {
             6 => "insufficient funds".into(),
             7 => "the provided chain id was invalid".into(),
             8 => "the requested value was not found".into(),
+            9 => "the transaction expired in the app's mempool".into(),
+            10 => "the transaction failed to execute in prepare_proposal()".into(),
             other => format!("unknown non-zero abci error code: {other}").into(),
         }
     }
@@ -61,6 +65,8 @@ impl From<NonZeroU32> for AbciErrorCode {
             6 => Self::INSUFFICIENT_FUNDS,
             7 => Self::INVALID_CHAIN_ID,
             8 => Self::VALUE_NOT_FOUND,
+            9 => Self::TRANSACTION_EXPIRED,
+            10 => Self::TRANSACTION_FAILED,
             other => Self(other),
         }
     }

--- a/crates/astria-sequencer/Cargo.toml
+++ b/crates/astria-sequencer/Cargo.toml
@@ -67,6 +67,7 @@ config = { package = "astria-config", path = "../astria-config", features = [
   "tests",
 ] }
 insta = { workspace = true, features = ["json"] }
+tokio = { workspace = true, features = ["test-util"] }
 
 [build-dependencies]
 astria-build-info = { path = "../astria-build-info", features = ["build"] }


### PR DESCRIPTION
## Summary
This PR adds to the App's mempool a way to signal to CometBFT when transactions should be removed from the CometBFT mempool. 

## Background
The CometBFT and App mempools currently get transactions that fail to execute stuck in them. This is because when a transaction fails to execute in `prepare_proposal()`, it doesn't get removed from the CometBFT mempool. CometBFT only clears out transactions if they either fail `handleCheckTx()` or are included in a block. Because of this, CometBFT will re-add the failed transaction to the App mempool during its `handleCheckTx()` maintenance, which will cause it to be fed to `prepare_proposal()` again.

We also need a way for full nodes to clear out these invalid transactions. Since these nodes don't run `prepare_proposal()`, we need an additional way, like a tx TTL, to signal when transactions can be dropped.

## Changes
- Added a transaction cache to the App's mempool which signals to CometBFT when a transaction should be removed.
- Tracks in the App's mempool when a transaction is first seen.
- Transactions that fail in `prepare_proposal()` get added to the App's removal cache.
- Transactions that are older than 10 minutes are added to the App's removal cache.

## Testing
Unit tests and local testing of invalid transactions. 

## Metrics
Added `CHECK_TX_REMOVED_FAILED_EXECUTION` counter to the sequencer's metrics. 
Added `CHECK_TX_REMOVED_EXPIRED` counter to the sequencer's metrics.

## Related
Closes #979