### PR TITLE
fix(core, sequencer): prefix removal source non-refund ics20 packet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ target/
 
 # We don't want to commit the dependency directory of charts
 charts/*/charts
+
+crates/astria-bridge-withdrawer/src/withdrawer/ethereum/generated/

--- a/crates/astria-bridge-withdrawer/src/withdrawer/ethereum/convert.rs
+++ b/crates/astria-bridge-withdrawer/src/withdrawer/ethereum/convert.rs
@@ -131,9 +131,8 @@ fn event_to_ics20_withdrawal(
     let sender = event.sender.to_fixed_bytes();
     let denom = rollup_asset_denom.clone();
 
-    let (_, channel) = denom
-        .prefix()
-        .rsplit_once('/')
+    let channel = denom
+        .channel()
         .ok_or_eyre("denom must have a channel to be withdrawn via IBC")?;
 
     let memo = Ics20WithdrawalFromRollupMemo {
@@ -189,12 +188,14 @@ fn calculate_packet_timeout_time(timeout_delta: Duration) -> eyre::Result<u64> {
 
 #[cfg(test)]
 mod tests {
+    use asset::default_native_asset;
+
     use super::*;
     use crate::withdrawer::ethereum::astria_withdrawer_interface::SequencerWithdrawalFilter;
 
     #[test]
     fn event_to_bridge_unlock() {
-        let denom = Denom::from("nria".to_string());
+        let denom = default_native_asset();
         let event_with_meta = EventWithMetadata {
             event: WithdrawalEvent::Sequencer(SequencerWithdrawalFilter {
                 sender: [0u8; 20].into(),
@@ -238,7 +239,7 @@ mod tests {
 
     #[test]
     fn event_to_bridge_unlock_divide_value() {
-        let denom = Denom::from("nria".to_string());
+        let denom = default_native_asset();
         let event_with_meta = EventWithMetadata {
             event: WithdrawalEvent::Sequencer(SequencerWithdrawalFilter {
                 sender: [0u8; 20].into(),
@@ -283,7 +284,7 @@ mod tests {
 
     #[test]
     fn event_to_ics20_withdrawal() {
-        let denom = Denom::from("transfer/channel-0/utia".to_string());
+        let denom = "transfer/channel-0/utia".parse::<Denom>().unwrap();
         let destination_chain_address = "address".to_string();
         let event_with_meta = EventWithMetadata {
             event: WithdrawalEvent::Ics20(Ics20WithdrawalFilter {

--- a/crates/astria-bridge-withdrawer/src/withdrawer/ethereum/watcher.rs
+++ b/crates/astria-bridge-withdrawer/src/withdrawer/ethereum/watcher.rs
@@ -79,7 +79,7 @@ impl Builder {
         let contract_address = address_from_string(&ethereum_contract_address)
             .wrap_err("failed to parse ethereum contract address")?;
 
-        if rollup_asset_denom.prefix().is_empty() {
+        if !rollup_asset_denom.is_prefixed() {
             warn!(
                 "rollup asset denomination is not prefixed; Ics20Withdrawal actions will not be \
                  submitted"
@@ -419,6 +419,7 @@ fn address_from_string(s: &str) -> Result<ethers::types::Address> {
 
 #[cfg(test)]
 mod tests {
+    use asset::default_native_asset;
     use astria_core::{
         primitive::v1::{
             Address,
@@ -547,8 +548,8 @@ mod tests {
             block_number: receipt.block_number.unwrap(),
             transaction_hash: receipt.transaction_hash,
         };
-        let denom: Denom = Denom::from_base_denom("nria");
         let bridge_address = crate::astria_address([1u8; 20]);
+        let denom = default_native_asset();
         let expected_action =
             event_to_action(expected_event, denom.id(), denom.clone(), 1, bridge_address).unwrap();
         let Action::BridgeUnlock(expected_action) = expected_action else {
@@ -638,8 +639,8 @@ mod tests {
             block_number: receipt.block_number.unwrap(),
             transaction_hash: receipt.transaction_hash,
         };
-        let denom = Denom::from("transfer/channel-0/utia".to_string());
         let bridge_address = crate::astria_address([1u8; 20]);
+        let denom = "transfer/channel-0/utia".parse::<Denom>().unwrap();
         let Action::Ics20Withdrawal(mut expected_action) =
             event_to_action(expected_event, denom.id(), denom.clone(), 1, bridge_address).unwrap()
         else {

--- a/crates/astria-bridge-withdrawer/src/withdrawer/ethereum/watcher.rs
+++ b/crates/astria-bridge-withdrawer/src/withdrawer/ethereum/watcher.rs
@@ -762,7 +762,7 @@ mod tests {
             block_number: receipt.block_number.unwrap(),
             transaction_hash: receipt.transaction_hash,
         };
-        let denom: Denom = Denom::from_base_denom("nria");
+        let denom = default_native_asset();
         let bridge_address = crate::astria_address([1u8; 20]);
         let expected_action =
             event_to_action(expected_event, denom.id(), denom.clone(), 1, bridge_address).unwrap();
@@ -863,7 +863,7 @@ mod tests {
             block_number: receipt.block_number.unwrap(),
             transaction_hash: receipt.transaction_hash,
         };
-        let denom = Denom::from("transfer/channel-0/utia".to_string());
+        let denom = "transfer/channel-0/utia".parse::<Denom>().unwrap();
         let bridge_address = crate::astria_address([1u8; 20]);
         let Action::Ics20Withdrawal(mut expected_action) =
             event_to_action(expected_event, denom.id(), denom.clone(), 1, bridge_address).unwrap()

--- a/crates/astria-bridge-withdrawer/src/withdrawer/mod.rs
+++ b/crates/astria-bridge-withdrawer/src/withdrawer/mod.rs
@@ -100,8 +100,7 @@ impl Service {
             submitter_handle,
             shutdown_token: shutdown_handle.token(),
             state: state.clone(),
-            rollup_asset_denom: cfg
-                .rollup_asset_denomination
+            rollup_asset_denom: rollup_asset_denomination
                 .parse::<Denom>()
                 .wrap_err("failed to parse ROLLUP_ASSET_DENOMINATION as Denom")?,
             bridge_address: sequencer_bridge_address,

--- a/crates/astria-bridge-withdrawer/src/withdrawer/mod.rs
+++ b/crates/astria-bridge-withdrawer/src/withdrawer/mod.rs
@@ -5,7 +5,10 @@ use std::{
 };
 
 use astria_core::primitive::v1::{
-    asset,
+    asset::{
+        self,
+        Denom,
+    },
     Address,
 };
 use astria_eyre::eyre::{
@@ -97,7 +100,10 @@ impl Service {
             submitter_handle,
             shutdown_token: shutdown_handle.token(),
             state: state.clone(),
-            rollup_asset_denom: asset::Denom::from(rollup_asset_denomination),
+            rollup_asset_denom: cfg
+                .rollup_asset_denomination
+                .parse::<Denom>()
+                .wrap_err("failed to parse ROLLUP_ASSET_DENOMINATION as Denom")?,
             bridge_address: sequencer_bridge_address,
         }
         .build()

--- a/crates/astria-bridge-withdrawer/src/withdrawer/submitter/tests.rs
+++ b/crates/astria-bridge-withdrawer/src/withdrawer/submitter/tests.rs
@@ -12,7 +12,7 @@ use astria_core::{
     generated::protocol::account::v1alpha1::NonceResponse,
     primitive::v1::{
         asset::{
-            self,
+            default_native_asset,
             Denom,
         },
         Address,
@@ -270,7 +270,7 @@ async fn register_sync_guards(cometbft_mock: &MockServer) -> HashMap<String, Moc
 }
 
 fn make_ics20_withdrawal_action() -> Action {
-    let denom = Denom::from(DEFAULT_IBC_DENOM.to_string());
+    let denom = "transfer/channel-0/utia".parse::<Denom>().unwrap();
     let destination_chain_address = "address".to_string();
     let inner = Ics20Withdrawal {
         denom: denom.clone(),
@@ -299,7 +299,7 @@ fn make_ics20_withdrawal_action() -> Action {
 }
 
 fn make_bridge_unlock_action() -> Action {
-    let denom = Denom::from(DEFAULT_NATIVE_DEMON.to_string());
+    let denom = default_native_asset();
     let inner = BridgeUnlockAction {
         to: Address::builder()
             .array([0u8; 20])

--- a/crates/astria-bridge-withdrawer/src/withdrawer/submitter/tests.rs
+++ b/crates/astria-bridge-withdrawer/src/withdrawer/submitter/tests.rs
@@ -12,6 +12,7 @@ use astria_core::{
     generated::protocol::account::v1alpha1::NonceResponse,
     primitive::v1::{
         asset::{
+            self,
             default_native_asset,
             Denom,
         },
@@ -91,7 +92,6 @@ const SEQUENCER_CHAIN_ID: &str = "test_sequencer-1000";
 const DEFAULT_LAST_ROLLUP_HEIGHT: u64 = 1;
 const DEFAULT_LAST_SEQUENCER_HEIGHT: u64 = 0;
 const DEFAULT_SEQUENCER_NONCE: u32 = 0;
-const DEFAULT_NATIVE_DEMON: &str = "nria";
 const DEFAULT_IBC_DENOM: &str = "transfer/channel-0/utia";
 
 static TELEMETRY: Lazy<()> = Lazy::new(|| {
@@ -151,7 +151,7 @@ impl TestSubmitter {
             sequencer_chain_id: SEQUENCER_CHAIN_ID.to_string(),
             sequencer_cometbft_endpoint,
             state,
-            expected_fee_asset_id: Denom::from(DEFAULT_NATIVE_DEMON.to_string()).id(),
+            expected_fee_asset_id: default_native_asset().id(),
             min_expected_fee_asset_balance: 1_000_000,
         }
         .build()
@@ -214,7 +214,7 @@ async fn register_default_chain_id_guard(cometbft_mock: &MockServer) -> MockGuar
 }
 
 async fn register_default_fee_asset_ids_guard(cometbft_mock: &MockServer) -> MockGuard {
-    let fee_asset_ids = vec![Denom::from(DEFAULT_NATIVE_DEMON.to_string()).id()];
+    let fee_asset_ids = vec![default_native_asset().id()];
     register_allowed_fee_asset_ids_response(fee_asset_ids, cometbft_mock).await
 }
 
@@ -223,7 +223,7 @@ async fn register_default_min_expected_fee_asset_balance_guard(
 ) -> MockGuard {
     register_get_latest_balance(
         vec![AssetBalance {
-            denom: Denom::from(DEFAULT_NATIVE_DEMON.to_string()),
+            denom: default_native_asset(),
             balance: 1_000_000u128,
         }],
         cometbft_mock,
@@ -270,7 +270,7 @@ async fn register_sync_guards(cometbft_mock: &MockServer) -> HashMap<String, Moc
 }
 
 fn make_ics20_withdrawal_action() -> Action {
-    let denom = "transfer/channel-0/utia".parse::<Denom>().unwrap();
+    let denom = DEFAULT_IBC_DENOM.parse::<Denom>().unwrap();
     let destination_chain_address = "address".to_string();
     let inner = Ics20Withdrawal {
         denom: denom.clone(),

--- a/crates/astria-cli/src/commands/sequencer.rs
+++ b/crates/astria-cli/src/commands/sequencer.rs
@@ -1,6 +1,9 @@
 use astria_core::{
     crypto::SigningKey,
-    primitive::v1::asset,
+    primitive::v1::{
+        asset,
+        asset::default_native_asset,
+    },
     protocol::transaction::v1alpha1::{
         action::{
             Action,
@@ -172,8 +175,6 @@ pub(crate) async fn get_block_height(args: &BlockHeightGetArgs) -> eyre::Result<
 /// * If the http client cannot be created
 /// * If the latest block height cannot be retrieved
 pub(crate) async fn send_transfer(args: &TransferArgs) -> eyre::Result<()> {
-    use astria_core::primitive::v1::asset::default_native_asset_id;
-
     let res = submit_transaction(
         args.sequencer_url.as_str(),
         args.sequencer_chain_id.clone(),
@@ -181,8 +182,8 @@ pub(crate) async fn send_transfer(args: &TransferArgs) -> eyre::Result<()> {
         Action::Transfer(TransferAction {
             to: args.to_address.0,
             amount: args.amount,
-            asset_id: default_native_asset_id(),
-            fee_asset_id: default_native_asset_id(),
+            asset_id: default_native_asset().id(),
+            fee_asset_id: default_native_asset().id(),
         }),
     )
     .await
@@ -254,10 +255,7 @@ pub(crate) async fn ibc_relayer_remove(args: &IbcRelayerChangeArgs) -> eyre::Res
 /// * If the http client cannot be created
 /// * If the transaction failed to be included
 pub(crate) async fn init_bridge_account(args: &InitBridgeAccountArgs) -> eyre::Result<()> {
-    use astria_core::primitive::v1::{
-        asset::default_native_asset_id,
-        RollupId,
-    };
+    use astria_core::primitive::v1::RollupId;
 
     let rollup_id = RollupId::from_unhashed_bytes(args.rollup_name.as_bytes());
     let res = submit_transaction(
@@ -266,8 +264,8 @@ pub(crate) async fn init_bridge_account(args: &InitBridgeAccountArgs) -> eyre::R
         args.private_key.as_str(),
         Action::InitBridgeAccount(InitBridgeAccountAction {
             rollup_id,
-            asset_id: default_native_asset_id(),
-            fee_asset_id: default_native_asset_id(),
+            asset_id: default_native_asset().id(),
+            fee_asset_id: default_native_asset().id(),
             sudo_address: None,
             withdrawer_address: None,
         }),
@@ -293,17 +291,15 @@ pub(crate) async fn init_bridge_account(args: &InitBridgeAccountArgs) -> eyre::R
 /// * If the http client cannot be created
 /// * If the transaction failed to be included
 pub(crate) async fn bridge_lock(args: &BridgeLockArgs) -> eyre::Result<()> {
-    use astria_core::primitive::v1::asset::default_native_asset_id;
-
     let res = submit_transaction(
         args.sequencer_url.as_str(),
         args.sequencer_chain_id.clone(),
         args.private_key.as_str(),
         Action::BridgeLock(BridgeLockAction {
             to: args.to_address.0,
-            asset_id: default_native_asset_id(),
+            asset_id: default_native_asset().id(),
             amount: args.amount,
-            fee_asset_id: default_native_asset_id(),
+            fee_asset_id: default_native_asset().id(),
             destination_chain_address: args.destination_chain_address.clone(),
         }),
     )

--- a/crates/astria-composer/src/collectors/geth.rs
+++ b/crates/astria-composer/src/collectors/geth.rs
@@ -17,7 +17,7 @@ use std::time::Duration;
 
 use astria_core::{
     primitive::v1::{
-        asset::default_native_asset_id,
+        asset::default_native_asset,
         RollupId,
     },
     protocol::transaction::v1alpha1::action::SequenceAction,
@@ -211,7 +211,7 @@ impl Geth {
                         let seq_action = SequenceAction {
                             rollup_id,
                             data,
-                            fee_asset_id: default_native_asset_id(),
+                            fee_asset_id: default_native_asset().id(),
                         };
 
                         metrics::counter!(

--- a/crates/astria-composer/src/collectors/grpc.rs
+++ b/crates/astria-composer/src/collectors/grpc.rs
@@ -9,7 +9,7 @@ use astria_core::{
         SubmitRollupTransactionResponse,
     },
     primitive::v1::{
-        asset::default_native_asset_id,
+        asset::default_native_asset,
         RollupId,
     },
     protocol::transaction::v1alpha1::action::SequenceAction,
@@ -63,7 +63,7 @@ impl GrpcCollectorService for Grpc {
         let sequence_action = SequenceAction {
             rollup_id,
             data: submit_rollup_tx_request.data,
-            fee_asset_id: default_native_asset_id(),
+            fee_asset_id: default_native_asset().id(),
         };
 
         metrics::counter!(

--- a/crates/astria-composer/src/executor/bundle_factory/tests.rs
+++ b/crates/astria-composer/src/executor/bundle_factory/tests.rs
@@ -2,7 +2,7 @@
 mod sized_bundle_tests {
     use astria_core::{
         primitive::v1::{
-            asset::default_native_asset_id,
+            asset::default_native_asset,
             RollupId,
             FEE_ASSET_ID_LEN,
             ROLLUP_ID_LEN,
@@ -29,7 +29,7 @@ mod sized_bundle_tests {
         let seq_action = SequenceAction {
             rollup_id: RollupId::new([0; ROLLUP_ID_LEN]),
             data: vec![0; 100 - ROLLUP_ID_LEN - FEE_ASSET_ID_LEN],
-            fee_asset_id: default_native_asset_id(),
+            fee_asset_id: default_native_asset().id(),
         };
         let seq_action_size = estimate_size_of_sequence_action(&seq_action);
 
@@ -46,7 +46,7 @@ mod sized_bundle_tests {
         let seq_action = SequenceAction {
             rollup_id: RollupId::new([0; ROLLUP_ID_LEN]),
             data: vec![0; 100 - ROLLUP_ID_LEN - FEE_ASSET_ID_LEN + 1],
-            fee_asset_id: default_native_asset_id(),
+            fee_asset_id: default_native_asset().id(),
         };
 
         assert!(estimate_size_of_sequence_action(&seq_action) > 100);
@@ -65,7 +65,7 @@ mod sized_bundle_tests {
         let initial_seq_action = SequenceAction {
             rollup_id: RollupId::new([0; ROLLUP_ID_LEN]),
             data: vec![0; 100 - ROLLUP_ID_LEN - FEE_ASSET_ID_LEN],
-            fee_asset_id: default_native_asset_id(),
+            fee_asset_id: default_native_asset().id(),
         };
         bundle.try_push(initial_seq_action).unwrap();
 
@@ -74,7 +74,7 @@ mod sized_bundle_tests {
         let seq_action = SequenceAction {
             rollup_id: RollupId::new([0; ROLLUP_ID_LEN]),
             data: vec![0; 1],
-            fee_asset_id: default_native_asset_id(),
+            fee_asset_id: default_native_asset().id(),
         };
 
         assert!(estimate_size_of_sequence_action(&seq_action) < 100);
@@ -94,7 +94,7 @@ mod sized_bundle_tests {
         let seq_action = SequenceAction {
             rollup_id: RollupId::new([0; ROLLUP_ID_LEN]),
             data: vec![1; 100 - ROLLUP_ID_LEN - FEE_ASSET_ID_LEN],
-            fee_asset_id: default_native_asset_id(),
+            fee_asset_id: default_native_asset().id(),
         };
         bundle.try_push(seq_action.clone()).unwrap();
 
@@ -117,17 +117,17 @@ mod sized_bundle_tests {
         let seq_action1 = SequenceAction {
             rollup_id: RollupId::new([1; ROLLUP_ID_LEN]),
             data: vec![1; 50 - ROLLUP_ID_LEN],
-            fee_asset_id: default_native_asset_id(),
+            fee_asset_id: default_native_asset().id(),
         };
         let seq_action1_2 = SequenceAction {
             rollup_id: RollupId::new([1; ROLLUP_ID_LEN]),
             data: vec![1; 50 - ROLLUP_ID_LEN],
-            fee_asset_id: default_native_asset_id(),
+            fee_asset_id: default_native_asset().id(),
         };
         let seq_action2 = SequenceAction {
             rollup_id: RollupId::new([2; ROLLUP_ID_LEN]),
             data: vec![2; 100 - ROLLUP_ID_LEN - FEE_ASSET_ID_LEN],
-            fee_asset_id: default_native_asset_id(),
+            fee_asset_id: default_native_asset().id(),
         };
         bundle.try_push(seq_action1).unwrap();
         bundle.try_push(seq_action1_2).unwrap();
@@ -152,7 +152,7 @@ mod sized_bundle_tests {
 mod bundle_factory_tests {
     use astria_core::{
         primitive::v1::{
-            asset::default_native_asset_id,
+            asset::default_native_asset,
             RollupId,
             FEE_ASSET_ID_LEN,
             ROLLUP_ID_LEN,
@@ -175,7 +175,7 @@ mod bundle_factory_tests {
         let seq_action = SequenceAction {
             rollup_id: RollupId::new([0; ROLLUP_ID_LEN]),
             data: vec![0; 100 - ROLLUP_ID_LEN - FEE_ASSET_ID_LEN],
-            fee_asset_id: default_native_asset_id(),
+            fee_asset_id: default_native_asset().id(),
         };
         bundle_factory.try_push(seq_action).unwrap();
 
@@ -192,7 +192,7 @@ mod bundle_factory_tests {
         let seq_action = SequenceAction {
             rollup_id: RollupId::new([0; ROLLUP_ID_LEN]),
             data: vec![0; 100 - ROLLUP_ID_LEN - FEE_ASSET_ID_LEN + 1],
-            fee_asset_id: default_native_asset_id(),
+            fee_asset_id: default_native_asset().id(),
         };
         let actual_size = estimate_size_of_sequence_action(&seq_action);
 
@@ -214,7 +214,7 @@ mod bundle_factory_tests {
         let seq_action0 = SequenceAction {
             rollup_id: RollupId::new([0; ROLLUP_ID_LEN]),
             data: vec![0; 100 - ROLLUP_ID_LEN - FEE_ASSET_ID_LEN],
-            fee_asset_id: default_native_asset_id(),
+            fee_asset_id: default_native_asset().id(),
         };
         bundle_factory.try_push(seq_action0.clone()).unwrap();
 
@@ -223,7 +223,7 @@ mod bundle_factory_tests {
         let seq_action1 = SequenceAction {
             rollup_id: RollupId::new([1; ROLLUP_ID_LEN]),
             data: vec![1; 100 - ROLLUP_ID_LEN - FEE_ASSET_ID_LEN],
-            fee_asset_id: default_native_asset_id(),
+            fee_asset_id: default_native_asset().id(),
         };
         bundle_factory.try_push(seq_action1).unwrap();
 
@@ -246,7 +246,7 @@ mod bundle_factory_tests {
         let seq_action = SequenceAction {
             rollup_id: RollupId::new([0; ROLLUP_ID_LEN]),
             data: vec![0; 100 - ROLLUP_ID_LEN - FEE_ASSET_ID_LEN],
-            fee_asset_id: default_native_asset_id(),
+            fee_asset_id: default_native_asset().id(),
         };
         bundle_factory.try_push(seq_action.clone()).unwrap();
 
@@ -283,7 +283,7 @@ mod bundle_factory_tests {
         let seq_action = SequenceAction {
             rollup_id: RollupId::new([0; ROLLUP_ID_LEN]),
             data: vec![0; 100 - ROLLUP_ID_LEN - FEE_ASSET_ID_LEN],
-            fee_asset_id: default_native_asset_id(),
+            fee_asset_id: default_native_asset().id(),
         };
         bundle_factory.try_push(seq_action.clone()).unwrap();
 
@@ -303,7 +303,7 @@ mod bundle_factory_tests {
         let seq_action = SequenceAction {
             rollup_id: RollupId::new([0; ROLLUP_ID_LEN]),
             data: vec![0; 100 - ROLLUP_ID_LEN - FEE_ASSET_ID_LEN],
-            fee_asset_id: default_native_asset_id(),
+            fee_asset_id: default_native_asset().id(),
         };
         bundle_factory.try_push(seq_action.clone()).unwrap();
 
@@ -316,7 +316,7 @@ mod bundle_factory_tests {
         let seq_action1 = SequenceAction {
             rollup_id: RollupId::new([1; ROLLUP_ID_LEN]),
             data: vec![1; 100 - ROLLUP_ID_LEN - FEE_ASSET_ID_LEN],
-            fee_asset_id: default_native_asset_id(),
+            fee_asset_id: default_native_asset().id(),
         };
         let full_err = bundle_factory.try_push(seq_action1.clone());
 
@@ -349,7 +349,7 @@ mod bundle_factory_tests {
         let seq_action = SequenceAction {
             rollup_id: RollupId::new([0; ROLLUP_ID_LEN]),
             data: vec![0; 100 - ROLLUP_ID_LEN - FEE_ASSET_ID_LEN],
-            fee_asset_id: default_native_asset_id(),
+            fee_asset_id: default_native_asset().id(),
         };
         bundle_factory.try_push(seq_action.clone()).unwrap();
 
@@ -371,7 +371,7 @@ mod bundle_factory_tests {
         let seq_action0 = SequenceAction {
             rollup_id: RollupId::new([0; ROLLUP_ID_LEN]),
             data: vec![0; 100 - ROLLUP_ID_LEN - FEE_ASSET_ID_LEN],
-            fee_asset_id: default_native_asset_id(),
+            fee_asset_id: default_native_asset().id(),
         };
         bundle_factory.try_push(seq_action0.clone()).unwrap();
 
@@ -380,7 +380,7 @@ mod bundle_factory_tests {
         let seq_action1 = SequenceAction {
             rollup_id: RollupId::new([1; ROLLUP_ID_LEN]),
             data: vec![1; 100 - ROLLUP_ID_LEN - FEE_ASSET_ID_LEN],
-            fee_asset_id: default_native_asset_id(),
+            fee_asset_id: default_native_asset().id(),
         };
         bundle_factory.try_push(seq_action1).unwrap();
 
@@ -414,7 +414,7 @@ mod bundle_factory_tests {
         let seq_action0 = SequenceAction {
             rollup_id: RollupId::new([0; ROLLUP_ID_LEN]),
             data: vec![0; 100 - ROLLUP_ID_LEN - FEE_ASSET_ID_LEN],
-            fee_asset_id: default_native_asset_id(),
+            fee_asset_id: default_native_asset().id(),
         };
         bundle_factory.try_push(seq_action0.clone()).unwrap();
 
@@ -423,7 +423,7 @@ mod bundle_factory_tests {
         let seq_action1 = SequenceAction {
             rollup_id: RollupId::new([1; ROLLUP_ID_LEN]),
             data: vec![1; 100 - ROLLUP_ID_LEN - FEE_ASSET_ID_LEN],
-            fee_asset_id: default_native_asset_id(),
+            fee_asset_id: default_native_asset().id(),
         };
         bundle_factory.try_push(seq_action1.clone()).unwrap();
 
@@ -461,7 +461,7 @@ mod bundle_factory_tests {
         let seq_action = SequenceAction {
             rollup_id: RollupId::new([0; ROLLUP_ID_LEN]),
             data: vec![0; 100 - ROLLUP_ID_LEN - FEE_ASSET_ID_LEN],
-            fee_asset_id: default_native_asset_id(),
+            fee_asset_id: default_native_asset().id(),
         };
         bundle_factory.try_push(seq_action.clone()).unwrap();
 

--- a/crates/astria-composer/src/executor/tests.rs
+++ b/crates/astria-composer/src/executor/tests.rs
@@ -5,7 +5,7 @@ use std::{
 
 use astria_core::{
     primitive::v1::{
-        asset::default_native_asset_id,
+        asset::default_native_asset,
         RollupId,
         FEE_ASSET_ID_LEN,
         ROLLUP_ID_LEN,
@@ -234,13 +234,13 @@ async fn full_bundle() {
     let seq0 = SequenceAction {
         rollup_id: RollupId::new([0; ROLLUP_ID_LEN]),
         data: vec![0u8; cfg.max_bytes_per_bundle - ROLLUP_ID_LEN - FEE_ASSET_ID_LEN],
-        fee_asset_id: default_native_asset_id(),
+        fee_asset_id: default_native_asset().id(),
     };
 
     let seq1 = SequenceAction {
         rollup_id: RollupId::new([1; ROLLUP_ID_LEN]),
         data: vec![1u8; 1],
-        fee_asset_id: default_native_asset_id(),
+        fee_asset_id: default_native_asset().id(),
     };
 
     // push both sequence actions to the executor in order to force the full bundle to be sent
@@ -325,7 +325,7 @@ async fn bundle_triggered_by_block_timer() {
     let seq0 = SequenceAction {
         rollup_id: RollupId::new([0; ROLLUP_ID_LEN]),
         data: vec![0u8; cfg.max_bytes_per_bundle / 4],
-        fee_asset_id: default_native_asset_id(),
+        fee_asset_id: default_native_asset().id(),
     };
 
     // make sure at least one block has passed so that the executor will submit the bundle
@@ -409,13 +409,13 @@ async fn two_seq_actions_single_bundle() {
     let seq0 = SequenceAction {
         rollup_id: RollupId::new([0; ROLLUP_ID_LEN]),
         data: vec![0u8; cfg.max_bytes_per_bundle / 4],
-        fee_asset_id: default_native_asset_id(),
+        fee_asset_id: default_native_asset().id(),
     };
 
     let seq1 = SequenceAction {
         rollup_id: RollupId::new([1; ROLLUP_ID_LEN]),
         data: vec![1u8; cfg.max_bytes_per_bundle / 4],
-        fee_asset_id: default_native_asset_id(),
+        fee_asset_id: default_native_asset().id(),
     };
 
     // make sure at least one block has passed so that the executor will submit the bundle

--- a/crates/astria-core/src/primitive/v1/asset.rs
+++ b/crates/astria-core/src/primitive/v1/asset.rs
@@ -1,18 +1,39 @@
-use std::{
-    fmt,
-    fmt::{
-        Display,
-        Formatter,
-    },
+use std::fmt::{
+    self,
+    Display,
+    Formatter,
+    Write,
 };
 
 /// The default sequencer asset base denomination.
 pub const DEFAULT_NATIVE_ASSET_DENOM: &str = "nria";
 
 /// Returns the default sequencer asset ID.
+// allow: parsing single-segment assets is unit tested
+#[allow(clippy::missing_panics_doc)]
+// allow: used in many places already
+#[allow(clippy::module_name_repetitions)]
+#[must_use]
+pub fn default_native_asset() -> Denom {
+    DEFAULT_NATIVE_ASSET_DENOM
+        .parse::<Denom>()
+        .expect("parsing a single segment string must work")
+}
+
+/// Returns the default sequencer asset ID.
+// allow: parsing single-segment assets is unit tested
+#[allow(clippy::missing_panics_doc)]
 #[must_use]
 pub fn default_native_asset_id() -> Id {
-    Denom::from_base_denom(DEFAULT_NATIVE_ASSET_DENOM).id()
+    DEFAULT_NATIVE_ASSET_DENOM
+        .parse::<Denom>()
+        .expect("parsing a single segment string must work")
+        .id()
+}
+
+struct DenomFmt<'a> {
+    prefix_segments: &'a [String],
+    base_denom: &'a str,
 }
 
 /// Represents a denomination of a sequencer asset.
@@ -26,25 +47,14 @@ pub fn default_native_asset_id() -> Id {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Denom {
     id: Id,
-
-    /// The base denomination of the asset; ie. the name of
-    /// the smallest unit of the asset.
+    prefix_segments: Vec<String>,
     base_denom: String,
-
-    /// the IBC denomination prefix.
-    prefix: String,
 }
 
 impl Denom {
     #[must_use]
-    pub fn from_base_denom(base_denom: &str) -> Self {
-        let id = Id::from_denom(base_denom);
-
-        Self {
-            id,
-            base_denom: base_denom.to_string(),
-            prefix: String::new(),
-        }
+    pub fn is_prefixed(&self) -> bool {
+        !self.prefix_segments.is_empty()
     }
 
     /// Returns the asset ID, which is the hash of the denomination trace.
@@ -59,61 +69,166 @@ impl Denom {
     }
 
     #[must_use]
-    pub fn prefix(&self) -> &str {
-        &self.prefix
+    pub fn channel(&self) -> Option<&str> {
+        if self.prefix_segments.len() < 2 {
+            return None;
+        }
+        self.prefix_segments.last().map(|seg| &**seg)
     }
 
     #[must_use]
     pub fn prefix_is(&self, prefix: &str) -> bool {
-        self.prefix == prefix
+        // For the current implementation, the number of slashes in a prefix is equal to the number
+        // of segments + 1.
+        let number_of_slashes = prefix
+            .strip_suffix('/')
+            .unwrap_or(prefix)
+            .chars()
+            .filter(|c| *c == '/')
+            .count();
+        if number_of_slashes.saturating_add(1) != self.prefix_segments.len() {
+            return false;
+        }
+        self.is_prefixed_by(prefix)
+    }
+
+    #[must_use]
+    pub fn is_prefixed_by(&self, prefix: &str) -> bool {
+        let prefix = prefix.strip_suffix('/').unwrap_or(prefix);
+        for (i, argument_segment) in prefix.split('/').enumerate() {
+            match self.prefix_segments.get(i) {
+                Some(denom_segment) if denom_segment == argument_segment => continue,
+                _ => return false,
+            }
+        }
+        true
+    }
+
+    #[must_use]
+    pub fn remove_prefix(&self, prefix: &str) -> Option<Self> {
+        if !self.is_prefixed_by(prefix) {
+            return None;
+        }
+        // We already know it's a prefix, so just split the prefix and skip ahead
+        let segments_to_drop = prefix
+            .strip_suffix('/')
+            .unwrap_or(prefix)
+            .split('/')
+            .count();
+        let prefix_segments = self.prefix_segments[segments_to_drop..].to_vec();
+        let id = Id::from_denom_fmt(&DenomFmt {
+            prefix_segments: &prefix_segments,
+            base_denom: &self.base_denom,
+        });
+        Some(Self {
+            id,
+            prefix_segments,
+            base_denom: self.base_denom.clone(),
+        })
     }
 
     #[must_use]
     pub fn denomination_trace(&self) -> String {
-        if self.prefix.is_empty() {
-            return self.base_denom.clone();
-        }
-
-        format!("{}/{}", self.prefix, self.base_denom)
+        self.to_string()
     }
 
-    /// Create a new [`Denom`] with the same base denomination,
-    /// but without the prefix of the original.
-    #[must_use]
-    pub fn to_base_denom(&self) -> Self {
-        Self::from_base_denom(&self.base_denom)
+    // /// Create a new [`Denom`] with the same base denomination,
+    // /// but without the prefix of the original.
+    // #[must_use]
+    // pub fn to_base_denom(&self) -> Self {
+    //     Self::from_base_denom(&self.base_denom)
+    // }
+
+    fn as_fmt(&self) -> DenomFmt<'_> {
+        DenomFmt {
+            prefix_segments: &self.prefix_segments,
+            base_denom: &self.base_denom,
+        }
     }
 }
 
 impl std::fmt::Display for Denom {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.prefix.is_empty() {
-            return write!(f, "{}", self.base_denom);
-        }
-
-        write!(f, "{}/{}", self.prefix, self.base_denom)
+        self.as_fmt().fmt(f)
     }
 }
 
-/// Creates an `Denom` given a denomination trace.
-///
-/// Note: if there is no slash in the denomination trace, then
-/// it is assumed that the asset is native, and thus the prefix is empty.
-impl From<String> for Denom {
-    fn from(denom: String) -> Self {
-        let Some((prefix, base_denom)) = denom.rsplit_once('/') else {
-            return Self {
-                id: Id::from_denom(&denom),
-                base_denom: denom,
-                prefix: String::new(),
-            };
-        };
-
-        Self {
-            id: Id::from_denom(&denom),
-            base_denom: base_denom.to_string(),
-            prefix: prefix.to_string(),
+impl<'a> std::fmt::Display for DenomFmt<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for segment in self.prefix_segments {
+            f.write_str(segment)?;
+            f.write_char('/')?;
         }
+        f.write_str(self.base_denom)
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub struct ParseDenomError(ParseDenomErrorKind);
+
+impl ParseDenomError {
+    fn empty_segment() -> Self {
+        Self(ParseDenomErrorKind::EmptySegment)
+    }
+
+    fn leading_or_trailing_slashes() -> Self {
+        Self(ParseDenomErrorKind::LeadingOrTrailingSlashes)
+    }
+
+    fn whitespace() -> Self {
+        Self(ParseDenomErrorKind::Whitespace)
+    }
+}
+
+#[derive(Debug, thiserror::Error, PartialEq)]
+enum ParseDenomErrorKind {
+    #[error("one or more segments were empty (only whitespace or neighboring slashes)")]
+    EmptySegment,
+    #[error("input has leading or trailing slashes")]
+    LeadingOrTrailingSlashes,
+    #[error("segment contains whitesapce")]
+    Whitespace,
+}
+
+impl std::str::FromStr for Denom {
+    type Err = ParseDenomError;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        fn parse_segment(s: &str) -> Result<String, ParseDenomError> {
+            if s.as_bytes().iter().any(u8::is_ascii_whitespace) {
+                return Err(ParseDenomError::whitespace());
+            }
+            if s.is_empty() {
+                return Err(ParseDenomError::empty_segment());
+            }
+            Ok(s.to_string())
+        }
+
+        // leading/trailing whitespace is ok
+        let input = input.trim();
+        let trimmed = input.trim_matches('/');
+
+        if trimmed.len() != input.len() {
+            return Err(Self::Err::leading_or_trailing_slashes());
+        }
+
+        let mut segments = trimmed.split('/').peekable();
+        let mut prefix_segments = Vec::new();
+        let mut base_denom = String::new();
+        while let Some(segment) = segments.next() {
+            let parsed = parse_segment(segment)?;
+            if segments.peek().is_some() {
+                prefix_segments.push(parsed);
+            } else {
+                base_denom = parsed;
+            }
+        }
+        Ok(Self {
+            id: Id::from_denom(trimmed),
+            base_denom,
+            prefix_segments,
+        })
     }
 }
 
@@ -137,6 +252,13 @@ impl Id {
     #[must_use]
     pub fn from_denom(denom: &str) -> Self {
         use sha2::Digest as _;
+        let hash = sha2::Sha256::digest(denom.as_bytes());
+        Self(hash.into())
+    }
+
+    fn from_denom_fmt(denom_fmt: &DenomFmt<'_>) -> Self {
+        use sha2::Digest as _;
+        let denom = denom_fmt.to_string();
         let hash = sha2::Sha256::digest(denom.as_bytes());
         Self(hash.into())
     }
@@ -192,4 +314,113 @@ impl Display for Id {
 #[error("expected 32 bytes, got {received}")]
 pub struct IncorrectAssetIdLength {
     received: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Denom;
+    use crate::primitive::v1::asset::ParseDenomErrorKind;
+
+    #[test]
+    fn prefixed_input_gives_denom_with_correct_number_of_segments() {
+        let input = "path/to/denom";
+        let denom = input.parse::<Denom>().unwrap();
+        assert_eq!(2, denom.prefix_segments.len());
+        assert_eq!("path", denom.prefix_segments[0]);
+        assert_eq!("to", denom.prefix_segments[1]);
+        assert_eq!("denom", denom.base_denom);
+    }
+
+    #[test]
+    fn denom_with_slashed_prefix_suffix_is_rejected() {
+        use ParseDenomErrorKind::{
+            EmptySegment,
+            LeadingOrTrailingSlashes,
+            Whitespace,
+        };
+        #[track_caller]
+        // allow: silly lint
+        #[allow(clippy::needless_pass_by_value)]
+        fn assert_error(input: &str, kind: ParseDenomErrorKind) {
+            let error = input
+                .parse::<Denom>()
+                .expect_err("an error was expected, but a valid denomination was returned");
+            assert_eq!(kind, error.0);
+        }
+        assert_error("/path/to/denom", LeadingOrTrailingSlashes);
+        assert_error("path/to/denom/", LeadingOrTrailingSlashes);
+        assert_error("path//to/denom", EmptySegment);
+        assert_error("path/ /to/denom", Whitespace);
+        assert_error("path/to /denom", Whitespace);
+        assert_error("path/to/ denom", Whitespace);
+        assert_error("", EmptySegment);
+        assert_error(" ", EmptySegment);
+    }
+
+    #[test]
+    fn denom_is_correctly_formatted() {
+        let input = "path/to/denom";
+        let denom = input.parse::<Denom>().unwrap();
+        let output = denom.to_string();
+        assert_eq!(input, output);
+    }
+
+    #[test]
+    fn full_prefix_of_denom() {
+        let input = "path/to/denom";
+        let denom = input.parse::<Denom>().unwrap();
+        assert!(denom.prefix_is("path/to"));
+        assert!(denom.prefix_is("path/to/"));
+        assert!(!denom.prefix_is("path/to/denom"));
+        assert!(!denom.prefix_is("/path/to"));
+        assert!(!denom.prefix_is("/path/to/"));
+    }
+
+    #[test]
+    fn partial_prefix_of_denom() {
+        let input = "path/to/denom";
+        let denom = input.parse::<Denom>().unwrap();
+        assert!(denom.is_prefixed_by("path"));
+        assert!(denom.is_prefixed_by("path/"));
+        assert!(denom.is_prefixed_by("path/to"));
+        assert!(denom.is_prefixed_by("path/to/"));
+        assert!(!denom.is_prefixed_by(" path"));
+        assert!(!denom.is_prefixed_by(" path/"));
+        assert!(!denom.is_prefixed_by(" path/to"));
+        assert!(!denom.is_prefixed_by(" path/to/"));
+        assert!(!denom.is_prefixed_by("path "));
+        assert!(!denom.is_prefixed_by("path/ "));
+        assert!(!denom.is_prefixed_by("path/to "));
+        assert!(!denom.is_prefixed_by("path/to/ "));
+        assert!(!denom.is_prefixed_by("/path"));
+        assert!(!denom.is_prefixed_by("/path/"));
+        assert!(!denom.is_prefixed_by("/path/to"));
+        assert!(!denom.is_prefixed_by("/path/to/"));
+    }
+
+    #[test]
+    fn prefix_is_removed() {
+        let input = "path/to/denom";
+        let denom = input.parse::<Denom>().unwrap();
+        assert_eq!(
+            denom.remove_prefix("path"),
+            "to/denom".parse::<Denom>().ok()
+        );
+        assert_eq!(
+            denom.remove_prefix("path/"),
+            "to/denom".parse::<Denom>().ok()
+        );
+        assert_eq!(
+            denom.remove_prefix("path/to"),
+            "denom".parse::<Denom>().ok()
+        );
+        assert_eq!(
+            denom.remove_prefix("path/to/"),
+            "denom".parse::<Denom>().ok()
+        );
+        assert!(denom.remove_prefix("other").is_none());
+        assert!(denom.remove_prefix(" path/to").is_none());
+        assert!(denom.remove_prefix("path/to ").is_none());
+        assert!(denom.remove_prefix("path/to/denom").is_none());
+    }
 }

--- a/crates/astria-core/src/primitive/v1/asset.rs
+++ b/crates/astria-core/src/primitive/v1/asset.rs
@@ -86,8 +86,7 @@ impl Denom {
     #[must_use]
     pub fn prefix_matches_exactly(&self, prefix: &str) -> bool {
         self.count_matching_prefix_segments(prefix)
-            .map(|count| count == self.prefix_segments.len())
-            .unwrap_or(false)
+            .is_some_and(|count| count == self.prefix_segments.len())
     }
 
     #[must_use]

--- a/crates/astria-core/src/primitive/v1/asset.rs
+++ b/crates/astria-core/src/primitive/v1/asset.rs
@@ -8,7 +8,7 @@ use std::fmt::{
 /// The default sequencer asset base denomination.
 pub const DEFAULT_NATIVE_ASSET_DENOM: &str = "nria";
 
-/// Returns the default sequencer asset ID.
+/// Returns the default sequencer asset [`Denom`].
 // allow: parsing single-segment assets is unit tested
 #[allow(clippy::missing_panics_doc)]
 // allow: used in many places already

--- a/crates/astria-core/src/primitive/v1/asset.rs
+++ b/crates/astria-core/src/primitive/v1/asset.rs
@@ -20,17 +20,6 @@ pub fn default_native_asset() -> Denom {
         .expect("parsing a single segment string must work")
 }
 
-/// Returns the default sequencer asset ID.
-// allow: parsing single-segment assets is unit tested
-#[allow(clippy::missing_panics_doc)]
-#[must_use]
-pub fn default_native_asset_id() -> Id {
-    DEFAULT_NATIVE_ASSET_DENOM
-        .parse::<Denom>()
-        .expect("parsing a single segment string must work")
-        .id()
-}
-
 struct DenomFmt<'a> {
     prefix_segments: &'a [String],
     base_denom: &'a str,

--- a/crates/astria-core/src/protocol/account/v1alpha1/mod.rs
+++ b/crates/astria-core/src/protocol/account/v1alpha1/mod.rs
@@ -69,20 +69,6 @@ impl raw::BalanceResponse {
             balances: balances.into_iter().map(AssetBalance::into_raw).collect(),
         }
     }
-
-    // /// Converts a protobuf [`raw::BalanceResponse`] to an astria
-    // /// native [`BalanceResponse`].
-    // #[must_use]
-    // pub fn try_into_native(self) -> Result<BalanceResponse, BalanceResponseError> {
-    //     BalanceResponse::try_from_raw(&self)
-    // }
-
-    // /// Converts a protobuf [`raw::BalanceResponse`] to an astria
-    // /// native [`BalanceResponse`] by allocating a new [`v1alpha::BalanceResponse`].
-    // #[must_use]
-    // pub fn try_to_native(&self) -> Result<BalanceResponse, BalanceResponseError> {
-    //     BalanceResponse::try_from_raw(self)
-    // }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/astria-core/src/protocol/account/v1alpha1/mod.rs
+++ b/crates/astria-core/src/protocol/account/v1alpha1/mod.rs
@@ -1,5 +1,26 @@
 use super::raw;
-use crate::primitive::v1::asset::Denom;
+use crate::primitive::v1::asset::{
+    Denom,
+    ParseDenomError,
+};
+
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub struct AssetBalanceError(AssetBalanceErrorKind);
+impl AssetBalanceError {
+    #[must_use]
+    fn invalid_denom(source: ParseDenomError) -> Self {
+        Self(AssetBalanceErrorKind::InvalidDenom {
+            source,
+        })
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum AssetBalanceErrorKind {
+    #[error("`denom` field was invalid")]
+    InvalidDenom { source: ParseDenomError },
+}
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct AssetBalance {
@@ -10,16 +31,17 @@ pub struct AssetBalance {
 impl AssetBalance {
     /// Converts a protobuf [`raw::AssetBalance`] to an astria
     /// native [`AssetBalance`].
-    #[must_use]
-    pub fn from_raw(proto: &raw::AssetBalance) -> Self {
+    /// # Errors
+    /// Returns an error if the protobuf `denom` field can't be pased as a [`Denom`].
+    pub fn try_from_raw(proto: &raw::AssetBalance) -> Result<Self, AssetBalanceError> {
         let raw::AssetBalance {
             denom,
             balance,
         } = proto;
-        Self {
-            denom: Denom::from(denom.to_owned()),
+        Ok(Self {
+            denom: denom.parse().map_err(AssetBalanceError::invalid_denom)?,
             balance: balance.map_or(0, Into::into),
-        }
+        })
     }
 
     /// Converts an astria native [`AssetBalance`] to a
@@ -48,19 +70,38 @@ impl raw::BalanceResponse {
         }
     }
 
-    /// Converts a protobuf [`raw::BalanceResponse`] to an astria
-    /// native [`BalanceResponse`].
-    #[must_use]
-    pub fn into_native(self) -> BalanceResponse {
-        BalanceResponse::from_raw(&self)
-    }
+    // /// Converts a protobuf [`raw::BalanceResponse`] to an astria
+    // /// native [`BalanceResponse`].
+    // #[must_use]
+    // pub fn try_into_native(self) -> Result<BalanceResponse, BalanceResponseError> {
+    //     BalanceResponse::try_from_raw(&self)
+    // }
 
-    /// Converts a protobuf [`raw::BalanceResponse`] to an astria
-    /// native [`BalanceResponse`] by allocating a new [`v1alpha::BalanceResponse`].
+    // /// Converts a protobuf [`raw::BalanceResponse`] to an astria
+    // /// native [`BalanceResponse`] by allocating a new [`v1alpha::BalanceResponse`].
+    // #[must_use]
+    // pub fn try_to_native(&self) -> Result<BalanceResponse, BalanceResponseError> {
+    //     BalanceResponse::try_from_raw(self)
+    // }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub struct BalanceResponseError(BalanceResponseErrorKind);
+
+impl BalanceResponseError {
     #[must_use]
-    pub fn to_native(&self) -> BalanceResponse {
-        self.clone().into_native()
+    fn asset_balance(source: AssetBalanceError) -> Self {
+        Self(BalanceResponseErrorKind::AssetBalance {
+            source,
+        })
     }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum BalanceResponseErrorKind {
+    #[error("`balances` contained an invalid asset balance")]
+    AssetBalance { source: AssetBalanceError },
 }
 
 /// The sequencer response to a balance request for a given account at a given height.
@@ -73,15 +114,23 @@ pub struct BalanceResponse {
 impl BalanceResponse {
     /// Converts a protobuf [`raw::BalanceResponse`] to an astria
     /// native [`BalanceResponse`].
-    pub fn from_raw(proto: &raw::BalanceResponse) -> Self {
+    ///
+    /// # Errors
+    /// Returns an error if one or more of the strings in the protobuf `balances` field can't
+    /// be pased as a [`Denom`].
+    pub fn try_from_raw(proto: &raw::BalanceResponse) -> Result<Self, BalanceResponseError> {
         let raw::BalanceResponse {
             height,
             balances,
         } = proto;
-        Self {
+        Ok(Self {
             height: *height,
-            balances: balances.iter().map(AssetBalance::from_raw).collect(),
-        }
+            balances: balances
+                .iter()
+                .map(AssetBalance::try_from_raw)
+                .collect::<Result<_, _>>()
+                .map_err(BalanceResponseError::asset_balance)?,
+        })
     }
 
     /// Converts an astria native [`BalanceResponse`] to a
@@ -163,14 +212,14 @@ mod tests {
     #[test]
     fn balance_roundtrip_is_correct() {
         let balances = vec![AssetBalance {
-            denom: "nria".to_owned().into(),
+            denom: "nria".parse().unwrap(),
             balance: 999,
         }];
         let expected = BalanceResponse {
             height: 42,
             balances,
         };
-        let actual = expected.clone().into_raw().into_native();
+        let actual = BalanceResponse::try_from_raw(&expected.clone().into_raw()).unwrap();
         assert_eq!(expected, actual);
     }
 

--- a/crates/astria-core/src/protocol/test_utils.rs
+++ b/crates/astria-core/src/protocol/test_utils.rs
@@ -15,7 +15,7 @@ use super::{
 use crate::{
     crypto::SigningKey,
     primitive::v1::{
-        asset::default_native_asset_id,
+        asset::default_native_asset,
         derive_merkle_tree_from_rollup_txs,
         RollupId,
     },
@@ -96,7 +96,7 @@ impl ConfigureSequencerBlock {
                 SequenceAction {
                     rollup_id,
                     data,
-                    fee_asset_id: default_native_asset_id(),
+                    fee_asset_id: default_native_asset().id(),
                 }
                 .into()
             })

--- a/crates/astria-core/src/protocol/transaction/v1alpha1/mod.rs
+++ b/crates/astria-core/src/protocol/transaction/v1alpha1/mod.rs
@@ -514,7 +514,7 @@ mod test {
     use super::*;
     use crate::{
         primitive::v1::{
-            asset::default_native_asset_id,
+            asset::default_native_asset,
             Address,
             ASTRIA_ADDRESS_PREFIX,
         },
@@ -542,8 +542,8 @@ mod test {
                 .try_build()
                 .unwrap(),
             amount: 0,
-            asset_id: default_native_asset_id(),
-            fee_asset_id: default_native_asset_id(),
+            asset_id: default_native_asset().id(),
+            fee_asset_id: default_native_asset().id(),
         };
 
         let params = TransactionParams::try_from_raw(raw::TransactionParams {
@@ -580,8 +580,8 @@ mod test {
                 .try_build()
                 .unwrap(),
             amount: 0,
-            asset_id: default_native_asset_id(),
-            fee_asset_id: default_native_asset_id(),
+            asset_id: default_native_asset().id(),
+            fee_asset_id: default_native_asset().id(),
         };
 
         let params = TransactionParams::try_from_raw(raw::TransactionParams {

--- a/crates/astria-sequencer-client/src/extension_trait.rs
+++ b/crates/astria-sequencer-client/src/extension_trait.rs
@@ -455,7 +455,8 @@ pub trait SequencerClientExt: Client {
                     e,
                 )
             })?;
-        Ok(proto_response.to_native())
+        BalanceResponse::try_from_raw(&proto_response)
+            .map_err(|e| Error::native_conversion("BalanceResponse", Arc::new(e)))
     }
 
     /// Returns the current balance of the given account at the latest height.

--- a/crates/astria-sequencer-client/src/tests/http.rs
+++ b/crates/astria-sequencer-client/src/tests/http.rs
@@ -4,7 +4,7 @@ use astria_core::{
     primitive::v1::{
         asset::{
             self,
-            default_native_asset_id,
+            default_native_asset,
         },
         Address,
         ASTRIA_ADDRESS_PREFIX,
@@ -152,8 +152,8 @@ fn create_signed_transaction() -> SignedTransaction {
         TransferAction {
             to: bob_address(),
             amount: 333_333,
-            asset_id: default_native_asset_id(),
-            fee_asset_id: default_native_asset_id(),
+            asset_id: default_native_asset().id(),
+            fee_asset_id: default_native_asset().id(),
         }
         .into(),
     ];

--- a/crates/astria-sequencer/src/accounts/state_ext.rs
+++ b/crates/astria-sequencer/src/accounts/state_ext.rs
@@ -87,10 +87,12 @@ pub(crate) trait StateReadExt: StateRead {
             let native_asset = crate::asset::get_native_asset();
             if asset_id == native_asset.id() {
                 // TODO: this is jank, just have 1 denom type.
+                // TODO: Getting the base denom out of a native asset should not need a parse.
                 balances.push(AssetBalance {
-                    denom: astria_core::primitive::v1::asset::Denom::from(
-                        native_asset.base_denom().to_owned(),
-                    ),
+                    denom: native_asset
+                        .base_denom()
+                        .parse()
+                        .context("failed to parse a denom's base as a denom; this is a problem")?,
                     balance,
                 });
                 continue;
@@ -233,7 +235,7 @@ impl<T: StateWrite> StateWriteExt for T {}
 mod test {
     use astria_core::{
         primitive::v1::asset::{
-            Denom,
+            default_native_asset,
             Id,
             DEFAULT_NATIVE_ASSET_DENOM,
         },
@@ -544,19 +546,19 @@ mod test {
         asset::state_ext::StateWriteExt::put_ibc_asset(
             &mut state,
             asset_0,
-            &Denom::from_base_denom(DEFAULT_NATIVE_ASSET_DENOM),
+            &default_native_asset(),
         )
         .expect("should be able to call other trait method on state object");
         asset::state_ext::StateWriteExt::put_ibc_asset(
             &mut state,
             asset_1,
-            &Denom::from_base_denom("asset_1"),
+            &"asset_1".parse().unwrap(),
         )
         .expect("should be able to call other trait method on state object");
         asset::state_ext::StateWriteExt::put_ibc_asset(
             &mut state,
             asset_2,
-            &Denom::from_base_denom("asset_2"),
+            &"asset_2".parse().unwrap(),
         )
         .expect("should be able to call other trait method on state object");
 
@@ -586,15 +588,15 @@ mod test {
             balances,
             vec![
                 AssetBalance {
-                    denom: Denom::from_base_denom(DEFAULT_NATIVE_ASSET_DENOM),
+                    denom: default_native_asset(),
                     balance: amount_expected_0,
                 },
                 AssetBalance {
-                    denom: Denom::from_base_denom("asset_1"),
+                    denom: "asset_1".parse().unwrap(),
                     balance: amount_expected_1,
                 },
                 AssetBalance {
-                    denom: Denom::from_base_denom("asset_2"),
+                    denom: "asset_2".parse().unwrap(),
                     balance: amount_expected_2,
                 },
             ]

--- a/crates/astria-sequencer/src/app/test_utils.rs
+++ b/crates/astria-sequencer/src/app/test_utils.rs
@@ -1,7 +1,10 @@
 use astria_core::{
     crypto::SigningKey,
     primitive::v1::{
-        asset::DEFAULT_NATIVE_ASSET_DENOM,
+        asset::{
+            default_native_asset,
+            DEFAULT_NATIVE_ASSET_DENOM,
+        },
         Address,
         RollupId,
         ADDRESS_LEN,
@@ -109,7 +112,7 @@ pub(crate) async fn initialize_app_with_storage(
         ibc_relayer_addresses: vec![],
         native_asset_base_denomination: DEFAULT_NATIVE_ASSET_DENOM.to_string(),
         ibc_params: IBCParameters::default(),
-        allowed_fee_assets: vec![DEFAULT_NATIVE_ASSET_DENOM.to_owned().into()],
+        allowed_fee_assets: vec![default_native_asset()],
         fees: default_fees(),
     });
 

--- a/crates/astria-sequencer/src/app/test_utils.rs
+++ b/crates/astria-sequencer/src/app/test_utils.rs
@@ -149,7 +149,7 @@ pub(crate) fn get_mock_tx(nonce: u32) -> SignedTransaction {
             SequenceAction {
                 rollup_id: RollupId::from_unhashed_bytes([0; 32]),
                 data: vec![0x99],
-                fee_asset_id: astria_core::primitive::v1::asset::default_native_asset_id(),
+                fee_asset_id: astria_core::primitive::v1::asset::default_native_asset().id(),
             }
             .into(),
         ],

--- a/crates/astria-sequencer/src/app/tests_breaking_changes.rs
+++ b/crates/astria-sequencer/src/app/tests_breaking_changes.rs
@@ -16,7 +16,10 @@ use std::{
 
 use astria_core::{
     primitive::v1::{
-        asset::DEFAULT_NATIVE_ASSET_DENOM,
+        asset::{
+            default_native_asset,
+            DEFAULT_NATIVE_ASSET_DENOM,
+        },
         RollupId,
     },
     protocol::transaction::v1alpha1::{
@@ -182,7 +185,7 @@ async fn app_execute_transaction_with_every_action_snapshot() {
         ibc_relayer_addresses: vec![],
         native_asset_base_denomination: DEFAULT_NATIVE_ASSET_DENOM.to_string(),
         ibc_params: IBCParameters::default(),
-        allowed_fee_assets: vec![DEFAULT_NATIVE_ASSET_DENOM.to_owned().into()],
+        allowed_fee_assets: vec![default_native_asset()],
         fees: default_fees(),
     };
     let (mut app, storage) = initialize_app_with_storage(Some(genesis_state), vec![]).await;

--- a/crates/astria-sequencer/src/app/tests_execute_transaction.rs
+++ b/crates/astria-sequencer/src/app/tests_execute_transaction.rs
@@ -3,8 +3,12 @@ use std::sync::Arc;
 use astria_core::{
     crypto::SigningKey,
     primitive::v1::{
-        asset,
-        asset::DEFAULT_NATIVE_ASSET_DENOM,
+        asset::{
+            self,
+            default_native_asset,
+            Denom,
+            DEFAULT_NATIVE_ASSET_DENOM,
+        },
         RollupId,
     },
     protocol::transaction::v1alpha1::{
@@ -287,7 +291,7 @@ async fn app_execute_transaction_validator_update() {
         ibc_relayer_addresses: vec![],
         native_asset_base_denomination: DEFAULT_NATIVE_ASSET_DENOM.to_string(),
         ibc_params: IBCParameters::default(),
-        allowed_fee_assets: vec![DEFAULT_NATIVE_ASSET_DENOM.to_owned().into()],
+        allowed_fee_assets: vec![default_native_asset()],
         fees: default_fees(),
     };
     let mut app = initialize_app(Some(genesis_state), vec![]).await;
@@ -326,7 +330,7 @@ async fn app_execute_transaction_ibc_relayer_change_addition() {
         ibc_sudo_address: alice_address,
         ibc_relayer_addresses: vec![],
         native_asset_base_denomination: DEFAULT_NATIVE_ASSET_DENOM.to_string(),
-        allowed_fee_assets: vec![DEFAULT_NATIVE_ASSET_DENOM.to_owned().into()],
+        allowed_fee_assets: vec![default_native_asset()],
         ibc_params: IBCParameters::default(),
         fees: default_fees(),
     };
@@ -357,7 +361,7 @@ async fn app_execute_transaction_ibc_relayer_change_deletion() {
         ibc_sudo_address: alice_address,
         ibc_relayer_addresses: vec![alice_address],
         native_asset_base_denomination: DEFAULT_NATIVE_ASSET_DENOM.to_string(),
-        allowed_fee_assets: vec![DEFAULT_NATIVE_ASSET_DENOM.to_owned().into()],
+        allowed_fee_assets: vec![default_native_asset()],
         ibc_params: IBCParameters::default(),
         fees: default_fees(),
     };
@@ -388,7 +392,7 @@ async fn app_execute_transaction_ibc_relayer_change_invalid() {
         ibc_sudo_address: crate::astria_address([0; 20]),
         ibc_relayer_addresses: vec![alice_address],
         native_asset_base_denomination: DEFAULT_NATIVE_ASSET_DENOM.to_string(),
-        allowed_fee_assets: vec![DEFAULT_NATIVE_ASSET_DENOM.to_owned().into()],
+        allowed_fee_assets: vec![default_native_asset()],
         ibc_params: IBCParameters::default(),
         fees: default_fees(),
     };
@@ -418,7 +422,7 @@ async fn app_execute_transaction_sudo_address_change() {
         ibc_relayer_addresses: vec![],
         native_asset_base_denomination: DEFAULT_NATIVE_ASSET_DENOM.to_string(),
         ibc_params: IBCParameters::default(),
-        allowed_fee_assets: vec![DEFAULT_NATIVE_ASSET_DENOM.to_owned().into()],
+        allowed_fee_assets: vec![default_native_asset()],
         fees: default_fees(),
     };
     let mut app = initialize_app(Some(genesis_state), vec![]).await;
@@ -456,7 +460,7 @@ async fn app_execute_transaction_sudo_address_change_error() {
         ibc_relayer_addresses: vec![],
         native_asset_base_denomination: DEFAULT_NATIVE_ASSET_DENOM.to_string(),
         ibc_params: IBCParameters::default(),
-        allowed_fee_assets: vec![DEFAULT_NATIVE_ASSET_DENOM.to_owned().into()],
+        allowed_fee_assets: vec![default_native_asset()],
         fees: default_fees(),
     };
     let mut app = initialize_app(Some(genesis_state), vec![]).await;
@@ -495,7 +499,7 @@ async fn app_execute_transaction_fee_asset_change_addition() {
         ibc_relayer_addresses: vec![],
         native_asset_base_denomination: DEFAULT_NATIVE_ASSET_DENOM.to_string(),
         ibc_params: IBCParameters::default(),
-        allowed_fee_assets: vec![DEFAULT_NATIVE_ASSET_DENOM.to_owned().into()],
+        allowed_fee_assets: vec![default_native_asset()],
         fees: default_fees(),
     };
     let mut app = initialize_app(Some(genesis_state), vec![]).await;
@@ -525,7 +529,7 @@ async fn app_execute_transaction_fee_asset_change_removal() {
     use astria_core::protocol::transaction::v1alpha1::action::FeeAssetChangeAction;
 
     let (alice_signing_key, alice_address) = get_alice_signing_key_and_address();
-    let test_asset = asset::Denom::from_base_denom("test");
+    let test_asset = "test".parse::<Denom>().unwrap();
 
     let genesis_state = GenesisState {
         accounts: default_genesis_accounts(),
@@ -534,10 +538,7 @@ async fn app_execute_transaction_fee_asset_change_removal() {
         ibc_relayer_addresses: vec![],
         native_asset_base_denomination: DEFAULT_NATIVE_ASSET_DENOM.to_string(),
         ibc_params: IBCParameters::default(),
-        allowed_fee_assets: vec![
-            DEFAULT_NATIVE_ASSET_DENOM.to_owned().into(),
-            test_asset.clone(),
-        ],
+        allowed_fee_assets: vec![default_native_asset(), test_asset.clone()],
         fees: default_fees(),
     };
     let mut app = initialize_app(Some(genesis_state), vec![]).await;
@@ -578,7 +579,7 @@ async fn app_execute_transaction_fee_asset_change_invalid() {
         ibc_relayer_addresses: vec![],
         native_asset_base_denomination: DEFAULT_NATIVE_ASSET_DENOM.to_string(),
         ibc_params: IBCParameters::default(),
-        allowed_fee_assets: vec![DEFAULT_NATIVE_ASSET_DENOM.to_owned().into()],
+        allowed_fee_assets: vec![default_native_asset()],
         fees: default_fees(),
     };
     let mut app = initialize_app(Some(genesis_state), vec![]).await;

--- a/crates/astria-sequencer/src/asset/mod.rs
+++ b/crates/astria-sequencer/src/asset/mod.rs
@@ -13,7 +13,9 @@ pub(crate) fn initialize_native_asset(native_asset: &str) {
         return;
     }
 
-    let denom = Denom::from_base_denom(native_asset);
+    let denom = native_asset
+        .parse::<Denom>()
+        .expect("being unable to parse the native asset breaks sequencer");
     NATIVE_ASSET
         .set(denom)
         .expect("native asset should only be set once");

--- a/crates/astria-sequencer/src/asset/state_ext.rs
+++ b/crates/astria-sequencer/src/asset/state_ext.rs
@@ -52,7 +52,9 @@ pub(crate) trait StateReadExt: StateRead {
 
         let DenominationTrace(denom_str) =
             DenominationTrace::try_from_slice(&bytes).context("invalid asset bytes")?;
-        let denom: Denom = denom_str.into();
+        let denom = denom_str
+            .parse()
+            .context("failed to parse retrieved denom string as a Denom")?;
         Ok(Some(denom))
     }
 }
@@ -91,7 +93,7 @@ mod test {
         let snapshot = storage.latest_snapshot();
         let state = StateDelta::new(snapshot);
 
-        let asset = Id::from_denom("asset");
+        let asset = "asset".parse::<Denom>().unwrap().id();
 
         // gets for non existing assets should return none
         assert_eq!(
@@ -109,7 +111,7 @@ mod test {
         let snapshot = storage.latest_snapshot();
         let mut state = StateDelta::new(snapshot);
 
-        let denom = Denom::from_base_denom("asset");
+        let denom = "asset".parse::<Denom>().unwrap();
 
         // non existing calls are ok for 'has'
         assert!(
@@ -141,7 +143,7 @@ mod test {
         let mut state = StateDelta::new(snapshot);
 
         // can write new
-        let denom = Denom::from_base_denom("asset");
+        let denom = "asset".parse::<Denom>().unwrap();
         state
             .put_ibc_asset(denom.id(), &denom)
             .expect("putting ibc asset should not fail");
@@ -163,7 +165,7 @@ mod test {
         let mut state = StateDelta::new(snapshot);
 
         // can write new
-        let denom = Denom::from_base_denom("asset_0");
+        let denom = "asset_0".parse::<Denom>().unwrap();
         state
             .put_ibc_asset(denom.id(), &denom)
             .expect("putting ibc asset should not fail");
@@ -178,7 +180,7 @@ mod test {
         );
 
         // can write another without affecting original
-        let denom_1 = Denom::from_base_denom("asset_1");
+        let denom_1 = "asset_1".parse::<Denom>().unwrap();
         state
             .put_ibc_asset(denom_1.id(), &denom_1)
             .expect("putting ibc asset should not fail");
@@ -210,7 +212,7 @@ mod test {
 
         // can write unrelated ids and denoms
         let id_key = Id::from_denom("asset_0");
-        let denom = Denom::from_base_denom("asset_1");
+        let denom = "asset_1".parse::<Denom>().unwrap();
         state
             .put_ibc_asset(id_key, &denom)
             .expect("putting ibc asset should not fail");

--- a/crates/astria-sequencer/src/ibc/ics20_transfer.rs
+++ b/crates/astria-sequencer/src/ibc/ics20_transfer.rs
@@ -176,7 +176,10 @@ async fn refund_tokens_check<S: StateRead>(
 ) -> Result<()> {
     let packet_data: FungibleTokenPacketData =
         serde_json::from_slice(data).context("failed to decode fungible token packet data json")?;
-    let mut denom: Denom = packet_data.denom.clone().into();
+    let mut denom = packet_data
+        .denom
+        .parse::<Denom>()
+        .context("failed parsing denom packet data")?;
 
     // if the asset is prefixed with `ibc`, the rest of the denomination string is the asset ID,
     // so we need to look up the full trace from storage.
@@ -325,7 +328,7 @@ async fn convert_denomination_if_ibc_prefixed<S: StateReadExt>(
     // if the asset is prefixed with `ibc`, the rest of the denomination string is the asset ID,
     // so we need to look up the full trace from storage.
     // see https://github.com/cosmos/ibc-go/blob/main/docs/architecture/adr-001-coin-source-tracing.md#decision
-    let denom = if packet_denom.prefix().starts_with("ibc") {
+    let denom = if packet_denom.is_prefixed_by("ibc") {
         let id_bytes: [u8; 32] = hex::decode(packet_denom.base_denom())
             .context("failed to decode ibc/ prefixed id as hex")?
             .try_into()
@@ -351,7 +354,13 @@ fn prefix_denomination<'a>(
     if is_refund {
         packet_denom
     } else {
-        let denom: Denom = format!("{dest_port}/{dest_channel}/{packet_denom}").into();
+        // FIXME: we should provide a method on `denom` to prepend segments to its prefix
+        let denom: Denom = format!("{dest_port}/{dest_channel}/{packet_denom}")
+            .parse()
+            .expect(
+                "dest port and channel are valid prefix segments, so this concatenation must be a \
+                 valid denom",
+            );
         Cow::Owned(denom)
     }
 }
@@ -377,11 +386,14 @@ async fn execute_ics20_transfer<S: StateWriteExt>(
         packet_data.receiver
     };
 
-    let packet_denom: Denom = packet_data.denom.clone().into();
+    let packet_denom = packet_data
+        .denom
+        .parse::<Denom>()
+        .context("failed parsing denom in packet data as Denom")?;
 
     // convert denomination if it's prefixed with `ibc/`
     // note: this denomination might have a prefix, but it wasn't prefixed by us right now.
-    let packet_denom = convert_denomination_if_ibc_prefixed(state, packet_denom)
+    let unprefixed_denom = convert_denomination_if_ibc_prefixed(state, packet_denom)
         .await
         .context("failed to convert denomination if ibc/ prefixed")?;
 
@@ -398,7 +410,7 @@ async fn execute_ics20_transfer<S: StateWriteExt>(
         execute_rollup_withdrawal_refund(
             state,
             &memo.bridge_address,
-            &packet_denom,
+            &unprefixed_denom,
             packet_amount,
             recipient,
         )
@@ -410,7 +422,7 @@ async fn execute_ics20_transfer<S: StateWriteExt>(
     // the IBC packet should have the address as a bech32 string
     let recipient = Address::try_from_bech32m(&recipient).context("invalid recipient address")?;
 
-    let is_prefixed = is_prefixed(source_port, source_channel, &packet_denom);
+    let is_prefixed = is_prefixed(source_port, source_channel, &unprefixed_denom);
     let is_source = if is_refund {
         // we are the source if the denom is not prefixed by source_port/source_channel
         !is_prefixed
@@ -421,7 +433,7 @@ async fn execute_ics20_transfer<S: StateWriteExt>(
 
     // prefix the denomination with the destination port and channel if not a refund
     let prefixed_denomination = prefix_denomination(
-        Cow::Borrowed(&packet_denom),
+        Cow::Borrowed(&unprefixed_denom),
         dest_port,
         dest_channel,
         is_refund,
@@ -446,8 +458,15 @@ async fn execute_ics20_transfer<S: StateWriteExt>(
 
         // strip the prefix from the denom, as we're back on the source chain
         // note: if this is a refund, this is a no-op.
-        let denom = packet_denom.to_base_denom();
-
+        let denom = if is_refund {
+            unprefixed_denom
+        } else {
+            unprefixed_denom
+                .remove_prefix(&format!("{source_port}/{source_channel}"))
+                .context(
+                    "failed to remove prefix; this shouldn't happen - wasn't it checked above?!",
+                )?
+        };
         let escrow_channel = if is_refund {
             source_channel
         } else {
@@ -619,19 +638,19 @@ mod test {
     fn is_prefixed_test() {
         let source_port = "source_port".to_string().parse().unwrap();
         let source_channel = "source_channel".to_string().parse().unwrap();
-        let asset = Denom::from("source_port/source_channel/asset".to_string());
+        let asset = "source_port/source_channel/asset".parse().unwrap();
         // in the case of a transfer in that is not a refund,
         // we are the source if the packets are prefixed by the sending chain
         assert!(is_prefixed(&source_port, &source_channel, &asset));
         // in the case of a refund, we are the source if the packets are not
         // prefixed by the sending chain
-        let asset = Denom::from("other_port/source_channel/asset".to_string());
+        let asset = "other_port/source_channel/asset".parse().unwrap();
         assert!(!is_prefixed(&source_port, &source_channel, &asset));
     }
 
     #[tokio::test]
     async fn prefix_denomination_not_refund() {
-        let packet_denom = Denom::from("asset".to_string());
+        let packet_denom = "asset".parse().unwrap();
         let dest_port = "transfer".to_string().parse().unwrap();
         let dest_channel = "channel-99".to_string().parse().unwrap();
         let is_refund = false;
@@ -642,14 +661,14 @@ mod test {
             &dest_channel,
             is_refund,
         );
-        let expected = Denom::from("transfer/channel-99/asset".to_string());
+        let expected = "transfer/channel-99/asset".parse::<Denom>().unwrap();
 
         assert_eq!(denom.into_owned(), expected);
     }
 
     #[tokio::test]
     async fn prefix_denomination_refund() {
-        let packet_denom = Denom::from("asset".to_string());
+        let packet_denom = "asset".parse::<Denom>().unwrap();
         let dest_port = "transfer".to_string().parse().unwrap();
         let dest_channel = "channel-99".to_string().parse().unwrap();
         let is_refund = true;
@@ -670,13 +689,15 @@ mod test {
         let snapshot = storage.latest_snapshot();
         let mut state_tx = StateDelta::new(snapshot.clone());
 
-        let denom_trace = Denom::from("asset".to_string());
+        let denom_trace = "asset".parse::<Denom>().unwrap();
         state_tx
             .put_ibc_asset(denom_trace.id(), &denom_trace)
             .unwrap();
 
         let expected = denom_trace.clone();
-        let packet_denom = format!("ibc/{}", hex::encode(denom_trace.id().as_ref())).into();
+        let packet_denom = format!("ibc/{}", hex::encode(denom_trace.id().as_ref()))
+            .parse::<Denom>()
+            .unwrap();
         let denom = convert_denomination_if_ibc_prefixed(&mut state_tx, packet_denom)
             .await
             .unwrap();
@@ -689,7 +710,7 @@ mod test {
         let snapshot = storage.latest_snapshot();
         let mut state_tx = StateDelta::new(snapshot.clone());
 
-        let packet_denom = Denom::from("asset".to_string());
+        let packet_denom = "asset".parse::<Denom>().unwrap();
         let expected = packet_denom.clone();
         let denom = convert_denomination_if_ibc_prefixed(&mut state_tx, packet_denom)
             .await
@@ -703,12 +724,15 @@ mod test {
         let snapshot = storage.latest_snapshot();
         let mut state_tx = StateDelta::new(snapshot.clone());
 
-        let recipient_address = crate::astria_address([1; 20]);
+        let recipient = crate::try_astria_address(
+            &hex::decode("1c0c490f1b5528d8173c5de46d131160e4b2c0c3").unwrap(),
+        )
+        .unwrap();
         let packet = FungibleTokenPacketData {
             denom: "nootasset".to_string(),
             sender: String::new(),
             amount: "100".to_string(),
-            receiver: recipient_address.to_string(),
+            receiver: recipient.to_string(),
             memo: String::new(),
         };
         let packet_bytes = serde_json::to_vec(&packet).unwrap();
@@ -725,9 +749,9 @@ mod test {
         .await
         .expect("valid ics20 transfer to user account; recipient, memo, and asset ID are valid");
 
-        let denom: Denom = format!("dest_port/dest_channel/{}", "nootasset").into();
+        let denom = "dest_port/dest_channel/nootasset".parse::<Denom>().unwrap();
         let balance = state_tx
-            .get_account_balance(recipient_address, denom.id())
+            .get_account_balance(recipient, denom.id())
             .await
             .expect(
                 "ics20 transfer to user account should succeed and balance should be minted to \
@@ -744,7 +768,7 @@ mod test {
 
         let bridge_address = crate::astria_address([99; 20]);
         let rollup_id = RollupId::from_unhashed_bytes(b"testchainid");
-        let denom: Denom = "dest_port/dest_channel/nootasset".to_string().into();
+        let denom = "dest_port/dest_channel/nootasset".parse::<Denom>().unwrap();
 
         state_tx.put_bridge_account_rollup_id(&bridge_address, &rollup_id);
         state_tx
@@ -772,7 +796,7 @@ mod test {
         .await
         .expect("valid ics20 transfer to bridge account; recipient, memo, and asset ID are valid");
 
-        let denom: Denom = format!("dest_port/dest_channel/{}", "nootasset").into();
+        let denom = "dest_port/dest_channel/nootasset".parse::<Denom>().unwrap();
         let balance = state_tx
             .get_account_balance(bridge_address, denom.id())
             .await
@@ -797,7 +821,7 @@ mod test {
 
         let bridge_address = crate::astria_address([99; 20]);
         let rollup_id = RollupId::from_unhashed_bytes(b"testchainid");
-        let denom: Denom = "dest_port/dest_channel/nootasset".to_string().into();
+        let denom = "dest_port/dest_channel/nootasset".parse::<Denom>().unwrap();
 
         state_tx.put_bridge_account_rollup_id(&bridge_address, &rollup_id);
         state_tx
@@ -835,7 +859,7 @@ mod test {
 
         let bridge_address = crate::astria_address([99; 20]);
         let rollup_id = RollupId::from_unhashed_bytes(b"testchainid");
-        let denom: Denom = "dest_port/dest_channel/nootasset".to_string().into();
+        let denom = "dest_port/dest_channel/nootasset".parse::<Denom>().unwrap();
 
         state_tx.put_bridge_account_rollup_id(&bridge_address, &rollup_id);
         state_tx
@@ -873,7 +897,7 @@ mod test {
 
         let recipient_address = crate::astria_address([1; 20]);
         let amount = 100;
-        let base_denom: Denom = "nootasset".to_string().into();
+        let base_denom = "nootasset".parse::<Denom>().unwrap();
         state_tx
             .put_ibc_channel_balance(
                 &"dest_channel".to_string().parse().unwrap(),
@@ -926,7 +950,7 @@ mod test {
 
         let recipient_address = crate::astria_address([1; 20]);
         let amount = 100;
-        let base_denom: Denom = "nootasset".to_string().into();
+        let base_denom = "nootasset".parse::<Denom>().unwrap();
         state_tx
             .put_ibc_channel_balance(
                 &"source_channel".to_string().parse().unwrap(),
@@ -979,7 +1003,7 @@ mod test {
 
         let bridge_address = crate::astria_address([99u8; 20]);
         let rollup_id = RollupId::from_unhashed_bytes(b"testchainid");
-        let denom: Denom = "dest_port/dest_channel/nootasset".to_string().into();
+        let denom = "dest_port/dest_channel/nootasset".parse::<Denom>().unwrap();
 
         state_tx.put_bridge_account_rollup_id(&bridge_address, &rollup_id);
         state_tx
@@ -1019,7 +1043,7 @@ mod test {
 
         let destination_chain_address = "destinationchainaddress".to_string();
         let bridge_address = crate::astria_address([99u8; 20]);
-        let denom = Denom::from("nootasset".to_string());
+        let denom = "nootasset".parse::<Denom>().unwrap();
         let rollup_id = RollupId::from_unhashed_bytes(b"testchainid");
 
         state_tx.put_bridge_account_rollup_id(&bridge_address, &rollup_id);

--- a/crates/astria-sequencer/src/ibc/ics20_transfer.rs
+++ b/crates/astria-sequencer/src/ibc/ics20_transfer.rs
@@ -365,6 +365,8 @@ fn prefix_denomination<'a>(
     }
 }
 
+// FIXME: temporarily allowed, but this must be fixed
+#[allow(clippy::too_many_lines)]
 async fn execute_ics20_transfer<S: StateWriteExt>(
     state: &mut S,
     data: &[u8],

--- a/crates/astria-sequencer/src/ibc/ics20_transfer.rs
+++ b/crates/astria-sequencer/src/ibc/ics20_transfer.rs
@@ -184,7 +184,7 @@ async fn refund_tokens_check<S: StateRead>(
     // if the asset is prefixed with `ibc`, the rest of the denomination string is the asset ID,
     // so we need to look up the full trace from storage.
     // see https://github.com/cosmos/ibc-go/blob/main/docs/architecture/adr-001-coin-source-tracing.md#decision
-    if denom.prefix_is("ibc") {
+    if denom.prefix_matches_exactly("ibc") {
         denom = state
             .get_ibc_asset(denom.id())
             .await
@@ -216,7 +216,7 @@ async fn refund_tokens_check<S: StateRead>(
 
 fn is_prefixed(source_port: &PortId, source_channel: &ChannelId, asset: &Denom) -> bool {
     let prefix = format!("{source_port}/{source_channel}");
-    asset.prefix_is(&prefix)
+    asset.prefix_matches_exactly(&prefix)
 }
 
 #[async_trait::async_trait]

--- a/crates/astria-sequencer/src/ibc/ics20_withdrawal.rs
+++ b/crates/astria-sequencer/src/ibc/ics20_withdrawal.rs
@@ -215,7 +215,7 @@ impl ActionHandler for action::Ics20Withdrawal {
 
 fn is_source(source_port: &PortId, source_channel: &ChannelId, asset: &Denom) -> bool {
     let prefix = format!("{source_port}/{source_channel}/");
-    !asset.prefix_is(&prefix)
+    !asset.prefix_matches_exactly(&prefix)
 }
 
 #[cfg(test)]

--- a/crates/astria-sequencer/src/ibc/ics20_withdrawal.rs
+++ b/crates/astria-sequencer/src/ibc/ics20_withdrawal.rs
@@ -233,7 +233,7 @@ mod tests {
         let snapshot = storage.latest_snapshot();
         let state = StateDelta::new(snapshot);
 
-        let denom = Denom::from("test".to_string());
+        let denom = "test".parse::<Denom>().unwrap();
         let from = crate::astria_address([1u8; 20]);
         let action = action::Ics20Withdrawal {
             amount: 1,
@@ -268,7 +268,7 @@ mod tests {
         );
         state.put_bridge_account_withdrawer_address(&bridge_address, &bridge_address);
 
-        let denom = Denom::from("test".to_string());
+        let denom = "test".parse::<Denom>().unwrap();
         let action = action::Ics20Withdrawal {
             amount: 1,
             denom: denom.clone(),
@@ -305,7 +305,7 @@ mod tests {
             &crate::astria_address([2u8; 20]),
         );
 
-        let denom = Denom::from("test".to_string());
+        let denom = "test".parse::<Denom>().unwrap();
         let action = action::Ics20Withdrawal {
             amount: 1,
             denom: denom.clone(),
@@ -343,7 +343,7 @@ mod tests {
         );
         state.put_bridge_account_withdrawer_address(&bridge_address, &withdrawer_address);
 
-        let denom = Denom::from("test".to_string());
+        let denom = "test".parse::<Denom>().unwrap();
         let action = action::Ics20Withdrawal {
             amount: 1,
             denom: denom.clone(),
@@ -377,7 +377,7 @@ mod tests {
         );
         state.put_bridge_account_withdrawer_address(&bridge_address, &withdrawer_address);
 
-        let denom = Denom::from("test".to_string());
+        let denom = "test".parse::<Denom>().unwrap();
         let action = action::Ics20Withdrawal {
             amount: 1,
             denom: denom.clone(),
@@ -410,7 +410,7 @@ mod tests {
         // sender is not the withdrawer address, so must fail
         let not_bridge_address = crate::astria_address([1u8; 20]);
 
-        let denom = Denom::from("test".to_string());
+        let denom = "test".parse::<Denom>().unwrap();
         let action = action::Ics20Withdrawal {
             amount: 1,
             denom: denom.clone(),

--- a/crates/astria-sequencer/src/proposal/commitment.rs
+++ b/crates/astria-sequencer/src/proposal/commitment.rs
@@ -89,10 +89,7 @@ pub(crate) fn generate_rollup_datas_commitment(
 mod test {
     use astria_core::{
         crypto::SigningKey,
-        primitive::v1::asset::{
-            Denom,
-            DEFAULT_NATIVE_ASSET_DENOM,
-        },
+        primitive::v1::asset::default_native_asset,
         protocol::transaction::v1alpha1::{
             action::{
                 SequenceAction,
@@ -112,7 +109,7 @@ mod test {
 
     #[test]
     fn generate_rollup_datas_commitment_should_ignore_transfers() {
-        let _ = NATIVE_ASSET.set(Denom::from_base_denom(DEFAULT_NATIVE_ASSET_DENOM));
+        let _ = NATIVE_ASSET.set(default_native_asset());
 
         let sequence_action = SequenceAction {
             rollup_id: RollupId::from_unhashed_bytes(b"testchainid"),
@@ -169,7 +166,7 @@ mod test {
         // this tests that the commitment generated is what is expected via a test vector.
         // this test will only break in the case of a breaking change to the commitment scheme,
         // thus if this test needs to be updated, we should cut a new release.
-        let _ = NATIVE_ASSET.set(Denom::from_base_denom(DEFAULT_NATIVE_ASSET_DENOM));
+        let _ = NATIVE_ASSET.set(default_native_asset());
 
         let sequence_action = SequenceAction {
             rollup_id: RollupId::from_unhashed_bytes(b"testchainid"),

--- a/crates/astria-sequencer/src/service/consensus.rs
+++ b/crates/astria-sequencer/src/service/consensus.rs
@@ -224,7 +224,10 @@ mod test {
             VerificationKey,
         },
         primitive::v1::{
-            asset::DEFAULT_NATIVE_ASSET_DENOM,
+            asset::{
+                default_native_asset,
+                DEFAULT_NATIVE_ASSET_DENOM,
+            },
             RollupId,
         },
         protocol::transaction::v1alpha1::{
@@ -466,7 +469,7 @@ mod test {
                 ibc_relayer_addresses: vec![],
                 native_asset_base_denomination: DEFAULT_NATIVE_ASSET_DENOM.to_string(),
                 ibc_params: penumbra_ibc::params::IBCParameters::default(),
-                allowed_fee_assets: vec![DEFAULT_NATIVE_ASSET_DENOM.to_owned().into()],
+                allowed_fee_assets: vec![default_native_asset()],
                 fees: default_fees(),
             }
         }

--- a/crates/astria-sequencer/src/service/info/mod.rs
+++ b/crates/astria-sequencer/src/service/info/mod.rs
@@ -160,11 +160,15 @@ impl Service<InfoRequest> for Info {
 
 #[cfg(test)]
 mod test {
-    use astria_core::primitive::v1::{
-        asset,
-        asset::{
+    use astria_core::{
+        primitive::v1::asset::{
+            self,
             Denom,
             DEFAULT_NATIVE_ASSET_DENOM,
+        },
+        protocol::{
+            account::v1alpha1::BalanceResponse,
+            asset::v1alpha1::DenomResponse,
         },
     };
     use cnidarium::StateDelta;
@@ -244,9 +248,10 @@ mod test {
             balance,
         };
 
-        let balance_resp = raw::BalanceResponse::decode(query_response.value)
-            .unwrap()
-            .to_native();
+        let balance_resp = BalanceResponse::try_from_raw(
+            &raw::BalanceResponse::decode(query_response.value).unwrap(),
+        )
+        .unwrap();
         assert_eq!(balance_resp.balances.len(), 1);
         assert_eq!(balance_resp.balances[0], expected_balance);
         assert_eq!(balance_resp.height, height);
@@ -259,7 +264,7 @@ mod test {
         let storage = cnidarium::TempStorage::new().await.unwrap();
         let mut state = StateDelta::new(storage.latest_snapshot());
 
-        let denom: Denom = "some/ibc/asset".to_string().into();
+        let denom = "some/ibc/asset".parse::<Denom>().unwrap();
         let id = denom.id();
         let height = 99;
         state.put_block_height(height);
@@ -287,9 +292,9 @@ mod test {
         };
         assert!(query_response.code.is_ok());
 
-        let denom_resp = raw::DenomResponse::decode(query_response.value)
-            .unwrap()
-            .to_native();
+        let denom_resp =
+            DenomResponse::try_from_raw(&raw::DenomResponse::decode(query_response.value).unwrap())
+                .unwrap();
         assert_eq!(denom_resp.height, height);
         assert_eq!(denom_resp.denom, denom);
     }

--- a/crates/astria-sequencer/src/transaction/checks.rs
+++ b/crates/astria-sequencer/src/transaction/checks.rs
@@ -313,7 +313,7 @@ mod test {
 
         crate::asset::initialize_native_asset(DEFAULT_NATIVE_ASSET_DENOM);
         let native_asset = crate::asset::get_native_asset().id();
-        let other_asset = Denom::from_base_denom("other").id();
+        let other_asset = "other".parse::<Denom>().unwrap().id();
 
         let (alice_signing_key, alice_address) = get_alice_signing_key_and_address();
         let amount = 100;
@@ -381,7 +381,7 @@ mod test {
 
         crate::asset::initialize_native_asset(DEFAULT_NATIVE_ASSET_DENOM);
         let native_asset = crate::asset::get_native_asset().id();
-        let other_asset = Denom::from_base_denom("other").id();
+        let other_asset = "other".parse::<Denom>().unwrap().id();
 
         let (alice_signing_key, alice_address) = get_alice_signing_key_and_address();
         let amount = 100;


### PR DESCRIPTION
## Summary
Rewrites the IBC denomation construction by parsing its prefix into segments. This fixes the incorrect removal of prefxies for source non-refund ics20 packets.

## Background
follow up to https://github.com/astriaorg/astria/pull/851 which was an audit fix - this fixes the fix by removing the source prefix correctly, in the case assets we're the source of are transferred in. previously, the entire prefix was removed, would would have been invalid if the asset was prefixed by multiple hops, eg. transfer/channel-1/transfer/channel-2/denom would have become just denom when it should have become transfer/channel-2/denom.

## Changes
- refactor `astria_core::primitive::1::asset::Denom` to express its prefix as a list of segments
- ensure that only full prefix segments are removed
- make `Denom` construction a fallible operation by parsing it
- removed a bunch of constructors as they were only used in tests and not otherwise

## Testing
Provide exhaustive units.

## Related Issues
Replaces https://github.com/astriaorg/astria/pull/1131
