### PR TITLE
feat(core, proto)!: make bridge unlock memo string

### DIFF
--- a/crates/astria-bridge-withdrawer/src/bridge_withdrawer/ethereum/convert.rs
+++ b/crates/astria-bridge-withdrawer/src/bridge_withdrawer/ethereum/convert.rs
@@ -108,7 +108,7 @@ fn event_to_bridge_unlock(
             .ok_or(eyre::eyre!(
                 "failed to divide amount by asset withdrawal multiplier"
             ))?,
-        memo: serde_json::to_vec(&memo).wrap_err("failed to serialize memo to json")?,
+        memo: serde_json::to_string(&memo).wrap_err("failed to serialize memo to json")?,
         fee_asset,
         bridge_address: None,
     };
@@ -228,7 +228,7 @@ mod tests {
         let expected_action = BridgeUnlockAction {
             to: crate::astria_address([1u8; 20]),
             amount: 99,
-            memo: serde_json::to_vec(&bridge::UnlockMemo {
+            memo: serde_json::to_string(&bridge::UnlockMemo {
                 block_number: 1,
                 transaction_hash: [2u8; 32],
             })
@@ -269,7 +269,7 @@ mod tests {
         let expected_action = BridgeUnlockAction {
             to: crate::astria_address([1u8; 20]),
             amount: 99,
-            memo: serde_json::to_vec(&bridge::UnlockMemo {
+            memo: serde_json::to_string(&bridge::UnlockMemo {
                 block_number: 1,
                 transaction_hash: [2u8; 32],
             })

--- a/crates/astria-bridge-withdrawer/src/bridge_withdrawer/startup.rs
+++ b/crates/astria-bridge-withdrawer/src/bridge_withdrawer/startup.rs
@@ -335,7 +335,7 @@ fn rollup_height_from_signed_transaction(
 
     let last_batch_rollup_height = match withdrawal_action {
         Action::BridgeUnlock(action) => {
-            let memo: bridge::UnlockMemo = serde_json::from_slice(&action.memo)
+            let memo: bridge::UnlockMemo = serde_json::from_str(&action.memo)
                 .wrap_err("failed to parse memo from last transaction by the bridge account")?;
             Some(memo.block_number)
         }

--- a/crates/astria-bridge-withdrawer/src/bridge_withdrawer/submitter/tests.rs
+++ b/crates/astria-bridge-withdrawer/src/bridge_withdrawer/submitter/tests.rs
@@ -209,7 +209,7 @@ fn make_bridge_unlock_action() -> Action {
     let inner = BridgeUnlockAction {
         to: crate::astria_address([0u8; 20]),
         amount: 99,
-        memo: serde_json::to_vec(&bridge::UnlockMemo {
+        memo: serde_json::to_string(&bridge::UnlockMemo {
             block_number: DEFAULT_LAST_ROLLUP_HEIGHT,
             transaction_hash: [1u8; 32],
         })

--- a/crates/astria-core/src/generated/astria.protocol.transactions.v1alpha1.rs
+++ b/crates/astria-core/src/generated/astria.protocol.transactions.v1alpha1.rs
@@ -385,8 +385,8 @@ pub struct BridgeUnlockAction {
     #[prost(string, tag = "3")]
     pub fee_asset: ::prost::alloc::string::String,
     /// memo for double spend prevention
-    #[prost(bytes = "vec", tag = "4")]
-    pub memo: ::prost::alloc::vec::Vec<u8>,
+    #[prost(string, tag = "4")]
+    pub memo: ::prost::alloc::string::String,
     /// the address of the bridge account to transfer from,
     /// if the bridge account's withdrawer address is not the same as the bridge address.
     /// if unset, the signer of the transaction is used.

--- a/crates/astria-core/src/protocol/transaction/v1alpha1/action.rs
+++ b/crates/astria-core/src/protocol/transaction/v1alpha1/action.rs
@@ -1337,7 +1337,7 @@ pub struct BridgeUnlockAction {
     // asset to use for fee payment.
     pub fee_asset: asset::Denom,
     // memo for double spend protection.
-    pub memo: Vec<u8>,
+    pub memo: String,
     // the address of the bridge account to transfer from,
     // if the bridge account's withdrawer address is not the same as the bridge address.
     // if unset, the signer of the transaction is used.

--- a/crates/astria-sequencer/src/app/tests_breaking_changes.rs
+++ b/crates/astria-sequencer/src/app/tests_breaking_changes.rs
@@ -281,7 +281,7 @@ async fn app_execute_transaction_with_every_action_snapshot() {
                 to: bob_address,
                 amount: 10,
                 fee_asset: asset.clone(),
-                memo: vec![0u8; 32],
+                memo: "{}".into(),
                 bridge_address: None,
             }
             .into(),

--- a/crates/astria-sequencer/src/app/tests_execute_transaction.rs
+++ b/crates/astria-sequencer/src/app/tests_execute_transaction.rs
@@ -1014,7 +1014,7 @@ async fn app_execute_transaction_bridge_lock_unlock_action_ok() {
         to: alice_address,
         amount,
         fee_asset: asset.clone(),
-        memo: b"lilywashere".to_vec(),
+        memo: "{ \"msg\": \"lilywashere\" }".into(),
         bridge_address: None,
     };
 

--- a/crates/astria-sequencer/src/bridge/bridge_unlock_action.rs
+++ b/crates/astria-sequencer/src/bridge/bridge_unlock_action.rs
@@ -137,7 +137,7 @@ mod test {
             to: to_address,
             amount: transfer_amount,
             fee_asset: asset,
-            memo: vec![0u8; 32],
+            memo: "{}".into(),
             bridge_address: None,
         };
 
@@ -174,7 +174,7 @@ mod test {
             to: to_address,
             amount: transfer_amount,
             fee_asset: asset.clone(),
-            memo: vec![0u8; 32],
+            memo: "{}".into(),
             bridge_address: Some(bridge_address),
         };
 
@@ -212,7 +212,7 @@ mod test {
             to: to_address,
             amount: transfer_amount,
             fee_asset: asset,
-            memo: vec![0u8; 32],
+            memo: "{}".into(),
             bridge_address: Some(bridge_address),
         };
 
@@ -253,7 +253,7 @@ mod test {
             to: to_address,
             amount: transfer_amount,
             fee_asset: asset.clone(),
-            memo: vec![0u8; 32],
+            memo: "{}".into(),
             bridge_address: None,
         };
 
@@ -308,7 +308,7 @@ mod test {
             to: to_address,
             amount: transfer_amount,
             fee_asset: asset.clone(),
-            memo: vec![0u8; 32],
+            memo: "{}".into(),
             bridge_address: Some(bridge_address),
         };
 
@@ -360,7 +360,7 @@ mod test {
             to: to_address,
             amount: transfer_amount,
             fee_asset: asset.clone(),
-            memo: vec![0u8; 32],
+            memo: "{}".into(),
             bridge_address: None,
         };
 
@@ -412,7 +412,7 @@ mod test {
             to: to_address,
             amount: transfer_amount,
             fee_asset: asset.clone(),
-            memo: vec![0u8; 32],
+            memo: "{}".into(),
             bridge_address: Some(bridge_address),
         };
 

--- a/proto/protocolapis/astria/protocol/transactions/v1alpha1/types.proto
+++ b/proto/protocolapis/astria/protocol/transactions/v1alpha1/types.proto
@@ -210,7 +210,7 @@ message BridgeUnlockAction {
   // the asset used to pay the transaction fee
   string fee_asset = 3;
   // memo for double spend prevention
-  bytes memo = 4;
+  string memo = 4;
   // the address of the bridge account to transfer from,
   // if the bridge account's withdrawer address is not the same as the bridge address.
   // if unset, the signer of the transaction is used.


### PR DESCRIPTION
## Summary
Changes the memo field of bridge unlock actions from `bytes` to `string`.

## Background
IBC convention is to format all memos as json and encode as `string` rather than `bytes` when sending them over the wire. The `astria.protocol.transactions.v1alpha1.Ics20Withdrawal.memo` field is also `string`, so this change brings `astria.protocol.transactions.v1alpha1.BridgeUnlockAction.memo` in line.

## Changes
- Change `astria.protocol.transactions.v1alpha1.BridgeUnlockAction.memo` from `bytes` to `string`

## Testing
All tests are updated and pass.

## Breaking Changelist
This constitutes a breaking protobuf-change (as flagged by `buf`) but very likely neither a deployment nor network breaking change:

+ `bytes` and `string` are wire-compatible (from a protobuf point of view)
+ `sequencer` only passes the memo field through
+ `bridge-withdrawer` will be able to parse both formats as a Rust `String` is just `Vec<u8>` with extra checks for utf8 under the hood.

This change is only cosmetic, but marked as breaking due to `buf`.