### PR TITLE
Docs improvements

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,7 @@ Brief summary of the changes made, ie "what?"
 Brief background on why these changes were made, ie "why?"
 
 ## Changes
-- List changes which were made.
+- List changes that were made.
 
 ## Testing
 How are these changes tested?

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
           github_token: ${{ github.token }}
       - uses: bufbuild/buf-lint-action@v1
       - run: buf format -d --exit-code
-      # Run breaking changes against each module, running against whole workspace
+      # Run breaking changes against each module, running against the whole workspace
       # fails if new packages are added
       - uses: bufbuild/buf-breaking-action@v1
         with:

--- a/charts/README.md
+++ b/charts/README.md
@@ -30,7 +30,7 @@ preferred wallet using the private key in
 `helm/rollup/files/keys/private_key.txt`. This account should never be used for
 anything but test transactions.
 
-To change the wallet account which receives funds, use the `deploy-rollup`
+To change the wallet account that receives funds, use the `deploy-rollup`
 command with the optional arguments `evm_funding_address` and
 `evm_funding_private_key`.
 

--- a/charts/celestia-node/values.yaml
+++ b/charts/celestia-node/values.yaml
@@ -11,7 +11,7 @@ config:
   chainId: mocha-4
   coreIp: "full.consensus.mocha-4.celestia-mocha.com"
   type: light
-  tokenAuthLevel: read  # can set to nil or false to disable rpc auth
+  tokenAuthLevel: read  # can be set to nil or false to disable rpc auth
   coreGrpcPort: 9090
   customInfo: ''
   startHeight: "1"

--- a/charts/sequencer-faucet/values.yaml
+++ b/charts/sequencer-faucet/values.yaml
@@ -24,7 +24,7 @@ images:
   sequencerFaucet: "ghcr.io/astriaorg/seq-faucet:0.6.0"
 
 # When deploying in a production environment should use a secret provider
-# This is configured for use with GCP, need to set own resource names
+# This is configured for use with GCP, need to set your own resource names
 # and keys
 secretProvider:
   enabled: false

--- a/crates/astria-eyre/README.md
+++ b/crates/astria-eyre/README.md
@@ -51,7 +51,7 @@ fn main() -> Result<(), Report> {
 Errors can be emitted as part of tracing events by simply adding a
 display-formatted field. Because the `astria-eyre` hook ensures that the full
 cause-chain is written it is not necessary to cast the error to a trait
-object to trigger trigger formatting via
+object to trigger formatting via
 [`tracing::field::Value for &dyn std::error::Error`].
 
 ```rust


### PR DESCRIPTION
This PR addresses several typographical errors across various files in the project. The changes improve readability and maintain the professional standard of the documentation and code comments.

Justification
Typographical errors, while minor, can detract from the overall quality of the project. Correcting these errors ensures clarity and professionalism, making the project more accessible and understandable for current and future contributors.

Hope it helps.