### PR TITLE
chore(chart)!: dusk-8 chart version updates

### DIFF
--- a/charts/deploy.just
+++ b/charts/deploy.just
@@ -61,8 +61,9 @@ wait-for-ingress-controller:
 validatorName := "single"
 deploy-sequencer name=validatorName:
   helm dependency update charts/sequencer > /dev/null
-  helm install --debug \
-    {{ replace('-f dev/values/validators/#.yml' , '#', name) }} \
+  helm install \
+    -f dev/values/validators/all.yml \
+    -f dev/values/validators/{{name}}.yml \
     -n astria-validator-{{name}} --create-namespace \
     {{name}}-sequencer-chart ./charts/sequencer
 deploy-sequencers: (deploy-sequencer "node0") (deploy-sequencer "node1") (deploy-sequencer "node2")
@@ -147,6 +148,7 @@ deploy-smoke-test tag=defaultTag:
   @helm dependency update charts/evm-rollup > /dev/null
   @echo "Setting up single astria sequencer..." && helm install \
     -n astria-validator-single single-sequencer-chart ./charts/sequencer \
+    -f dev/values/validators/all.yml \
     -f dev/values/validators/single.yml \
     {{ if tag != '' { replace('--set images.sequencer.devTag=# --set sequencer-relayer.images.sequencerRelayer.devTag=#', '#', tag) } else { '' } }} \
     --create-namespace > /dev/null

--- a/charts/evm-rollup/Chart.yaml
+++ b/charts/evm-rollup/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.20.3
+version: 0.21.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.11.0"
+appVersion: "0.12.0"
 
 dependencies:
   - name: celestia-node

--- a/charts/evm-rollup/files/genesis/geth-genesis.json
+++ b/charts/evm-rollup/files/genesis/geth-genesis.json
@@ -39,11 +39,11 @@
         "astriaCelestiaHeightVariance": {{ toString .Values.config.celestia.heightVariance | replace "\"" "" }},
         "astriaBridgeAddresses": {{ toPrettyJson .Values.config.rollup.genesis.bridgeAddresses | indent 8 | trim }},
         "astriaFeeCollectors": {{ toPrettyJson .Values.config.rollup.genesis.feeCollectors | indent 8 | trim }},
-        "astriaEIP1559Params": {{ toPrettyJson .Values.config.rollup.genesis.eip1559Params | indent 8 | trim }}
-        {{- if not .Values.global.dev }}
-        {{- else }},
+        "astriaEIP1559Params": {{ toPrettyJson .Values.config.rollup.genesis.eip1559Params | indent 8 | trim }},
         "astriaBridgeSenderAddress": "{{ .Values.config.rollup.genesis.bridgeSenderAddress }}",
         "astriaSequencerHrpPrefix": "{{ .Values.config.sequencer.addressPrefixes.base }}"
+        {{- if not .Values.global.dev }}
+        {{- else }}
         {{- end }}
     },
     "difficulty": "0",

--- a/charts/evm-rollup/templates/configmap.yaml
+++ b/charts/evm-rollup/templates/configmap.yaml
@@ -53,6 +53,8 @@ data:
   ASTRIA_COMPOSER_MAX_BYTES_PER_BUNDLE: "{{ .Values.config.rollup.maxBytesPerBundle }}"
   ASTRIA_COMPOSER_BUNDLE_QUEUE_CAPACITY: "{{ .Values.config.rollup.bundleQueueCapacity }}"
   ASTRIA_COMPOSER_MAX_SUBMIT_INTERVAL_MS: "{{ .Values.config.rollup.maxSubmitInterval }}"
+  ASTRIA_COMPOSER_SEQUENCER_ADDRESS_PREFIX: "{{ .Values.config.sequencer.addressPrefixes.base }}"
+  ASTRIA_COMPOSER_FEE_ASSET: "{{ .Values.config.sequencer.nativeAssetBaseDenomination }}"
   ASTRIA_COMPOSER_NO_METRICS: "{{ not .Values.config.rollup.metrics.enabled }}"
   ASTRIA_COMPOSER_METRICS_HTTP_LISTENER_ADDR: "0.0.0.0:{{ .Values.ports.composerMetrics }}"
   ASTRIA_COMPOSER_FORCE_STDOUT: "{{ .Values.global.useTTY }}"
