### PR TITLE
feat(sequencer)!: implement `Ics20TransferDepositMemo` format for incoming ics20 transfers to bridge accounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,6 +669,7 @@ dependencies = [
 name = "astria-core"
 version = "0.1.0"
 dependencies = [
+ "astria-core",
  "astria-merkle",
  "base64 0.21.7",
  "base64-serde",

--- a/crates/astria-core/Cargo.toml
+++ b/crates/astria-core/Cargo.toml
@@ -60,3 +60,6 @@ brotli = ["dep:brotli"]
 insta = { workspace = true, features = ["json"] }
 rand = { workspace = true }
 tempfile = { workspace = true }
+astria-core = { path = ".", features = [
+  "serde"
+] }

--- a/crates/astria-core/Cargo.toml
+++ b/crates/astria-core/Cargo.toml
@@ -60,6 +60,4 @@ brotli = ["dep:brotli"]
 insta = { workspace = true, features = ["json"] }
 rand = { workspace = true }
 tempfile = { workspace = true }
-astria-core = { path = ".", features = [
-  "serde"
-] }
+astria-core = { path = ".", features = ["serde"] }

--- a/crates/astria-core/src/bridge.rs
+++ b/crates/astria-core/src/bridge.rs
@@ -14,7 +14,10 @@ pub struct Ics20WithdrawalFromRollupMemo {
     pub block_number: u64,
     #[cfg_attr(
         feature = "serde",
-        serde(serialize_with = "crate::serde::base64_serialize")
+        serde(
+            serialize_with = "crate::serde::base64_serialize",
+            deserialize_with = "crate::serde::base64_deserialize_array"
+        )
     )]
     pub transaction_hash: [u8; 32],
 }

--- a/crates/astria-core/src/bridge.rs
+++ b/crates/astria-core/src/bridge.rs
@@ -12,6 +12,10 @@ pub struct Ics20WithdrawalFromRollupMemo {
     pub memo: String,
     pub bridge_address: Address,
     pub block_number: u64,
+    #[cfg_attr(
+        feature = "serde",
+        serde(serialize_with = "crate::serde::base64_serialize")
+    )]
     pub transaction_hash: [u8; 32],
 }
 
@@ -21,11 +25,10 @@ pub struct Ics20WithdrawalFromRollupMemo {
 #[cfg_attr(
     feature = "serde",
     derive(serde::Serialize),
-    derive(serde::Deserialize)
+    derive(serde::Deserialize),
+    serde(rename_all = "camelCase", deny_unknown_fields)
 )]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Ics20TransferDepositMemo {
     /// the destination address for the deposit on the rollup
-    #[serde(rename = "rollupAddress")]
     pub rollup_address: String,
 }

--- a/crates/astria-core/src/bridge.rs
+++ b/crates/astria-core/src/bridge.rs
@@ -1,5 +1,7 @@
 use crate::primitive::v1::Address;
 
+/// Memo format for a ICS20 withdrawal from the rollup which is sent to
+/// an external IBC-enabled chain.
 #[derive(Debug, Clone)]
 #[cfg_attr(
     feature = "serde",
@@ -11,4 +13,19 @@ pub struct Ics20WithdrawalFromRollupMemo {
     pub bridge_address: Address,
     pub block_number: u64,
     pub transaction_hash: [u8; 32],
+}
+
+/// Memo format for a ICS20 transfer to Astria which is sent to a
+/// bridge account, which will then be deposited into the rollup.
+#[derive(Debug, Clone)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize),
+    derive(serde::Deserialize)
+)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Ics20TransferDepositMemo {
+    /// the destination address for the deposit on the rollup
+    #[serde(rename = "rollupAddress")]
+    pub rollup_address: String,
 }

--- a/crates/astria-core/src/serde.rs
+++ b/crates/astria-core/src/serde.rs
@@ -1,5 +1,8 @@
 use base64_serde::base64_serde_type;
-use serde::Serializer;
+use serde::{
+    Deserializer,
+    Serializer,
+};
 
 base64_serde_type!(pub(crate) Base64Standard, base64::engine::general_purpose::STANDARD);
 pub(crate) fn base64_serialize<T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
@@ -8,4 +11,13 @@ where
     S: Serializer,
 {
     Base64Standard::serialize(value, serializer)
+}
+
+pub(crate) fn base64_deserialize_array<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+where
+    T: TryFrom<Vec<u8>>,
+    D: Deserializer<'de>,
+{
+    let bytes = Base64Standard::deserialize(deserializer)?;
+    T::try_from(bytes).map_err(|_| serde::de::Error::custom("invalid array length"))
 }

--- a/crates/astria-sequencer/src/ibc/ics20_transfer.rs
+++ b/crates/astria-sequencer/src/ibc/ics20_transfer.rs
@@ -77,8 +77,11 @@ use crate::{
     },
 };
 
-/// The maximum length of the encoded Ics20 FungibleTokenPacketData in bytes.
+/// The maximum length of the encoded Ics20 `FungibleTokenPacketData` in bytes.
 const MAX_PACKET_DATA_BYTE_LENGTH: usize = 2048;
+
+/// The maximum length of the rollup address in bytes.
+const MAX_ROLLUP_ADDRESS_BYTE_LENGTH: usize = 256;
 
 /// The ICS20 transfer handler.
 ///
