### PR TITLE
feat(core)!: lowerCamelCase for protobuf json mapping

### DIFF
--- a/crates/astria-conductor/tests/blackbox/helpers/macros.rs
+++ b/crates/astria-conductor/tests/blackbox/helpers/macros.rs
@@ -241,8 +241,8 @@ macro_rules! mount_executed_block {
         $test_env.mount_execute_block(
             $mock_name.into(),
             ::serde_json::json!({
-                "prev_block_hash": BASE64_STANDARD.encode($parent),
-                "transactions": [{"sequenced_data": BASE64_STANDARD.encode($crate::helpers::data())}],
+                "prevBlockHash": BASE64_STANDARD.encode($parent),
+                "transactions": [{"sequencedData": BASE64_STANDARD.encode($crate::helpers::data())}],
             }),
             $crate::block!(
                 number: $number,

--- a/crates/astria-core/src/generated/astria.execution.v1alpha2.serde.rs
+++ b/crates/astria-core/src/generated/astria.execution.v1alpha2.serde.rs
@@ -210,7 +210,7 @@ impl serde::Serialize for Block {
         }
         if !self.parent_block_hash.is_empty() {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("parent_block_hash", pbjson::private::base64::encode(&self.parent_block_hash).as_str())?;
+            struct_ser.serialize_field("parentBlockHash", pbjson::private::base64::encode(&self.parent_block_hash).as_str())?;
         }
         if let Some(v) = self.timestamp.as_ref() {
             struct_ser.serialize_field("timestamp", v)?;
@@ -346,11 +346,11 @@ impl serde::Serialize for BlockIdentifier {
         if let Some(v) = self.identifier.as_ref() {
             match v {
                 block_identifier::Identifier::BlockNumber(v) => {
-                    struct_ser.serialize_field("block_number", v)?;
+                    struct_ser.serialize_field("blockNumber", v)?;
                 }
                 block_identifier::Identifier::BlockHash(v) => {
                     #[allow(clippy::needless_borrow)]
-                    struct_ser.serialize_field("block_hash", pbjson::private::base64::encode(&v).as_str())?;
+                    struct_ser.serialize_field("blockHash", pbjson::private::base64::encode(&v).as_str())?;
                 }
             }
         }
@@ -467,7 +467,7 @@ impl serde::Serialize for CommitmentState {
         }
         if self.base_celestia_height != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("base_celestia_height", ToString::to_string(&self.base_celestia_height).as_str())?;
+            struct_ser.serialize_field("baseCelestiaHeight", ToString::to_string(&self.base_celestia_height).as_str())?;
         }
         struct_ser.end()
     }
@@ -590,7 +590,7 @@ impl serde::Serialize for ExecuteBlockRequest {
         let mut struct_ser = serializer.serialize_struct("astria.execution.v1alpha2.ExecuteBlockRequest", len)?;
         if !self.prev_block_hash.is_empty() {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("prev_block_hash", pbjson::private::base64::encode(&self.prev_block_hash).as_str())?;
+            struct_ser.serialize_field("prevBlockHash", pbjson::private::base64::encode(&self.prev_block_hash).as_str())?;
         }
         if !self.transactions.is_empty() {
             struct_ser.serialize_field("transactions", &self.transactions)?;
@@ -719,14 +719,14 @@ impl serde::Serialize for GenesisInfo {
         let mut struct_ser = serializer.serialize_struct("astria.execution.v1alpha2.GenesisInfo", len)?;
         if !self.rollup_id.is_empty() {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("rollup_id", pbjson::private::base64::encode(&self.rollup_id).as_str())?;
+            struct_ser.serialize_field("rollupId", pbjson::private::base64::encode(&self.rollup_id).as_str())?;
         }
         if self.sequencer_genesis_block_height != 0 {
-            struct_ser.serialize_field("sequencer_genesis_block_height", &self.sequencer_genesis_block_height)?;
+            struct_ser.serialize_field("sequencerGenesisBlockHeight", &self.sequencer_genesis_block_height)?;
         }
         if self.celestia_block_variance != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("celestia_block_variance", ToString::to_string(&self.celestia_block_variance).as_str())?;
+            struct_ser.serialize_field("celestiaBlockVariance", ToString::to_string(&self.celestia_block_variance).as_str())?;
         }
         struct_ser.end()
     }
@@ -1081,7 +1081,7 @@ impl serde::Serialize for UpdateCommitmentStateRequest {
         }
         let mut struct_ser = serializer.serialize_struct("astria.execution.v1alpha2.UpdateCommitmentStateRequest", len)?;
         if let Some(v) = self.commitment_state.as_ref() {
-            struct_ser.serialize_field("commitment_state", v)?;
+            struct_ser.serialize_field("commitmentState", v)?;
         }
         struct_ser.end()
     }

--- a/crates/astria-core/src/generated/astria.primitive.v1.serde.rs
+++ b/crates/astria-core/src/generated/astria.primitive.v1.serde.rs
@@ -109,7 +109,7 @@ impl serde::Serialize for Denom {
             struct_ser.serialize_field("id", pbjson::private::base64::encode(&self.id).as_str())?;
         }
         if !self.base_denom.is_empty() {
-            struct_ser.serialize_field("base_denom", &self.base_denom)?;
+            struct_ser.serialize_field("baseDenom", &self.base_denom)?;
         }
         struct_ser.end()
     }
@@ -221,15 +221,15 @@ impl serde::Serialize for Proof {
         let mut struct_ser = serializer.serialize_struct("astria.primitive.v1.Proof", len)?;
         if !self.audit_path.is_empty() {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("audit_path", pbjson::private::base64::encode(&self.audit_path).as_str())?;
+            struct_ser.serialize_field("auditPath", pbjson::private::base64::encode(&self.audit_path).as_str())?;
         }
         if self.leaf_index != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("leaf_index", ToString::to_string(&self.leaf_index).as_str())?;
+            struct_ser.serialize_field("leafIndex", ToString::to_string(&self.leaf_index).as_str())?;
         }
         if self.tree_size != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("tree_size", ToString::to_string(&self.tree_size).as_str())?;
+            struct_ser.serialize_field("treeSize", ToString::to_string(&self.tree_size).as_str())?;
         }
         struct_ser.end()
     }