@@ -67,8 +69,6 @@ data:
   OTEL_SERVICE_NAME: "{{ tpl .Values.config.rollup.otel.serviceNamePrefix . }}-composer"
   {{- if not .Values.global.dev }}
   {{- else }}
-  ASTRIA_COMPOSER_SEQUENCER_ADDRESS_PREFIX: "{{ .Values.config.sequencer.addressPrefixes.base }}"
-  ASTRIA_COMPOSER_FEE_ASSET: "{{ .Values.config.sequencer.nativeAssetBaseDenomination }}"
   {{- end }}
 ---
 {{- if .Values.config.faucet.enabled }}

--- a/charts/evm-rollup/values.yaml
+++ b/charts/evm-rollup/values.yaml
@@ -9,15 +9,15 @@ global:
 images:
   geth:
     repo: ghcr.io/astriaorg/astria-geth
-    tag: 0.11.0
+    tag: 0.12.0
     devTag: latest
   conductor:
     repo: ghcr.io/astriaorg/conductor
-    tag: "0.17.0"
+    tag: "0.18.0"
     devTag: latest
   composer:
     repo: ghcr.io/astriaorg/composer
-    tag: "0.7.0"
+    tag: "0.8.0"
     devTag: latest
 
   # Rollup faucet

--- a/charts/sequencer-relayer/Chart.yaml
+++ b/charts/sequencer-relayer/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.5
+version: 0.9.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.13.0"
+appVersion: "0.15.0"
 
 maintainers:
   - name: wafflesvonmaple

--- a/charts/sequencer-relayer/templates/configmaps.yaml
+++ b/charts/sequencer-relayer/templates/configmaps.yaml
@@ -26,12 +26,10 @@ data:
   OTEL_EXPORTER_OTLP_TRACE_HEADERS: "{{ .Values.config.relayer.otel.traceHeaders }}"
   OTEL_SERVICE_NAME: "{{ tpl .Values.config.relayer.otel.serviceName . }}"
   ASTRIA_SEQUENCER_RELAYER_ONLY_INCLUDE_ROLLUPS: "{{ .Values.config.relayer.onlyIncludeRollups }}"
-  {{- if not .Values.global.dev }}
-  ASTRIA_SEQUENCER_RELAYER_VALIDATOR_KEY_FILE: /cometbft/config/priv_validator_key.json
-  ASTRIA_SEQUENCER_RELAYER_RELAY_ONLY_VALIDATOR_KEY_BLOCKS: "false"
-  {{- else }}
   ASTRIA_SEQUENCER_RELAYER_SEQUENCER_CHAIN_ID: "{{ .Values.config.relayer.sequencerChainId }}"
   ASTRIA_SEQUENCER_RELAYER_CELESTIA_CHAIN_ID: "{{ .Values.config.relayer.celestiaChainId }}"
+  {{- if not .Values.global.dev }}
+  {{- else }}
   {{- end }}
 ---
 apiVersion: v1

--- a/charts/sequencer-relayer/values.yaml
+++ b/charts/sequencer-relayer/values.yaml
@@ -13,7 +13,7 @@ global:
 images:
   sequencerRelayer:
     repo: ghcr.io/astriaorg/sequencer-relayer
-    tag: "0.14.0"
+    tag: "0.15.0"
     devTag: latest
 
 config:

--- a/charts/sequencer/Chart.lock
+++ b/charts/sequencer/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: sequencer-relayer
   repository: file://../sequencer-relayer
-  version: 0.8.5
-digest: sha256:66ce8c4cd8500a63282f7ab112682f8cd50c2253a0b046ec41e0c637c9b66bd9
-generated: "2024-06-12T20:19:19.560729+03:00"
+  version: 0.9.0
+digest: sha256:46eea5a5a35a87d2d27c57766c82ae253ee0fa6b171157ddfb6daa57f6ab0171
+generated: "2024-06-27T14:02:36.489567-07:00"

