### PR TITLE
sequencer: reduce cometbft mempool.max_txs_bytes to 64MiB

### DIFF
--- a/charts/sequencer/files/cometbft/config/config.toml
+++ b/charts/sequencer/files/cometbft/config/config.toml
@@ -302,7 +302,7 @@ size = 5000
 # Limit the total size of all txs in the mempool.
 # This only accounts for raw transactions (e.g. given 1MB transactions and
 # max_txs_bytes=5MB, mempool will only accept 5 transactions).
-max_txs_bytes = 1073741824
+max_txs_bytes = 67108864
 
 # Size of the cache (used to filter transactions we saw earlier) in transactions
 cache_size = 10000


### PR DESCRIPTION

## Summary
Reduce the maximum size of the mempool from 1GiB to 64MiB.

## Background

The default value for `mempool.max_txs_bytes` was reduced upstream in CometBFT recently:

https://github.com/cometbft/cometbft/pull/2767

## Changes
- edit 1 line in config.toml

## Related Issues

https://github.com/astriaorg/astria/pull/1183