--- a/crates/astria-core/src/generated/astria.sequencerblock.v1alpha1.serde.rs
+++ b/crates/astria-core/src/generated/astria.sequencerblock.v1alpha1.serde.rs
@@ -23,10 +23,10 @@ impl serde::Serialize for Deposit {
         }
         let mut struct_ser = serializer.serialize_struct("astria.sequencerblock.v1alpha1.Deposit", len)?;
         if let Some(v) = self.bridge_address.as_ref() {
-            struct_ser.serialize_field("bridge_address", v)?;
+            struct_ser.serialize_field("bridgeAddress", v)?;
         }
         if let Some(v) = self.rollup_id.as_ref() {
-            struct_ser.serialize_field("rollup_id", v)?;
+            struct_ser.serialize_field("rollupId", v)?;
         }
         if let Some(v) = self.amount.as_ref() {
             struct_ser.serialize_field("amount", v)?;
@@ -35,7 +35,7 @@ impl serde::Serialize for Deposit {
             struct_ser.serialize_field("asset", &self.asset)?;
         }
         if !self.destination_chain_address.is_empty() {
-            struct_ser.serialize_field("destination_chain_address", &self.destination_chain_address)?;
+            struct_ser.serialize_field("destinationChainAddress", &self.destination_chain_address)?;
         }
         struct_ser.end()
     }
@@ -189,22 +189,22 @@ impl serde::Serialize for FilteredSequencerBlock {
         let mut struct_ser = serializer.serialize_struct("astria.sequencerblock.v1alpha1.FilteredSequencerBlock", len)?;
         if !self.block_hash.is_empty() {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("block_hash", pbjson::private::base64::encode(&self.block_hash).as_str())?;
+            struct_ser.serialize_field("blockHash", pbjson::private::base64::encode(&self.block_hash).as_str())?;
         }
         if let Some(v) = self.header.as_ref() {
             struct_ser.serialize_field("header", v)?;
         }
         if !self.rollup_transactions.is_empty() {
-            struct_ser.serialize_field("rollup_transactions", &self.rollup_transactions)?;
+            struct_ser.serialize_field("rollupTransactions", &self.rollup_transactions)?;
         }
         if let Some(v) = self.rollup_transactions_proof.as_ref() {
-            struct_ser.serialize_field("rollup_transactions_proof", v)?;
+            struct_ser.serialize_field("rollupTransactionsProof", v)?;
         }
         if !self.all_rollup_ids.is_empty() {
-            struct_ser.serialize_field("all_rollup_ids", &self.all_rollup_ids.iter().map(pbjson::private::base64::encode).collect::<Vec<_>>())?;
+            struct_ser.serialize_field("allRollupIds", &self.all_rollup_ids.iter().map(pbjson::private::base64::encode).collect::<Vec<_>>())?;
         }
         if let Some(v) = self.rollup_ids_proof.as_ref() {
-            struct_ser.serialize_field("rollup_ids_proof", v)?;
+            struct_ser.serialize_field("rollupIdsProof", v)?;
         }
         struct_ser.end()
     }