--- a/charts/sequencer/Chart.yaml
+++ b/charts/sequencer/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.16.2
+version: 0.17.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.13.0"
+appVersion: "0.14.0"
 
 dependencies:
   - name: sequencer-relayer

--- a/charts/sequencer/Chart.yaml
+++ b/charts/sequencer/Chart.yaml
@@ -24,7 +24,7 @@ appVersion: "0.13.0"
 
 dependencies:
   - name: sequencer-relayer
-    version: "0.8.5"
+    version: "0.9.0"
     repository: "file://../sequencer-relayer"
     condition: sequencer-relayer.enabled
 

--- a/charts/sequencer/files/cometbft/config/config.toml
+++ b/charts/sequencer/files/cometbft/config/config.toml
@@ -8,7 +8,7 @@
 
 # The version of the CometBFT binary that created or
 # last modified the config file. Do not modify this.
-version = "0.38.6"
+version = "0.38.8"
 # edit
 #######################################################################
 ###                   Main Base Config Options                      ###
@@ -168,6 +168,11 @@ experimental_close_on_slow_client = false
 # See https://github.com/tendermint/tendermint/issues/3435
 timeout_broadcast_tx_commit = "10s"
 
+# Maximum number of requests that can be sent in a batch
+# If the value is set to '0' (zero-value), then no maximum batch size will be
+# enforced for a JSON-RPC batch request.
+max_request_batch_size = 10
+
 # Maximum size of request body, in bytes
 max_body_bytes = 1_000_000
 
@@ -283,6 +288,17 @@ type = "flood"
 # you can disable rechecking.
 recheck = true
 
+# recheck_timeout is the time the application has during the rechecking process
+# to return CheckTx responses, once all requests have been sent. Responses that
+# arrive after the timeout expires are discarded. It only applies to
+# non-local ABCI clients and when recheck is enabled.
+#
+# The ideal value will strongly depend on the application. It could roughly be estimated as the
+# average size of the mempool multiplied by the average time it takes the application to validate one
+# transaction. We consider that the ABCI application runs in the same location as the CometBFT binary
+# so that the recheck duration is not affected by network delays when making requests and receiving responses.
+recheck_timeout = "1s"
+
 # Broadcast (default: true) defines whether the mempool should relay
 # transactions to other peers. Setting this to false will stop the mempool
 # from relaying transactions to other peers until they are included in a
@@ -299,13 +315,13 @@ wal_dir = ""
 # Maximum number of transactions in the mempool
 size = {{ .Values.cometbft.config.mempool.size }}
 
+# Size of the cache (used to filter transactions we saw earlier) in transactions
+cache_size = {{ .Values.cometbft.config.mempool.cacheSize}}
+
 # Limit the total size of all txs in the mempool.
 # This only accounts for raw transactions (e.g. given 1MB transactions and
 # max_txs_bytes=5MB, mempool will only accept 5 transactions).
 max_txs_bytes = {{ .Values.cometbft.config.mempool.maxTxsBytes}}
-
-# Size of the cache (used to filter transactions we saw earlier) in transactions
-cache_size = {{ .Values.cometbft.config.mempool.cacheSize}}
 
 # Do not remove invalid transactions from the cache (default: false)
 # Set to true if it's not possible for any invalid transaction to become valid

--- a/charts/sequencer/files/cometbft/config/genesis.json
+++ b/charts/sequencer/files/cometbft/config/genesis.json
@@ -22,25 +22,6 @@
       "inbound_ics20_transfers_enabled": {{ .Values.genesis.ibc.inboundEnabled }},
       "outbound_ics20_transfers_enabled": {{ .Values.genesis.ibc.outboundEnabled }}
     },
