### PR TITLE
ignore RUSTSEC-2021-0139

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -14,3 +14,5 @@ jobs:
       - uses: rustsec/audit-check@v1.4.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          # `ansi_term` is Unmaintained. It is a transient dependency of penumbra crates and dylint, so cannot easily be replaced.
+          ignore: RUSTSEC-2021-0139

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,6 +92,8 @@ jobs:
       - uses: rustsec/audit-check@v1.4.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          # `ansi_term` is Unmaintained. It is a transient dependency of penumbra crates and dylint, so cannot easily be replaced.
+          ignore: RUSTSEC-2021-0139
 
   rust:
     runs-on: buildjet-8vcpu-ubuntu-2204

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4319,9 +4319,9 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.29"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f08474e32172238f2827bd160c67871cdb2801430f65c3979184dc362e3ca118"
+checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
 dependencies = [
  "libc",
 ]


### PR DESCRIPTION
## Summary
Ignore rustsec warning.

## Background
We get a non-critical warning when running `cargo audit`: [RUSTSEC-2021-0139](https://rustsec.org/advisories/RUSTSEC-2021-0139).

When running `cargo tree -i -p=ansi_term` we can see that `ansi_term` is a dependency of `dylint` and `tracing-subscriber` v0.2.  While `tracing-subscriber` v0.3 doesn't depend upon `ansi_term`, we can't easily upgrade to that version as several of our dependencies do not support v0.3.  Also, `dylint`'s latest version still depends upon `ansi_term`.

Given that the rustsec report doesn't suggest any concrete problems with `ansi_term` and how difficult it will be to move away from this dependency, I have just ignored this warning in CI.

We also have a further audit warning about v0.1.29 of `jobserver` being yanked, so I have updated that dependency.

## Changes
- Ignore rustsec warning in CI files.

## Testing
CI.

## Related Issues
Closes #914.