### PR TITLE
chore(core, proto)!: remove non-bech32m address bytes

### DIFF
--- a/crates/astria-core/src/generated/astria.primitive.v1.rs
+++ b/crates/astria-core/src/generated/astria.primitive.v1.rs
@@ -86,15 +86,6 @@ impl ::prost::Name for RollupId {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Address {
-    /// The first 20 bytes of a sha256-hashed ed25519 public key.
-    /// Implementors must avoid setting this field in favor of `bech32m`.
-    /// Implementors must not accept both `inner` and `bech32m` being set.
-    /// DEPRECATED: this field is deprecated and only exists for backward compatibility.
-    /// Astria services assume an implicit prefix of "astria" if this field is set.
-    /// Astria services will read this field but will never emit it.
-    #[deprecated]
-    #[prost(bytes = "bytes", tag = "1")]
-    pub inner: ::prost::bytes::Bytes,
     /// A bech32m encoded string. The data are the first 20 bytes of a sha256-hashed ed25519
     /// public key. Implementors must not accept both the `bytes` and `bech32m` being set.
     #[prost(string, tag = "2")]

--- a/crates/astria-core/src/generated/astria.primitive.v1.serde.rs
+++ b/crates/astria-core/src/generated/astria.primitive.v1.serde.rs
@@ -6,17 +6,10 @@ impl serde::Serialize for Address {
     {
         use serde::ser::SerializeStruct;
         let mut len = 0;
-        if !self.inner.is_empty() {
-            len += 1;
-        }
         if !self.bech32m.is_empty() {
             len += 1;
         }
         let mut struct_ser = serializer.serialize_struct("astria.primitive.v1.Address", len)?;
-        if !self.inner.is_empty() {
-            #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("inner", pbjson::private::base64::encode(&self.inner).as_str())?;
-        }
         if !self.bech32m.is_empty() {
             struct_ser.serialize_field("bech32m", &self.bech32m)?;
         }
@@ -30,13 +23,11 @@ impl<'de> serde::Deserialize<'de> for Address {
         D: serde::Deserializer<'de>,
     {
         const FIELDS: &[&str] = &[
-            "inner",
             "bech32m",
         ];
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
-            Inner,
             Bech32m,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
@@ -59,7 +50,6 @@ impl<'de> serde::Deserialize<'de> for Address {
                         E: serde::de::Error,
                     {
                         match value {
-                            "inner" => Ok(GeneratedField::Inner),
                             "bech32m" => Ok(GeneratedField::Bech32m),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
@@ -80,18 +70,9 @@ impl<'de> serde::Deserialize<'de> for Address {
                 where
                     V: serde::de::MapAccess<'de>,
             {
-                let mut inner__ = None;
                 let mut bech32m__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
-                        GeneratedField::Inner => {
-                            if inner__.is_some() {
-                                return Err(serde::de::Error::duplicate_field("inner"));
-                            }
-                            inner__ = 
-                                Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
-                            ;
-                        }
                         GeneratedField::Bech32m => {
                             if bech32m__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("bech32m"));
@@ -101,7 +82,6 @@ impl<'de> serde::Deserialize<'de> for Address {
                     }
                 }
                 Ok(Address {
-                    inner: inner__.unwrap_or_default(),
                     bech32m: bech32m__.unwrap_or_default(),
                 })
             }

--- a/crates/astria-core/src/primitive/v1/mod.rs
+++ b/crates/astria-core/src/primitive/v1/mod.rs
@@ -7,7 +7,6 @@ use base64::{
     display::Base64Display,
     prelude::BASE64_STANDARD,
 };
-use bytes::Bytes;
 use sha2::{
     Digest as _,
     Sha256,
@@ -267,10 +266,6 @@ impl AddressError {
         })
     }
 
-    fn fields_are_mutually_exclusive() -> Self {
-        Self(AddressErrorKind::FieldsAreMutuallyExclusive)
-    }
-
     fn incorrect_address_length(received: usize) -> Self {
         Self(AddressErrorKind::IncorrectAddressLength {
             received,
@@ -282,8 +277,6 @@ impl AddressError {
 enum AddressErrorKind {
     #[error("failed decoding provided bech32m string")]
     Bech32mDecode { source: bech32::DecodeError },
-    #[error("fields `inner` and `bech32m` are mutually exclusive, only one can be set")]
-    FieldsAreMutuallyExclusive,
     #[error("expected an address of 20 bytes, got `{received}`")]
     IncorrectAddressLength { received: usize },
     #[error("the provided prefix was not a valid bech32 human readable prefix")]
@@ -410,7 +403,6 @@ impl Address {
         // allow: the field is deprecated, but we must still fill it in
         #[allow(deprecated)]
         raw::Address {
-            inner: Bytes::new(),
             bech32m,
         }
     }
@@ -426,23 +418,10 @@ impl Address {
     ///
     /// Returns an error if the account buffer was not 20 bytes long.
     pub fn try_from_raw(raw: &raw::Address) -> Result<Self, AddressError> {
-        const ASTRIA_ADDRESS_PREFIX: &str = "astria";
-        // allow: `Address::inner` field is deprecated, but we must still check it
-        #[allow(deprecated)]
         let raw::Address {
-            inner,
             bech32m,
         } = raw;
-        if bech32m.is_empty() {
-            return Self::builder()
-                .slice(inner.as_ref())
-                .prefix(ASTRIA_ADDRESS_PREFIX)
-                .try_build();
-        }
-        if inner.is_empty() {
-            return bech32m.parse();
-        }
-        Err(AddressError::fields_are_mutually_exclusive())
+        bech32m.parse()
     }
 }
 
@@ -507,10 +486,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use bytes::Bytes;
+    use insta::assert_json_snapshot;
 
     use super::{
-        raw,
         Address,
         AddressError,
         AddressErrorKind,
@@ -570,78 +548,17 @@ mod tests {
     }
 
     #[test]
-    fn bech32m_and_deprecated_bytes_field_are_mutually_exclusive() {
-        // allow: `Address::inner` field is deprecated, but we must still check it
-        #![allow(deprecated)]
-        let bytes = Bytes::copy_from_slice(&[24u8; ADDRESS_LEN]);
-        let bech32m = [42u8; ADDRESS_LEN];
-        let proto = super::raw::Address {
-            inner: bytes.clone(),
-            bech32m: bech32::encode_lower::<bech32::Bech32m>(
-                bech32::Hrp::parse(ASTRIA_ADDRESS_PREFIX).unwrap(),
-                &bech32m,
-            )
-            .unwrap(),
-        };
-        let expected = AddressErrorKind::FieldsAreMutuallyExclusive;
-        let actual = Address::try_from_raw(&proto)
-            .expect_err("returned a valid address where it should have errored");
-        assert_eq!(expected, actual.0);
-    }
-
-    #[test]
-    fn proto_with_missing_bech32m_is_accepted_and_assumed_astria() {
-        // allow: `Address::inner` field is deprecated, but we must still check it
-        #![allow(deprecated)]
+    fn address_to_unchecked_roundtrip() {
         let bytes = [42u8; ADDRESS_LEN];
-        let input = raw::Address {
-            inner: Bytes::copy_from_slice(&bytes),
-            bech32m: String::new(),
-        };
-        let address = Address::try_from_raw(&input).unwrap();
-        assert_eq!("astria", address.prefix.as_str());
-        assert_eq!(bytes, address.bytes());
-    }
-
-    #[test]
-    fn proto_with_missing_bytes_is_accepted() {
-        // allow: `Address::inner` field is deprecated, but we must still check it
-        #![allow(deprecated)]
-        let bytes = [42u8; ADDRESS_LEN];
-        let input = raw::Address {
-            inner: Bytes::new(),
-            bech32m: bech32::encode_lower::<bech32::Bech32m>(
-                bech32::Hrp::parse(ASTRIA_ADDRESS_PREFIX).unwrap(),
-                &bytes,
-            )
-            .unwrap(),
-        };
-        let address = Address::try_from_raw(&input).unwrap();
-        assert_eq!(bytes, address.bytes());
-    }
-
-    #[test]
-    fn protobuf_only_has_bech32m_populated() {
-        // allow: `Address::inner` field is deprecated, but we must still check it
-        #![allow(deprecated)]
-        let bytes = [42u8; ADDRESS_LEN];
-        let address = Address::builder()
+        let input = Address::builder()
             .array(bytes)
             .prefix(ASTRIA_ADDRESS_PREFIX)
             .try_build()
             .unwrap();
-        let output = address.into_raw();
-        assert!(
-            output.inner.is_empty(),
-            "the deprecated bytes field must not be set"
-        );
-        assert_eq!(
-            bech32::encode_lower::<bech32::Bech32m>(
-                bech32::Hrp::parse(ASTRIA_ADDRESS_PREFIX).unwrap(),
-                &bytes
-            )
-            .unwrap(),
-            output.bech32m
-        );
+        let unchecked = input.into_raw();
+        let roundtripped = Address::try_from_raw(&unchecked).unwrap();
+        assert_eq!(input, roundtripped);
+        assert_eq!(input.bytes(), roundtripped.bytes());
+        assert_eq!("astria", input.prefix());
     }
 }

--- a/crates/astria-core/src/primitive/v1/mod.rs
+++ b/crates/astria-core/src/primitive/v1/mod.rs
@@ -486,8 +486,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use insta::assert_json_snapshot;
-
     use super::{
         Address,
         AddressError,
@@ -526,13 +524,12 @@ mod tests {
     #[cfg(feature = "serde")]
     #[test]
     fn snapshots() {
-        use insta::assert_json_snapshot;
         let address = Address::builder()
             .array([42; 20])
             .prefix(ASTRIA_ADDRESS_PREFIX)
             .try_build()
             .unwrap();
-        assert_json_snapshot!(address);
+        insta::assert_json_snapshot!(address);
     }
 
     #[test]

--- a/proto/primitives/astria/primitive/v1/types.proto
+++ b/proto/primitives/astria/primitive/v1/types.proto
@@ -47,15 +47,11 @@ message RollupId {
 // Astria addresses are bech32m encoded strings, with the data part being the
 // first 20 entries of a sha256-hashed ed25519 public key.
 message Address {
-  // The first 20 bytes of a sha256-hashed ed25519 public key.
-  // Implementors must avoid setting this field in favor of `bech32m`.
-  // Implementors must not accept both `inner` and `bech32m` being set.
-  // DEPRECATED: this field is deprecated and only exists for backward compatibility.
-  // Astria services assume an implicit prefix of "astria" if this field is set.
-  // Astria services will read this field but will never emit it.
-  bytes inner = 1 [deprecated = true];
-
   // A bech32m encoded string. The data are the first 20 bytes of a sha256-hashed ed25519
   // public key. Implementors must not accept both the `bytes` and `bech32m` being set.
   string bech32m = 2;
+
+  // deprecated `bytes inner = 1;`
+  reserved 1;
+  reserved "inner";
 }


### PR DESCRIPTION
## Summary
Removes the non-bech32m address bytes field.

## Background
The change introduced in https://github.com/astriaorg/astria/pull/1124 is a breaking change that ripples through the rest of the Astria stack. While in principle we can keep the non-bech32m address around for backward compatibility, in practice it's cleaner to regenesis.

## Changes
- Remove `astria.primitive.v1.Address.inner`, reserving its number and name.

## Testing
Updates and removed all unit tests. All blackbox tests that use addresses in some form still work.

## Breaking Changelist
Since this is protobuf breaking it is also network breaking.