@@ -582,6 +585,11 @@ async fn execute_ics20_transfer_bridge_lock<S: StateWriteExt>(
     ensure!(
         !deposit_memo.rollup_address.is_empty(),
         "packet memo field must be set for bridge account recipient",
+    );
+
+    ensure!(
+        deposit_memo.rollup_address.len() <= MAX_ROLLUP_ADDRESS_BYTE_LENGTH,
+        "rollup address is too long: exceeds MAX_ROLLUP_ADDRESS_BYTE_LENGTH",
     );
 
     execute_deposit(state, recipient, denom, amount, deposit_memo.rollup_address).await

--- a/crates/astria-sequencer/src/ibc/ics20_transfer.rs
+++ b/crates/astria-sequencer/src/ibc/ics20_transfer.rs
@@ -18,7 +18,10 @@ use anyhow::{
     Result,
 };
 use astria_core::{
-    bridge::Ics20WithdrawalFromRollupMemo,
+    bridge::{
+        Ics20TransferDepositMemo,
+        Ics20WithdrawalFromRollupMemo,
+    },
     primitive::v1::{
         asset::{
             denom,
@@ -73,6 +76,9 @@ use crate::{
         StateWriteExt,
     },
 };
+
+/// The maximum length of the encoded Ics20 FungibleTokenPacketData in bytes.
+const MAX_PACKET_DATA_BYTE_LENGTH: usize = 2048;
 
 /// The ICS20 transfer handler.
 ///
@@ -133,8 +139,17 @@ impl AppHandlerCheck for Ics20Transfer {
         Ok(())
     }
 
-    async fn recv_packet_check<S: StateRead>(_: S, _: &MsgRecvPacket) -> Result<()> {
-        // checks performed in `execute`
+    async fn recv_packet_check<S: StateRead>(_: S, msg: &MsgRecvPacket) -> Result<()> {
+        // most checks performed in `execute`
+        // perform stateless checks here
+        if msg.packet.data.is_empty() {
+            anyhow::bail!("packet data is empty");
+        }
+
+        if msg.packet.data.len() > MAX_PACKET_DATA_BYTE_LENGTH {
+            anyhow::bail!("packet data is too long: exceeds MAX_PACKET_DATA_BYTE_LENGTH");
+        }
+
         Ok(())
     }
 
@@ -533,7 +548,7 @@ async fn execute_ics20_transfer_bridge_lock<S: StateWriteExt>(
     recipient: &Address,
     denom: &denom::TracePrefixed,
     amount: u128,
-    destination_address: String,
+    memo: String,
     is_refund: bool,
 ) -> Result<()> {
     // check if the recipient is a bridge account; if so,
@@ -560,12 +575,16 @@ async fn execute_ics20_transfer_bridge_lock<S: StateWriteExt>(
         return Ok(());
     }
 
+    // assert memo is valid
+    let deposit_memo: Ics20TransferDepositMemo =
+        serde_json::from_str(&memo).context("failed to parse memo as Ics20TransferDepositMemo")?;
+
     ensure!(
-        !destination_address.is_empty(),
+        !deposit_memo.rollup_address.is_empty(),
         "packet memo field must be set for bridge account recipient",
     );
 
-    execute_deposit(state, recipient, denom, amount, destination_address).await
+    execute_deposit(state, recipient, denom, amount, deposit_memo.rollup_address).await
 }
 
 async fn execute_deposit<S: StateWriteExt>(
@@ -740,12 +759,16 @@ mod test {
             .put_bridge_account_asset_id(&bridge_address, &denom.id())
             .unwrap();
 
+        let memo = Ics20TransferDepositMemo {
+            rollup_address: "rollupaddress".to_string(),
+        };
+
         let packet = FungibleTokenPacketData {
             denom: "nootasset".to_string(),
             sender: String::new(),
             amount: "100".to_string(),
             receiver: bridge_address.to_string(),
-            memo: "destinationaddress".to_string(),
+            memo: serde_json::to_string(&memo).unwrap(),
         };
         let packet_bytes = serde_json::to_vec(&packet).unwrap();
 
@@ -793,13 +816,13 @@ mod test {
             .put_bridge_account_asset_id(&bridge_address, &denom.id())
             .unwrap();
 
-        // use empty memo, which should fail
+        // use invalid memo, which should fail
         let packet = FungibleTokenPacketData {
             denom: "nootasset".to_string(),
             sender: String::new(),
             amount: "100".to_string(),
             receiver: bridge_address.to_string(),
-            memo: String::new(),
+            memo: "invalid".to_string(),
         };
         let packet_bytes = serde_json::to_vec(&packet).unwrap();
 


### PR DESCRIPTION
## Summary
 implement `Ics20TransferDepositMemo` format and handling for incoming ics20 transfers to bridge accounts, which requires the memo be of a specific format instead of assuming the entire memo is the destination chain address.

## Background
the memo being just a destination chain address is not good for UX and could lead to error.

## Changes
- implement `Ics20TransferDepositMemo` type which contains the destination `rollup_address`
- add stateless check that the `FungibleTokenPacketData` (which is the ics20 transfer packet itself) is not empty or too long
-  parsing and handling of the memo for incoming ics20 transfers

## Testing
unit tests

## Breaking Changelist
- the validation of the ICS20 memo is different, so this will break previously sent ICS20 transfers to bridge accounts.