### PR TITLE
refactor(sequencer): output private key into file instead of console

### DIFF
--- a/crates/astria-cli/src/commands/sequencer.rs
+++ b/crates/astria-cli/src/commands/sequencer.rs
@@ -1,3 +1,5 @@
+use std::fs;
+
 use astria_core::{
     crypto::SigningKey,
     primitive::v1::{
@@ -71,7 +73,8 @@ fn get_address_pretty(signing_key: &SigningKey) -> String {
     hex::encode(signing_key.verification_key().address_bytes())
 }
 
-/// Generates a new ED25519 keypair and prints the public key, private key, and address
+/// Generates a new ED25519 keypair and prints the public key, address,
+/// and output private key to file
 pub(crate) fn create_account() {
     let signing_key = get_new_signing_key();
     let public_key_pretty = get_public_key_pretty(&signing_key);
@@ -80,11 +83,12 @@ pub(crate) fn create_account() {
 
     println!("Create Sequencer Account");
     println!();
-    // TODO: don't print private keys to CLI, prefer writing to file:
-    // https://github.com/astriaorg/astria/issues/594
-    println!("Private Key: {private_key_pretty:?}");
     println!("Public Key:  {public_key_pretty:?}");
     println!("Address:     {address_pretty:?}");
+    fs::write("priv.key", private_key_pretty).expect("write private key to file error");
+    println!(
+        "Private Key has been output into priv.key.\nNote: Do not share or lose this private key!"
+    );
 }
 
 /// Gets the balance of a Sequencer account


### PR DESCRIPTION
## Summary
Writing private key to file when running `astria-cli sequencer account create`

## Background
Addressed part of issue #594

## Changes
* Writing private key to file when running `astria-cli sequencer account create`
* Update output message for private key
* Update `create_account` function comment

## Testing
```shell
halimao@Halimao:astria$ ./target/release/astria-cli sequencer account create
Create Sequencer Account

Public Key:  "8703d3134c9de51b6ef1fb62a87f690410f2b4291b6acfc3c8e1a6bd9f338dd2"
Address:     "1e9edbd537755379be766fb59a0a2aba1e864230"
Private Key has been output into priv.key.
Note: Do not share or lose this private key!
halimao@Halimao:astria$ cat priv.key 
*******bcd354f3226a3351747b718e591*********
```

## Metrics
## Breaking Changelist
## Related Issues
closes #594

