### PR TITLE
fix(conductor): allow soft update commitment to be skipped in soft_and_firm test

### DIFF
--- a/crates/astria-conductor/tests/blackbox/helpers/macros.rs
+++ b/crates/astria-conductor/tests/blackbox/helpers/macros.rs
@@ -182,7 +182,8 @@ macro_rules! mount_update_commitment_state {
         mock_name: $mock_name:expr,
         firm: ( number: $firm_number:expr, hash: $firm_hash:expr, parent: $firm_parent:expr$(,)? ),
         soft: ( number: $soft_number:expr, hash: $soft_hash:expr, parent: $soft_parent:expr$(,)? ),
-        base_celestia_height: $base_celestia_height:expr
+        base_celestia_height: $base_celestia_height:expr,
+        is_soft_mount: $is_soft_mount:expr,
         $(,)?
     ) => {
         $test_env
@@ -201,6 +202,7 @@ macro_rules! mount_update_commitment_state {
                     ),
                     base_celestia_height: $base_celestia_height,
                 ),
+                $is_soft_mount,
         )
         .await
     };
@@ -217,6 +219,7 @@ macro_rules! mount_update_commitment_state {
             firm: ( number: $firm_number, hash: $firm_hash, parent: $firm_parent, ),
             soft: ( number: $soft_number, hash: $soft_hash, parent: $soft_parent, ),
             base_celestia_height: $base_celestia_height,
+            is_soft_mount: false,
         )
     };
 }

--- a/crates/astria-conductor/tests/blackbox/helpers/mod.rs
+++ b/crates/astria-conductor/tests/blackbox/helpers/mod.rs
@@ -399,6 +399,7 @@ impl TestConductor {
         &self,
         mock_name: Option<&str>,
         commitment_state: CommitmentState,
+        is_soft_mount: bool,
     ) -> astria_grpc_mock::MockGuard {
         use astria_core::generated::execution::v1alpha2::UpdateCommitmentStateRequest;
         use astria_grpc_mock::{
@@ -416,9 +417,15 @@ impl TestConductor {
         if let Some(name) = mock_name {
             mock = mock.with_name(name);
         }
-        mock.expect(1)
-            .mount_as_scoped(&self.mock_grpc.mock_server)
-            .await
+        if is_soft_mount {
+            mock.expect(0..=1)
+                .mount_as_scoped(&self.mock_grpc.mock_server)
+                .await
+        } else {
+            mock.expect(1)
+                .mount_as_scoped(&self.mock_grpc.mock_server)
+                .await
+        }
     }
 
     pub async fn mount_validator_set(

--- a/crates/astria-conductor/tests/blackbox/soft_and_firm.rs
+++ b/crates/astria-conductor/tests/blackbox/soft_and_firm.rs
@@ -100,6 +100,7 @@ async fn simple() {
 
     let update_commitment_state_soft = mount_update_commitment_state!(
         test_conductor,
+        mock_name: None,
         firm: (
             number: 1,
             hash: [1; 64],
@@ -111,6 +112,7 @@ async fn simple() {
             parent: [1; 64],
         ),
         base_celestia_height: 1,
+        is_soft_mount: true,
     );
 
     let update_commitment_state_firm = mount_update_commitment_state!(
@@ -130,9 +132,8 @@ async fn simple() {
 
     timeout(
         Duration::from_millis(1000),
-        join3(
+        join(
             execute_block.wait_until_satisfied(),
-            update_commitment_state_soft.wait_until_satisfied(),
             update_commitment_state_firm.wait_until_satisfied(),
         ),
     )

--- a/crates/astria-conductor/tests/blackbox/soft_only.rs
+++ b/crates/astria-conductor/tests/blackbox/soft_only.rs
@@ -150,6 +150,7 @@ async fn submits_two_heights_in_succession() {
             parent: [1; 64],
         ),
         base_celestia_height: 1,
+        is_soft_mount: false,
     );
 
     let execute_block_number_3 = mount_executed_block!(
@@ -174,6 +175,7 @@ async fn submits_two_heights_in_succession() {
             parent: [2; 64],
         ),
         base_celestia_height: 1,
+        is_soft_mount: false,
     );
 
     timeout(
@@ -331,5 +333,27 @@ async fn requests_from_later_genesis_height() {
     .expect(
         "conductor should have executed the soft block and updated the soft commitment state \
          within 1000ms",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn soft_update_commitment_is_skipped() {
+    let test_conductor = spawn_conductor(CommitLevel::SoftOnly).await;
+
+    let _update_commitment_state = mount_update_commitment_state!(
+        test_conductor,
+        mock_name: None,
+        firm: (
+            number: 1,
+            hash: [1; 64],
+            parent: [0; 64],
+        ),
+        soft: (
+            number: 2,
+            hash: [2; 64],
+            parent: [1; 64],
+        ),
+        base_celestia_height: 1,
+        is_soft_mount: true,
     );
 }


### PR DESCRIPTION
## Summary
Allows for update commitment guard to be skipped when it is "soft".

## Background
In the conductor soft_and_firm blackbox test, if the firm block was received from Celestia before the soft, the test would fail.

## Changes
- Added argument `is_soft_mount` to `mount_update_commitment_state` function and macro. The value is automatically set to `false` when not specified in macro.
- Changed `mount_update_commitment_state` to accept no response when `is_soft_mount` is `true`.
- Updated tests to correctly pass `is_soft_mount` when needed.

## Testing
Added blackbox test to ensure soft update commitment mount will accept no response.

## Related Issues
closes #1143 
