### PR TITLE
sequencer: reduce maximum block size to 4MiB

### DIFF
--- a/charts/sequencer/files/cometbft/config/genesis.json
+++ b/charts/sequencer/files/cometbft/config/genesis.json
@@ -46,7 +46,7 @@
   "chain_id": "{{ .Values.config.cometBFT.chainId }}",
   "consensus_params": {
     "block": {
-      "max_bytes": "22020096",
+      "max_bytes": "4194304",
       "max_gas": "-1"
     },
     "evidence": {

--- a/charts/sequencer/files/cometbft/config/genesis.json
+++ b/charts/sequencer/files/cometbft/config/genesis.json
@@ -47,7 +47,7 @@
   "consensus_params": {
     "block": {
       "max_bytes": "4194304",
-      "max_gas": "-1"
+      "max_gas": "10000000"
     },
     "evidence": {
       "max_age_duration": "172800000000000",


### PR DESCRIPTION
## Summary
Set genesis params to match new upstream values.

## Background
21MiB was the old default set by upstream, 4MiB is the new, safer default after discovering the p2p storms issue. See:

https://github.com/cometbft/cometbft/pull/1518
https://github.com/cometbft/cometbft/security/advisories/GHSA-hq58-p9mv-338c
https://github.com/notional-labs/placid

## Changes
- Reduce maximum block size from 21MiB to 4MiB.
- Reduce gas limit from limitless to 10 million.

## Testing

Launch a new testnet with the new genesis.json?

