### PR TITLE
fix(sequencer-relayer): avoid hanging while waiting for submitter task to return

### DIFF
--- a/crates/astria-sequencer-relayer/src/main.rs
+++ b/crates/astria-sequencer-relayer/src/main.rs
@@ -59,7 +59,6 @@ async fn main() -> ExitCode {
         SequencerRelayer::new(cfg).expect("could not initialize sequencer relayer");
     let sequencer_relayer_handle = tokio::spawn(sequencer_relayer.run());
 
-    let shutdown_token = shutdown_handle.token();
     tokio::select!(
         _ = sigterm.recv() => {
             // We don't care about the result (i.e. whether there could be more SIGTERM signals
@@ -67,7 +66,7 @@ async fn main() -> ExitCode {
             info!("received SIGTERM, issuing shutdown to all services");
             shutdown_handle.shutdown();
         }
-        () = shutdown_token.cancelled() => {
+        () = shutdown_handle.cancelled() => {
             warn!("stopped waiting for SIGTERM");
         }
     );

--- a/crates/astria-sequencer-relayer/src/sequencer_relayer.rs
+++ b/crates/astria-sequencer-relayer/src/sequencer_relayer.rs
@@ -17,7 +17,10 @@ use tokio::{
     },
     time::timeout,
 };
-use tokio_util::sync::CancellationToken;
+use tokio_util::sync::{
+    CancellationToken,
+    WaitForCancellationFuture,
+};
 use tracing::{
     error,
     info,
@@ -36,7 +39,7 @@ use crate::{
 pub struct SequencerRelayer {
     api_server: api::ApiServer,
     relayer: Relayer,
-    shutdown_token: CancellationToken,
+    shutdown_handle: ShutdownHandle,
 }
 
 impl SequencerRelayer {
@@ -66,7 +69,7 @@ impl SequencerRelayer {
         } = cfg;
 
         let relayer = relayer::Builder {
-            shutdown_token: shutdown_handle.token(),
+            relayer_shutdown_token: shutdown_handle.token.child_token(),
             sequencer_chain_id,
             celestia_chain_id,
             celestia_app_grpc_endpoint,
@@ -90,7 +93,7 @@ impl SequencerRelayer {
         let relayer = Self {
             api_server,
             relayer,
-            shutdown_token: shutdown_handle.token(),
+            shutdown_handle: shutdown_handle.clone(),
         };
         Ok((relayer, shutdown_handle))
     }
@@ -104,7 +107,7 @@ impl SequencerRelayer {
         let Self {
             api_server,
             relayer,
-            shutdown_token,
+            shutdown_handle,
         } = self;
         // Separate the API shutdown signal from the cancellation token because we want it to live
         // until the very end.
@@ -125,11 +128,11 @@ impl SequencerRelayer {
         let shutdown = select!(
             o = &mut api_task => {
                 report_exit("api server", o);
-                ShutDown { api_task: None, relayer_task: Some(relayer_task), api_shutdown_signal, shutdown_token }
+                ShutDown { api_task: None, relayer_task: Some(relayer_task), api_shutdown_signal, shutdown_handle }
             }
             o = &mut relayer_task => {
                 report_exit("relayer worker", o);
-                ShutDown { api_task: Some(api_task), relayer_task: None, api_shutdown_signal, shutdown_token }
+                ShutDown { api_task: Some(api_task), relayer_task: None, api_shutdown_signal, shutdown_handle }
             }
 
         );
@@ -142,6 +145,7 @@ impl SequencerRelayer {
 /// It is returned along with its related `SequencerRelayer` from [`SequencerRelayer::new`].  The
 /// `SequencerRelayer` will begin to shut down as soon as [`ShutdownHandle::shutdown`] is called or
 /// when the `ShutdownHandle` is dropped.
+#[derive(Clone)]
 pub struct ShutdownHandle {
     token: CancellationToken,
 }
@@ -154,13 +158,16 @@ impl ShutdownHandle {
         }
     }
 
-    /// Returns a clone of the wrapped cancellation token.
-    #[must_use]
-    pub fn token(&self) -> CancellationToken {
-        self.token.clone()
+    /// Returns a `Future` that gets fulfilled when cancellation is requested.
+    ///
+    /// See [`CancellationToken::cancelled`] for further details.
+    pub fn cancelled(&self) -> WaitForCancellationFuture<'_> {
+        self.token.cancelled()
     }
 
     /// Consumes `self` and cancels the wrapped cancellation token.
+    ///
+    /// See [`CancellationToken::cancel`] for further details.
     pub fn shutdown(self) {
         self.token.cancel();
     }
@@ -195,7 +202,7 @@ struct ShutDown {
     api_task: Option<JoinHandle<eyre::Result<()>>>,
     relayer_task: Option<JoinHandle<eyre::Result<()>>>,
     api_shutdown_signal: oneshot::Sender<()>,
-    shutdown_token: CancellationToken,
+    shutdown_handle: ShutdownHandle,
 }
 
 impl ShutDown {
@@ -204,9 +211,9 @@ impl ShutDown {
             api_task,
             relayer_task,
             api_shutdown_signal,
-            shutdown_token,
+            shutdown_handle,
         } = self;
-        shutdown_token.cancel();
+        shutdown_handle.shutdown();
         // Giving relayer 25 seconds to shutdown because Kubernetes issues a SIGKILL after 30.
         if let Some(mut relayer_task) = relayer_task {
             info!("waiting for relayer task to shut down");

--- a/crates/astria-sequencer-relayer/tests/blackbox/helpers/test_sequencer_relayer.rs
+++ b/crates/astria-sequencer-relayer/tests/blackbox/helpers/test_sequencer_relayer.rs
@@ -126,7 +126,8 @@ const STATUS_RESPONSE: &str = r#"
 static TELEMETRY: Lazy<()> = Lazy::new(|| {
     astria_eyre::install().unwrap();
     if std::env::var_os("TEST_LOG").is_some() {
-        let filter_directives = std::env::var("RUST_LOG").unwrap_or_else(|_| "info".into());
+        let filter_directives = std::env::var("RUST_LOG")
+            .unwrap_or_else(|_| "astria_sequencer_relayer=trace,blackbox=trace,info".into());
         println!("initializing telemetry");
         telemetry::configure()
             .no_otel()
@@ -607,6 +608,7 @@ impl TestSequencerRelayer {
             .and_then(|value: serde_json::Value| serde_json::from_value::<ZPage>(value).ok())
             .map_or("unknown".to_string(), |zpage| zpage.status);
 
+            error!("timed out; context: `{context}`, state: `{state}`, healthz: `{healthz}`");
             panic!("timed out; context: `{context}`, state: `{state}`, healthz: `{healthz}`");
         }
     }


### PR DESCRIPTION
## Summary
This fixes a bug whereby the relayer hangs during shutdown due to the submitter task not being instructed to shut down.

## Background
Bugfix.

## Changes
- Rather than cloning a single cancellation token, we now have the following hierarchy:
    - `SequencerRelayer::new` constructs a `ShutdownHandle` which wraps the top-level cancellation token.  This handle is held as a member variable of `SequencerRelayer` and is used to cancel all relayer child tasks if the API task exits. A clone of the `ShutdownHandle`  is also held in `main` and is used to cancel all tasks if a `SIGTERM` is received.
    - A child of `ShutdownHandle`'s token is provided to the relayer task, named `relayer_shutdown_token`.  It is never actively cancelled - only ever via the parent token.
    - A child of `relayer_shutdown_token` is provided to the submitter task and also held as a member of `Relayer`.  It is actively cancelled after the relayer's main `select!` loop has exited if the submitter task is still running.

## Testing
Manual test only.  I could see no way to artificially cause the relayer's `select!` loop to exit.  We could potentially try dropping in some `#[cfg(test)]` gated code in the loop to force this, but that would also mean we couldn't use the blackbox tests for it. 

## Related Issues
Closes #1095.