### PR TITLE
release(sequencer): 0.14.1 patch release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "astria-sequencer"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "astria-build-info",

--- a/crates/astria-sequencer/Cargo.toml
+++ b/crates/astria-sequencer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astria-sequencer"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 rust-version = "1.76"


### PR DESCRIPTION
Includes changes to abci query for assets to enabled bridge withdrawer usage.
