### PR TITLE
chore(charts): update for new geth update

### DIFF
--- a/charts/evm-rollup/Chart.yaml
+++ b/charts/evm-rollup/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.21.0
+version: 0.22.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.12.0"
+appVersion: "0.13.0"
 
 dependencies:
   - name: celestia-node

--- a/charts/evm-rollup/files/genesis/geth-genesis.json
+++ b/charts/evm-rollup/files/genesis/geth-genesis.json
@@ -41,7 +41,7 @@
         "astriaFeeCollectors": {{ toPrettyJson .Values.config.rollup.genesis.feeCollectors | indent 8 | trim }},
         "astriaEIP1559Params": {{ toPrettyJson .Values.config.rollup.genesis.eip1559Params | indent 8 | trim }},
         "astriaBridgeSenderAddress": "{{ .Values.config.rollup.genesis.bridgeSenderAddress }}",
-        "astriaSequencerHrpPrefix": "{{ .Values.config.sequencer.addressPrefixes.base }}"
+        "astriaSequencerAddressPrefix": "{{ .Values.config.sequencer.addressPrefixes.base }}"
         {{- if not .Values.global.dev }}
         {{- else }}
         {{- end }}

--- a/charts/evm-rollup/values.yaml
+++ b/charts/evm-rollup/values.yaml
@@ -9,8 +9,8 @@ global:
 images:
   geth:
     repo: ghcr.io/astriaorg/astria-geth
-    tag: 0.12.0
-    devTag: latest
+    tag: 0.13.0
+    devTag: pr-34
   conductor:
     repo: ghcr.io/astriaorg/conductor
     tag: "0.18.0"

--- a/charts/evm-rollup/values.yaml
+++ b/charts/evm-rollup/values.yaml
@@ -10,7 +10,7 @@ images:
   geth:
     repo: ghcr.io/astriaorg/astria-geth
     tag: 0.13.0
-    devTag: pr-34
+    devTag: latest
   conductor:
     repo: ghcr.io/astriaorg/conductor
     tag: "0.18.0"


### PR DESCRIPTION
## Summary
Updates the chart to support new version of geth in https://github.com/astriaorg/astria-geth/pull/34 which updates a genesis parameter name.
