### PR TITLE
refactor(core, bridge-withdrawer)!: move bridge-unlock memo to core

### DIFF
--- a/crates/astria-bridge-withdrawer/src/bridge_withdrawer/ethereum/convert.rs
+++ b/crates/astria-bridge-withdrawer/src/bridge_withdrawer/ethereum/convert.rs
@@ -5,7 +5,10 @@ use astria_bridge_contracts::i_astria_withdrawer::{
     SequencerWithdrawalFilter,
 };
 use astria_core::{
-    bridge::Ics20WithdrawalFromRollupMemo,
+    bridge::{
+        BridgeUnlockMemo,
+        Ics20WithdrawalFromRollupMemo,
+    },
     primitive::v1::{
         asset::{
             self,
@@ -31,10 +34,6 @@ use ethers::types::{
     U64,
 };
 use ibc_types::core::client::Height as IbcHeight;
-use serde::{
-    Deserialize,
-    Serialize,
-};
 
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum WithdrawalEvent {
@@ -83,12 +82,6 @@ pub(crate) fn event_to_action(
     Ok(action)
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-pub(crate) struct BridgeUnlockMemo {
-    pub(crate) block_number: U64,
-    pub(crate) transaction_hash: TxHash,
-}
-
 fn event_to_bridge_unlock(
     event: &SequencerWithdrawalFilter,
     block_number: U64,
@@ -97,8 +90,11 @@ fn event_to_bridge_unlock(
     asset_withdrawal_divisor: u128,
 ) -> eyre::Result<Action> {
     let memo = BridgeUnlockMemo {
-        block_number,
-        transaction_hash,
+        // XXX: The documentation mentions that the ethers U64 type will panic if it cannot be
+        // converted to u64. However, this is part of a catch-all documentation that does not apply
+        // to U64.
+        block_number: block_number.as_u64(),
+        transaction_hash: transaction_hash.into(),
     };
     let action = BridgeUnlockAction {
         to: event
@@ -233,8 +229,8 @@ mod tests {
             to: crate::astria_address([1u8; 20]),
             amount: 99,
             memo: serde_json::to_vec(&BridgeUnlockMemo {
-                block_number: 1.into(),
-                transaction_hash: [2u8; 32].into(),
+                block_number: 1,
+                transaction_hash: [2u8; 32],
             })
             .unwrap(),
             fee_asset: denom,
@@ -274,8 +270,8 @@ mod tests {
             to: crate::astria_address([1u8; 20]),
             amount: 99,
             memo: serde_json::to_vec(&BridgeUnlockMemo {
-                block_number: 1.into(),
-                transaction_hash: [2u8; 32].into(),
+                block_number: 1,
+                transaction_hash: [2u8; 32],
             })
             .unwrap(),
             fee_asset: denom,

--- a/crates/astria-bridge-withdrawer/src/bridge_withdrawer/ethereum/convert.rs
+++ b/crates/astria-bridge-withdrawer/src/bridge_withdrawer/ethereum/convert.rs
@@ -6,7 +6,7 @@ use astria_bridge_contracts::i_astria_withdrawer::{
 };
 use astria_core::{
     bridge::{
-        BridgeUnlockMemo,
+        self,
         Ics20WithdrawalFromRollupMemo,
     },
     primitive::v1::{
@@ -89,7 +89,7 @@ fn event_to_bridge_unlock(
     fee_asset: asset::Denom,
     asset_withdrawal_divisor: u128,
 ) -> eyre::Result<Action> {
-    let memo = BridgeUnlockMemo {
+    let memo = bridge::UnlockMemo {
         // XXX: The documentation mentions that the ethers U64 type will panic if it cannot be
         // converted to u64. However, this is part of a catch-all documentation that does not apply
         // to U64.
@@ -228,7 +228,7 @@ mod tests {
         let expected_action = BridgeUnlockAction {
             to: crate::astria_address([1u8; 20]),
             amount: 99,
-            memo: serde_json::to_vec(&BridgeUnlockMemo {
+            memo: serde_json::to_vec(&bridge::UnlockMemo {
                 block_number: 1,
                 transaction_hash: [2u8; 32],
             })
@@ -269,7 +269,7 @@ mod tests {
         let expected_action = BridgeUnlockAction {
             to: crate::astria_address([1u8; 20]),
             amount: 99,
-            memo: serde_json::to_vec(&BridgeUnlockMemo {
+            memo: serde_json::to_vec(&bridge::UnlockMemo {
                 block_number: 1,
                 transaction_hash: [2u8; 32],
             })

--- a/crates/astria-bridge-withdrawer/src/bridge_withdrawer/submitter/mod.rs
+++ b/crates/astria-bridge-withdrawer/src/bridge_withdrawer/submitter/mod.rs
@@ -5,7 +5,7 @@ use std::{
 
 use astria_core::{
     bridge::{
-        BridgeUnlockMemo,
+        self,
         Ics20WithdrawalFromRollupMemo,
     },
     primitive::v1::asset,
@@ -715,7 +715,7 @@ fn rollup_height_from_signed_transaction(
 
     let last_batch_rollup_height = match withdrawal_action {
         Action::BridgeUnlock(action) => {
-            let memo: BridgeUnlockMemo = serde_json::from_slice(&action.memo)
+            let memo: bridge::UnlockMemo = serde_json::from_slice(&action.memo)
                 .wrap_err("failed to parse memo from last transaction by the bridge account")?;
             Some(memo.block_number)
         }

--- a/crates/astria-bridge-withdrawer/src/bridge_withdrawer/submitter/mod.rs
+++ b/crates/astria-bridge-withdrawer/src/bridge_withdrawer/submitter/mod.rs
@@ -4,7 +4,10 @@ use std::{
 };
 
 use astria_core::{
-    bridge::Ics20WithdrawalFromRollupMemo,
+    bridge::{
+        BridgeUnlockMemo,
+        Ics20WithdrawalFromRollupMemo,
+    },
     primitive::v1::asset,
     protocol::{
         asset::v1alpha1::AllowedFeeAssetsResponse,
@@ -69,10 +72,7 @@ use super::{
     state,
     SequencerStartupInfo,
 };
-use crate::{
-    bridge_withdrawer::ethereum::convert::BridgeUnlockMemo,
-    metrics::Metrics,
-};
+use crate::metrics::Metrics;
 
 mod builder;
 mod signer;
@@ -717,7 +717,7 @@ fn rollup_height_from_signed_transaction(
         Action::BridgeUnlock(action) => {
             let memo: BridgeUnlockMemo = serde_json::from_slice(&action.memo)
                 .wrap_err("failed to parse memo from last transaction by the bridge account")?;
-            Some(memo.block_number.as_u64())
+            Some(memo.block_number)
         }
         Action::Ics20Withdrawal(action) => {
             let memo: Ics20WithdrawalFromRollupMemo = serde_json::from_str(&action.memo)

--- a/crates/astria-bridge-withdrawer/src/bridge_withdrawer/submitter/tests.rs
+++ b/crates/astria-bridge-withdrawer/src/bridge_withdrawer/submitter/tests.rs
@@ -8,7 +8,7 @@ use std::{
 
 use astria_core::{
     bridge::{
-        BridgeUnlockMemo,
+        self,
         Ics20WithdrawalFromRollupMemo,
     },
     crypto::SigningKey,
@@ -304,7 +304,7 @@ fn make_bridge_unlock_action() -> Action {
     let inner = BridgeUnlockAction {
         to: crate::astria_address([0u8; 20]),
         amount: 99,
-        memo: serde_json::to_vec(&BridgeUnlockMemo {
+        memo: serde_json::to_vec(&bridge::UnlockMemo {
             block_number: DEFAULT_LAST_ROLLUP_HEIGHT,
             transaction_hash: [1u8; 32],
         })

--- a/crates/astria-bridge-withdrawer/src/bridge_withdrawer/submitter/tests.rs
+++ b/crates/astria-bridge-withdrawer/src/bridge_withdrawer/submitter/tests.rs
@@ -7,7 +7,10 @@ use std::{
 };
 
 use astria_core::{
-    bridge::Ics20WithdrawalFromRollupMemo,
+    bridge::{
+        BridgeUnlockMemo,
+        Ics20WithdrawalFromRollupMemo,
+    },
     crypto::SigningKey,
     generated::protocol::account::v1alpha1::NonceResponse,
     primitive::v1::asset,
@@ -76,7 +79,6 @@ use super::Submitter;
 use crate::{
     bridge_withdrawer::{
         batch::Batch,
-        ethereum::convert::BridgeUnlockMemo,
         state,
         submitter,
     },
@@ -303,8 +305,8 @@ fn make_bridge_unlock_action() -> Action {
         to: crate::astria_address([0u8; 20]),
         amount: 99,
         memo: serde_json::to_vec(&BridgeUnlockMemo {
-            block_number: DEFAULT_LAST_ROLLUP_HEIGHT.into(),
-            transaction_hash: [1u8; 32].into(),
+            block_number: DEFAULT_LAST_ROLLUP_HEIGHT,
+            transaction_hash: [1u8; 32],
         })
         .unwrap(),
         fee_asset: denom,

--- a/crates/astria-core/src/bridge.rs
+++ b/crates/astria-core/src/bridge.rs
@@ -1,5 +1,23 @@
 use crate::primitive::v1::Address;
 
+#[derive(Clone, Debug)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize),
+    derive(serde::Deserialize)
+)]
+pub struct BridgeUnlockMemo {
+    pub block_number: u64,
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            serialize_with = "crate::serde::base64_serialize",
+            deserialize_with = "crate::serde::base64_deserialize_array"
+        )
+    )]
+    pub transaction_hash: [u8; 32],
+}
+
 /// Memo format for a ICS20 withdrawal from the rollup which is sent to
 /// an external IBC-enabled chain.
 #[derive(Debug, Clone)]
@@ -39,6 +57,16 @@ pub struct Ics20TransferDepositMemo {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn bridge_unlock_memo_snapshot() {
+        let memo = BridgeUnlockMemo {
+            block_number: 42,
+            transaction_hash: [88; 32],
+        };
+
+        insta::assert_json_snapshot!(memo);
+    }
 
     #[test]
     fn ics20_withdrawal_from_rollup_memo_snapshot() {

--- a/crates/astria-core/src/bridge.rs
+++ b/crates/astria-core/src/bridge.rs
@@ -6,7 +6,7 @@ use crate::primitive::v1::Address;
     derive(serde::Serialize),
     derive(serde::Deserialize)
 )]
-pub struct BridgeUnlockMemo {
+pub struct UnlockMemo {
     pub block_number: u64,
     #[cfg_attr(
         feature = "serde",
@@ -60,7 +60,7 @@ mod test {
 
     #[test]
     fn bridge_unlock_memo_snapshot() {
-        let memo = BridgeUnlockMemo {
+        let memo = UnlockMemo {
             block_number: 42,
             transaction_hash: [88; 32],
         };

--- a/crates/astria-core/src/snapshots/astria_core__bridge__test__bridge_unlock_memo_snapshot.snap
+++ b/crates/astria-core/src/snapshots/astria_core__bridge__test__bridge_unlock_memo_snapshot.snap
@@ -1,0 +1,8 @@
+---
+source: crates/astria-core/src/bridge.rs
+expression: memo
+---
+{
+  "block_number": 42,
+  "transaction_hash": "WFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFg="
+}


### PR DESCRIPTION
## Summary
Moves the bridge-unlock memo out of `astria-bridge-withdrawer` and into `astria-core`.

## Background
This type needs to be publicly readable for `astria-cli` and other consumers.

## Changes
- Move the `BridgeUnlockMemo` type to `astria_core::bridge`
- Change the public memo fields from ethers types to native Rust types
- Encode the contained transaction hash as base64
- Provide snapshot tests

## Testing
bridge-withdrawer tests still pass.

## Breaking Changelist
The transaction hash field in the memo being encoded as `base64` is a breaking change for bridge-withdrawer.