### PR TITLE
fix: rollup archive node configurations

### DIFF
--- a/charts/evm-rollup/Chart.yaml
+++ b/charts/evm-rollup/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.23.0
+version: 0.23.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/evm-rollup/templates/statefulsets.yaml
+++ b/charts/evm-rollup/templates/statefulsets.yaml
@@ -64,6 +64,7 @@ spec:
             - --maxpeers=0
             {{- if .Values.config.rollup.archiveNode }}
             - --gcmode=archive
+            - --state.scheme=hash
             - --history.transactions=0
             {{- else }}
             - --state.scheme=path

--- a/charts/evm-rollup/templates/statefulsets.yaml
+++ b/charts/evm-rollup/templates/statefulsets.yaml
@@ -66,8 +66,10 @@ spec:
             - --gcmode=archive
             - --state.scheme=hash
             - --history.transactions=0
+            - --history.state=0
             {{- else }}
             - --state.scheme=path
+            - --history.state=540000
             {{- end }}
             {{ if .Values.config.rollup.metrics.enabled }}
             - --metrics


### PR DESCRIPTION
## Summary
`geth v1.14.0` introduced changes to archive node configurations, now need to set `--state.scheme=hash` to enable archive node
