### PR TITLE
chore(sequencer)!: add metrics

### DIFF
--- a/crates/astria-sequencer/Cargo.toml
+++ b/crates/astria-sequencer/Cargo.toml
@@ -30,7 +30,9 @@ priority-queue = "2.0.2"
 tower = "0.4"
 tower-abci = "0.12.0"
 tower-actor = "0.1.0"
-cnidarium = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.78.0" }
+cnidarium = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.78.0", features = [
+  "metrics",
+] }
 cnidarium-component = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.78.0" }
 
 async-trait = { workspace = true }

--- a/crates/astria-sequencer/src/app/mod.rs
+++ b/crates/astria-sequencer/src/app/mod.rs
@@ -603,6 +603,7 @@ impl App {
         self.mempool.insert_all(txs_to_readd_to_mempool).await;
         let mempool_len = self.mempool.len().await;
         debug!(mempool_len, "finished executing transactions from mempool");
+        self.metrics.set_transactions_in_mempool_total(mempool_len);
 
         self.execution_results = Some(execution_results);
         Ok((validated_txs, included_signed_txs))

--- a/crates/astria-sequencer/src/sequencer.rs
+++ b/crates/astria-sequencer/src/sequencer.rs
@@ -49,6 +49,9 @@ impl Sequencer {
     pub async fn run_until_stopped(config: Config) -> Result<()> {
         static METRICS: OnceLock<Metrics> = OnceLock::new();
         let metrics = METRICS.get_or_init(Metrics::new);
+        cnidarium::register_metrics();
+        metrics::histogram!("cnidarium_get_raw_duration_seconds");
+        metrics::histogram!("cnidarium_nonverifiable_get_raw_duration_seconds");
 
         if config
             .db_filepath

--- a/crates/astria-sequencer/src/service/mempool.rs
+++ b/crates/astria-sequencer/src/service/mempool.rs
@@ -4,6 +4,7 @@ use std::{
         Context,
         Poll,
     },
+    time::Instant,
 };
 
 use astria_core::{
@@ -105,12 +106,16 @@ async fn handle_check_tx<S: StateReadExt + 'static>(
 ) -> response::CheckTx {
     use sha2::Digest as _;
 
-    let tx_hash = sha2::Sha256::digest(&req.tx).into();
+    let start_parsing = Instant::now();
 
     let request::CheckTx {
         tx, ..
     } = req;
-    if tx.len() > MAX_TX_SIZE {
+
+    let tx_hash = sha2::Sha256::digest(&tx).into();
+    let tx_len = tx.len();
+
+    if tx_len > MAX_TX_SIZE {
         mempool.remove(tx_hash).await;
         metrics.increment_check_tx_removed_too_large();
         return response::CheckTx {
@@ -151,6 +156,11 @@ async fn handle_check_tx<S: StateReadExt + 'static>(
         }
     };
 
+    let finished_parsing = Instant::now();
+    metrics.record_check_tx_duration_seconds_parse_tx(
+        finished_parsing.saturating_duration_since(start_parsing),
+    );
+
     if let Err(e) = transaction::check_stateless(&signed_tx).await {
         mempool.remove(tx_hash).await;
         metrics.increment_check_tx_removed_failed_stateless();
@@ -161,6 +171,11 @@ async fn handle_check_tx<S: StateReadExt + 'static>(
             ..response::CheckTx::default()
         };
     };
+
+    let finished_check_stateless = Instant::now();
+    metrics.record_check_tx_duration_seconds_check_stateless(
+        finished_check_stateless.saturating_duration_since(finished_parsing),
+    );
 
     if let Err(e) = transaction::check_nonce_mempool(&signed_tx, &state).await {
         mempool.remove(tx_hash).await;
@@ -173,6 +188,11 @@ async fn handle_check_tx<S: StateReadExt + 'static>(
         };
     };
 
+    let finished_check_nonce = Instant::now();
+    metrics.record_check_tx_duration_seconds_check_nonce(
+        finished_check_nonce.saturating_duration_since(finished_check_stateless),
+    );
+
     if let Err(e) = transaction::check_chain_id_mempool(&signed_tx, &state).await {
         mempool.remove(tx_hash).await;
         return response::CheckTx {
@@ -182,6 +202,11 @@ async fn handle_check_tx<S: StateReadExt + 'static>(
             ..response::CheckTx::default()
         };
     }
+
+    let finished_check_chain_id = Instant::now();
+    metrics.record_check_tx_duration_seconds_check_chain_id(
+        finished_check_chain_id.saturating_duration_since(finished_check_nonce),
+    );
 
     if let Err(e) = transaction::check_balance_mempool(&signed_tx, &state).await {
         mempool.remove(tx_hash).await;
@@ -193,6 +218,11 @@ async fn handle_check_tx<S: StateReadExt + 'static>(
             ..response::CheckTx::default()
         };
     };
+
+    let finished_check_balance = Instant::now();
+    metrics.record_check_tx_duration_seconds_check_balance(
+        finished_check_balance.saturating_duration_since(finished_check_chain_id),
+    );
 
     if let Some(removal_reason) = mempool.check_removed_comet_bft(tx_hash).await {
         mempool.remove(tx_hash).await;
@@ -219,6 +249,11 @@ async fn handle_check_tx<S: StateReadExt + 'static>(
         }
     };
 