-    {{- if not .Values.global.dev }}
-    "accounts": [
-      {{- range $index, $value := .Values.genesis.genesisAccounts }}
-      {{- if $index }},{{- end }}
-      {
-        "address": "{{ $value.address }}",
-        "balance": {{ toString $value.balance | replace "\"" "" }}
-      }
-      {{- end }}
-    ],
-    "authority_sudo_address": "{{ .Values.genesis.authoritySudoAddress }}",
-    "ibc_sudo_address": "{{ .Values.genesis.ibc.sudoAddress }}",
-    "ibc_relayer_addresses": [
-      {{- range $index, $value := .Values.genesis.ibc.relayerAddresses }}
-      {{- if $index }},{{- end }}
-      "{{ $value }}"
-      {{- end }}
-    ]
-    {{- else }}
     "address_prefixes": {
       "base": "{{ .Values.genesis.addressPrefixes.base }}"
     },
@@ -61,6 +42,8 @@
       {{ include "sequencer.address" $value }}
       {{- end }}
     ]
+    {{- if not .Values.global.dev }}
+    {{- else }}
     {{- end}}
   },
   "chain_id": "{{ .Values.genesis.chainId }}",

--- a/charts/sequencer/values.yaml
+++ b/charts/sequencer/values.yaml
@@ -13,42 +13,33 @@ global:
 images:
   cometBFT:
     repo: docker.io/cometbft/cometbft
-    tag: v0.38.6
-    devTag: v0.38.6
+    tag: v0.38.8
+    devTag: v0.38.8
   sequencer:
     repo: ghcr.io/astriaorg/sequencer
-    tag: "0.13.0"
+    tag: "0.14.0"
     devTag: latest
 
-moniker: "node"
+moniker: ""
 genesis:
-  chainId: 'sequencer-test-chain-0'
-  genesisTime: '2023-09-22T17:22:35.092832Z'
+  chainId: ""
+  genesisTime: "" # '2023-09-22T17:22:35.092832Z'
   addressPrefixes:
     base: "astria"
-  authoritySudoAddress: 1c0c490f1b5528d8173c5de46d131160e4b2c0c3
+  authoritySudoAddress: ""
   nativeAssetBaseDenomination: nria
   allowedFeeAssets:
-    - nria
+    # - nria
   ibc:
     enabled: true
     inboundEnabled: true
     outboundEnabled: true
-    sudoAddress: 1c0c490f1b5528d8173c5de46d131160e4b2c0c3
-    relayerAddresses:
-      - 1c0c490f1b5528d8173c5de46d131160e4b2c0c3
-      - 34fec43c7fcab9aef3b3cf8aba855e41ee69ca3a
+    sudoAddress: ""
+    relayerAddresses: []
   # Note large balances must be strings support templating with the u128 size account balances
   genesisAccounts:
-  - address: 1c0c490f1b5528d8173c5de46d131160e4b2c0c3
-    balance: "333333333333333333"
-  - address: 34fec43c7fcab9aef3b3cf8aba855e41ee69ca3a
-    balance: "333333333333333333"
-  - address: 60709e2d391864b732b4f0f51e387abb76743871
-    balance: "333333333333333333"
-    # NOTE - the following address matches the privKey that funds the sequencer-faucet
-  - address: 00d75b270542084a54fcf0d0f6eab0402982d156
-    balance: "333333333333333333"
+    # - address: 1c0c490f1b5528d8173c5de46d131160e4b2c0c3
+    #   balance: "333333333333333333"
 
   consensusParams:
     blockMaxBytes: "1048576"

--- a/charts/sequencer/values.yaml
+++ b/charts/sequencer/values.yaml
@@ -28,7 +28,7 @@ genesis:
     base: "astria"
   authoritySudoAddress: ""
   nativeAssetBaseDenomination: nria
-  allowedFeeAssets:
+  allowedFeeAssets: []
     # - nria
   ibc:
     enabled: true
@@ -37,7 +37,7 @@ genesis:
     sudoAddress: ""
     relayerAddresses: []
   # Note large balances must be strings support templating with the u128 size account balances
-  genesisAccounts:
+  genesisAccounts: []
     # - address: 1c0c490f1b5528d8173c5de46d131160e4b2c0c3
     #   balance: "333333333333333333"
 

--- a/charts/sequencer/values.yaml
+++ b/charts/sequencer/values.yaml
@@ -23,7 +23,7 @@ images:
 moniker: ""
 genesis:
   chainId: ""