@@ -367,7 +367,7 @@ impl serde::Serialize for GetFilteredSequencerBlockRequest {
             struct_ser.serialize_field("height", ToString::to_string(&self.height).as_str())?;
         }
         if !self.rollup_ids.is_empty() {
-            struct_ser.serialize_field("rollup_ids", &self.rollup_ids)?;
+            struct_ser.serialize_field("rollupIds", &self.rollup_ids)?;
         }
         struct_ser.end()
     }
@@ -753,7 +753,7 @@ impl serde::Serialize for RollupData {
             match v {
                 rollup_data::Value::SequencedData(v) => {
                     #[allow(clippy::needless_borrow)]
-                    struct_ser.serialize_field("sequenced_data", pbjson::private::base64::encode(&v).as_str())?;
+                    struct_ser.serialize_field("sequencedData", pbjson::private::base64::encode(&v).as_str())?;
                 }
                 rollup_data::Value::Deposit(v) => {
                     struct_ser.serialize_field("deposit", v)?;
@@ -866,7 +866,7 @@ impl serde::Serialize for RollupTransactions {
         }
         let mut struct_ser = serializer.serialize_struct("astria.sequencerblock.v1alpha1.RollupTransactions", len)?;
         if let Some(v) = self.rollup_id.as_ref() {
-            struct_ser.serialize_field("rollup_id", v)?;
+            struct_ser.serialize_field("rollupId", v)?;
         }
         if !self.transactions.is_empty() {
             struct_ser.serialize_field("transactions", &self.transactions.iter().map(pbjson::private::base64::encode).collect::<Vec<_>>())?;
@@ -1004,17 +1004,17 @@ impl serde::Serialize for SequencerBlock {
             struct_ser.serialize_field("header", v)?;
         }
         if !self.rollup_transactions.is_empty() {
-            struct_ser.serialize_field("rollup_transactions", &self.rollup_transactions)?;
+            struct_ser.serialize_field("rollupTransactions", &self.rollup_transactions)?;
         }
         if let Some(v) = self.rollup_transactions_proof.as_ref() {
-            struct_ser.serialize_field("rollup_transactions_proof", v)?;
+            struct_ser.serialize_field("rollupTransactionsProof", v)?;
         }
         if let Some(v) = self.rollup_ids_proof.as_ref() {
-            struct_ser.serialize_field("rollup_ids_proof", v)?;
+            struct_ser.serialize_field("rollupIdsProof", v)?;
         }
         if !self.block_hash.is_empty() {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("block_hash", pbjson::private::base64::encode(&self.block_hash).as_str())?;
+            struct_ser.serialize_field("blockHash", pbjson::private::base64::encode(&self.block_hash).as_str())?;
         }
         struct_ser.end()
     }
@@ -1170,7 +1170,7 @@ impl serde::Serialize for SequencerBlockHeader {
         }
         let mut struct_ser = serializer.serialize_struct("astria.sequencerblock.v1alpha1.SequencerBlockHeader", len)?;
         if !self.chain_id.is_empty() {
-            struct_ser.serialize_field("chain_id", &self.chain_id)?;
+            struct_ser.serialize_field("chainId", &self.chain_id)?;
         }
         if self.height != 0 {
             #[allow(clippy::needless_borrow)]
@@ -1181,15 +1181,15 @@ impl serde::Serialize for SequencerBlockHeader {
         }
         if !self.data_hash.is_empty() {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("data_hash", pbjson::private::base64::encode(&self.data_hash).as_str())?;
+            struct_ser.serialize_field("dataHash", pbjson::private::base64::encode(&self.data_hash).as_str())?;
         }
         if !self.proposer_address.is_empty() {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("proposer_address", pbjson::private::base64::encode(&self.proposer_address).as_str())?;
+            struct_ser.serialize_field("proposerAddress", pbjson::private::base64::encode(&self.proposer_address).as_str())?;
         }
         if !self.rollup_transactions_root.is_empty() {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("rollup_transactions_root", pbjson::private::base64::encode(&self.rollup_transactions_root).as_str())?;
+            struct_ser.serialize_field("rollupTransactionsRoot", pbjson::private::base64::encode(&self.rollup_transactions_root).as_str())?;
         }
         struct_ser.end()
     }
@@ -1360,19 +1360,19 @@ impl serde::Serialize for SubmittedMetadata {
         let mut struct_ser = serializer.serialize_struct("astria.sequencerblock.v1alpha1.SubmittedMetadata", len)?;
         if !self.block_hash.is_empty() {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("block_hash", pbjson::private::base64::encode(&self.block_hash).as_str())?;
+            struct_ser.serialize_field("blockHash", pbjson::private::base64::encode(&self.block_hash).as_str())?;
         }
         if let Some(v) = self.header.as_ref() {
             struct_ser.serialize_field("header", v)?;
         }
         if !self.rollup_ids.is_empty() {
-            struct_ser.serialize_field("rollup_ids", &self.rollup_ids)?;
+            struct_ser.serialize_field("rollupIds", &self.rollup_ids)?;
         }
         if let Some(v) = self.rollup_transactions_proof.as_ref() {
-            struct_ser.serialize_field("rollup_transactions_proof", v)?;
+            struct_ser.serialize_field("rollupTransactionsProof", v)?;
         }
         if let Some(v) = self.rollup_ids_proof.as_ref() {
-            struct_ser.serialize_field("rollup_ids_proof", v)?;
+            struct_ser.serialize_field("rollupIdsProof", v)?;
         }
         struct_ser.end()
     }
@@ -1614,10 +1614,10 @@ impl serde::Serialize for SubmittedRollupData {
         let mut struct_ser = serializer.serialize_struct("astria.sequencerblock.v1alpha1.SubmittedRollupData", len)?;
         if !self.sequencer_block_hash.is_empty() {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("sequencer_block_hash", pbjson::private::base64::encode(&self.sequencer_block_hash).as_str())?;
+            struct_ser.serialize_field("sequencerBlockHash", pbjson::private::base64::encode(&self.sequencer_block_hash).as_str())?;
         }
         if let Some(v) = self.rollup_id.as_ref() {
-            struct_ser.serialize_field("rollup_id", v)?;
+            struct_ser.serialize_field("rollupId", v)?;
         }
         if !self.transactions.is_empty() {
             struct_ser.serialize_field("transactions", &self.transactions.iter().map(pbjson::private::base64::encode).collect::<Vec<_>>())?;

--- a/crates/astria-core/src/generated/celestia.blob.v1.serde.rs
+++ b/crates/astria-core/src/generated/celestia.blob.v1.serde.rs
@@ -29,13 +29,13 @@ impl serde::Serialize for MsgPayForBlobs {
             struct_ser.serialize_field("namespaces", &self.namespaces.iter().map(pbjson::private::base64::encode).collect::<Vec<_>>())?;
         }
         if !self.blob_sizes.is_empty() {
-            struct_ser.serialize_field("blob_sizes", &self.blob_sizes)?;
+            struct_ser.serialize_field("blobSizes", &self.blob_sizes)?;
         }
         if !self.share_commitments.is_empty() {
-            struct_ser.serialize_field("share_commitments", &self.share_commitments.iter().map(pbjson::private::base64::encode).collect::<Vec<_>>())?;
+            struct_ser.serialize_field("shareCommitments", &self.share_commitments.iter().map(pbjson::private::base64::encode).collect::<Vec<_>>())?;
         }
         if !self.share_versions.is_empty() {
-            struct_ser.serialize_field("share_versions", &self.share_versions)?;
+            struct_ser.serialize_field("shareVersions", &self.share_versions)?;
         }
         struct_ser.end()
     }
@@ -188,11 +188,11 @@ impl serde::Serialize for Params {
         }
         let mut struct_ser = serializer.serialize_struct("celestia.blob.v1.Params", len)?;
         if self.gas_per_blob_byte != 0 {
-            struct_ser.serialize_field("gas_per_blob_byte", &self.gas_per_blob_byte)?;
+            struct_ser.serialize_field("gasPerBlobByte", &self.gas_per_blob_byte)?;
         }
         if self.gov_max_square_size != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("gov_max_square_size", ToString::to_string(&self.gov_max_square_size).as_str())?;
+            struct_ser.serialize_field("govMaxSquareSize", ToString::to_string(&self.gov_max_square_size).as_str())?;
         }
         struct_ser.end()
     }

--- a/crates/astria-core/src/generated/cosmos.auth.v1beta1.serde.rs
+++ b/crates/astria-core/src/generated/cosmos.auth.v1beta1.serde.rs
@@ -23,11 +23,11 @@ impl serde::Serialize for BaseAccount {
             struct_ser.serialize_field("address", &self.address)?;
         }
         if let Some(v) = self.pub_key.as_ref() {
-            struct_ser.serialize_field("pub_key", v)?;
+            struct_ser.serialize_field("pubKey", v)?;
         }
         if self.account_number != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("account_number", ToString::to_string(&self.account_number).as_str())?;
+            struct_ser.serialize_field("accountNumber", ToString::to_string(&self.account_number).as_str())?;
         }
         if self.sequence != 0 {
             #[allow(clippy::needless_borrow)]
@@ -174,23 +174,23 @@ impl serde::Serialize for Params {
         let mut struct_ser = serializer.serialize_struct("cosmos.auth.v1beta1.Params", len)?;
         if self.max_memo_characters != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("max_memo_characters", ToString::to_string(&self.max_memo_characters).as_str())?;
+            struct_ser.serialize_field("maxMemoCharacters", ToString::to_string(&self.max_memo_characters).as_str())?;
         }
         if self.tx_sig_limit != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("tx_sig_limit", ToString::to_string(&self.tx_sig_limit).as_str())?;
+            struct_ser.serialize_field("txSigLimit", ToString::to_string(&self.tx_sig_limit).as_str())?;
         }
         if self.tx_size_cost_per_byte != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("tx_size_cost_per_byte", ToString::to_string(&self.tx_size_cost_per_byte).as_str())?;
+            struct_ser.serialize_field("txSizeCostPerByte", ToString::to_string(&self.tx_size_cost_per_byte).as_str())?;
         }
         if self.sig_verify_cost_ed25519 != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("sig_verify_cost_ed25519", ToString::to_string(&self.sig_verify_cost_ed25519).as_str())?;
