### PR TITLE
fix(sequencer-utils): fixes issue in `parse_blob` tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1898,9 +1898,12 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "colour"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692e39ee1f14432931eb080a5e8e8930a7eff3d19e638cd04091534ebc40b928"
+checksum = "b536eebcabe54980476d120a182f7da2268fe02d22575cca99cee5fdda178280"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "compiletest_rs"

--- a/crates/astria-sequencer-utils/Cargo.toml
+++ b/crates/astria-sequencer-utils/Cargo.toml
@@ -16,7 +16,7 @@ clap = { workspace = true, features = [
   "derive",
   "wrap_help",
 ] }
-colour = "2.0.0"
+colour = "2.1.0"
 ethers-core = "2.0.14"
 hex = { workspace = true }
 indenter = "0.3.3"

--- a/crates/astria-sequencer-utils/tests/parse_blob.rs
+++ b/crates/astria-sequencer-utils/tests/parse_blob.rs
@@ -26,8 +26,6 @@ impl Resources {
     /// Reads the contents of the files in the `tests/resources/parse_blob/<test_case>` folder to
     /// the respective fields of `Self`.
     fn new(test_case: &str) -> Result<Self> {
-        // Disable colored output to make the snapshots more legible.
-        colour::force_no_colour().unwrap();
         let dir = Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("tests")
             .join("resources")
@@ -103,7 +101,8 @@ impl Resources {
 
 fn new_command() -> Result<Command> {
     let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME"))?;
-    cmd.arg("parse-blob");
+    // Disable colored output to make the snapshots more legible.
+    cmd.arg("parse-blob").env("NO_COLOR", "1");
     Ok(cmd)
 }
 


### PR DESCRIPTION
## Summary
This PR fixes a bug in the `parse_blob` tests.

## Background
The existing tests use `colour::force_no_colour()` to avoid `sequencer-utils` from generating coloured output in order to make the snapshots more legible.  However, setting that actually has no effect (under the hood, `colour` was deciding to not use coloured output due to `io::stdout().is_terminal()` returning `false`).

By updating to `colour` v2.1.0 this becomes apparent, as that version also takes the `TERM` env var into account.  `TERM` is set to a value other than `dumb`, so coloured output is emitted.

## Changes
- The fix is to set the `NO_COLOR` env var for the subprocess, as this has highest priority in disabling coloured output.

## Testing
The tests broken after updating `colour` now pass.