### PR TITLE
chore(sequencer-relayer)!: remove functionality to restrict relaying blocks to only those proposed by a given validator

### DIFF
--- a/charts/sequencer-relayer/Chart.yaml
+++ b/charts/sequencer-relayer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.4
+version: 0.8.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sequencer-relayer/templates/configmaps.yaml
+++ b/charts/sequencer-relayer/templates/configmaps.yaml
@@ -6,8 +6,6 @@ metadata:
 data:
   ASTRIA_SEQUENCER_RELAYER_LOG: "astria_sequencer_relayer=debug"
   ASTRIA_SEQUENCER_RELAYER_BLOCK_TIME: "1000"
-  ASTRIA_SEQUENCER_RELAYER_VALIDATOR_KEY_FILE: /cometbft/config/priv_validator_key.json
-  ASTRIA_SEQUENCER_RELAYER_RELAY_ONLY_VALIDATOR_KEY_BLOCKS: "false"
   ASTRIA_SEQUENCER_RELAYER_COMETBFT_ENDPOINT: "{{ .Values.config.relayer.cometbftRpc }}"
   ASTRIA_SEQUENCER_RELAYER_SEQUENCER_GRPC_ENDPOINT: "{{ .Values.config.relayer.sequencerGrpc }}"
   ASTRIA_SEQUENCER_RELAYER_CELESTIA_APP_GRPC_ENDPOINT: "{{ .Values.config.relayer.celestiaAppGrpc }}"
@@ -29,6 +27,8 @@ data:
   OTEL_SERVICE_NAME: "{{ tpl .Values.config.relayer.otel.serviceName . }}"
   ASTRIA_SEQUENCER_RELAYER_ONLY_INCLUDE_ROLLUPS: "{{ .Values.config.relayer.onlyIncludeRollups }}"
   {{- if not .Values.global.dev }}
+  ASTRIA_SEQUENCER_RELAYER_VALIDATOR_KEY_FILE: /cometbft/config/priv_validator_key.json
+  ASTRIA_SEQUENCER_RELAYER_RELAY_ONLY_VALIDATOR_KEY_BLOCKS: "false"
   {{- else }}
   ASTRIA_SEQUENCER_RELAYER_SEQUENCER_CHAIN_ID: "{{ .Values.config.relayer.sequencerChainId }}"
   ASTRIA_SEQUENCER_RELAYER_CELESTIA_CHAIN_ID: "{{ .Values.config.relayer.celestiaChainId }}"

--- a/charts/sequencer/Chart.lock
+++ b/charts/sequencer/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: sequencer-relayer
   repository: file://../sequencer-relayer
-  version: 0.8.4
-digest: sha256:fa980cbe23353b162aad741afbf2ccde4d93b6d017be5fe478d5994bcfd1c992
-generated: "2024-05-30T17:09:44.161456347+01:00"
+  version: 0.8.5
+digest: sha256:66ce8c4cd8500a63282f7ab112682f8cd50c2253a0b046ec41e0c637c9b66bd9
+generated: "2024-06-10T13:21:58.112283375+01:00"

--- a/charts/sequencer/Chart.yaml
+++ b/charts/sequencer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.15.5
+version: 0.15.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,7 +25,7 @@ appVersion: "0.13.0"
 
 dependencies:
   - name: sequencer-relayer
-    version: "0.8.4"
+    version: "0.8.5"
     repository: "file://../sequencer-relayer"
     condition: sequencer-relayer.enabled
 

--- a/crates/astria-sequencer-relayer/local.env.example
+++ b/crates/astria-sequencer-relayer/local.env.example
@@ -48,9 +48,6 @@ ASTRIA_SEQUENCER_RELAYER_CELESTIA_APP_KEY_FILE=/path/to/priv_celestia_key.json
 # requesting a new block from sequencer.
 ASTRIA_SEQUENCER_RELAYER_BLOCK_TIME=1000
 
-# Set to true to only relay blocks proposed by the validator key in `ASTRIA_SEQUENCER_RELAYER_VALIDATOR_KEY_FILE`.
-ASTRIA_SEQUENCER_RELAYER_RELAY_ONLY_VALIDATOR_KEY_BLOCKS=false
-
 # A comma-separated list of base64-encoded rollup IDs, often the sha256
 # hash of a rollup name.
 # Only data from these rollups will be submitted to Celestia.