+            struct_ser.serialize_field("sigVerifyCostEd25519", ToString::to_string(&self.sig_verify_cost_ed25519).as_str())?;
         }
         if self.sig_verify_cost_secp256k1 != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("sig_verify_cost_secp256k1", ToString::to_string(&self.sig_verify_cost_secp256k1).as_str())?;
+            struct_ser.serialize_field("sigVerifyCostSecp256k1", ToString::to_string(&self.sig_verify_cost_secp256k1).as_str())?;
         }
         struct_ser.end()
     }

--- a/crates/astria-core/src/generated/cosmos.base.abci.v1beta1.serde.rs
+++ b/crates/astria-core/src/generated/cosmos.base.abci.v1beta1.serde.rs
@@ -17,7 +17,7 @@ impl serde::Serialize for AbciMessageLog {
         }
         let mut struct_ser = serializer.serialize_struct("cosmos.base.abci.v1beta1.ABCIMessageLog", len)?;
         if self.msg_index != 0 {
-            struct_ser.serialize_field("msg_index", &self.msg_index)?;
+            struct_ser.serialize_field("msgIndex", &self.msg_index)?;
         }
         if !self.log.is_empty() {
             struct_ser.serialize_field("log", &self.log)?;
@@ -407,7 +407,7 @@ impl serde::Serialize for TxResponse {
             struct_ser.serialize_field("data", &self.data)?;
         }
         if !self.raw_log.is_empty() {
-            struct_ser.serialize_field("raw_log", &self.raw_log)?;
+            struct_ser.serialize_field("rawLog", &self.raw_log)?;
         }
         if !self.logs.is_empty() {
             struct_ser.serialize_field("logs", &self.logs)?;
@@ -417,11 +417,11 @@ impl serde::Serialize for TxResponse {
         }
         if self.gas_wanted != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("gas_wanted", ToString::to_string(&self.gas_wanted).as_str())?;
+            struct_ser.serialize_field("gasWanted", ToString::to_string(&self.gas_wanted).as_str())?;
         }
         if self.gas_used != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("gas_used", ToString::to_string(&self.gas_used).as_str())?;
+            struct_ser.serialize_field("gasUsed", ToString::to_string(&self.gas_used).as_str())?;
         }
         if let Some(v) = self.tx.as_ref() {
             struct_ser.serialize_field("tx", v)?;

--- a/crates/astria-core/src/generated/cosmos.base.node.v1beta1.serde.rs
+++ b/crates/astria-core/src/generated/cosmos.base.node.v1beta1.serde.rs
@@ -82,7 +82,7 @@ impl serde::Serialize for ConfigResponse {
         }
         let mut struct_ser = serializer.serialize_struct("cosmos.base.node.v1beta1.ConfigResponse", len)?;
         if !self.minimum_gas_price.is_empty() {
-            struct_ser.serialize_field("minimum_gas_price", &self.minimum_gas_price)?;
+            struct_ser.serialize_field("minimumGasPrice", &self.minimum_gas_price)?;
         }
         struct_ser.end()
     }