+    let finished_check_removed = Instant::now();
+    metrics.record_check_tx_duration_seconds_check_removed(
+        finished_check_removed.saturating_duration_since(finished_check_balance),
+    );
+
     // tx is valid, push to mempool
     let current_account_nonce = state
         .get_account_nonce(crate::address::base_prefixed(
@@ -227,6 +262,8 @@ async fn handle_check_tx<S: StateReadExt + 'static>(
         .await
         .expect("can fetch account nonce");
 
+    let actions_count = signed_tx.actions().len();
+
     mempool
         .insert(signed_tx, current_account_nonce)
         .await
@@ -234,5 +271,13 @@ async fn handle_check_tx<S: StateReadExt + 'static>(
             "tx nonce is greater than or equal to current account nonce; this was checked in \
              check_nonce_mempool",
         );
+    let mempool_len = mempool.len().await;
+
+    metrics
+        .record_check_tx_duration_seconds_insert_to_app_mempool(finished_check_removed.elapsed());
+    metrics.record_actions_per_transaction_in_mempool(actions_count);
+    metrics.record_transaction_in_mempool_size_bytes(tx_len);
+    metrics.set_transactions_in_mempool_total(mempool_len);
+
     response::CheckTx::default()
 }


### PR DESCRIPTION
## Summary
This adds further metrics to the sequencer.

## Background
This should help diagnose block production slowdown when the sequencer is stress-tested.

## Changes
- Added metrics (see below for list).
- Enabled `cnidarium` metrics.

Note that all histograms are still rendered as Prometheus summaries for now.  I have [an open PR](https://github.com/astriaorg/astria/pull/1192) which will make it simple to provide buckets for histograms, after which they will be rendered as true histograms.

## Testing
How are these changes tested?

## Metrics
- Added `astria_sequencer_check_tx_duration_seconds` histograms with the following labels:
    - `length check and parse raw tx`
    - `stateless check`
    - `nonce check`
    - `chain id check`
    - `balance check`
    - `check for removal`
    - `insert to app mempool`
- Added `astria_sequencer_actions_per_transaction_in_mempool` histogram
- Added `astria_sequencer_transaction_in_mempool_size_bytes` histogram
- Added `astria_sequencer_transactions_in_mempool_total` gauge
- Enabled `cnidarium_get_raw_duration_seconds` histogram
- Enabled `cnidarium_nonverifiable_get_raw_duration_seconds` histogram

## Related Issues
Closes #1247.
