### PR TITLE
fix(sequencer): store native asset ibc->trace mapping in init_chain

### DIFF
--- a/crates/astria-sequencer/src/app/mod.rs
+++ b/crates/astria-sequencer/src/app/mod.rs
@@ -69,6 +69,7 @@ use crate::{
     },
     address::StateWriteExt as _,
     api_state_ext::StateWriteExt as _,
+    asset::state_ext::StateWriteExt as _,
     authority::{
         component::{
             AuthorityComponent,
@@ -220,6 +221,12 @@ impl App {
         state_tx.put_base_prefix(&genesis_state.address_prefixes().base);
 
         crate::asset::initialize_native_asset(genesis_state.native_asset_base_denomination());
+        let native_asset = crate::asset::get_native_asset();
+        if let Some(trace_native_asset) = native_asset.as_trace_prefixed() {
+            state_tx
+                .put_ibc_asset(trace_native_asset)
+                .context("failed to put native asset")?;
+        }
         state_tx.put_native_asset_denom(genesis_state.native_asset_base_denomination());
         state_tx.put_chain_id_and_revision_number(chain_id.try_into().context("invalid chain ID")?);
         state_tx.put_block_height(0);


### PR DESCRIPTION
## Summary
we need to store the native asset ibc to "trace" mapping in the state, otherwise queries for the native asset using the ID will fail. for example `get_bridge_account_info` where the asset is the native asset fails right now

## Changes
-  store native asset ibc->trace mapping in `init_chain`

