### PR TITLE
feat(core): implement with verification key for address builder and crypto improvements

### DIFF
--- a/crates/astria-core/src/crypto.rs
+++ b/crates/astria-core/src/crypto.rs
@@ -99,6 +99,12 @@ impl<'a> From<&'a SigningKey> for VerificationKey {
     }
 }
 
+impl From<Ed25519SigningKey> for SigningKey {
+    fn from(key: Ed25519SigningKey) -> Self {
+        Self(key)
+    }
+}
+
 impl TryFrom<&[u8]> for SigningKey {
     type Error = ed25519_consensus::Error;
 
@@ -210,6 +216,14 @@ impl AsRef<[u8]> for VerificationKey {
     }
 }
 
+impl From<Ed25519VerificationKey> for VerificationKey {
+    fn from(key: Ed25519VerificationKey) -> Self {
+        Self {
+            key,
+        }
+    }
+}
+
 impl TryFrom<&[u8]> for VerificationKey {
     type Error = Error;
 
@@ -259,6 +273,12 @@ impl Display for Signature {
 impl From<[u8; 64]> for Signature {
     fn from(bytes: [u8; 64]) -> Self {
         Self(Ed25519Signature::from(bytes))
+    }
+}
+
+impl From<Ed25519Signature> for Signature {
+    fn from(signature: Ed25519Signature) -> Self {
+        Self(signature)
     }
 }
 

--- a/crates/astria-core/src/primitive/v1/mod.rs
+++ b/crates/astria-core/src/primitive/v1/mod.rs
@@ -327,6 +327,11 @@ impl<TBytes, TPrefix> AddressBuilder<TBytes, TPrefix> {
         }
     }
 
+    /// Use the given verification key for address generation.
+    ///
+    /// The verification key is hashed with SHA256 and the first 20 bytes are used as the address
+    /// bytes.
+    #[allow(clippy::missing_panics_doc)] // allow clippy, as the conversion is infallible
     #[must_use = "the builder must be built to construct an address to be useful"]
     pub fn verification_key(
         self,

--- a/crates/astria-core/src/primitive/v1/mod.rs
+++ b/crates/astria-core/src/primitive/v1/mod.rs
@@ -328,6 +328,18 @@ impl<TBytes, TPrefix> AddressBuilder<TBytes, TPrefix> {
     }
 
     #[must_use = "the builder must be built to construct an address to be useful"]
+    pub fn verification_key(
+        self,
+        key: &crate::crypto::VerificationKey,
+    ) -> AddressBuilder<WithBytes<'static>, TPrefix> {
+        let hash = Sha256::digest(key.as_bytes());
+        let array: [u8; ADDRESS_LEN] = hash[0..ADDRESS_LEN]
+            .try_into()
+            .expect("hash is 32 bytes long, so must always be able to convert to 20 bytes");
+        self.array(array)
+    }
+
+    #[must_use = "the builder must be built to construct an address to be useful"]
     pub fn prefix<'a, T: Into<std::borrow::Cow<'a, str>>>(
         self,
         prefix: T,


### PR DESCRIPTION
## Summary
it's unclear/difficult of how an external user can construct an address given a verification key (i ran into this while updating hermes). this adds a `verification_key` method to the `Address::builder` to easily construct an address. also added `From` the ed25519 consensus types for the crypto module types.

## Background
much better for ux, updating hermes would be painful without these.

## Changes
- adds a `verification_key` method to the `Address::builder` to easily construct an address
-  added `From` the ed25519 consensus types for the crypto module types.

## Testing
n/a