@@ -59,11 +56,6 @@ ASTRIA_SEQUENCER_RELAYER_RELAY_ONLY_VALIDATOR_KEY_BLOCKS=false
 # Example for only submitting transactions for rollups of the provided IDs:
 # ASTRIA_SEQUENCER_RELAYER_ONLY_INCLUDE_ROLLUPS=AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA=,IB8eHRwbGhkYFxYVFBMSERAPDg0MCwoJCAcGBQQDAgE=
 ASTRIA_SEQUENCER_RELAYER_ONLY_INCLUDE_ROLLUPS=
-
-# The path to the file storing the cometbft validator key.
-# Used to sign data before submitting it to celestia.
-# Ignored if `ASTRIA_SEQUENCER_RELAYER_RELAY_ONLY_VALIDATOR_KEY_BLOCKS=false`.
-ASTRIA_SEQUENCER_RELAYER_VALIDATOR_KEY_FILE=.cometbft/config/priv_validator_key.json
 
 # The socket address at which sequencer relayer will server healthz, readyz, and status calls.
 ASTRIA_SEQUENCER_RELAYER_API_ADDR=127.0.0.1:2450

--- a/crates/astria-sequencer-relayer/src/config.rs
+++ b/crates/astria-sequencer-relayer/src/config.rs
@@ -31,9 +31,6 @@ pub struct Config {
     pub celestia_app_grpc_endpoint: String,
     pub celestia_app_key_file: String,
     pub block_time: u64,
-    pub relay_only_validator_key_blocks: bool,
-    #[serde(default)]
-    pub validator_key_file: String,
     // Would ideally be private; accessed via the public getter which converts this to a collection
     // of `RollupId`s.  Left public for integration tests.
     #[doc(hidden)]

--- a/crates/astria-sequencer-relayer/src/relayer/builder.rs
+++ b/crates/astria-sequencer-relayer/src/relayer/builder.rs
@@ -20,10 +20,7 @@ use super::{
     CelestiaClientBuilder,
     CelestiaKeys,
 };
-use crate::{
-    validator::Validator,
-    IncludeRollup,
-};
+use crate::IncludeRollup;
 
 pub(crate) struct Builder {
     pub(crate) shutdown_token: tokio_util::sync::CancellationToken,
@@ -34,7 +31,6 @@ pub(crate) struct Builder {
     pub(crate) cometbft_endpoint: String,
     pub(crate) sequencer_poll_period: Duration,
     pub(crate) sequencer_grpc_endpoint: String,
-    pub(crate) validator_key_path: Option<String>,
     pub(crate) rollup_filter: IncludeRollup,
     pub(crate) pre_submit_path: PathBuf,
     pub(crate) post_submit_path: PathBuf,
@@ -52,7 +48,6 @@ impl Builder {
             cometbft_endpoint,
             sequencer_poll_period,
             sequencer_grpc_endpoint,
-            validator_key_path,
             rollup_filter,
             pre_submit_path,
             post_submit_path,
@@ -67,11 +62,6 @@ impl Builder {
             let endpoint = Endpoint::from(uri);
             SequencerServiceClient::new(endpoint.connect_lazy())
         };
-
-        let validator = validator_key_path
-            .map(Validator::from_path)
-            .transpose()
-            .wrap_err("failed to get validator info from file")?;
 
         let state = Arc::new(State::new());
 
@@ -92,7 +82,6 @@ impl Builder {
             sequencer_grpc_client,
             sequencer_poll_period,
             celestia_client_builder,
-            validator,
             rollup_filter,
             state,
             pre_submit_path,

--- a/crates/astria-sequencer-relayer/src/relayer/mod.rs
+++ b/crates/astria-sequencer-relayer/src/relayer/mod.rs
@@ -45,7 +45,6 @@ use tonic::transport::Channel;
 use tracing::{
     debug,
     error,
-    field::DisplayValue,
     info,
     instrument,
     trace,
@@ -96,9 +95,6 @@ pub(crate) struct Relayer {
 
     /// The gRPC client for submitting sequencer blocks to celestia.
     celestia_client_builder: CelestiaClientBuilder,
-
-    /// If this is set, only relay blocks to DA which are proposed by the same validator key.
-    validator: Option<Validator>,
 
     /// The rollups whose data should be included in submissions.
     rollup_filter: IncludeRollup,
@@ -245,19 +241,6 @@ impl Relayer {
         reason.map(|_| ())
     }
 
-    fn report_validator(&self) -> Option<DisplayValue<ReportValidator<'_>>> {
-        self.validator
-            .as_ref()
-            .map(ReportValidator)
-            .map(tracing::field::display)
-    }
-
-    fn block_does_not_match_validator(&self, block: &SequencerBlock) -> bool {
-        self.validator
-            .as_ref()
-            .is_some_and(|val| &val.address != block.header().proposer_address())
-    }
-
     #[instrument(skip_all, fields(%height))]
     fn forward_block_for_submission(
         &self,
@@ -275,14 +258,6 @@ impl Relayer {
              congested and this future is in-flight",
         );
 
-        if self.block_does_not_match_validator(&block) {
-            info!(
-                address.validator = self.report_validator(),
-                address.block_proposer = %block.header().proposer_address(),
-                "block proposer does not match internal validator; dropping",
-            );
-            return Ok(());
-        }
         if let Err(error) = submitter.try_send(block) {
             debug!(
                 // Just print the error directly: TrySendError has no cause chain.

--- a/crates/astria-sequencer-relayer/src/sequencer_relayer.rs
+++ b/crates/astria-sequencer-relayer/src/sequencer_relayer.rs
@@ -54,15 +54,12 @@ impl SequencerRelayer {
             celestia_app_grpc_endpoint,
             celestia_app_key_file,
             block_time,
-            relay_only_validator_key_blocks,
-            validator_key_file,
             api_addr,
             pre_submit_path,
             post_submit_path,
             ..
         } = cfg;
 
-        let validator_key_path = relay_only_validator_key_blocks.then_some(validator_key_file);
         let relayer = relayer::Builder {
             shutdown_token: shutdown_handle.token(),
             sequencer_chain_id,
@@ -72,7 +69,6 @@ impl SequencerRelayer {
             cometbft_endpoint,
             sequencer_poll_period: Duration::from_millis(block_time),
             sequencer_grpc_endpoint,
-            validator_key_path,
             rollup_filter,
             pre_submit_path,
             post_submit_path,

--- a/crates/astria-sequencer-relayer/tests/blackbox/helpers/mock_sequencer_server.rs
+++ b/crates/astria-sequencer-relayer/tests/blackbox/helpers/mock_sequencer_server.rs
@@ -75,24 +75,22 @@ impl MockSequencerServer {
         }
     }
 
-    pub async fn mount_sequencer_block_response<const RELAY_SELF: bool>(
+    pub async fn mount_sequencer_block_response(
         &self,
-        account: AccountId,
         block_to_mount: SequencerBlockToMount,
         debug_name: impl Into<String>,
     ) {
-        prepare_sequencer_block_response::<RELAY_SELF>(account, block_to_mount, debug_name)
+        prepare_sequencer_block_response(block_to_mount, debug_name)
             .mount(&self.mock_server)
             .await;
     }
 
-    pub async fn mount_sequencer_block_response_as_scoped<const RELAY_SELF: bool>(
+    pub async fn mount_sequencer_block_response_as_scoped(
         &self,
-        account: AccountId,
         block_to_mount: SequencerBlockToMount,
         debug_name: impl Into<String>,
     ) -> MockGuard {
-        prepare_sequencer_block_response::<RELAY_SELF>(account, block_to_mount, debug_name)
+        prepare_sequencer_block_response(block_to_mount, debug_name)
             .mount_as_scoped(&self.mock_server)
             .await
     }
@@ -136,17 +134,11 @@ impl SequencerService for SequencerServiceImpl {
     }
 }
 
-fn prepare_sequencer_block_response<const RELAY_SELF: bool>(
-    account: AccountId,
+fn prepare_sequencer_block_response(
     block_to_mount: SequencerBlockToMount,
     debug_name: impl Into<String>,
 ) -> Mock {
-    let proposer = if RELAY_SELF {
-        account
-    } else {
-        AccountId::try_from(vec![0u8; 20]).unwrap()
-    };
-
+    let proposer = AccountId::try_from(vec![0u8; 20]).unwrap();
     let should_corrupt = matches!(block_to_mount, SequencerBlockToMount::BadAtHeight(_));
 
     let block = match block_to_mount {

--- a/crates/astria-sequencer-relayer/tests/blackbox/main.rs
+++ b/crates/astria-sequencer-relayer/tests/blackbox/main.rs
@@ -15,9 +15,6 @@ use helpers::{
 use reqwest::StatusCode;
 use tendermint::account::Id as AccountId;
 
-const RELAY_SELF: bool = true;
-const RELAY_ALL: bool = false;
-
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn one_block_is_relayed_to_celestia() {
     let sequencer_relayer = TestSequencerRelayerConfig::default().spawn_relayer().await;
@@ -25,7 +22,7 @@ async fn one_block_is_relayed_to_celestia() {
     sequencer_relayer.mount_abci_response(1).await;
     let block_to_mount = SequencerBlockToMount::GoodAtHeight(1);
     sequencer_relayer
-        .mount_sequencer_block_response::<RELAY_ALL>(block_to_mount, "good block 1")
+        .mount_sequencer_block_response(block_to_mount, "good block 1")
         .await;
     sequencer_relayer
         .mount_celestia_app_broadcast_tx_response("broadcast tx 1")
@@ -75,7 +72,7 @@ async fn report_degraded_if_block_fetch_fails() {
     sequencer_relayer.mount_abci_response(1).await;
     let block_to_mount = SequencerBlockToMount::GoodAtHeight(1);
     sequencer_relayer
-        .mount_sequencer_block_response::<RELAY_ALL>(block_to_mount, "good block 1")
+        .mount_sequencer_block_response(block_to_mount, "good block 1")
         .await;
     sequencer_relayer
         .mount_celestia_app_broadcast_tx_response("broadcast tx 1")
@@ -99,7 +96,7 @@ async fn report_degraded_if_block_fetch_fails() {
     sequencer_relayer.mount_abci_response(2).await;
     let block_to_mount = SequencerBlockToMount::BadAtHeight(2);
     let block_guard = sequencer_relayer
-        .mount_sequencer_block_response_as_scoped::<RELAY_ALL>(block_to_mount, "bad block 2")
+        .mount_sequencer_block_response_as_scoped(block_to_mount, "bad block 2")
         .await;
 
     // Relayer reports 500 on /healthz after fetching the block failed.
@@ -134,7 +131,7 @@ async fn later_height_in_state_leads_to_expected_relay() {
     sequencer_relayer.mount_abci_response(7).await;
     let block_to_mount = SequencerBlockToMount::GoodAtHeight(6);
     sequencer_relayer
-        .mount_sequencer_block_response::<RELAY_ALL>(block_to_mount, "good block 1")
+        .mount_sequencer_block_response(block_to_mount, "good block 1")
         .await;
     sequencer_relayer
         .mount_celestia_app_broadcast_tx_response("broadcast tx 1")
@@ -175,19 +172,19 @@ async fn three_blocks_are_relayed() {
     sequencer_relayer.mount_abci_response(1).await;
     let block_to_mount = SequencerBlockToMount::GoodAtHeight(1);
     sequencer_relayer
-        .mount_sequencer_block_response::<RELAY_ALL>(block_to_mount, "good block 1")
+        .mount_sequencer_block_response(block_to_mount, "good block 1")
         .await;
 
     sequencer_relayer.mount_abci_response(2).await;
     let block_to_mount = SequencerBlockToMount::GoodAtHeight(2);
     sequencer_relayer
-        .mount_sequencer_block_response::<RELAY_ALL>(block_to_mount, "good block 2")
+        .mount_sequencer_block_response(block_to_mount, "good block 2")
         .await;
 
     sequencer_relayer.mount_abci_response(3).await;
     let block_to_mount = SequencerBlockToMount::GoodAtHeight(3);
     sequencer_relayer
-        .mount_sequencer_block_response::<RELAY_ALL>(block_to_mount, "good block 3")
+        .mount_sequencer_block_response(block_to_mount, "good block 3")
         .await;
 
     sequencer_relayer
@@ -237,73 +234,6 @@ async fn three_blocks_are_relayed() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn block_from_other_proposer_is_skipped() {
-    let sequencer_relayer = TestSequencerRelayerConfig {
-        relay_only_self: true,
-        ..TestSequencerRelayerConfig::default()
-    }
-    .spawn_relayer()
-    .await;
-
-    sequencer_relayer.mount_abci_response(1).await;
-    let block_to_mount = SequencerBlockToMount::GoodAtHeight(1);
-    sequencer_relayer
-        .mount_sequencer_block_response::<RELAY_SELF>(block_to_mount, "good block 1")
-        .await;
-
-    sequencer_relayer.mount_abci_response(2).await;
-    let block_to_mount = SequencerBlockToMount::GoodAtHeight(2);
-    sequencer_relayer
-        .mount_sequencer_block_response::<RELAY_ALL>(block_to_mount, "good block 2")
-        .await;
-
-    sequencer_relayer.mount_abci_response(3).await;
-    let block_to_mount = SequencerBlockToMount::GoodAtHeight(3);
-    sequencer_relayer
-        .mount_sequencer_block_response::<RELAY_SELF>(block_to_mount, "good block 3")
-        .await;
-
-    // We only expect two broadcast/get Tx gRPCs - block 2 should not have been broadcast.
-    sequencer_relayer
-        .mount_celestia_app_broadcast_tx_response("broadcast tx 1")
-        .await;
-    sequencer_relayer
-        .mount_celestia_app_get_tx_response(53, "get tx 1")
-        .await;
-    sequencer_relayer
-        .mount_celestia_app_broadcast_tx_response("broadcast tx 2")
-        .await;
-    let get_tx_guard = sequencer_relayer
-        .mount_celestia_app_get_tx_response_as_scoped(53, "get tx 2")
-        .await;
-    // Each block will have taken ~1 second due to the delay before each `GetTx`, so use 4 seconds.
-    sequencer_relayer
-        .timeout_ms(
-            4_000,
-            "waiting for get tx guard",
-            get_tx_guard.wait_until_satisfied(),
-        )
-        .await;
-
-    // Assert the relayer reports the correct Celestia and sequencer heights.
-    sequencer_relayer
-        .wait_for_latest_confirmed_celestia_height(53, 1_000)
-        .await;
-    sequencer_relayer
-        .wait_for_latest_fetched_sequencer_height(3, 1_000)
-        .await;
-    sequencer_relayer
-        .wait_for_latest_observed_sequencer_height(3, 1_000)
-        .await;
-
-    assert_eq!(
-        sequencer_relayer.celestia_app_received_blob_count(),
-        4,
-        "expected 4 blobs in total, 1 header blob and 1 rollup blob per block"
-    );
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn should_filter_rollup() {
     let included_rollup_ids: HashSet<_> = (0..5).map(|x| RollupId::new([x; 32])).collect();
     let excluded_rollup_ids: HashSet<_> = (0..5).map(|x| RollupId::new([100 + x; 32])).collect();
@@ -333,7 +263,7 @@ async fn should_filter_rollup() {
 
     sequencer_relayer.mount_abci_response(1).await;
     sequencer_relayer
-        .mount_sequencer_block_response::<RELAY_ALL>(block_to_mount, "good block 1")
+        .mount_sequencer_block_response(block_to_mount, "good block 1")
         .await;
     sequencer_relayer
         .mount_celestia_app_broadcast_tx_response("broadcast tx 1")
@@ -374,7 +304,7 @@ async fn should_shut_down() {
     sequencer_relayer.mount_abci_response(1).await;
     let block_to_mount = SequencerBlockToMount::GoodAtHeight(1);
     sequencer_relayer
-        .mount_sequencer_block_response::<RELAY_ALL>(block_to_mount, "good block 1")
+        .mount_sequencer_block_response(block_to_mount, "good block 1")
         .await;
     let broadcast_guard = sequencer_relayer
         .mount_celestia_app_broadcast_tx_response_as_scoped("broadcast tx 1")


### PR DESCRIPTION
## Summary
This changes the relayer to relay all blocks regardless of which validator proposed them.

## Background
We had functionality to allow providing a validator secret key to the relayer and an option to only relay blocks proposed by that validator.  The functionality wasn't being used anywhere, so it has been removed.

## Changes
- Removed configuration options (see below) and supporting code.

## Testing
N/A

## Breaking Changelist
- Removed env var `ASTRIA_SEQUENCER_RELAYER_VALIDATOR_KEY_FILE`.
- Removed env var `ASTRIA_SEQUENCER_RELAYER_RELAY_ONLY_VALIDATOR_KEY_BLOCKS`.

## Related Issues
Closes #1010.
