### PR TITLE
feat(charts): option to purge geth mempool

### DIFF
--- a/charts/evm-rollup/Chart.yaml
+++ b/charts/evm-rollup/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.19.1
+version: 0.19.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/evm-rollup/templates/statefulsets.yaml
+++ b/charts/evm-rollup/templates/statefulsets.yaml
@@ -17,6 +17,18 @@ spec:
         app: {{ .Values.config.rollup.name }}-astria-dev-cluster
     spec:
       initContainers:
+        {{- if .Values.config.rollup.purgeMempool }}
+        - name: purge-mempool
+          image: {{ include "rollup.image" . }}
+          command: [ "sh", "-c", "rm -f $data_dir/geth/transactions.rlp" ]
+          envFrom:
+            - configMapRef:
+                name: {{ .Values.config.rollup.name }}-geth-env
+          volumeMounts:
+            - mountPath: /home/geth
+              name: {{ $.Values.config.rollup.name }}-rollup-shared-storage-vol
+              subPath: {{ .Values.config.rollup.name }}/executor
+        {{- end }}
         - name: init-geth
           command: [ "/scripts/init-geth.sh" ]
           image: {{ include "rollup.image" . }}

--- a/charts/evm-rollup/templates/storageclasses.yaml
+++ b/charts/evm-rollup/templates/storageclasses.yaml
@@ -9,7 +9,7 @@ metadata:
 provisioner: kubernetes.io/no-provisioner
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Retain
-    {{- if .Values.config.blockscout.enabled }}
+    {{- if $.Values.config.blockscout.enabled }}
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass

--- a/charts/evm-rollup/values.yaml
+++ b/charts/evm-rollup/values.yaml
@@ -44,6 +44,8 @@ config:
     dbEngine: pebble
     # Set to true to keep history of all blocks
     archiveNode: false
+    # Set to true to clear the mempool on startup/restart
+    purgeMempool: false
     # EVM network ID used by the chain
     networkId: "1337"
     # Determines what will drive block execution, options are:
@@ -328,7 +330,7 @@ resources:
       memory: 16Gi
 
 storage:
-  enabled: false
+  enabled: true
   local: true
   entities:
     rollupSharedStorage:

--- a/charts/evm-rollup/values.yaml
+++ b/charts/evm-rollup/values.yaml
@@ -330,7 +330,7 @@ resources:
       memory: 16Gi
 
 storage:
-  enabled: true
+  enabled: false
   local: true
   entities:
     rollupSharedStorage:


### PR DESCRIPTION
## Summary
Add a `purgeMempool` flag to the rollup config which will force purge the geth mempool on startup if set to true.

## Testing
- Started local dev cluster w/ storage enabled and `purgeMempool` disabled.
- Forced two (2) queued tx in mempool by sending tx with higher nonce than account's current nonce
- Checked 2 queued tx were in mempool using `txpool_status` rpc call (✅ passed)
- Deleted geth pod to force it to restart
- Checked 2 queued tx were in mempool using `txpool_status` rpc call (✅ passed)
- Enabled `purgeMempool` and updated helm chart
- Deleted geth pod to force it to restart
- Checked pending and queued tx were 0 using `txpool_status` rpc call (✅ passed)