--- a/crates/astria-core/src/generated/cosmos.base.tendermint.v1beta1.serde.rs
+++ b/crates/astria-core/src/generated/cosmos.base.tendermint.v1beta1.serde.rs
@@ -85,10 +85,10 @@ impl serde::Serialize for GetNodeInfoResponse {
         }
         let mut struct_ser = serializer.serialize_struct("cosmos.base.tendermint.v1beta1.GetNodeInfoResponse", len)?;
         if let Some(v) = self.default_node_info.as_ref() {
-            struct_ser.serialize_field("default_node_info", v)?;
+            struct_ser.serialize_field("defaultNodeInfo", v)?;
         }
         if let Some(v) = self.application_version.as_ref() {
-            struct_ser.serialize_field("application_version", v)?;
+            struct_ser.serialize_field("applicationVersion", v)?;
         }
         struct_ser.end()
     }
@@ -341,25 +341,25 @@ impl serde::Serialize for VersionInfo {
             struct_ser.serialize_field("name", &self.name)?;
         }
         if !self.app_name.is_empty() {
-            struct_ser.serialize_field("app_name", &self.app_name)?;
+            struct_ser.serialize_field("appName", &self.app_name)?;
         }
         if !self.version.is_empty() {
             struct_ser.serialize_field("version", &self.version)?;
         }
         if !self.git_commit.is_empty() {
-            struct_ser.serialize_field("git_commit", &self.git_commit)?;
+            struct_ser.serialize_field("gitCommit", &self.git_commit)?;
         }
         if !self.build_tags.is_empty() {
-            struct_ser.serialize_field("build_tags", &self.build_tags)?;
+            struct_ser.serialize_field("buildTags", &self.build_tags)?;
         }
         if !self.go_version.is_empty() {
-            struct_ser.serialize_field("go_version", &self.go_version)?;
+            struct_ser.serialize_field("goVersion", &self.go_version)?;
         }
         if !self.build_deps.is_empty() {
-            struct_ser.serialize_field("build_deps", &self.build_deps)?;
+            struct_ser.serialize_field("buildDeps", &self.build_deps)?;
         }
         if !self.cosmos_sdk_version.is_empty() {
-            struct_ser.serialize_field("cosmos_sdk_version", &self.cosmos_sdk_version)?;
+            struct_ser.serialize_field("cosmosSdkVersion", &self.cosmos_sdk_version)?;
         }
         struct_ser.end()
     }

