### PR TITLE
chore(chart)!: update default cometbft config vals

### DIFF
--- a/charts/sequencer/Chart.yaml
+++ b/charts/sequencer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.15.6
+version: 0.16.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -32,7 +32,7 @@ dependencies:
 maintainers:
   - name: wafflesvonmaple
     url: astria.org
-  - name: steezeburger
+  - name: quasystaty1
     url: astria.org
   - name: joroshiba
     url: astria.org

--- a/charts/sequencer/files/cometbft/config/config.toml
+++ b/charts/sequencer/files/cometbft/config/config.toml
@@ -169,10 +169,10 @@ experimental_close_on_slow_client = false
 timeout_broadcast_tx_commit = "10s"
 
 # Maximum size of request body, in bytes
-max_body_bytes = 1000000
+max_body_bytes = 1_000_000
 
 # Maximum size of request header, in bytes
-max_header_bytes = 1048576
+max_header_bytes = 1_048_576
 
 # The path to a file containing certificate that is used to create the HTTPS server.
 # Might be either absolute path or path related to CometBFT's config directory.
@@ -219,10 +219,10 @@ addr_book_file = "config/addrbook.json"
 addr_book_strict = true
 
 # Maximum number of inbound peers
-max_num_inbound_peers = 40
+max_num_inbound_peers = 100
 
 # Maximum number of outbound peers to connect to, excluding persistent peers
-max_num_outbound_peers = 10
+max_num_outbound_peers = 40
 
 # List of node IDs, to which a connection will be (re)established ignoring any existing limits
 unconditional_peer_ids = "{{ join "," .Values.config.cometBFT.p2p.unconditionalPeers }}"
@@ -237,10 +237,10 @@ flush_throttle_timeout = "100ms"
 max_packet_msg_payload_size = 1024
 
 # Rate at which packets can be sent, in bytes/second
-send_rate = 5120000
+send_rate = 5_120_000
 
 # Rate at which packets can be received, in bytes/second
-recv_rate = 5120000
+recv_rate = 5_120_000
 
 # Set true to enable the peer-exchange reactor
 pex = true
@@ -297,15 +297,15 @@ broadcast = true
 wal_dir = ""
 
 # Maximum number of transactions in the mempool
-size = 5000
+size = 2000
 
 # Limit the total size of all txs in the mempool.
 # This only accounts for raw transactions (e.g. given 1MB transactions and
 # max_txs_bytes=5MB, mempool will only accept 5 transactions).
-max_txs_bytes = 1073741824
+max_txs_bytes = 100_000_000
 
 # Size of the cache (used to filter transactions we saw earlier) in transactions
-cache_size = 10000
+cache_size = 10_000
 
 # Do not remove invalid transactions from the cache (default: false)
 # Set to true if it's not possible for any invalid transaction to become valid
@@ -314,7 +314,7 @@ keep-invalid-txs-in-cache = false
 
 # Maximum size of a single transaction.
 # NOTE: the max size of a tx transmitted over the network is {max_tx_bytes}.
-max_tx_bytes = 1048576
+max_tx_bytes = 250_000
 
 # Maximum size of a batch of transactions to send to a peer
 # Including space needed by encoding (one varint per transaction).
@@ -393,7 +393,7 @@ version = "v0"
 wal_file = "data/cs.wal/wal"
 
 # How long we wait for a proposal block before prevoting nil
-timeout_propose = "3s"
+timeout_propose = "2s"
 # How much timeout_propose increases with each round
 timeout_propose_delta = "500ms"
 # How long we wait after receiving +2/3 prevotes for “anything” (ie. not a single block or nil)
@@ -407,7 +407,7 @@ timeout_precommit_delta = "500ms"
 # How long we wait after committing a block, before starting on the new
 # height (this gives us a chance to receive some more precommits, even
 # though we already have +2/3).
-timeout_commit = "2s"
+timeout_commit = "1.5s"
 
 # How many blocks to look back to check existence of the node's consensus votes before joining consensus
 # When non-zero, the node will panic upon restart
@@ -486,4 +486,4 @@ prometheus_listen_addr = ":26660"
 max_open_connections = 3
 
 # Instrumentation namespace
-namespace = "cometbft"
+namespace = "astria_cometbft"

--- a/charts/sequencer/files/cometbft/config/genesis.json
+++ b/charts/sequencer/files/cometbft/config/genesis.json
@@ -46,12 +46,12 @@
   "chain_id": "{{ .Values.config.cometBFT.chainId }}",
   "consensus_params": {
     "block": {
-      "max_bytes": "22020096",
+      "max_bytes": "1000000",
       "max_gas": "-1"
     },
     "evidence": {
-      "max_age_duration": "172800000000000",
-      "max_age_num_blocks": "100000",
+      "max_age_duration": "1209600000000000",
+      "max_age_num_blocks": "4000000",
       "max_bytes": "1048576"
     },
     "validator": {

--- a/charts/sequencer/templates/service.yaml
+++ b/charts/sequencer/templates/service.yaml
@@ -53,6 +53,8 @@ apiVersion: v1
 metadata:
   name: {{ .Values.config.moniker }}-sequencer-metrics
   namespace: {{ include "sequencer.namespace" . }}
+  labels:
+    app: {{ .Values.config.moniker }}-sequencer
 spec:
   selector:
     app: {{ .Values.config.moniker }}-sequencer


### PR DESCRIPTION
## Summary
Updates default CometBFT configuration, and genesis.

## Background
We have been running on mostly defaults without much thought to it, gave a more thorough review.

## Breaking Changelist
- Changes genesis parameters and thus cannot be used with existing networks without adding ability to make more configurable w/ these as defaults.