-  genesisTime: "" # '2023-09-22T17:22:35.092832Z'
+  genesisTime: ""  # '2023-09-22T17:22:35.092832Z'
   addressPrefixes:
     base: "astria"
   authoritySudoAddress: ""

--- a/dev/values/validators/all.yml
+++ b/dev/values/validators/all.yml
@@ -1,0 +1,33 @@
+global:
+  dev: true
+
+genesis:
+  chainId: 'sequencer-test-chain-0'
+  genesisTime: '2023-09-22T17:22:35.092832Z'
+  addressPrefixes:
+    base: "astria"
+  authoritySudoAddress: astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm
+  nativeAssetBaseDenomination: nria
+  allowedFeeAssets:
+    - nria
+  ibc:
+    enabled: true
+    inboundEnabled: true
+    outboundEnabled: true
+    sudoAddress: astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm
+    relayerAddresses:
+      - astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm
+      - astria1xnlvg0rle2u6auane79t4p27g8hxnj36ja960z
+  # Note large balances must be strings support templating with the u128 size
+  # account balances
+  genesisAccounts:
+    - address: astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm
+      balance: "333333333333333333"
+    - address: astria1xnlvg0rle2u6auane79t4p27g8hxnj36ja960z
+      balance: "333333333333333333"
+    - address: astria1vpcfutferpjtwv457r63uwr6hdm8gwr3pxt5ny
+      balance: "333333333333333333"
+    # NOTE - the following address matches the privKey that funds the
+    # sequencer-faucet
+    - address: astria1qrt4kfc9ggyy548u7rg0d64sgq5c952kzk9tg9
+      balance: "333333333333333333"

--- a/dev/values/validators/node0.yml
+++ b/dev/values/validators/node0.yml
@@ -1,37 +1,9 @@
 # Override value example for second validator from main chart
 global:
   namespaceOverride: astria-dev-cluster
-  dev: true
 
 moniker: node0
-
 genesis:
-  addressPrefixes:
-    base: "astria"
-  authoritySudoAddress: astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm
-  nativeAssetBaseDenomination: nria
-  allowedFeeAssets:
-    - nria
-  ibc:
-    enabled: true
-    inboundEnabled: true
-    outboundEnabled: true
-    sudoAddress: astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm
-    relayerAddresses:
-      - astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm
-      - astria1xnlvg0rle2u6auane79t4p27g8hxnj36ja960z
-  # Note large balances must be strings support templating with the u128 size account balances
-  genesisAccounts:
-    - address: astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm
-      balance: "333333333333333333"
-    - address: astria1xnlvg0rle2u6auane79t4p27g8hxnj36ja960z
-      balance: "333333333333333333"
-    - address: astria1vpcfutferpjtwv457r63uwr6hdm8gwr3pxt5ny
-      balance: "333333333333333333"
-      # NOTE - the following address matches the privKey that funds the sequencer-faucet
-    - address: astria1qrt4kfc9ggyy548u7rg0d64sgq5c952kzk9tg9
-      balance: "333333333333333333"
-
   validators:
     - name: node0
       power: '1'
@@ -45,7 +17,7 @@ genesis:
       power: '1'
       address: 8C17BBDC7C350C83C550163458FC9B7A5B54A64E
       pubKey: 4v1RdMiKkWgBBTTP26iRSLOEkAY99gMVfZijm6OCzjs=
-   
+
 cometbft:
   secrets:
     nodeKey:
@@ -59,15 +31,8 @@ cometbft:
           value: lV57+rGs2vac7mvkGHP1oBFGHPJM3a+WoAzeFDCJDNU=
         priv_key:
           value: dGOTAweQV8Do9P2n+A8m5EnboDrlxgD3dg4vrYpdIRqVXnv6saza9pzua+QYc/WgEUYc8kzdr5agDN4UMIkM1Q==
-  config:  
+  config:
     p2p:
