### PR TITLE
fix(astria-bridge-withdrawer): use correct file paths in build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Then:
 ```sh
 git clone https://github.com/astriaorg/astria.git
 cd astria
+git submodule update --init
 cargo build --release
 ```
 

--- a/crates/astria-bridge-withdrawer/build.rs
+++ b/crates/astria-bridge-withdrawer/build.rs
@@ -1,32 +1,42 @@
+use std::path::Path;
+
 use ethers::contract::Abigen;
+
+fn emit_rerun_if_changed(file: &str) {
+    assert!(
+        Path::new(file).is_file(),
+        "rerun-if-changed file does not exist at `{file}`"
+    );
+    println!("cargo:rerun-if-changed={file}");
+}
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     astria_build_info::emit("bridge-withdrawer-v")?;
 
-    println!("cargo:rerun-if-changed=ethereum/src/AstriaWithdrawer.sol");
-    println!("cargo:rerun-if-changed=ethereum/src/IAstriaWithdrawer.sol");
-    println!("cargo:rerun-if-changed=ethereum/src/AstriaBridgeableERC20.sol");
+    emit_rerun_if_changed("astria-bridge-contracts/src/AstriaWithdrawer.sol");
+    emit_rerun_if_changed("astria-bridge-contracts/src/IAstriaWithdrawer.sol");
+    emit_rerun_if_changed("astria-bridge-contracts/src/AstriaBridgeableERC20.sol");
 
     Abigen::new(
         "IAstriaWithdrawer",
-        "./astria-bridge-contracts/out/IAstriaWithdrawer.sol/IAstriaWithdrawer.json",
+        "astria-bridge-contracts/out/IAstriaWithdrawer.sol/IAstriaWithdrawer.json",
     )?
     .generate()?
-    .write_to_file("./src/bridge_withdrawer/ethereum/generated/astria_withdrawer_interface.rs")?;
+    .write_to_file("src/bridge_withdrawer/ethereum/generated/astria_withdrawer_interface.rs")?;
 
     Abigen::new(
         "AstriaWithdrawer",
-        "./astria-bridge-contracts/out/AstriaWithdrawer.sol/AstriaWithdrawer.json",
+        "astria-bridge-contracts/out/AstriaWithdrawer.sol/AstriaWithdrawer.json",
     )?
     .generate()?
-    .write_to_file("./src/bridge_withdrawer/ethereum/generated/astria_withdrawer.rs")?;
+    .write_to_file("src/bridge_withdrawer/ethereum/generated/astria_withdrawer.rs")?;
 
     Abigen::new(
         "AstriaBridgeableERC20",
-        "./astria-bridge-contracts/out/AstriaBridgeableERC20.sol/AstriaBridgeableERC20.json",
+        "astria-bridge-contracts/out/AstriaBridgeableERC20.sol/AstriaBridgeableERC20.json",
     )?
     .generate()?
-    .write_to_file("./src/bridge_withdrawer/ethereum/generated/astria_bridgeable_erc20.rs")?;
+    .write_to_file("src/bridge_withdrawer/ethereum/generated/astria_bridgeable_erc20.rs")?;
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
Corrected the file paths in the withdrawer build script.

## Background
The wrong paths were being specified when emitting `cargo:rerun-if-changed`.  This caused the build to always be out of date, meaning rebuilding would always trigger a recompile, even if no sources changed.  It was visible by running `cargo b && cargo b -v` in the withdrawer folder, where the output would include:
```txt
       Dirty astria-bridge-withdrawer v0.1.0 (/home/fraser/Rust/astria/crates/astria-bridge-withdrawer): the file `crates/astria-bridge-withdrawer/ethereum/src/AstriaWithdrawer.sol` is missing
   Compiling astria-bridge-withdrawer v0.1.0 (/home/fraser/Rust/astria/crates/astria-bridge-withdrawer)
``` 

## Changes
- Corrected the file paths and added assertions that the specified files exist.
- Added an extra instruction in the main README.md about initializing submodules.

## Testing
Ran `cargo b && cargo b` to ensure rebuilding doesn't recompile.
