### PR TITLE
fix(lint): upgrade rust toolchain nightly version

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ markdown.
 
 ```sh
 # Install rustfmt
-rustup +nightly-2024-02-07 component add rustfmt
+rustup +nightly-2024-07-10 component add rustfmt
 # Run rustfmt
 just fmt rust
 ```

--- a/justfile
+++ b/justfile
@@ -48,11 +48,11 @@ _fmt-all:
 
 [no-exit-message]
 _fmt-rust:
-  cargo +nightly-2024-02-07 fmt --all
+  cargo +nightly-2024-07-10 fmt --all
 
 [no-exit-message]
 _lint-rust:
-  cargo +nightly-2024-02-07 fmt --all -- --check
+  cargo +nightly-2024-07-10 fmt --all -- --check
   cargo clippy -- --warn clippy::pedantic
   cargo dylint --all
 


### PR DESCRIPTION
## Summary
Running `just fmt rust` would fail. This PR upgrades the nightly version of the rust toolchain to fix this.
```shell
rustup +nightly-2024-02-07 component add rustfmt
info: syncing channel updates for 'nightly-2024-02-07-x86_64-unknown-linux-gnu'
error: no release found for 'nightly-2024-02-07'
```

## Background
After making some code changes, I want to check the code fmt by running `just fmt rust`, but fail.

## Changes
- Upgrade rust toolchain version `nightly-2024-02-07` to `nightly-2024-07-10`

## Testing

## Metrics

## Breaking Changelist

## Related Issues