### PR TITLE
chore(chart): update evm chart for new prefix field

### DIFF
--- a/charts/evm-rollup/Chart.yaml
+++ b/charts/evm-rollup/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.20.0
+version: 0.20.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/evm-rollup/files/genesis/geth-genesis.json
+++ b/charts/evm-rollup/files/genesis/geth-genesis.json
@@ -41,9 +41,9 @@
         "astriaFeeCollectors": {{ toPrettyJson .Values.config.rollup.genesis.feeCollectors | indent 8 | trim }},
         "astriaEIP1559Params": {{ toPrettyJson .Values.config.rollup.genesis.eip1559Params | indent 8 | trim }}
         {{- if not .Values.global.dev }}
-        {{- else }}
+        {{- else }},
         "astriaBridgeSenderAddress": "{{ .Values.config.rollup.genesis.bridgeSenderAddress }}",
-        "astriaSequencerHrpPrefix": "{{ .Values.config.sequencer.addressPrefixes.base }}",
+        "astriaSequencerHrpPrefix": "{{ .Values.config.sequencer.addressPrefixes.base }}"
         {{- end }}
     },
     "difficulty": "0",

--- a/charts/evm-rollup/files/genesis/geth-genesis.json
+++ b/charts/evm-rollup/files/genesis/geth-genesis.json
@@ -42,6 +42,7 @@
         "astriaEIP1559Params": {{ toPrettyJson .Values.config.rollup.genesis.eip1559Params | indent 8 | trim }}
         {{- if not .Values.global.dev }}
         {{- else }}
+        "astriaBridgeSenderAddress": "{{ .Values.config.rollup.genesis.bridgeSenderAddress }}",
         "astriaSequencerHrpPrefix": "{{ .Values.config.sequencer.addressPrefixes.base }}",
         {{- end }}
     },

--- a/charts/evm-rollup/files/genesis/geth-genesis.json
+++ b/charts/evm-rollup/files/genesis/geth-genesis.json
@@ -42,6 +42,7 @@
         "astriaEIP1559Params": {{ toPrettyJson .Values.config.rollup.genesis.eip1559Params | indent 8 | trim }}
         {{- if not .Values.global.dev }}
         {{- else }}
+        "astriaSequencerHrpPrefix": "{{ .Values.config.sequencer.addressPrefixes.base }}",
         {{- end }}
     },
     "difficulty": "0",

--- a/charts/evm-rollup/values.yaml
+++ b/charts/evm-rollup/values.yaml
@@ -78,6 +78,9 @@ config:
       extraDataOverride: ""
       # If set to true the genesis block will contain extra data
       overrideGenesisExtraData: true
+      # When using an erc20 canonical bridge, the address from which tokens will
+      # be sent via the bridge contract
+      bridgeSenderAddress: "0x0000000000000000000000000000000000000000"
       # Configure the sequencer bridge addresses and allowed assets if using
       # the astria canonical bridge. Recommend removing alloc values if so.
       bridgeAddresses: []

--- a/charts/evm-rollup/values.yaml
+++ b/charts/evm-rollup/values.yaml
@@ -10,7 +10,7 @@ images:
   geth:
     repo: ghcr.io/astriaorg/astria-geth
     tag: 0.11.0
-    devTag: latest
+    devTag: pr-30
   conductor:
     repo: ghcr.io/astriaorg/conductor
     tag: "0.17.0"


### PR DESCRIPTION
## Summary
Update the evm chart to utilize the newest version of geth with breaking genesis changes before merging into main with geth repo.