--- a/crates/astria-core/src/generated/cosmos.crypto.multisig.v1beta1.serde.rs
+++ b/crates/astria-core/src/generated/cosmos.crypto.multisig.v1beta1.serde.rs
@@ -14,7 +14,7 @@ impl serde::Serialize for CompactBitArray {
         }
         let mut struct_ser = serializer.serialize_struct("cosmos.crypto.multisig.v1beta1.CompactBitArray", len)?;
         if self.extra_bits_stored != 0 {
-            struct_ser.serialize_field("extra_bits_stored", &self.extra_bits_stored)?;
+            struct_ser.serialize_field("extraBitsStored", &self.extra_bits_stored)?;
         }
         if !self.elems.is_empty() {
             #[allow(clippy::needless_borrow)]

--- a/crates/astria-core/src/generated/cosmos.tx.v1beta1.serde.rs
+++ b/crates/astria-core/src/generated/cosmos.tx.v1beta1.serde.rs
@@ -17,7 +17,7 @@ impl serde::Serialize for AuthInfo {
         }
         let mut struct_ser = serializer.serialize_struct("cosmos.tx.v1beta1.AuthInfo", len)?;
         if !self.signer_infos.is_empty() {
-            struct_ser.serialize_field("signer_infos", &self.signer_infos)?;
+            struct_ser.serialize_field("signerInfos", &self.signer_infos)?;
         }
         if let Some(v) = self.fee.as_ref() {
             struct_ser.serialize_field("fee", v)?;
@@ -218,7 +218,7 @@ impl serde::Serialize for BroadcastTxRequest {
         let mut struct_ser = serializer.serialize_struct("cosmos.tx.v1beta1.BroadcastTxRequest", len)?;
         if !self.tx_bytes.is_empty() {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("tx_bytes", pbjson::private::base64::encode(&self.tx_bytes).as_str())?;
+            struct_ser.serialize_field("txBytes", pbjson::private::base64::encode(&self.tx_bytes).as_str())?;
         }
         if self.mode != 0 {
             let v = BroadcastMode::try_from(self.mode)
@@ -328,7 +328,7 @@ impl serde::Serialize for BroadcastTxResponse {
         }
         let mut struct_ser = serializer.serialize_struct("cosmos.tx.v1beta1.BroadcastTxResponse", len)?;
         if let Some(v) = self.tx_response.as_ref() {
-            struct_ser.serialize_field("tx_response", v)?;
+            struct_ser.serialize_field("txResponse", v)?;
         }
         struct_ser.end()
     }
@@ -433,7 +433,7 @@ impl serde::Serialize for Fee {
         }
         if self.gas_limit != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("gas_limit", ToString::to_string(&self.gas_limit).as_str())?;
+            struct_ser.serialize_field("gasLimit", ToString::to_string(&self.gas_limit).as_str())?;
         }
         if !self.payer.is_empty() {
             struct_ser.serialize_field("payer", &self.payer)?;
@@ -663,7 +663,7 @@ impl serde::Serialize for GetTxResponse {
             struct_ser.serialize_field("tx", v)?;
         }
         if let Some(v) = self.tx_response.as_ref() {
-            struct_ser.serialize_field("tx_response", v)?;
+            struct_ser.serialize_field("txResponse", v)?;
         }
         struct_ser.end()
     }
@@ -881,7 +881,7 @@ impl serde::Serialize for mode_info::Multi {
             struct_ser.serialize_field("bitarray", v)?;
         }
         if !self.mode_infos.is_empty() {
-            struct_ser.serialize_field("mode_infos", &self.mode_infos)?;
+            struct_ser.serialize_field("modeInfos", &self.mode_infos)?;
         }
         struct_ser.end()
     }
@@ -1087,18 +1087,18 @@ impl serde::Serialize for SignDoc {
         let mut struct_ser = serializer.serialize_struct("cosmos.tx.v1beta1.SignDoc", len)?;
         if !self.body_bytes.is_empty() {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("body_bytes", pbjson::private::base64::encode(&self.body_bytes).as_str())?;
+            struct_ser.serialize_field("bodyBytes", pbjson::private::base64::encode(&self.body_bytes).as_str())?;
         }
         if !self.auth_info_bytes.is_empty() {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("auth_info_bytes", pbjson::private::base64::encode(&self.auth_info_bytes).as_str())?;
+            struct_ser.serialize_field("authInfoBytes", pbjson::private::base64::encode(&self.auth_info_bytes).as_str())?;
         }
         if !self.chain_id.is_empty() {
-            struct_ser.serialize_field("chain_id", &self.chain_id)?;
+            struct_ser.serialize_field("chainId", &self.chain_id)?;
         }
         if self.account_number != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("account_number", ToString::to_string(&self.account_number).as_str())?;
+            struct_ser.serialize_field("accountNumber", ToString::to_string(&self.account_number).as_str())?;
         }
         struct_ser.end()
     }