-      laddr: "tcp://0.0.0.0"
-      # Address to advertise to peers for them to dial. If empty, will use the same
-      # port as the laddr, and will introspect on the listener to figure out the
-      # address. IP and port are required. Example: 159.89.10.97:26656
-      externalAddress: ""
-      # List of seeds to connect to
-      seeds: []
       # List of nodes to keep persistent connections to
       persistentPeers:
         - 2490c1fc41736a357c523fe049c319386d59d759@node0-sequencer-p2p-service.astria-dev-cluster.svc.cluster.local:26656

--- a/dev/values/validators/node1.yml
+++ b/dev/values/validators/node1.yml
@@ -1,36 +1,6 @@
 # Override value example for second validator from main chart
-global:
-  dev: true
-
 moniker: 'node1'
-
 genesis:
-  addressPrefixes:
-    base: "astria"
-  authoritySudoAddress: astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm
-  nativeAssetBaseDenomination: nria
-  allowedFeeAssets:
-    - nria
-  ibc:
-    enabled: true
-    inboundEnabled: true
-    outboundEnabled: true
-    sudoAddress: astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm
-    relayerAddresses:
-      - astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm
-      - astria1xnlvg0rle2u6auane79t4p27g8hxnj36ja960z
-  # Note large balances must be strings support templating with the u128 size account balances
-  genesisAccounts:
-    - address: astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm
-      balance: "333333333333333333"
-    - address: astria1xnlvg0rle2u6auane79t4p27g8hxnj36ja960z
-      balance: "333333333333333333"
-    - address: astria1vpcfutferpjtwv457r63uwr6hdm8gwr3pxt5ny
-      balance: "333333333333333333"
-      # NOTE - the following address matches the privKey that funds the sequencer-faucet
-    - address: astria1qrt4kfc9ggyy548u7rg0d64sgq5c952kzk9tg9
-      balance: "333333333333333333"
-
   validators:
     - name: node0
       power: '1'
@@ -59,17 +29,9 @@ cometbft:
           value: NDE9F44v3l4irmkZxNmrZkywoGmggLlaBo5rE/Cis8M=
         priv_key:
           value: q7D76sa0vCTcmXdHUqtVmRHV1tt9f2Ctvb8a1ijZMwA0MT0Xji/eXiKuaRnE2atmTLCgaaCAuVoGjmsT8KKzww==
-    
+
   config:
     p2p:
-      laddr: "tcp://0.0.0.0"
-      # Address to advertise to peers for them to dial. If empty, will use the same
-      # port as the laddr, and will introspect on the listener to figure out the
-      # address. IP and port are required. Example: 159.89.10.97:26656
-      externalAddress: ""
-      # List of seeds to connect to
-      seeds: []
-      # List of nodes to keep persistent connections to
       persistentPeers:
         - 2490c1fc41736a357c523fe049c319386d59d759@node0-sequencer-p2p-service.astria-dev-cluster.svc.cluster.local:26656
         - 96c652f63b5d5d5027b42e9af906082ee7c598d9@node1-sequencer-p2p-service.astria-validator-node1.svc.cluster.local:26656

--- a/dev/values/validators/node2.yml
+++ b/dev/values/validators/node2.yml
@@ -1,36 +1,6 @@
 # Override value example for second validator from main chart
-global:
-  dev: true
-
 moniker: 'node2'
-
 genesis:
-  addressPrefixes:
-    base: "astria"
-  authoritySudoAddress: astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm
-  nativeAssetBaseDenomination: nria
-  allowedFeeAssets:
-    - nria
-  ibc:
-    enabled: true
-    inboundEnabled: true
-    outboundEnabled: true
-    sudoAddress: astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm
-    relayerAddresses:
-      - astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm
-      - astria1xnlvg0rle2u6auane79t4p27g8hxnj36ja960z
-  # Note large balances must be strings support templating with the u128 size account balances
-  genesisAccounts:
-    - address: astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm
-      balance: "333333333333333333"
-    - address: astria1xnlvg0rle2u6auane79t4p27g8hxnj36ja960z
-      balance: "333333333333333333"
-    - address: astria1vpcfutferpjtwv457r63uwr6hdm8gwr3pxt5ny
-      balance: "333333333333333333"
-      # NOTE - the following address matches the privKey that funds the sequencer-faucet
-    - address: astria1qrt4kfc9ggyy548u7rg0d64sgq5c952kzk9tg9
-      balance: "333333333333333333"
-
   validators:
     - name: node0
       power: '1'
