### PR TITLE
feat(sequencer): implement `bridge/account_last_tx_hash` abci query

### DIFF
--- a/crates/astria-core/src/generated/astria.protocol.bridge.v1alpha1.rs
+++ b/crates/astria-core/src/generated/astria.protocol.bridge.v1alpha1.rs
@@ -1,0 +1,16 @@
+/// A response containing the last tx hash given some bridge address.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BridgeAccountLastTxHashResponse {
+    #[prost(uint64, tag = "2")]
+    pub height: u64,
+    #[prost(bytes = "vec", tag = "3")]
+    pub tx_hash: ::prost::alloc::vec::Vec<u8>,
+}
+impl ::prost::Name for BridgeAccountLastTxHashResponse {
+    const NAME: &'static str = "BridgeAccountLastTxHashResponse";
+    const PACKAGE: &'static str = "astria.protocol.bridge.v1alpha1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.protocol.bridge.v1alpha1.{}", Self::NAME)
+    }
+}

--- a/crates/astria-core/src/generated/mod.rs
+++ b/crates/astria-core/src/generated/mod.rs
@@ -53,6 +53,11 @@ pub mod protocol {
         pub mod v1alpha1;
     }
     #[path = ""]
+    pub mod bridge {
+        #[path = "astria.protocol.bridge.v1alpha1.rs"]
+        pub mod v1alpha1;
+    }
+    #[path = ""]
     pub mod transaction {
         #[path = "astria.protocol.transactions.v1alpha1.rs"]
         pub mod v1alpha1;

--- a/crates/astria-core/src/protocol/bridge/mod.rs
+++ b/crates/astria-core/src/protocol/bridge/mod.rs
@@ -1,0 +1,3 @@
+pub mod v1alpha1;
+
+use crate::generated::protocol::bridge::v1alpha1 as raw;

--- a/crates/astria-core/src/protocol/bridge/v1alpha1/mod.rs
+++ b/crates/astria-core/src/protocol/bridge/v1alpha1/mod.rs
@@ -7,6 +7,12 @@ pub struct BridgeAccountLastTxHashResponse {
 }
 
 impl BridgeAccountLastTxHashResponse {
+    /// Converts a native [`BridgeAccountLastTxHashResponse`] to a protobuf
+    /// [`raw::BridgeAccountLastTxHashResponse`].
+    ///
+    /// # Errors
+    ///
+    /// - if the transaction hash is not 32 bytes
     pub fn try_from_raw(
         raw: raw::BridgeAccountLastTxHashResponse,
     ) -> Result<Self, BridgeAccountLastTxHashResponseError> {
@@ -28,6 +34,12 @@ impl BridgeAccountLastTxHashResponse {
 }
 
 impl raw::BridgeAccountLastTxHashResponse {
+    /// Converts a protobuf [`raw::BridgeAccountLastTxHashResponse`] to a native
+    /// [`BridgeAccountLastTxHashResponse`].
+    ///
+    /// # Errors
+    ///
+    /// - if the transaction hash is not 32 bytes
     pub fn try_into_native(
         self,
     ) -> Result<BridgeAccountLastTxHashResponse, BridgeAccountLastTxHashResponseError> {
@@ -47,6 +59,7 @@ impl raw::BridgeAccountLastTxHashResponse {
 pub struct BridgeAccountLastTxHashResponseError(BridgeAccountLastTxHashResponseErrorKind);
 
 impl BridgeAccountLastTxHashResponseError {
+    #[must_use]
     pub fn invalid_tx_hash(bytes: usize) -> Self {
         Self(BridgeAccountLastTxHashResponseErrorKind::InvalidTxHash(
             bytes,

--- a/crates/astria-core/src/protocol/bridge/v1alpha1/mod.rs
+++ b/crates/astria-core/src/protocol/bridge/v1alpha1/mod.rs
@@ -1,0 +1,60 @@
+use super::raw;
+
+pub struct BridgeAccountLastTxHashResponse {
+    pub height: u64,
+    pub tx_hash: [u8; 32],
+}
+
+impl BridgeAccountLastTxHashResponse {
+    pub fn try_from_raw(
+        raw: raw::BridgeAccountLastTxHashResponse,
+    ) -> Result<Self, BridgeAccountLastTxHashResponseError> {
+        Ok(Self {
+            height: raw.height,
+            tx_hash: raw.tx_hash.try_into().map_err(|bytes: Vec<u8>| {
+                BridgeAccountLastTxHashResponseError::invalid_tx_hash(bytes.len())
+            })?,
+        })
+    }
+
+    #[must_use]
+    pub fn into_raw(self) -> raw::BridgeAccountLastTxHashResponse {
+        raw::BridgeAccountLastTxHashResponse {
+            height: self.height,
+            tx_hash: self.tx_hash.to_vec(),
+        }
+    }
+}
+
+impl raw::BridgeAccountLastTxHashResponse {
+    pub fn try_into_native(
+        self,
+    ) -> Result<BridgeAccountLastTxHashResponse, BridgeAccountLastTxHashResponseError> {
+        BridgeAccountLastTxHashResponse::try_from_raw(self)
+    }
+
+    #[must_use]
+    pub fn from_native(
+        native: BridgeAccountLastTxHashResponse,
+    ) -> raw::BridgeAccountLastTxHashResponse {
+        native.into_raw()
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub struct BridgeAccountLastTxHashResponseError(BridgeAccountLastTxHashResponseErrorKind);
+
+impl BridgeAccountLastTxHashResponseError {
+    pub fn invalid_tx_hash(bytes: usize) -> Self {
+        Self(BridgeAccountLastTxHashResponseErrorKind::InvalidTxHash(
+            bytes,
+        ))
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum BridgeAccountLastTxHashResponseErrorKind {
+    #[error("invalid tx hash; must be 32 bytes, got {0} bytes")]
+    InvalidTxHash(usize),
+}

--- a/crates/astria-core/src/protocol/bridge/v1alpha1/mod.rs
+++ b/crates/astria-core/src/protocol/bridge/v1alpha1/mod.rs
@@ -1,5 +1,6 @@
 use super::raw;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BridgeAccountLastTxHashResponse {
     pub height: u64,
     pub tx_hash: [u8; 32],

--- a/crates/astria-core/src/protocol/mod.rs
+++ b/crates/astria-core/src/protocol/mod.rs
@@ -6,6 +6,7 @@ use crate::primitive::v1::RollupId;
 pub mod abci;
 pub mod account;
 pub mod asset;
+pub mod bridge;
 pub mod transaction;
 
 #[cfg(any(feature = "test-utils", test))]

--- a/crates/astria-sequencer-client/src/extension_trait.rs
+++ b/crates/astria-sequencer-client/src/extension_trait.rs
@@ -26,7 +26,10 @@ use std::{
     sync::Arc,
 };
 
-use astria_core::protocol::asset::v1alpha1::AllowedFeeAssetIdsResponse;
+use astria_core::protocol::{
+    asset::v1alpha1::AllowedFeeAssetIdsResponse,
+    bridge::v1alpha1::BridgeAccountLastTxHashResponse,
+};
 pub use astria_core::{
     primitive::v1::Address,
     protocol::{
@@ -540,6 +543,39 @@ pub trait SequencerClientExt: Client {
         // This makes use of the fact that a height `None` and `Some(0)` are
         // treated the same.
         self.get_nonce(address, 0u32).await
+    }
+
+    async fn get_bridge_account_last_transaction_hash<A: Into<Address> + Send>(
+        &self,
+        address: A,
+    ) -> Result<BridgeAccountLastTxHashResponse, Error> {
+        const PREFIX: &[u8] = b"bridge/account_last_tx_hash/";
+
+        let path = make_path_from_prefix_and_address(PREFIX, address.into().get());
+
+        let response = self
+            .abci_query(Some(path), vec![], None, false)
+            .await
+            .map_err(|e| Error::tendermint_rpc("abci_query", e))?;
+
+        let proto_response =
+            astria_core::generated::protocol::bridge::v1alpha1::BridgeAccountLastTxHashResponse::decode(
+                &*response.value,
+            )
+            .map_err(|e| {
+                Error::abci_query_deserialization(
+                    "astria.protocol.bridge.v1alpha1.BridgeAccountLastTxHashResponse",
+                    response,
+                    e,
+                )
+            })?;
+        let native = proto_response.try_into_native().map_err(|e| {
+            Error::native_conversion(
+                "astria.protocol.bridge.v1alpha1.BridgeAccountLastTxHashResponse",
+                Arc::new(e),
+            )
+        })?;
+        Ok(native)
     }
 
     /// Submits the given transaction to the Sequencer node.

--- a/crates/astria-sequencer-client/src/tests/http.rs
+++ b/crates/astria-sequencer-client/src/tests/http.rs
@@ -235,6 +235,36 @@ async fn get_allowed_fee_assets() {
 }
 
 #[tokio::test]
+async fn get_bridge_account_last_transaction_hash() {
+    use astria_core::generated::protocol::bridge::v1alpha1::BridgeAccountLastTxHashResponse;
+
+    let MockSequencer {
+        server,
+        client,
+    } = MockSequencer::start().await;
+
+    let expected_response = BridgeAccountLastTxHashResponse {
+        height: 10,
+        tx_hash: [0; 32].to_vec(),
+    };
+
+    let _guard = register_abci_query_response(
+        &server,
+        "bridge/account_last_tx_hash",
+        expected_response.clone(),
+    )
+    .await;
+
+    let actual_response = client
+        .get_bridge_account_last_transaction_hash(ALICE_ADDRESS)
+        .await
+        .unwrap()
+        .into_raw();
+
+    assert_eq!(expected_response, actual_response);
+}
+
+#[tokio::test]
 async fn submit_tx_sync() {
     let MockSequencer {
         server,

--- a/crates/astria-sequencer/src/bridge/mod.rs
+++ b/crates/astria-sequencer/src/bridge/mod.rs
@@ -2,6 +2,7 @@ mod bridge_lock_action;
 mod bridge_unlock_action;
 pub(crate) mod component;
 pub(crate) mod init_bridge_account_action;
+pub(crate) mod query;
 pub(crate) mod state_ext;
 
 pub(crate) use bridge_lock_action::get_deposit_byte_len;

--- a/crates/astria-sequencer/src/bridge/query.rs
+++ b/crates/astria-sequencer/src/bridge/query.rs
@@ -1,0 +1,108 @@
+use anyhow::Context as _;
+use astria_core::{
+    primitive::v1::Address,
+    protocol::abci::AbciErrorCode,
+};
+use cnidarium::Storage;
+use prost::Message as _;
+use tendermint::abci::{
+    request,
+    response,
+};
+
+use crate::{
+    bridge::state_ext::StateReadExt as _,
+    state_ext::StateReadExt as _,
+};
+
+pub(crate) async fn bridge_account_last_tx_hash_request(
+    storage: Storage,
+    request: request::Query,
+    params: Vec<(String, String)>,
+) -> response::Query {
+    use astria_core::protocol::bridge::v1alpha1::BridgeAccountLastTxHashResponse;
+
+    let address = match preprocess_request(&params) {
+        Ok(tup) => tup,
+        Err(err_rsp) => return err_rsp,
+    };
+
+    // use latest snapshot, as this is a query for latest tx
+    let snapshot = storage.latest_snapshot();
+    let height = match snapshot.get_block_height().await {
+        Ok(height) => height,
+        Err(err) => {
+            return response::Query {
+                code: AbciErrorCode::INTERNAL_ERROR.into(),
+                info: AbciErrorCode::INTERNAL_ERROR.to_string(),
+                log: format!("failed getting block height: {err:#}"),
+                ..response::Query::default()
+            };
+        }
+    };
+
+    let tx_hash = match snapshot
+        .get_last_transaction_hash_for_bridge_account(&address)
+        .await
+    {
+        Ok(Some(tx_hash)) => tx_hash,
+        Ok(None) => {
+            return response::Query {
+                code: AbciErrorCode::VALUE_NOT_FOUND.into(),
+                info: AbciErrorCode::VALUE_NOT_FOUND.to_string(),
+                log: "no transaction hash found for provided address".into(),
+                ..response::Query::default()
+            };
+        }
+        Err(err) => {
+            return response::Query {
+                code: AbciErrorCode::INTERNAL_ERROR.into(),
+                info: AbciErrorCode::INTERNAL_ERROR.to_string(),
+                log: format!("failed getting balance for provided address: {err:?}"),
+                ..response::Query::default()
+            };
+        }
+    };
+    let payload = BridgeAccountLastTxHashResponse {
+        height,
+        tx_hash,
+    }
+    .into_raw()
+    .encode_to_vec()
+    .into();
+
+    let height = tendermint::block::Height::try_from(height).expect("height must fit into an i64");
+    response::Query {
+        code: 0.into(),
+        key: request.path.clone().into_bytes().into(),
+        value: payload,
+        height,
+        ..response::Query::default()
+    }
+}
+
+fn preprocess_request(params: &[(String, String)]) -> anyhow::Result<Address, response::Query> {
+    let Some(address) = params
+        .iter()
+        .find_map(|(k, v)| (k == "address").then_some(v))
+    else {
+        return Err(response::Query {
+            code: AbciErrorCode::INVALID_PARAMETER.into(),
+            info: AbciErrorCode::INVALID_PARAMETER.to_string(),
+            log: "path did not contain address parameter".into(),
+            ..response::Query::default()
+        });
+    };
+    let address = hex::decode(address)
+        .context("failed decoding hex encoded bytes")
+        .and_then(|addr| {
+            Address::try_from_slice(&addr).context("failed constructing address from bytes")
+        })
+        .map_err(|err| response::Query {
+            code: AbciErrorCode::INVALID_PARAMETER.into(),
+            info: AbciErrorCode::INVALID_PARAMETER.to_string(),
+            log: format!("address could not be constructed from provided parameter: {err:#}"),
+            ..response::Query::default()
+        })?;
+    Ok(address)
+}

--- a/crates/astria-sequencer/src/bridge/state_ext.rs
+++ b/crates/astria-sequencer/src/bridge/state_ext.rs
@@ -61,16 +61,22 @@ const DEPOSIT_PREFIX: &str = "deposit";
 const INIT_BRIDGE_ACCOUNT_BASE_FEE_STORAGE_KEY: &str = "initbridgeaccfee";
 const BRIDGE_LOCK_BYTE_COST_MULTIPLIER_STORAGE_KEY: &str = "bridgelockmultiplier";
 
-fn storage_key(address: &str) -> String {
+fn bridge_account_storage_key(address: &str) -> String {
     format!("{BRIDGE_ACCOUNT_PREFIX}/{address}")
 }
 
 fn rollup_id_storage_key(address: &Address) -> String {
-    format!("{}/rollupid", storage_key(&address.encode_hex::<String>()))
+    format!(
+        "{}/rollupid",
+        bridge_account_storage_key(&address.encode_hex::<String>())
+    )
 }
 
 fn asset_id_storage_key(address: &Address) -> String {
-    format!("{}/assetid", storage_key(&address.encode_hex::<String>()))
+    format!(
+        "{}/assetid",
+        bridge_account_storage_key(&address.encode_hex::<String>())
+    )
 }
 
 fn deposit_storage_key_prefix(rollup_id: &RollupId) -> String {
@@ -83,6 +89,14 @@ fn deposit_storage_key(rollup_id: &RollupId, nonce: u32) -> Vec<u8> {
 
 fn deposit_nonce_storage_key(rollup_id: &RollupId) -> Vec<u8> {
     format!("depositnonce/{}", rollup_id.encode_hex::<String>()).into()
+}
+
+fn last_transaction_hash_for_bridge_account_storage_key(address: &Address) -> Vec<u8> {
+    format!(
+        "{}/lasttx",
+        bridge_account_storage_key(&address.encode_hex::<String>())
+    )
+    .into_bytes()
 }
 
 #[async_trait]
@@ -205,6 +219,27 @@ pub(crate) trait StateReadExt: StateRead {
         let Fee(fee) = Fee::try_from_slice(&bytes).context("invalid fee bytes")?;
         Ok(fee)
     }
+
+    #[instrument(skip(self))]
+    async fn get_last_transaction_hash_for_bridge_account(
+        &self,
+        address: &Address,
+    ) -> Result<Option<[u8; 32]>> {
+        let Some(tx_hash_bytes) = self
+            .nonverifiable_get_raw(&last_transaction_hash_for_bridge_account_storage_key(
+                address,
+            ))
+            .await
+            .context("failed reading raw last transaction hash for bridge account from state")?
+        else {
+            return Ok(None);
+        };
+
+        let tx_hash = tx_hash_bytes
+            .try_into()
+            .expect("all transaction hashes stored should be 32 bytes; this is a bug");
+        Ok(Some(tx_hash))
+    }
 }
 
 impl<T: StateRead + ?Sized> StateReadExt for T {}
@@ -290,6 +325,18 @@ pub(crate) trait StateWriteExt: StateWrite {
         self.put_raw(
             BRIDGE_LOCK_BYTE_COST_MULTIPLIER_STORAGE_KEY.to_string(),
             borsh::to_vec(&Fee(fee)).expect("failed to serialize fee"),
+        );
+    }
+
+    #[instrument(skip(self))]
+    fn put_last_transaction_hash_for_bridge_account(
+        &mut self,
+        address: &Address,
+        tx_hash: &[u8; 32],
+    ) {
+        self.nonverifiable_put_raw(
+            last_transaction_hash_for_bridge_account_storage_key(address),
+            tx_hash.to_vec(),
         );
     }
 }

--- a/crates/astria-sequencer/src/service/info/mod.rs
+++ b/crates/astria-sequencer/src/service/info/mod.rs
@@ -64,6 +64,12 @@ impl Info {
                 crate::asset::query::allowed_fee_asset_ids_request,
             )
             .context("invalid path: `asset/allowed_fee_asset_ids`")?;
+        query_router
+            .insert(
+                "bridge/account_last_tx_hash/:address",
+                crate::bridge::query::bridge_account_last_tx_hash_request,
+            )
+            .context("invalid path: `bridge/account_last_tx_hash/:address`")?;
         Ok(Self {
             storage,
             query_router,

--- a/proto/protocolapis/astria/protocol/bridge/v1alpha1/types.proto
+++ b/proto/protocolapis/astria/protocol/bridge/v1alpha1/types.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package astria.protocol.bridge.v1alpha1;
+
+// A response containing the last tx hash given some bridge address.
+message BridgeAccountLastTxHashResponse {
+  uint64 height = 2;
+  bytes tx_hash = 3;
+}


### PR DESCRIPTION
## Summary
 implement `bridge/account_last_tx_hash` abci query which returns the last executed tx from the given bridge account.

## Background
required for the bridge withdrawer's sync logic (or rather, makes it much simpler to implement).

## Changes
- if a bridge account makes a tx, store this tx hash in the nonconsensus storage.
- implement `bridge/account_last_tx_hash` abci query which queries the nonconsensus storage for this tx hash given some address. 
- TODO: we can make this a config value, so only nodes that are configured to store this data store it. 

## Testing
unit tests

## Related Issues

closes #1107