@@ -1238,10 +1238,10 @@ impl serde::Serialize for SignerInfo {
         }
         let mut struct_ser = serializer.serialize_struct("cosmos.tx.v1beta1.SignerInfo", len)?;
         if let Some(v) = self.public_key.as_ref() {
-            struct_ser.serialize_field("public_key", v)?;
+            struct_ser.serialize_field("publicKey", v)?;
         }
         if let Some(v) = self.mode_info.as_ref() {
-            struct_ser.serialize_field("mode_info", v)?;
+            struct_ser.serialize_field("modeInfo", v)?;
         }
         if self.sequence != 0 {
             #[allow(clippy::needless_borrow)]
@@ -1479,7 +1479,7 @@ impl serde::Serialize for Tx {
             struct_ser.serialize_field("body", v)?;
         }
         if let Some(v) = self.auth_info.as_ref() {
-            struct_ser.serialize_field("auth_info", v)?;
+            struct_ser.serialize_field("authInfo", v)?;
         }
         if !self.signatures.is_empty() {
             struct_ser.serialize_field("signatures", &self.signatures.iter().map(pbjson::private::base64::encode).collect::<Vec<_>>())?;
@@ -1618,13 +1618,13 @@ impl serde::Serialize for TxBody {
         }
         if self.timeout_height != 0 {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("timeout_height", ToString::to_string(&self.timeout_height).as_str())?;
+            struct_ser.serialize_field("timeoutHeight", ToString::to_string(&self.timeout_height).as_str())?;
         }
         if !self.extension_options.is_empty() {
-            struct_ser.serialize_field("extension_options", &self.extension_options)?;
+            struct_ser.serialize_field("extensionOptions", &self.extension_options)?;
         }
         if !self.non_critical_extension_options.is_empty() {
-            struct_ser.serialize_field("non_critical_extension_options", &self.non_critical_extension_options)?;
+            struct_ser.serialize_field("nonCriticalExtensionOptions", &self.non_critical_extension_options)?;
         }
         struct_ser.end()
     }

--- a/crates/astria-core/src/generated/tendermint.p2p.serde.rs
+++ b/crates/astria-core/src/generated/tendermint.p2p.serde.rs
@@ -32,13 +32,13 @@ impl serde::Serialize for DefaultNodeInfo {
         }
         let mut struct_ser = serializer.serialize_struct("tendermint.p2p.DefaultNodeInfo", len)?;
         if let Some(v) = self.protocol_version.as_ref() {
-            struct_ser.serialize_field("protocol_version", v)?;
+            struct_ser.serialize_field("protocolVersion", v)?;
         }
         if !self.default_node_id.is_empty() {
-            struct_ser.serialize_field("default_node_id", &self.default_node_id)?;
+            struct_ser.serialize_field("defaultNodeId", &self.default_node_id)?;
         }
         if !self.listen_addr.is_empty() {
-            struct_ser.serialize_field("listen_addr", &self.listen_addr)?;
+            struct_ser.serialize_field("listenAddr", &self.listen_addr)?;
         }
         if !self.network.is_empty() {
             struct_ser.serialize_field("network", &self.network)?;
@@ -230,10 +230,10 @@ impl serde::Serialize for DefaultNodeInfoOther {
         }
         let mut struct_ser = serializer.serialize_struct("tendermint.p2p.DefaultNodeInfoOther", len)?;
         if !self.tx_index.is_empty() {
-            struct_ser.serialize_field("tx_index", &self.tx_index)?;
+            struct_ser.serialize_field("txIndex", &self.tx_index)?;
         }
         if !self.rpc_address.is_empty() {
-            struct_ser.serialize_field("rpc_address", &self.rpc_address)?;
+            struct_ser.serialize_field("rpcAddress", &self.rpc_address)?;
         }
         struct_ser.end()
     }

--- a/crates/astria-core/src/generated/tendermint.types.serde.rs
+++ b/crates/astria-core/src/generated/tendermint.types.serde.rs
@@ -21,17 +21,17 @@ impl serde::Serialize for Blob {
         let mut struct_ser = serializer.serialize_struct("tendermint.types.Blob", len)?;
         if !self.namespace_id.is_empty() {
             #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("namespace_id", pbjson::private::base64::encode(&self.namespace_id).as_str())?;
+            struct_ser.serialize_field("namespaceId", pbjson::private::base64::encode(&self.namespace_id).as_str())?;
         }
         if !self.data.is_empty() {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field("data", pbjson::private::base64::encode(&self.data).as_str())?;
         }
         if self.share_version != 0 {
-            struct_ser.serialize_field("share_version", &self.share_version)?;
+            struct_ser.serialize_field("shareVersion", &self.share_version)?;
         }
         if self.namespace_version != 0 {
-            struct_ser.serialize_field("namespace_version", &self.namespace_version)?;
+            struct_ser.serialize_field("namespaceVersion", &self.namespace_version)?;
         }
         struct_ser.end()
     }
@@ -179,7 +179,7 @@ impl serde::Serialize for BlobTx {
             struct_ser.serialize_field("blobs", &self.blobs)?;
         }
         if !self.type_id.is_empty() {
-            struct_ser.serialize_field("type_id", &self.type_id)?;
+            struct_ser.serialize_field("typeId", &self.type_id)?;
         }
         struct_ser.end()
     }

--- a/tools/protobuf-compiler/src/main.rs
+++ b/tools/protobuf-compiler/src/main.rs
@@ -107,7 +107,6 @@ fn main() {
     pbjson_build::Builder::new()
         .register_descriptors(&descriptor_set)
         .unwrap()
-        .preserve_proto_field_names()
         .out_dir(&out_dir)
         .build(&[
             ".astria.execution.v1alpha2",


### PR DESCRIPTION
## Summary
Use `lowerCamelCase` for protobuf message field names mapped to JSON object keys.

## Background
The Protobuf to JSON mapping prescribes that protobuf message fields must use `lowerCamelCase` when mapped to JSON object keys. The protobuf-compiler tool was erroneously preserving the Rust field names which re `snake_case`.

## Changes
- Remove `pbson_build::Builder::preserve_proto_field_names` from its build chain
- Regenerate serde `Serialize` and `Deserialize` impls for all protobuf Rust types
- Fix Conductor test mocks to use the correct case

## Testing
All tests still run.

## Breaking Changelist
This is neither network breaking nor service breaking because the Astria stack only uses protobuf (not its JSON counterparts) on the wire. However, this is still marked as breaking due to external consumers being affected.