@@ -61,14 +31,6 @@ cometbft:
   # Values for CometBFT node configuration
   config:
     p2p:
-      laddr: "tcp://0.0.0.0"
-      # Address to advertise to peers for them to dial. If empty, will use the same
-      # port as the laddr, and will introspect on the listener to figure out the
-      # address. IP and port are required. Example: 159.89.10.97:26656
-      externalAddress: ""
-      # List of seeds to connect to
-      seeds: []
-      # List of nodes to keep persistent connections to
       persistentPeers:
         - 2490c1fc41736a357c523fe049c319386d59d759@node0-sequencer-p2p-service.astria-dev-cluster.svc.cluster.local:26656
         - 96c652f63b5d5d5027b42e9af906082ee7c598d9@node1-sequencer-p2p-service.astria-validator-node1.svc.cluster.local:26656

--- a/dev/values/validators/single.yml
+++ b/dev/values/validators/single.yml
@@ -1,40 +1,13 @@
 global:
   namespaceOverride: astria-dev-cluster
-  dev: true
 
 moniker: node0
-
 genesis:
-  addressPrefixes:
-    base: "astria"
-  authoritySudoAddress: astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm
-  nativeAssetBaseDenomination: nria
-  allowedFeeAssets:
-    - nria
-  ibc:
-    enabled: true
-    inboundEnabled: true
-    outboundEnabled: true
-    sudoAddress: astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm
-    relayerAddresses:
-      - astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm
-      - astria1xnlvg0rle2u6auane79t4p27g8hxnj36ja960z
-  # Note large balances must be strings support templating with the u128 size account balances
-  genesisAccounts:
-    - address: astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm
-      balance: "333333333333333333"
-    - address: astria1xnlvg0rle2u6auane79t4p27g8hxnj36ja960z
-      balance: "333333333333333333"
-    - address: astria1vpcfutferpjtwv457r63uwr6hdm8gwr3pxt5ny
-      balance: "333333333333333333"
-      # NOTE - the following address matches the privKey that funds the sequencer-faucet
-    - address: astria1qrt4kfc9ggyy548u7rg0d64sgq5c952kzk9tg9
-      balance: "333333333333333333"
   validators:
-      - name: core
-        power: '1'
-        address: 091E47761C58C474534F4D414AF104A6CAF90C22
-        pubKey: lV57+rGs2vac7mvkGHP1oBFGHPJM3a+WoAzeFDCJDNU=
+    - name: core
+      power: '1'
+      address: 091E47761C58C474534F4D414AF104A6CAF90C22
+      pubKey: lV57+rGs2vac7mvkGHP1oBFGHPJM3a+WoAzeFDCJDNU=
 
 cometbft:
   secrets:
@@ -54,7 +27,7 @@ cometbft:
         # private key for the validator address
         # This is a secret key, should use a secret manager for production deployments
         priv_key:
-          value: dGOTAweQV8Do9P2n+A8m5EnboDrlxgD3dg4vrYpdIRqVXnv6saza9pzua+QYc/WgEUYc8kzdr5agDN4UMIkM1Q==    
+          value: dGOTAweQV8Do9P2n+A8m5EnboDrlxgD3dg4vrYpdIRqVXnv6saza9pzua+QYc/WgEUYc8kzdr5agDN4UMIkM1Q==
 
 sequencer-relayer:
   enabled: true


### PR DESCRIPTION
## Summary
Updates all charts to use latest releases for dusk-8, and updates to the latest CometBFT release.

## Background
New releases for services were cut.

## Changes
- Update all chart versions for astria releases, migrate dev mode to standard behaivior.
- Update to CometBFT 0.38.8
- Update default sequencer chart to not have any dev dependent fields filled out.

## Testing
running smoke test locally, plus CI runs
