### PR TITLE
(core, sequencer)!: generate serde traits impls for all protocol protobufs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -784,6 +784,7 @@ dependencies = [
  "priority-queue",
  "prost",
  "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "regex",
  "serde",
  "serde_json",

--- a/crates/astria-core/src/crypto.rs
+++ b/crates/astria-core/src/crypto.rs
@@ -114,7 +114,7 @@ impl From<[u8; 32]> for SigningKey {
 }
 
 /// An Ed25519 verification key.
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct VerificationKey {
     key: Ed25519VerificationKey,
 }

--- a/crates/astria-core/src/generated/astria.composer.v1alpha1.serde.rs
+++ b/crates/astria-core/src/generated/astria.composer.v1alpha1.serde.rs
@@ -1,0 +1,186 @@
+impl serde::Serialize for SubmitRollupTransactionRequest {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.rollup_id.is_empty() {
+            len += 1;
+        }
+        if !self.data.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.composer.v1alpha1.SubmitRollupTransactionRequest", len)?;
+        if !self.rollup_id.is_empty() {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("rollupId", pbjson::private::base64::encode(&self.rollup_id).as_str())?;
+        }
+        if !self.data.is_empty() {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("data", pbjson::private::base64::encode(&self.data).as_str())?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for SubmitRollupTransactionRequest {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "rollup_id",
+            "rollupId",
+            "data",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            RollupId,
+            Data,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "rollupId" | "rollup_id" => Ok(GeneratedField::RollupId),
+                            "data" => Ok(GeneratedField::Data),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = SubmitRollupTransactionRequest;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.composer.v1alpha1.SubmitRollupTransactionRequest")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<SubmitRollupTransactionRequest, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut rollup_id__ = None;
+                let mut data__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::RollupId => {
+                            if rollup_id__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("rollupId"));
+                            }
+                            rollup_id__ = 
+                                Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::Data => {
+                            if data__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("data"));
+                            }
+                            data__ = 
+                                Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
+                            ;
+                        }
+                    }
+                }
+                Ok(SubmitRollupTransactionRequest {
+                    rollup_id: rollup_id__.unwrap_or_default(),
+                    data: data__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.composer.v1alpha1.SubmitRollupTransactionRequest", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for SubmitRollupTransactionResponse {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let len = 0;
+        let struct_ser = serializer.serialize_struct("astria.composer.v1alpha1.SubmitRollupTransactionResponse", len)?;
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for SubmitRollupTransactionResponse {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                            Err(serde::de::Error::unknown_field(value, FIELDS))
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = SubmitRollupTransactionResponse;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.composer.v1alpha1.SubmitRollupTransactionResponse")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<SubmitRollupTransactionResponse, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                while map_.next_key::<GeneratedField>()?.is_some() {
+                    let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                }
+                Ok(SubmitRollupTransactionResponse {
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.composer.v1alpha1.SubmitRollupTransactionResponse", FIELDS, GeneratedVisitor)
+    }
+}

--- a/crates/astria-core/src/generated/astria.execution.v1alpha1.serde.rs
+++ b/crates/astria-core/src/generated/astria.execution.v1alpha1.serde.rs
@@ -1,0 +1,559 @@
+impl serde::Serialize for DoBlockRequest {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.prev_block_hash.is_empty() {
+            len += 1;
+        }
+        if !self.transactions.is_empty() {
+            len += 1;
+        }
+        if self.timestamp.is_some() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.execution.v1alpha1.DoBlockRequest", len)?;
+        if !self.prev_block_hash.is_empty() {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("prevBlockHash", pbjson::private::base64::encode(&self.prev_block_hash).as_str())?;
+        }
+        if !self.transactions.is_empty() {
+            struct_ser.serialize_field("transactions", &self.transactions.iter().map(pbjson::private::base64::encode).collect::<Vec<_>>())?;
+        }
+        if let Some(v) = self.timestamp.as_ref() {
+            struct_ser.serialize_field("timestamp", v)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for DoBlockRequest {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "prev_block_hash",
+            "prevBlockHash",
+            "transactions",
+            "timestamp",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            PrevBlockHash,
+            Transactions,
+            Timestamp,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "prevBlockHash" | "prev_block_hash" => Ok(GeneratedField::PrevBlockHash),
+                            "transactions" => Ok(GeneratedField::Transactions),
+                            "timestamp" => Ok(GeneratedField::Timestamp),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = DoBlockRequest;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.execution.v1alpha1.DoBlockRequest")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<DoBlockRequest, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut prev_block_hash__ = None;
+                let mut transactions__ = None;
+                let mut timestamp__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::PrevBlockHash => {
+                            if prev_block_hash__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("prevBlockHash"));
+                            }
+                            prev_block_hash__ = 
+                                Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::Transactions => {
+                            if transactions__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("transactions"));
+                            }
+                            transactions__ = 
+                                Some(map_.next_value::<Vec<::pbjson::private::BytesDeserialize<_>>>()?
+                                    .into_iter().map(|x| x.0).collect())
+                            ;
+                        }
+                        GeneratedField::Timestamp => {
+                            if timestamp__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("timestamp"));
+                            }
+                            timestamp__ = map_.next_value()?;
+                        }
+                    }
+                }
+                Ok(DoBlockRequest {
+                    prev_block_hash: prev_block_hash__.unwrap_or_default(),
+                    transactions: transactions__.unwrap_or_default(),
+                    timestamp: timestamp__,
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.execution.v1alpha1.DoBlockRequest", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for DoBlockResponse {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.block_hash.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.execution.v1alpha1.DoBlockResponse", len)?;
+        if !self.block_hash.is_empty() {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("blockHash", pbjson::private::base64::encode(&self.block_hash).as_str())?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for DoBlockResponse {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "block_hash",
+            "blockHash",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            BlockHash,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "blockHash" | "block_hash" => Ok(GeneratedField::BlockHash),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = DoBlockResponse;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.execution.v1alpha1.DoBlockResponse")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<DoBlockResponse, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut block_hash__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::BlockHash => {
+                            if block_hash__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("blockHash"));
+                            }
+                            block_hash__ = 
+                                Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
+                            ;
+                        }
+                    }
+                }
+                Ok(DoBlockResponse {
+                    block_hash: block_hash__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.execution.v1alpha1.DoBlockResponse", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for FinalizeBlockRequest {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.block_hash.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.execution.v1alpha1.FinalizeBlockRequest", len)?;
+        if !self.block_hash.is_empty() {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("blockHash", pbjson::private::base64::encode(&self.block_hash).as_str())?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for FinalizeBlockRequest {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "block_hash",
+            "blockHash",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            BlockHash,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "blockHash" | "block_hash" => Ok(GeneratedField::BlockHash),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = FinalizeBlockRequest;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.execution.v1alpha1.FinalizeBlockRequest")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<FinalizeBlockRequest, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut block_hash__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::BlockHash => {
+                            if block_hash__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("blockHash"));
+                            }
+                            block_hash__ = 
+                                Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
+                            ;
+                        }
+                    }
+                }
+                Ok(FinalizeBlockRequest {
+                    block_hash: block_hash__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.execution.v1alpha1.FinalizeBlockRequest", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for FinalizeBlockResponse {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let len = 0;
+        let struct_ser = serializer.serialize_struct("astria.execution.v1alpha1.FinalizeBlockResponse", len)?;
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for FinalizeBlockResponse {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                            Err(serde::de::Error::unknown_field(value, FIELDS))
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = FinalizeBlockResponse;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.execution.v1alpha1.FinalizeBlockResponse")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<FinalizeBlockResponse, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                while map_.next_key::<GeneratedField>()?.is_some() {
+                    let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                }
+                Ok(FinalizeBlockResponse {
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.execution.v1alpha1.FinalizeBlockResponse", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for InitStateRequest {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let len = 0;
+        let struct_ser = serializer.serialize_struct("astria.execution.v1alpha1.InitStateRequest", len)?;
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for InitStateRequest {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                            Err(serde::de::Error::unknown_field(value, FIELDS))
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = InitStateRequest;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.execution.v1alpha1.InitStateRequest")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<InitStateRequest, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                while map_.next_key::<GeneratedField>()?.is_some() {
+                    let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                }
+                Ok(InitStateRequest {
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.execution.v1alpha1.InitStateRequest", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for InitStateResponse {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.block_hash.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.execution.v1alpha1.InitStateResponse", len)?;
+        if !self.block_hash.is_empty() {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("blockHash", pbjson::private::base64::encode(&self.block_hash).as_str())?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for InitStateResponse {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "block_hash",
+            "blockHash",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            BlockHash,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "blockHash" | "block_hash" => Ok(GeneratedField::BlockHash),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = InitStateResponse;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.execution.v1alpha1.InitStateResponse")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<InitStateResponse, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut block_hash__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::BlockHash => {
+                            if block_hash__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("blockHash"));
+                            }
+                            block_hash__ = 
+                                Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
+                            ;
+                        }
+                    }
+                }
+                Ok(InitStateResponse {
+                    block_hash: block_hash__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.execution.v1alpha1.InitStateResponse", FIELDS, GeneratedVisitor)
+    }
+}

--- a/crates/astria-core/src/generated/astria.protocol.accounts.v1alpha1.serde.rs
+++ b/crates/astria-core/src/generated/astria.protocol.accounts.v1alpha1.serde.rs
@@ -1,0 +1,332 @@
+impl serde::Serialize for AssetBalance {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.denom.is_empty() {
+            len += 1;
+        }
+        if self.balance.is_some() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.protocol.accounts.v1alpha1.AssetBalance", len)?;
+        if !self.denom.is_empty() {
+            struct_ser.serialize_field("denom", &self.denom)?;
+        }
+        if let Some(v) = self.balance.as_ref() {
+            struct_ser.serialize_field("balance", v)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for AssetBalance {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "denom",
+            "balance",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Denom,
+            Balance,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "denom" => Ok(GeneratedField::Denom),
+                            "balance" => Ok(GeneratedField::Balance),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = AssetBalance;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.protocol.accounts.v1alpha1.AssetBalance")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<AssetBalance, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut denom__ = None;
+                let mut balance__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Denom => {
+                            if denom__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("denom"));
+                            }
+                            denom__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Balance => {
+                            if balance__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("balance"));
+                            }
+                            balance__ = map_.next_value()?;
+                        }
+                    }
+                }
+                Ok(AssetBalance {
+                    denom: denom__.unwrap_or_default(),
+                    balance: balance__,
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.protocol.accounts.v1alpha1.AssetBalance", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for BalanceResponse {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.height != 0 {
+            len += 1;
+        }
+        if !self.balances.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.protocol.accounts.v1alpha1.BalanceResponse", len)?;
+        if self.height != 0 {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("height", ToString::to_string(&self.height).as_str())?;
+        }
+        if !self.balances.is_empty() {
+            struct_ser.serialize_field("balances", &self.balances)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for BalanceResponse {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "height",
+            "balances",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Height,
+            Balances,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "height" => Ok(GeneratedField::Height),
+                            "balances" => Ok(GeneratedField::Balances),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = BalanceResponse;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.protocol.accounts.v1alpha1.BalanceResponse")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<BalanceResponse, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut height__ = None;
+                let mut balances__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Height => {
+                            if height__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("height"));
+                            }
+                            height__ = 
+                                Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::Balances => {
+                            if balances__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("balances"));
+                            }
+                            balances__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(BalanceResponse {
+                    height: height__.unwrap_or_default(),
+                    balances: balances__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.protocol.accounts.v1alpha1.BalanceResponse", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for NonceResponse {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.height != 0 {
+            len += 1;
+        }
+        if self.nonce != 0 {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.protocol.accounts.v1alpha1.NonceResponse", len)?;
+        if self.height != 0 {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("height", ToString::to_string(&self.height).as_str())?;
+        }
+        if self.nonce != 0 {
+            struct_ser.serialize_field("nonce", &self.nonce)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for NonceResponse {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "height",
+            "nonce",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Height,
+            Nonce,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "height" => Ok(GeneratedField::Height),
+                            "nonce" => Ok(GeneratedField::Nonce),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = NonceResponse;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.protocol.accounts.v1alpha1.NonceResponse")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<NonceResponse, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut height__ = None;
+                let mut nonce__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Height => {
+                            if height__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("height"));
+                            }
+                            height__ = 
+                                Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::Nonce => {
+                            if nonce__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("nonce"));
+                            }
+                            nonce__ = 
+                                Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                    }
+                }
+                Ok(NonceResponse {
+                    height: height__.unwrap_or_default(),
+                    nonce: nonce__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.protocol.accounts.v1alpha1.NonceResponse", FIELDS, GeneratedVisitor)
+    }
+}

--- a/crates/astria-core/src/generated/astria.protocol.asset.v1alpha1.serde.rs
+++ b/crates/astria-core/src/generated/astria.protocol.asset.v1alpha1.serde.rs
@@ -1,0 +1,223 @@
+impl serde::Serialize for AllowedFeeAssetsResponse {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.height != 0 {
+            len += 1;
+        }
+        if !self.fee_assets.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.protocol.asset.v1alpha1.AllowedFeeAssetsResponse", len)?;
+        if self.height != 0 {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("height", ToString::to_string(&self.height).as_str())?;
+        }
+        if !self.fee_assets.is_empty() {
+            struct_ser.serialize_field("feeAssets", &self.fee_assets)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for AllowedFeeAssetsResponse {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "height",
+            "fee_assets",
+            "feeAssets",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Height,
+            FeeAssets,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "height" => Ok(GeneratedField::Height),
+                            "feeAssets" | "fee_assets" => Ok(GeneratedField::FeeAssets),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = AllowedFeeAssetsResponse;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.protocol.asset.v1alpha1.AllowedFeeAssetsResponse")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<AllowedFeeAssetsResponse, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut height__ = None;
+                let mut fee_assets__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Height => {
+                            if height__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("height"));
+                            }
+                            height__ = 
+                                Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::FeeAssets => {
+                            if fee_assets__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("feeAssets"));
+                            }
+                            fee_assets__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(AllowedFeeAssetsResponse {
+                    height: height__.unwrap_or_default(),
+                    fee_assets: fee_assets__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.protocol.asset.v1alpha1.AllowedFeeAssetsResponse", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for DenomResponse {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.height != 0 {
+            len += 1;
+        }
+        if !self.denom.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.protocol.asset.v1alpha1.DenomResponse", len)?;
+        if self.height != 0 {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("height", ToString::to_string(&self.height).as_str())?;
+        }
+        if !self.denom.is_empty() {
+            struct_ser.serialize_field("denom", &self.denom)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for DenomResponse {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "height",
+            "denom",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Height,
+            Denom,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "height" => Ok(GeneratedField::Height),
+                            "denom" => Ok(GeneratedField::Denom),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = DenomResponse;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.protocol.asset.v1alpha1.DenomResponse")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<DenomResponse, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut height__ = None;
+                let mut denom__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Height => {
+                            if height__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("height"));
+                            }
+                            height__ = 
+                                Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::Denom => {
+                            if denom__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("denom"));
+                            }
+                            denom__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(DenomResponse {
+                    height: height__.unwrap_or_default(),
+                    denom: denom__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.protocol.asset.v1alpha1.DenomResponse", FIELDS, GeneratedVisitor)
+    }
+}

--- a/crates/astria-core/src/generated/astria.protocol.bridge.v1alpha1.serde.rs
+++ b/crates/astria-core/src/generated/astria.protocol.bridge.v1alpha1.serde.rs
@@ -1,0 +1,280 @@
+impl serde::Serialize for BridgeAccountInfoResponse {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.height != 0 {
+            len += 1;
+        }
+        if self.rollup_id.is_some() {
+            len += 1;
+        }
+        if self.asset.is_some() {
+            len += 1;
+        }
+        if self.sudo_address.is_some() {
+            len += 1;
+        }
+        if self.withdrawer_address.is_some() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.protocol.bridge.v1alpha1.BridgeAccountInfoResponse", len)?;
+        if self.height != 0 {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("height", ToString::to_string(&self.height).as_str())?;
+        }
+        if let Some(v) = self.rollup_id.as_ref() {
+            struct_ser.serialize_field("rollupId", v)?;
+        }
+        if let Some(v) = self.asset.as_ref() {
+            struct_ser.serialize_field("asset", v)?;
+        }
+        if let Some(v) = self.sudo_address.as_ref() {
+            struct_ser.serialize_field("sudoAddress", v)?;
+        }
+        if let Some(v) = self.withdrawer_address.as_ref() {
+            struct_ser.serialize_field("withdrawerAddress", v)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for BridgeAccountInfoResponse {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "height",
+            "rollup_id",
+            "rollupId",
+            "asset",
+            "sudo_address",
+            "sudoAddress",
+            "withdrawer_address",
+            "withdrawerAddress",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Height,
+            RollupId,
+            Asset,
+            SudoAddress,
+            WithdrawerAddress,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "height" => Ok(GeneratedField::Height),
+                            "rollupId" | "rollup_id" => Ok(GeneratedField::RollupId),
+                            "asset" => Ok(GeneratedField::Asset),
+                            "sudoAddress" | "sudo_address" => Ok(GeneratedField::SudoAddress),
+                            "withdrawerAddress" | "withdrawer_address" => Ok(GeneratedField::WithdrawerAddress),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = BridgeAccountInfoResponse;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.protocol.bridge.v1alpha1.BridgeAccountInfoResponse")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<BridgeAccountInfoResponse, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut height__ = None;
+                let mut rollup_id__ = None;
+                let mut asset__ = None;
+                let mut sudo_address__ = None;
+                let mut withdrawer_address__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Height => {
+                            if height__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("height"));
+                            }
+                            height__ = 
+                                Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::RollupId => {
+                            if rollup_id__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("rollupId"));
+                            }
+                            rollup_id__ = map_.next_value()?;
+                        }
+                        GeneratedField::Asset => {
+                            if asset__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("asset"));
+                            }
+                            asset__ = map_.next_value()?;
+                        }
+                        GeneratedField::SudoAddress => {
+                            if sudo_address__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("sudoAddress"));
+                            }
+                            sudo_address__ = map_.next_value()?;
+                        }
+                        GeneratedField::WithdrawerAddress => {
+                            if withdrawer_address__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("withdrawerAddress"));
+                            }
+                            withdrawer_address__ = map_.next_value()?;
+                        }
+                    }
+                }
+                Ok(BridgeAccountInfoResponse {
+                    height: height__.unwrap_or_default(),
+                    rollup_id: rollup_id__,
+                    asset: asset__,
+                    sudo_address: sudo_address__,
+                    withdrawer_address: withdrawer_address__,
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.protocol.bridge.v1alpha1.BridgeAccountInfoResponse", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for BridgeAccountLastTxHashResponse {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.height != 0 {
+            len += 1;
+        }
+        if self.tx_hash.is_some() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.protocol.bridge.v1alpha1.BridgeAccountLastTxHashResponse", len)?;
+        if self.height != 0 {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("height", ToString::to_string(&self.height).as_str())?;
+        }
+        if let Some(v) = self.tx_hash.as_ref() {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("txHash", pbjson::private::base64::encode(&v).as_str())?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for BridgeAccountLastTxHashResponse {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "height",
+            "tx_hash",
+            "txHash",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Height,
+            TxHash,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "height" => Ok(GeneratedField::Height),
+                            "txHash" | "tx_hash" => Ok(GeneratedField::TxHash),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = BridgeAccountLastTxHashResponse;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.protocol.bridge.v1alpha1.BridgeAccountLastTxHashResponse")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<BridgeAccountLastTxHashResponse, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut height__ = None;
+                let mut tx_hash__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Height => {
+                            if height__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("height"));
+                            }
+                            height__ = 
+                                Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::TxHash => {
+                            if tx_hash__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("txHash"));
+                            }
+                            tx_hash__ = 
+                                map_.next_value::<::std::option::Option<::pbjson::private::BytesDeserialize<_>>>()?.map(|x| x.0)
+                            ;
+                        }
+                    }
+                }
+                Ok(BridgeAccountLastTxHashResponse {
+                    height: height__.unwrap_or_default(),
+                    tx_hash: tx_hash__,
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.protocol.bridge.v1alpha1.BridgeAccountLastTxHashResponse", FIELDS, GeneratedVisitor)
+    }
+}

--- a/crates/astria-core/src/generated/astria.protocol.transactions.v1alpha1.rs
+++ b/crates/astria-core/src/generated/astria.protocol.transactions.v1alpha1.rs
@@ -91,7 +91,9 @@ pub mod action {
         #[prost(message, tag = "50")]
         SudoAddressChangeAction(super::SudoAddressChangeAction),
         #[prost(message, tag = "51")]
-        ValidatorUpdateAction(::tendermint_proto::abci::ValidatorUpdate),
+        ValidatorUpdateAction(
+            crate::generated::astria_vendored::tendermint::abci::ValidatorUpdate,
+        ),
         #[prost(message, tag = "52")]
         IbcRelayerChangeAction(super::IbcRelayerChangeAction),
         #[prost(message, tag = "53")]

--- a/crates/astria-core/src/generated/astria.protocol.transactions.v1alpha1.serde.rs
+++ b/crates/astria-core/src/generated/astria.protocol.transactions.v1alpha1.serde.rs
@@ -1,0 +1,2598 @@
+impl serde::Serialize for Action {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.value.is_some() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.protocol.transactions.v1alpha1.Action", len)?;
+        if let Some(v) = self.value.as_ref() {
+            match v {
+                action::Value::TransferAction(v) => {
+                    struct_ser.serialize_field("transferAction", v)?;
+                }
+                action::Value::SequenceAction(v) => {
+                    struct_ser.serialize_field("sequenceAction", v)?;
+                }
+                action::Value::InitBridgeAccountAction(v) => {
+                    struct_ser.serialize_field("initBridgeAccountAction", v)?;
+                }
+                action::Value::BridgeLockAction(v) => {
+                    struct_ser.serialize_field("bridgeLockAction", v)?;
+                }
+                action::Value::BridgeUnlockAction(v) => {
+                    struct_ser.serialize_field("bridgeUnlockAction", v)?;
+                }
+                action::Value::BridgeSudoChangeAction(v) => {
+                    struct_ser.serialize_field("bridgeSudoChangeAction", v)?;
+                }
+                action::Value::IbcAction(v) => {
+                    struct_ser.serialize_field("ibcAction", v)?;
+                }
+                action::Value::Ics20Withdrawal(v) => {
+                    struct_ser.serialize_field("ics20Withdrawal", v)?;
+                }
+                action::Value::SudoAddressChangeAction(v) => {
+                    struct_ser.serialize_field("sudoAddressChangeAction", v)?;
+                }
+                action::Value::ValidatorUpdateAction(v) => {
+                    struct_ser.serialize_field("validatorUpdateAction", v)?;
+                }
+                action::Value::IbcRelayerChangeAction(v) => {
+                    struct_ser.serialize_field("ibcRelayerChangeAction", v)?;
+                }
+                action::Value::FeeAssetChangeAction(v) => {
+                    struct_ser.serialize_field("feeAssetChangeAction", v)?;
+                }
+                action::Value::FeeChangeAction(v) => {
+                    struct_ser.serialize_field("feeChangeAction", v)?;
+                }
+            }
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for Action {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "transfer_action",
+            "transferAction",
+            "sequence_action",
+            "sequenceAction",
+            "init_bridge_account_action",
+            "initBridgeAccountAction",
+            "bridge_lock_action",
+            "bridgeLockAction",
+            "bridge_unlock_action",
+            "bridgeUnlockAction",
+            "bridge_sudo_change_action",
+            "bridgeSudoChangeAction",
+            "ibc_action",
+            "ibcAction",
+            "ics20_withdrawal",
+            "ics20Withdrawal",
+            "sudo_address_change_action",
+            "sudoAddressChangeAction",
+            "validator_update_action",
+            "validatorUpdateAction",
+            "ibc_relayer_change_action",
+            "ibcRelayerChangeAction",
+            "fee_asset_change_action",
+            "feeAssetChangeAction",
+            "fee_change_action",
+            "feeChangeAction",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            TransferAction,
+            SequenceAction,
+            InitBridgeAccountAction,
+            BridgeLockAction,
+            BridgeUnlockAction,
+            BridgeSudoChangeAction,
+            IbcAction,
+            Ics20Withdrawal,
+            SudoAddressChangeAction,
+            ValidatorUpdateAction,
+            IbcRelayerChangeAction,
+            FeeAssetChangeAction,
+            FeeChangeAction,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "transferAction" | "transfer_action" => Ok(GeneratedField::TransferAction),
+                            "sequenceAction" | "sequence_action" => Ok(GeneratedField::SequenceAction),
+                            "initBridgeAccountAction" | "init_bridge_account_action" => Ok(GeneratedField::InitBridgeAccountAction),
+                            "bridgeLockAction" | "bridge_lock_action" => Ok(GeneratedField::BridgeLockAction),
+                            "bridgeUnlockAction" | "bridge_unlock_action" => Ok(GeneratedField::BridgeUnlockAction),
+                            "bridgeSudoChangeAction" | "bridge_sudo_change_action" => Ok(GeneratedField::BridgeSudoChangeAction),
+                            "ibcAction" | "ibc_action" => Ok(GeneratedField::IbcAction),
+                            "ics20Withdrawal" | "ics20_withdrawal" => Ok(GeneratedField::Ics20Withdrawal),
+                            "sudoAddressChangeAction" | "sudo_address_change_action" => Ok(GeneratedField::SudoAddressChangeAction),
+                            "validatorUpdateAction" | "validator_update_action" => Ok(GeneratedField::ValidatorUpdateAction),
+                            "ibcRelayerChangeAction" | "ibc_relayer_change_action" => Ok(GeneratedField::IbcRelayerChangeAction),
+                            "feeAssetChangeAction" | "fee_asset_change_action" => Ok(GeneratedField::FeeAssetChangeAction),
+                            "feeChangeAction" | "fee_change_action" => Ok(GeneratedField::FeeChangeAction),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = Action;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.protocol.transactions.v1alpha1.Action")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Action, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut value__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::TransferAction => {
+                            if value__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("transferAction"));
+                            }
+                            value__ = map_.next_value::<::std::option::Option<_>>()?.map(action::Value::TransferAction)
+;
+                        }
+                        GeneratedField::SequenceAction => {
+                            if value__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("sequenceAction"));
+                            }
+                            value__ = map_.next_value::<::std::option::Option<_>>()?.map(action::Value::SequenceAction)
+;
+                        }
+                        GeneratedField::InitBridgeAccountAction => {
+                            if value__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("initBridgeAccountAction"));
+                            }
+                            value__ = map_.next_value::<::std::option::Option<_>>()?.map(action::Value::InitBridgeAccountAction)
+;
+                        }
+                        GeneratedField::BridgeLockAction => {
+                            if value__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("bridgeLockAction"));
+                            }
+                            value__ = map_.next_value::<::std::option::Option<_>>()?.map(action::Value::BridgeLockAction)
+;
+                        }
+                        GeneratedField::BridgeUnlockAction => {
+                            if value__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("bridgeUnlockAction"));
+                            }
+                            value__ = map_.next_value::<::std::option::Option<_>>()?.map(action::Value::BridgeUnlockAction)
+;
+                        }
+                        GeneratedField::BridgeSudoChangeAction => {
+                            if value__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("bridgeSudoChangeAction"));
+                            }
+                            value__ = map_.next_value::<::std::option::Option<_>>()?.map(action::Value::BridgeSudoChangeAction)
+;
+                        }
+                        GeneratedField::IbcAction => {
+                            if value__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("ibcAction"));
+                            }
+                            value__ = map_.next_value::<::std::option::Option<_>>()?.map(action::Value::IbcAction)
+;
+                        }
+                        GeneratedField::Ics20Withdrawal => {
+                            if value__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("ics20Withdrawal"));
+                            }
+                            value__ = map_.next_value::<::std::option::Option<_>>()?.map(action::Value::Ics20Withdrawal)
+;
+                        }
+                        GeneratedField::SudoAddressChangeAction => {
+                            if value__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("sudoAddressChangeAction"));
+                            }
+                            value__ = map_.next_value::<::std::option::Option<_>>()?.map(action::Value::SudoAddressChangeAction)
+;
+                        }
+                        GeneratedField::ValidatorUpdateAction => {
+                            if value__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("validatorUpdateAction"));
+                            }
+                            value__ = map_.next_value::<::std::option::Option<_>>()?.map(action::Value::ValidatorUpdateAction)
+;
+                        }
+                        GeneratedField::IbcRelayerChangeAction => {
+                            if value__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("ibcRelayerChangeAction"));
+                            }
+                            value__ = map_.next_value::<::std::option::Option<_>>()?.map(action::Value::IbcRelayerChangeAction)
+;
+                        }
+                        GeneratedField::FeeAssetChangeAction => {
+                            if value__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("feeAssetChangeAction"));
+                            }
+                            value__ = map_.next_value::<::std::option::Option<_>>()?.map(action::Value::FeeAssetChangeAction)
+;
+                        }
+                        GeneratedField::FeeChangeAction => {
+                            if value__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("feeChangeAction"));
+                            }
+                            value__ = map_.next_value::<::std::option::Option<_>>()?.map(action::Value::FeeChangeAction)
+;
+                        }
+                    }
+                }
+                Ok(Action {
+                    value: value__,
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.protocol.transactions.v1alpha1.Action", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for BridgeLockAction {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.to.is_some() {
+            len += 1;
+        }
+        if self.amount.is_some() {
+            len += 1;
+        }
+        if !self.asset.is_empty() {
+            len += 1;
+        }
+        if !self.fee_asset.is_empty() {
+            len += 1;
+        }
+        if !self.destination_chain_address.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.protocol.transactions.v1alpha1.BridgeLockAction", len)?;
+        if let Some(v) = self.to.as_ref() {
+            struct_ser.serialize_field("to", v)?;
+        }
+        if let Some(v) = self.amount.as_ref() {
+            struct_ser.serialize_field("amount", v)?;
+        }
+        if !self.asset.is_empty() {
+            struct_ser.serialize_field("asset", &self.asset)?;
+        }
+        if !self.fee_asset.is_empty() {
+            struct_ser.serialize_field("feeAsset", &self.fee_asset)?;
+        }
+        if !self.destination_chain_address.is_empty() {
+            struct_ser.serialize_field("destinationChainAddress", &self.destination_chain_address)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for BridgeLockAction {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "to",
+            "amount",
+            "asset",
+            "fee_asset",
+            "feeAsset",
+            "destination_chain_address",
+            "destinationChainAddress",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            To,
+            Amount,
+            Asset,
+            FeeAsset,
+            DestinationChainAddress,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "to" => Ok(GeneratedField::To),
+                            "amount" => Ok(GeneratedField::Amount),
+                            "asset" => Ok(GeneratedField::Asset),
+                            "feeAsset" | "fee_asset" => Ok(GeneratedField::FeeAsset),
+                            "destinationChainAddress" | "destination_chain_address" => Ok(GeneratedField::DestinationChainAddress),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = BridgeLockAction;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.protocol.transactions.v1alpha1.BridgeLockAction")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<BridgeLockAction, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut to__ = None;
+                let mut amount__ = None;
+                let mut asset__ = None;
+                let mut fee_asset__ = None;
+                let mut destination_chain_address__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::To => {
+                            if to__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("to"));
+                            }
+                            to__ = map_.next_value()?;
+                        }
+                        GeneratedField::Amount => {
+                            if amount__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("amount"));
+                            }
+                            amount__ = map_.next_value()?;
+                        }
+                        GeneratedField::Asset => {
+                            if asset__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("asset"));
+                            }
+                            asset__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::FeeAsset => {
+                            if fee_asset__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("feeAsset"));
+                            }
+                            fee_asset__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::DestinationChainAddress => {
+                            if destination_chain_address__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("destinationChainAddress"));
+                            }
+                            destination_chain_address__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(BridgeLockAction {
+                    to: to__,
+                    amount: amount__,
+                    asset: asset__.unwrap_or_default(),
+                    fee_asset: fee_asset__.unwrap_or_default(),
+                    destination_chain_address: destination_chain_address__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.protocol.transactions.v1alpha1.BridgeLockAction", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for BridgeSudoChangeAction {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.bridge_address.is_some() {
+            len += 1;
+        }
+        if self.new_sudo_address.is_some() {
+            len += 1;
+        }
+        if self.new_withdrawer_address.is_some() {
+            len += 1;
+        }
+        if !self.fee_asset.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.protocol.transactions.v1alpha1.BridgeSudoChangeAction", len)?;
+        if let Some(v) = self.bridge_address.as_ref() {
+            struct_ser.serialize_field("bridgeAddress", v)?;
+        }
+        if let Some(v) = self.new_sudo_address.as_ref() {
+            struct_ser.serialize_field("newSudoAddress", v)?;
+        }
+        if let Some(v) = self.new_withdrawer_address.as_ref() {
+            struct_ser.serialize_field("newWithdrawerAddress", v)?;
+        }
+        if !self.fee_asset.is_empty() {
+            struct_ser.serialize_field("feeAsset", &self.fee_asset)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for BridgeSudoChangeAction {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "bridge_address",
+            "bridgeAddress",
+            "new_sudo_address",
+            "newSudoAddress",
+            "new_withdrawer_address",
+            "newWithdrawerAddress",
+            "fee_asset",
+            "feeAsset",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            BridgeAddress,
+            NewSudoAddress,
+            NewWithdrawerAddress,
+            FeeAsset,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "bridgeAddress" | "bridge_address" => Ok(GeneratedField::BridgeAddress),
+                            "newSudoAddress" | "new_sudo_address" => Ok(GeneratedField::NewSudoAddress),
+                            "newWithdrawerAddress" | "new_withdrawer_address" => Ok(GeneratedField::NewWithdrawerAddress),
+                            "feeAsset" | "fee_asset" => Ok(GeneratedField::FeeAsset),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = BridgeSudoChangeAction;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.protocol.transactions.v1alpha1.BridgeSudoChangeAction")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<BridgeSudoChangeAction, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut bridge_address__ = None;
+                let mut new_sudo_address__ = None;
+                let mut new_withdrawer_address__ = None;
+                let mut fee_asset__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::BridgeAddress => {
+                            if bridge_address__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("bridgeAddress"));
+                            }
+                            bridge_address__ = map_.next_value()?;
+                        }
+                        GeneratedField::NewSudoAddress => {
+                            if new_sudo_address__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("newSudoAddress"));
+                            }
+                            new_sudo_address__ = map_.next_value()?;
+                        }
+                        GeneratedField::NewWithdrawerAddress => {
+                            if new_withdrawer_address__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("newWithdrawerAddress"));
+                            }
+                            new_withdrawer_address__ = map_.next_value()?;
+                        }
+                        GeneratedField::FeeAsset => {
+                            if fee_asset__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("feeAsset"));
+                            }
+                            fee_asset__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(BridgeSudoChangeAction {
+                    bridge_address: bridge_address__,
+                    new_sudo_address: new_sudo_address__,
+                    new_withdrawer_address: new_withdrawer_address__,
+                    fee_asset: fee_asset__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.protocol.transactions.v1alpha1.BridgeSudoChangeAction", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for BridgeUnlockAction {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.to.is_some() {
+            len += 1;
+        }
+        if self.amount.is_some() {
+            len += 1;
+        }
+        if !self.fee_asset.is_empty() {
+            len += 1;
+        }
+        if !self.memo.is_empty() {
+            len += 1;
+        }
+        if self.bridge_address.is_some() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.protocol.transactions.v1alpha1.BridgeUnlockAction", len)?;
+        if let Some(v) = self.to.as_ref() {
+            struct_ser.serialize_field("to", v)?;
+        }
+        if let Some(v) = self.amount.as_ref() {
+            struct_ser.serialize_field("amount", v)?;
+        }
+        if !self.fee_asset.is_empty() {
+            struct_ser.serialize_field("feeAsset", &self.fee_asset)?;
+        }
+        if !self.memo.is_empty() {
+            struct_ser.serialize_field("memo", &self.memo)?;
+        }
+        if let Some(v) = self.bridge_address.as_ref() {
+            struct_ser.serialize_field("bridgeAddress", v)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for BridgeUnlockAction {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "to",
+            "amount",
+            "fee_asset",
+            "feeAsset",
+            "memo",
+            "bridge_address",
+            "bridgeAddress",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            To,
+            Amount,
+            FeeAsset,
+            Memo,
+            BridgeAddress,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "to" => Ok(GeneratedField::To),
+                            "amount" => Ok(GeneratedField::Amount),
+                            "feeAsset" | "fee_asset" => Ok(GeneratedField::FeeAsset),
+                            "memo" => Ok(GeneratedField::Memo),
+                            "bridgeAddress" | "bridge_address" => Ok(GeneratedField::BridgeAddress),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = BridgeUnlockAction;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.protocol.transactions.v1alpha1.BridgeUnlockAction")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<BridgeUnlockAction, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut to__ = None;
+                let mut amount__ = None;
+                let mut fee_asset__ = None;
+                let mut memo__ = None;
+                let mut bridge_address__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::To => {
+                            if to__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("to"));
+                            }
+                            to__ = map_.next_value()?;
+                        }
+                        GeneratedField::Amount => {
+                            if amount__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("amount"));
+                            }
+                            amount__ = map_.next_value()?;
+                        }
+                        GeneratedField::FeeAsset => {
+                            if fee_asset__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("feeAsset"));
+                            }
+                            fee_asset__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Memo => {
+                            if memo__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("memo"));
+                            }
+                            memo__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::BridgeAddress => {
+                            if bridge_address__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("bridgeAddress"));
+                            }
+                            bridge_address__ = map_.next_value()?;
+                        }
+                    }
+                }
+                Ok(BridgeUnlockAction {
+                    to: to__,
+                    amount: amount__,
+                    fee_asset: fee_asset__.unwrap_or_default(),
+                    memo: memo__.unwrap_or_default(),
+                    bridge_address: bridge_address__,
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.protocol.transactions.v1alpha1.BridgeUnlockAction", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for FeeAssetChangeAction {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.value.is_some() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.protocol.transactions.v1alpha1.FeeAssetChangeAction", len)?;
+        if let Some(v) = self.value.as_ref() {
+            match v {
+                fee_asset_change_action::Value::Addition(v) => {
+                    struct_ser.serialize_field("addition", v)?;
+                }
+                fee_asset_change_action::Value::Removal(v) => {
+                    struct_ser.serialize_field("removal", v)?;
+                }
+            }
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for FeeAssetChangeAction {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "addition",
+            "removal",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Addition,
+            Removal,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "addition" => Ok(GeneratedField::Addition),
+                            "removal" => Ok(GeneratedField::Removal),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = FeeAssetChangeAction;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.protocol.transactions.v1alpha1.FeeAssetChangeAction")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<FeeAssetChangeAction, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut value__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Addition => {
+                            if value__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("addition"));
+                            }
+                            value__ = map_.next_value::<::std::option::Option<_>>()?.map(fee_asset_change_action::Value::Addition);
+                        }
+                        GeneratedField::Removal => {
+                            if value__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("removal"));
+                            }
+                            value__ = map_.next_value::<::std::option::Option<_>>()?.map(fee_asset_change_action::Value::Removal);
+                        }
+                    }
+                }
+                Ok(FeeAssetChangeAction {
+                    value: value__,
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.protocol.transactions.v1alpha1.FeeAssetChangeAction", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for FeeChangeAction {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.value.is_some() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.protocol.transactions.v1alpha1.FeeChangeAction", len)?;
+        if let Some(v) = self.value.as_ref() {
+            match v {
+                fee_change_action::Value::TransferBaseFee(v) => {
+                    struct_ser.serialize_field("transferBaseFee", v)?;
+                }
+                fee_change_action::Value::SequenceBaseFee(v) => {
+                    struct_ser.serialize_field("sequenceBaseFee", v)?;
+                }
+                fee_change_action::Value::SequenceByteCostMultiplier(v) => {
+                    struct_ser.serialize_field("sequenceByteCostMultiplier", v)?;
+                }
+                fee_change_action::Value::InitBridgeAccountBaseFee(v) => {
+                    struct_ser.serialize_field("initBridgeAccountBaseFee", v)?;
+                }
+                fee_change_action::Value::BridgeLockByteCostMultiplier(v) => {
+                    struct_ser.serialize_field("bridgeLockByteCostMultiplier", v)?;
+                }
+                fee_change_action::Value::BridgeSudoChangeBaseFee(v) => {
+                    struct_ser.serialize_field("bridgeSudoChangeBaseFee", v)?;
+                }
+                fee_change_action::Value::Ics20WithdrawalBaseFee(v) => {
+                    struct_ser.serialize_field("ics20WithdrawalBaseFee", v)?;
+                }
+            }
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for FeeChangeAction {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "transfer_base_fee",
+            "transferBaseFee",
+            "sequence_base_fee",
+            "sequenceBaseFee",
+            "sequence_byte_cost_multiplier",
+            "sequenceByteCostMultiplier",
+            "init_bridge_account_base_fee",
+            "initBridgeAccountBaseFee",
+            "bridge_lock_byte_cost_multiplier",
+            "bridgeLockByteCostMultiplier",
+            "bridge_sudo_change_base_fee",
+            "bridgeSudoChangeBaseFee",
+            "ics20_withdrawal_base_fee",
+            "ics20WithdrawalBaseFee",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            TransferBaseFee,
+            SequenceBaseFee,
+            SequenceByteCostMultiplier,
+            InitBridgeAccountBaseFee,
+            BridgeLockByteCostMultiplier,
+            BridgeSudoChangeBaseFee,
+            Ics20WithdrawalBaseFee,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "transferBaseFee" | "transfer_base_fee" => Ok(GeneratedField::TransferBaseFee),
+                            "sequenceBaseFee" | "sequence_base_fee" => Ok(GeneratedField::SequenceBaseFee),
+                            "sequenceByteCostMultiplier" | "sequence_byte_cost_multiplier" => Ok(GeneratedField::SequenceByteCostMultiplier),
+                            "initBridgeAccountBaseFee" | "init_bridge_account_base_fee" => Ok(GeneratedField::InitBridgeAccountBaseFee),
+                            "bridgeLockByteCostMultiplier" | "bridge_lock_byte_cost_multiplier" => Ok(GeneratedField::BridgeLockByteCostMultiplier),
+                            "bridgeSudoChangeBaseFee" | "bridge_sudo_change_base_fee" => Ok(GeneratedField::BridgeSudoChangeBaseFee),
+                            "ics20WithdrawalBaseFee" | "ics20_withdrawal_base_fee" => Ok(GeneratedField::Ics20WithdrawalBaseFee),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = FeeChangeAction;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.protocol.transactions.v1alpha1.FeeChangeAction")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<FeeChangeAction, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut value__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::TransferBaseFee => {
+                            if value__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("transferBaseFee"));
+                            }
+                            value__ = map_.next_value::<::std::option::Option<_>>()?.map(fee_change_action::Value::TransferBaseFee)
+;
+                        }
+                        GeneratedField::SequenceBaseFee => {
+                            if value__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("sequenceBaseFee"));
+                            }
+                            value__ = map_.next_value::<::std::option::Option<_>>()?.map(fee_change_action::Value::SequenceBaseFee)
+;
+                        }
+                        GeneratedField::SequenceByteCostMultiplier => {
+                            if value__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("sequenceByteCostMultiplier"));
+                            }
+                            value__ = map_.next_value::<::std::option::Option<_>>()?.map(fee_change_action::Value::SequenceByteCostMultiplier)
+;
+                        }
+                        GeneratedField::InitBridgeAccountBaseFee => {
+                            if value__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("initBridgeAccountBaseFee"));
+                            }
+                            value__ = map_.next_value::<::std::option::Option<_>>()?.map(fee_change_action::Value::InitBridgeAccountBaseFee)
+;
+                        }
+                        GeneratedField::BridgeLockByteCostMultiplier => {
+                            if value__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("bridgeLockByteCostMultiplier"));
+                            }
+                            value__ = map_.next_value::<::std::option::Option<_>>()?.map(fee_change_action::Value::BridgeLockByteCostMultiplier)
+;
+                        }
+                        GeneratedField::BridgeSudoChangeBaseFee => {
+                            if value__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("bridgeSudoChangeBaseFee"));
+                            }
+                            value__ = map_.next_value::<::std::option::Option<_>>()?.map(fee_change_action::Value::BridgeSudoChangeBaseFee)
+;
+                        }
+                        GeneratedField::Ics20WithdrawalBaseFee => {
+                            if value__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("ics20WithdrawalBaseFee"));
+                            }
+                            value__ = map_.next_value::<::std::option::Option<_>>()?.map(fee_change_action::Value::Ics20WithdrawalBaseFee)
+;
+                        }
+                    }
+                }
+                Ok(FeeChangeAction {
+                    value: value__,
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.protocol.transactions.v1alpha1.FeeChangeAction", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for IbcHeight {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.revision_number != 0 {
+            len += 1;
+        }
+        if self.revision_height != 0 {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.protocol.transactions.v1alpha1.IbcHeight", len)?;
+        if self.revision_number != 0 {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("revisionNumber", ToString::to_string(&self.revision_number).as_str())?;
+        }
+        if self.revision_height != 0 {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("revisionHeight", ToString::to_string(&self.revision_height).as_str())?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for IbcHeight {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "revision_number",
+            "revisionNumber",
+            "revision_height",
+            "revisionHeight",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            RevisionNumber,
+            RevisionHeight,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "revisionNumber" | "revision_number" => Ok(GeneratedField::RevisionNumber),
+                            "revisionHeight" | "revision_height" => Ok(GeneratedField::RevisionHeight),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = IbcHeight;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.protocol.transactions.v1alpha1.IbcHeight")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<IbcHeight, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut revision_number__ = None;
+                let mut revision_height__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::RevisionNumber => {
+                            if revision_number__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("revisionNumber"));
+                            }
+                            revision_number__ = 
+                                Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::RevisionHeight => {
+                            if revision_height__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("revisionHeight"));
+                            }
+                            revision_height__ = 
+                                Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                    }
+                }
+                Ok(IbcHeight {
+                    revision_number: revision_number__.unwrap_or_default(),
+                    revision_height: revision_height__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.protocol.transactions.v1alpha1.IbcHeight", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for IbcRelayerChangeAction {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.value.is_some() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.protocol.transactions.v1alpha1.IbcRelayerChangeAction", len)?;
+        if let Some(v) = self.value.as_ref() {
+            match v {
+                ibc_relayer_change_action::Value::Addition(v) => {
+                    struct_ser.serialize_field("addition", v)?;
+                }
+                ibc_relayer_change_action::Value::Removal(v) => {
+                    struct_ser.serialize_field("removal", v)?;
+                }
+            }
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for IbcRelayerChangeAction {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "addition",
+            "removal",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Addition,
+            Removal,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "addition" => Ok(GeneratedField::Addition),
+                            "removal" => Ok(GeneratedField::Removal),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = IbcRelayerChangeAction;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.protocol.transactions.v1alpha1.IbcRelayerChangeAction")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<IbcRelayerChangeAction, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut value__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Addition => {
+                            if value__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("addition"));
+                            }
+                            value__ = map_.next_value::<::std::option::Option<_>>()?.map(ibc_relayer_change_action::Value::Addition)
+;
+                        }
+                        GeneratedField::Removal => {
+                            if value__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("removal"));
+                            }
+                            value__ = map_.next_value::<::std::option::Option<_>>()?.map(ibc_relayer_change_action::Value::Removal)
+;
+                        }
+                    }
+                }
+                Ok(IbcRelayerChangeAction {
+                    value: value__,
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.protocol.transactions.v1alpha1.IbcRelayerChangeAction", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for Ics20Withdrawal {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.amount.is_some() {
+            len += 1;
+        }
+        if !self.denom.is_empty() {
+            len += 1;
+        }
+        if !self.destination_chain_address.is_empty() {
+            len += 1;
+        }
+        if self.return_address.is_some() {
+            len += 1;
+        }
+        if self.timeout_height.is_some() {
+            len += 1;
+        }
+        if self.timeout_time != 0 {
+            len += 1;
+        }
+        if !self.source_channel.is_empty() {
+            len += 1;
+        }
+        if !self.fee_asset.is_empty() {
+            len += 1;
+        }
+        if !self.memo.is_empty() {
+            len += 1;
+        }
+        if self.bridge_address.is_some() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.protocol.transactions.v1alpha1.Ics20Withdrawal", len)?;
+        if let Some(v) = self.amount.as_ref() {
+            struct_ser.serialize_field("amount", v)?;
+        }
+        if !self.denom.is_empty() {
+            struct_ser.serialize_field("denom", &self.denom)?;
+        }
+        if !self.destination_chain_address.is_empty() {
+            struct_ser.serialize_field("destinationChainAddress", &self.destination_chain_address)?;
+        }
+        if let Some(v) = self.return_address.as_ref() {
+            struct_ser.serialize_field("returnAddress", v)?;
+        }
+        if let Some(v) = self.timeout_height.as_ref() {
+            struct_ser.serialize_field("timeoutHeight", v)?;
+        }
+        if self.timeout_time != 0 {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("timeoutTime", ToString::to_string(&self.timeout_time).as_str())?;
+        }
+        if !self.source_channel.is_empty() {
+            struct_ser.serialize_field("sourceChannel", &self.source_channel)?;
+        }
+        if !self.fee_asset.is_empty() {
+            struct_ser.serialize_field("feeAsset", &self.fee_asset)?;
+        }
+        if !self.memo.is_empty() {
+            struct_ser.serialize_field("memo", &self.memo)?;
+        }
+        if let Some(v) = self.bridge_address.as_ref() {
+            struct_ser.serialize_field("bridgeAddress", v)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for Ics20Withdrawal {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "amount",
+            "denom",
+            "destination_chain_address",
+            "destinationChainAddress",
+            "return_address",
+            "returnAddress",
+            "timeout_height",
+            "timeoutHeight",
+            "timeout_time",
+            "timeoutTime",
+            "source_channel",
+            "sourceChannel",
+            "fee_asset",
+            "feeAsset",
+            "memo",
+            "bridge_address",
+            "bridgeAddress",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Amount,
+            Denom,
+            DestinationChainAddress,
+            ReturnAddress,
+            TimeoutHeight,
+            TimeoutTime,
+            SourceChannel,
+            FeeAsset,
+            Memo,
+            BridgeAddress,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "amount" => Ok(GeneratedField::Amount),
+                            "denom" => Ok(GeneratedField::Denom),
+                            "destinationChainAddress" | "destination_chain_address" => Ok(GeneratedField::DestinationChainAddress),
+                            "returnAddress" | "return_address" => Ok(GeneratedField::ReturnAddress),
+                            "timeoutHeight" | "timeout_height" => Ok(GeneratedField::TimeoutHeight),
+                            "timeoutTime" | "timeout_time" => Ok(GeneratedField::TimeoutTime),
+                            "sourceChannel" | "source_channel" => Ok(GeneratedField::SourceChannel),
+                            "feeAsset" | "fee_asset" => Ok(GeneratedField::FeeAsset),
+                            "memo" => Ok(GeneratedField::Memo),
+                            "bridgeAddress" | "bridge_address" => Ok(GeneratedField::BridgeAddress),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = Ics20Withdrawal;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.protocol.transactions.v1alpha1.Ics20Withdrawal")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Ics20Withdrawal, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut amount__ = None;
+                let mut denom__ = None;
+                let mut destination_chain_address__ = None;
+                let mut return_address__ = None;
+                let mut timeout_height__ = None;
+                let mut timeout_time__ = None;
+                let mut source_channel__ = None;
+                let mut fee_asset__ = None;
+                let mut memo__ = None;
+                let mut bridge_address__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Amount => {
+                            if amount__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("amount"));
+                            }
+                            amount__ = map_.next_value()?;
+                        }
+                        GeneratedField::Denom => {
+                            if denom__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("denom"));
+                            }
+                            denom__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::DestinationChainAddress => {
+                            if destination_chain_address__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("destinationChainAddress"));
+                            }
+                            destination_chain_address__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::ReturnAddress => {
+                            if return_address__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("returnAddress"));
+                            }
+                            return_address__ = map_.next_value()?;
+                        }
+                        GeneratedField::TimeoutHeight => {
+                            if timeout_height__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("timeoutHeight"));
+                            }
+                            timeout_height__ = map_.next_value()?;
+                        }
+                        GeneratedField::TimeoutTime => {
+                            if timeout_time__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("timeoutTime"));
+                            }
+                            timeout_time__ = 
+                                Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::SourceChannel => {
+                            if source_channel__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("sourceChannel"));
+                            }
+                            source_channel__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::FeeAsset => {
+                            if fee_asset__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("feeAsset"));
+                            }
+                            fee_asset__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Memo => {
+                            if memo__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("memo"));
+                            }
+                            memo__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::BridgeAddress => {
+                            if bridge_address__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("bridgeAddress"));
+                            }
+                            bridge_address__ = map_.next_value()?;
+                        }
+                    }
+                }
+                Ok(Ics20Withdrawal {
+                    amount: amount__,
+                    denom: denom__.unwrap_or_default(),
+                    destination_chain_address: destination_chain_address__.unwrap_or_default(),
+                    return_address: return_address__,
+                    timeout_height: timeout_height__,
+                    timeout_time: timeout_time__.unwrap_or_default(),
+                    source_channel: source_channel__.unwrap_or_default(),
+                    fee_asset: fee_asset__.unwrap_or_default(),
+                    memo: memo__.unwrap_or_default(),
+                    bridge_address: bridge_address__,
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.protocol.transactions.v1alpha1.Ics20Withdrawal", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for InitBridgeAccountAction {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.rollup_id.is_some() {
+            len += 1;
+        }
+        if !self.asset.is_empty() {
+            len += 1;
+        }
+        if !self.fee_asset.is_empty() {
+            len += 1;
+        }
+        if self.sudo_address.is_some() {
+            len += 1;
+        }
+        if self.withdrawer_address.is_some() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.protocol.transactions.v1alpha1.InitBridgeAccountAction", len)?;
+        if let Some(v) = self.rollup_id.as_ref() {
+            struct_ser.serialize_field("rollupId", v)?;
+        }
+        if !self.asset.is_empty() {
+            struct_ser.serialize_field("asset", &self.asset)?;
+        }
+        if !self.fee_asset.is_empty() {
+            struct_ser.serialize_field("feeAsset", &self.fee_asset)?;
+        }
+        if let Some(v) = self.sudo_address.as_ref() {
+            struct_ser.serialize_field("sudoAddress", v)?;
+        }
+        if let Some(v) = self.withdrawer_address.as_ref() {
+            struct_ser.serialize_field("withdrawerAddress", v)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for InitBridgeAccountAction {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "rollup_id",
+            "rollupId",
+            "asset",
+            "fee_asset",
+            "feeAsset",
+            "sudo_address",
+            "sudoAddress",
+            "withdrawer_address",
+            "withdrawerAddress",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            RollupId,
+            Asset,
+            FeeAsset,
+            SudoAddress,
+            WithdrawerAddress,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "rollupId" | "rollup_id" => Ok(GeneratedField::RollupId),
+                            "asset" => Ok(GeneratedField::Asset),
+                            "feeAsset" | "fee_asset" => Ok(GeneratedField::FeeAsset),
+                            "sudoAddress" | "sudo_address" => Ok(GeneratedField::SudoAddress),
+                            "withdrawerAddress" | "withdrawer_address" => Ok(GeneratedField::WithdrawerAddress),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = InitBridgeAccountAction;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.protocol.transactions.v1alpha1.InitBridgeAccountAction")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<InitBridgeAccountAction, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut rollup_id__ = None;
+                let mut asset__ = None;
+                let mut fee_asset__ = None;
+                let mut sudo_address__ = None;
+                let mut withdrawer_address__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::RollupId => {
+                            if rollup_id__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("rollupId"));
+                            }
+                            rollup_id__ = map_.next_value()?;
+                        }
+                        GeneratedField::Asset => {
+                            if asset__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("asset"));
+                            }
+                            asset__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::FeeAsset => {
+                            if fee_asset__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("feeAsset"));
+                            }
+                            fee_asset__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::SudoAddress => {
+                            if sudo_address__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("sudoAddress"));
+                            }
+                            sudo_address__ = map_.next_value()?;
+                        }
+                        GeneratedField::WithdrawerAddress => {
+                            if withdrawer_address__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("withdrawerAddress"));
+                            }
+                            withdrawer_address__ = map_.next_value()?;
+                        }
+                    }
+                }
+                Ok(InitBridgeAccountAction {
+                    rollup_id: rollup_id__,
+                    asset: asset__.unwrap_or_default(),
+                    fee_asset: fee_asset__.unwrap_or_default(),
+                    sudo_address: sudo_address__,
+                    withdrawer_address: withdrawer_address__,
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.protocol.transactions.v1alpha1.InitBridgeAccountAction", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for SequenceAction {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.rollup_id.is_some() {
+            len += 1;
+        }
+        if !self.data.is_empty() {
+            len += 1;
+        }
+        if !self.fee_asset.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.protocol.transactions.v1alpha1.SequenceAction", len)?;
+        if let Some(v) = self.rollup_id.as_ref() {
+            struct_ser.serialize_field("rollupId", v)?;
+        }
+        if !self.data.is_empty() {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("data", pbjson::private::base64::encode(&self.data).as_str())?;
+        }
+        if !self.fee_asset.is_empty() {
+            struct_ser.serialize_field("feeAsset", &self.fee_asset)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for SequenceAction {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "rollup_id",
+            "rollupId",
+            "data",
+            "fee_asset",
+            "feeAsset",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            RollupId,
+            Data,
+            FeeAsset,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "rollupId" | "rollup_id" => Ok(GeneratedField::RollupId),
+                            "data" => Ok(GeneratedField::Data),
+                            "feeAsset" | "fee_asset" => Ok(GeneratedField::FeeAsset),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = SequenceAction;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.protocol.transactions.v1alpha1.SequenceAction")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<SequenceAction, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut rollup_id__ = None;
+                let mut data__ = None;
+                let mut fee_asset__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::RollupId => {
+                            if rollup_id__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("rollupId"));
+                            }
+                            rollup_id__ = map_.next_value()?;
+                        }
+                        GeneratedField::Data => {
+                            if data__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("data"));
+                            }
+                            data__ = 
+                                Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::FeeAsset => {
+                            if fee_asset__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("feeAsset"));
+                            }
+                            fee_asset__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(SequenceAction {
+                    rollup_id: rollup_id__,
+                    data: data__.unwrap_or_default(),
+                    fee_asset: fee_asset__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.protocol.transactions.v1alpha1.SequenceAction", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for SignedTransaction {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.signature.is_empty() {
+            len += 1;
+        }
+        if !self.public_key.is_empty() {
+            len += 1;
+        }
+        if self.transaction.is_some() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.protocol.transactions.v1alpha1.SignedTransaction", len)?;
+        if !self.signature.is_empty() {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("signature", pbjson::private::base64::encode(&self.signature).as_str())?;
+        }
+        if !self.public_key.is_empty() {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("publicKey", pbjson::private::base64::encode(&self.public_key).as_str())?;
+        }
+        if let Some(v) = self.transaction.as_ref() {
+            struct_ser.serialize_field("transaction", v)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for SignedTransaction {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "signature",
+            "public_key",
+            "publicKey",
+            "transaction",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Signature,
+            PublicKey,
+            Transaction,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "signature" => Ok(GeneratedField::Signature),
+                            "publicKey" | "public_key" => Ok(GeneratedField::PublicKey),
+                            "transaction" => Ok(GeneratedField::Transaction),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = SignedTransaction;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.protocol.transactions.v1alpha1.SignedTransaction")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<SignedTransaction, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut signature__ = None;
+                let mut public_key__ = None;
+                let mut transaction__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Signature => {
+                            if signature__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("signature"));
+                            }
+                            signature__ = 
+                                Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::PublicKey => {
+                            if public_key__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("publicKey"));
+                            }
+                            public_key__ = 
+                                Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::Transaction => {
+                            if transaction__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("transaction"));
+                            }
+                            transaction__ = map_.next_value()?;
+                        }
+                    }
+                }
+                Ok(SignedTransaction {
+                    signature: signature__.unwrap_or_default(),
+                    public_key: public_key__.unwrap_or_default(),
+                    transaction: transaction__,
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.protocol.transactions.v1alpha1.SignedTransaction", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for SudoAddressChangeAction {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.new_address.is_some() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.protocol.transactions.v1alpha1.SudoAddressChangeAction", len)?;
+        if let Some(v) = self.new_address.as_ref() {
+            struct_ser.serialize_field("newAddress", v)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for SudoAddressChangeAction {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "new_address",
+            "newAddress",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            NewAddress,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "newAddress" | "new_address" => Ok(GeneratedField::NewAddress),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = SudoAddressChangeAction;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.protocol.transactions.v1alpha1.SudoAddressChangeAction")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<SudoAddressChangeAction, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut new_address__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::NewAddress => {
+                            if new_address__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("newAddress"));
+                            }
+                            new_address__ = map_.next_value()?;
+                        }
+                    }
+                }
+                Ok(SudoAddressChangeAction {
+                    new_address: new_address__,
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.protocol.transactions.v1alpha1.SudoAddressChangeAction", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for TransactionFee {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.asset.is_empty() {
+            len += 1;
+        }
+        if self.fee.is_some() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.protocol.transactions.v1alpha1.TransactionFee", len)?;
+        if !self.asset.is_empty() {
+            struct_ser.serialize_field("asset", &self.asset)?;
+        }
+        if let Some(v) = self.fee.as_ref() {
+            struct_ser.serialize_field("fee", v)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for TransactionFee {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "asset",
+            "fee",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Asset,
+            Fee,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "asset" => Ok(GeneratedField::Asset),
+                            "fee" => Ok(GeneratedField::Fee),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = TransactionFee;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.protocol.transactions.v1alpha1.TransactionFee")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<TransactionFee, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut asset__ = None;
+                let mut fee__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Asset => {
+                            if asset__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("asset"));
+                            }
+                            asset__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Fee => {
+                            if fee__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("fee"));
+                            }
+                            fee__ = map_.next_value()?;
+                        }
+                    }
+                }
+                Ok(TransactionFee {
+                    asset: asset__.unwrap_or_default(),
+                    fee: fee__,
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.protocol.transactions.v1alpha1.TransactionFee", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for TransactionFeeResponse {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.height != 0 {
+            len += 1;
+        }
+        if !self.fees.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.protocol.transactions.v1alpha1.TransactionFeeResponse", len)?;
+        if self.height != 0 {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("height", ToString::to_string(&self.height).as_str())?;
+        }
+        if !self.fees.is_empty() {
+            struct_ser.serialize_field("fees", &self.fees)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for TransactionFeeResponse {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "height",
+            "fees",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Height,
+            Fees,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "height" => Ok(GeneratedField::Height),
+                            "fees" => Ok(GeneratedField::Fees),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = TransactionFeeResponse;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.protocol.transactions.v1alpha1.TransactionFeeResponse")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<TransactionFeeResponse, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut height__ = None;
+                let mut fees__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Height => {
+                            if height__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("height"));
+                            }
+                            height__ = 
+                                Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::Fees => {
+                            if fees__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("fees"));
+                            }
+                            fees__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(TransactionFeeResponse {
+                    height: height__.unwrap_or_default(),
+                    fees: fees__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.protocol.transactions.v1alpha1.TransactionFeeResponse", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for TransactionParams {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.nonce != 0 {
+            len += 1;
+        }
+        if !self.chain_id.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.protocol.transactions.v1alpha1.TransactionParams", len)?;
+        if self.nonce != 0 {
+            struct_ser.serialize_field("nonce", &self.nonce)?;
+        }
+        if !self.chain_id.is_empty() {
+            struct_ser.serialize_field("chainId", &self.chain_id)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for TransactionParams {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "nonce",
+            "chain_id",
+            "chainId",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Nonce,
+            ChainId,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "nonce" => Ok(GeneratedField::Nonce),
+                            "chainId" | "chain_id" => Ok(GeneratedField::ChainId),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = TransactionParams;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.protocol.transactions.v1alpha1.TransactionParams")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<TransactionParams, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut nonce__ = None;
+                let mut chain_id__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Nonce => {
+                            if nonce__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("nonce"));
+                            }
+                            nonce__ = 
+                                Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::ChainId => {
+                            if chain_id__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("chainId"));
+                            }
+                            chain_id__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(TransactionParams {
+                    nonce: nonce__.unwrap_or_default(),
+                    chain_id: chain_id__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.protocol.transactions.v1alpha1.TransactionParams", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for TransferAction {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.to.is_some() {
+            len += 1;
+        }
+        if self.amount.is_some() {
+            len += 1;
+        }
+        if !self.asset.is_empty() {
+            len += 1;
+        }
+        if !self.fee_asset.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.protocol.transactions.v1alpha1.TransferAction", len)?;
+        if let Some(v) = self.to.as_ref() {
+            struct_ser.serialize_field("to", v)?;
+        }
+        if let Some(v) = self.amount.as_ref() {
+            struct_ser.serialize_field("amount", v)?;
+        }
+        if !self.asset.is_empty() {
+            struct_ser.serialize_field("asset", &self.asset)?;
+        }
+        if !self.fee_asset.is_empty() {
+            struct_ser.serialize_field("feeAsset", &self.fee_asset)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for TransferAction {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "to",
+            "amount",
+            "asset",
+            "fee_asset",
+            "feeAsset",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            To,
+            Amount,
+            Asset,
+            FeeAsset,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "to" => Ok(GeneratedField::To),
+                            "amount" => Ok(GeneratedField::Amount),
+                            "asset" => Ok(GeneratedField::Asset),
+                            "feeAsset" | "fee_asset" => Ok(GeneratedField::FeeAsset),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = TransferAction;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.protocol.transactions.v1alpha1.TransferAction")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<TransferAction, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut to__ = None;
+                let mut amount__ = None;
+                let mut asset__ = None;
+                let mut fee_asset__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::To => {
+                            if to__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("to"));
+                            }
+                            to__ = map_.next_value()?;
+                        }
+                        GeneratedField::Amount => {
+                            if amount__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("amount"));
+                            }
+                            amount__ = map_.next_value()?;
+                        }
+                        GeneratedField::Asset => {
+                            if asset__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("asset"));
+                            }
+                            asset__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::FeeAsset => {
+                            if fee_asset__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("feeAsset"));
+                            }
+                            fee_asset__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(TransferAction {
+                    to: to__,
+                    amount: amount__,
+                    asset: asset__.unwrap_or_default(),
+                    fee_asset: fee_asset__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.protocol.transactions.v1alpha1.TransferAction", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for UnsignedTransaction {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.actions.is_empty() {
+            len += 1;
+        }
+        if self.params.is_some() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.protocol.transactions.v1alpha1.UnsignedTransaction", len)?;
+        if !self.actions.is_empty() {
+            struct_ser.serialize_field("actions", &self.actions)?;
+        }
+        if let Some(v) = self.params.as_ref() {
+            struct_ser.serialize_field("params", v)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for UnsignedTransaction {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "actions",
+            "params",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Actions,
+            Params,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "actions" => Ok(GeneratedField::Actions),
+                            "params" => Ok(GeneratedField::Params),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = UnsignedTransaction;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.protocol.transactions.v1alpha1.UnsignedTransaction")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<UnsignedTransaction, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut actions__ = None;
+                let mut params__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Actions => {
+                            if actions__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("actions"));
+                            }
+                            actions__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Params => {
+                            if params__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("params"));
+                            }
+                            params__ = map_.next_value()?;
+                        }
+                    }
+                }
+                Ok(UnsignedTransaction {
+                    actions: actions__.unwrap_or_default(),
+                    params: params__,
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.protocol.transactions.v1alpha1.UnsignedTransaction", FIELDS, GeneratedVisitor)
+    }
+}

--- a/crates/astria-core/src/generated/astria_vendored.penumbra.core.component.ibc.v1.serde.rs
+++ b/crates/astria-core/src/generated/astria_vendored.penumbra.core.component.ibc.v1.serde.rs
@@ -1,0 +1,92 @@
+impl serde::Serialize for IbcRelay {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.raw_action.is_some() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria_vendored.penumbra.core.component.ibc.v1.IbcRelay", len)?;
+        if let Some(v) = self.raw_action.as_ref() {
+            struct_ser.serialize_field("rawAction", v)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for IbcRelay {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "raw_action",
+            "rawAction",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            RawAction,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "rawAction" | "raw_action" => Ok(GeneratedField::RawAction),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = IbcRelay;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria_vendored.penumbra.core.component.ibc.v1.IbcRelay")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<IbcRelay, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut raw_action__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::RawAction => {
+                            if raw_action__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("rawAction"));
+                            }
+                            raw_action__ = map_.next_value()?;
+                        }
+                    }
+                }
+                Ok(IbcRelay {
+                    raw_action: raw_action__,
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria_vendored.penumbra.core.component.ibc.v1.IbcRelay", FIELDS, GeneratedVisitor)
+    }
+}

--- a/crates/astria-core/src/generated/astria_vendored.tendermint.abci.rs
+++ b/crates/astria-core/src/generated/astria_vendored.tendermint.abci.rs
@@ -1,0 +1,15 @@
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ValidatorUpdate {
+    #[prost(message, optional, tag = "1")]
+    pub pub_key: ::core::option::Option<super::crypto::PublicKey>,
+    #[prost(int64, tag = "2")]
+    pub power: i64,
+}
+impl ::prost::Name for ValidatorUpdate {
+    const NAME: &'static str = "ValidatorUpdate";
+    const PACKAGE: &'static str = "astria_vendored.tendermint.abci";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria_vendored.tendermint.abci.{}", Self::NAME)
+    }
+}

--- a/crates/astria-core/src/generated/astria_vendored.tendermint.abci.serde.rs
+++ b/crates/astria-core/src/generated/astria_vendored.tendermint.abci.serde.rs
@@ -1,0 +1,112 @@
+impl serde::Serialize for ValidatorUpdate {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.pub_key.is_some() {
+            len += 1;
+        }
+        if self.power != 0 {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria_vendored.tendermint.abci.ValidatorUpdate", len)?;
+        if let Some(v) = self.pub_key.as_ref() {
+            struct_ser.serialize_field("pubKey", v)?;
+        }
+        if self.power != 0 {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("power", ToString::to_string(&self.power).as_str())?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for ValidatorUpdate {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "pub_key",
+            "pubKey",
+            "power",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            PubKey,
+            Power,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "pubKey" | "pub_key" => Ok(GeneratedField::PubKey),
+                            "power" => Ok(GeneratedField::Power),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = ValidatorUpdate;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria_vendored.tendermint.abci.ValidatorUpdate")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<ValidatorUpdate, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut pub_key__ = None;
+                let mut power__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::PubKey => {
+                            if pub_key__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("pubKey"));
+                            }
+                            pub_key__ = map_.next_value()?;
+                        }
+                        GeneratedField::Power => {
+                            if power__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("power"));
+                            }
+                            power__ = 
+                                Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                    }
+                }
+                Ok(ValidatorUpdate {
+                    pub_key: pub_key__,
+                    power: power__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria_vendored.tendermint.abci.ValidatorUpdate", FIELDS, GeneratedVisitor)
+    }
+}

--- a/crates/astria-core/src/generated/astria_vendored.tendermint.crypto.rs
+++ b/crates/astria-core/src/generated/astria_vendored.tendermint.crypto.rs
@@ -1,0 +1,24 @@
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PublicKey {
+    #[prost(oneof = "public_key::Sum", tags = "1, 2")]
+    pub sum: ::core::option::Option<public_key::Sum>,
+}
+/// Nested message and enum types in `PublicKey`.
+pub mod public_key {
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Sum {
+        #[prost(bytes, tag = "1")]
+        Ed25519(::prost::alloc::vec::Vec<u8>),
+        #[prost(bytes, tag = "2")]
+        Secp256k1(::prost::alloc::vec::Vec<u8>),
+    }
+}
+impl ::prost::Name for PublicKey {
+    const NAME: &'static str = "PublicKey";
+    const PACKAGE: &'static str = "astria_vendored.tendermint.crypto";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria_vendored.tendermint.crypto.{}", Self::NAME)
+    }
+}

--- a/crates/astria-core/src/generated/astria_vendored.tendermint.crypto.serde.rs
+++ b/crates/astria-core/src/generated/astria_vendored.tendermint.crypto.serde.rs
@@ -1,0 +1,109 @@
+impl serde::Serialize for PublicKey {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.sum.is_some() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria_vendored.tendermint.crypto.PublicKey", len)?;
+        if let Some(v) = self.sum.as_ref() {
+            match v {
+                public_key::Sum::Ed25519(v) => {
+                    #[allow(clippy::needless_borrow)]
+                    struct_ser.serialize_field("ed25519", pbjson::private::base64::encode(&v).as_str())?;
+                }
+                public_key::Sum::Secp256k1(v) => {
+                    #[allow(clippy::needless_borrow)]
+                    struct_ser.serialize_field("secp256k1", pbjson::private::base64::encode(&v).as_str())?;
+                }
+            }
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for PublicKey {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "ed25519",
+            "secp256k1",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Ed25519,
+            Secp256k1,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "ed25519" => Ok(GeneratedField::Ed25519),
+                            "secp256k1" => Ok(GeneratedField::Secp256k1),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = PublicKey;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria_vendored.tendermint.crypto.PublicKey")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<PublicKey, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut sum__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Ed25519 => {
+                            if sum__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("ed25519"));
+                            }
+                            sum__ = map_.next_value::<::std::option::Option<::pbjson::private::BytesDeserialize<_>>>()?.map(|x| public_key::Sum::Ed25519(x.0));
+                        }
+                        GeneratedField::Secp256k1 => {
+                            if sum__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("secp256k1"));
+                            }
+                            sum__ = map_.next_value::<::std::option::Option<::pbjson::private::BytesDeserialize<_>>>()?.map(|x| public_key::Sum::Secp256k1(x.0));
+                        }
+                    }
+                }
+                Ok(PublicKey {
+                    sum: sum__,
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria_vendored.tendermint.crypto.PublicKey", FIELDS, GeneratedVisitor)
+    }
+}

--- a/crates/astria-core/src/generated/astria_vendored.tendermint.types.rs
+++ b/crates/astria-core/src/generated/astria_vendored.tendermint.types.rs
@@ -1,0 +1,74 @@
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BlockId {
+    #[prost(bytes = "vec", tag = "1")]
+    pub hash: ::prost::alloc::vec::Vec<u8>,
+    #[prost(message, optional, tag = "2")]
+    pub part_set_header: ::core::option::Option<PartSetHeader>,
+}
+impl ::prost::Name for BlockId {
+    const NAME: &'static str = "BlockID";
+    const PACKAGE: &'static str = "astria_vendored.tendermint.types";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria_vendored.tendermint.types.{}", Self::NAME)
+    }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PartSetHeader {
+    #[prost(uint32, tag = "1")]
+    pub total: u32,
+    #[prost(bytes = "vec", tag = "2")]
+    pub hash: ::prost::alloc::vec::Vec<u8>,
+}
+impl ::prost::Name for PartSetHeader {
+    const NAME: &'static str = "PartSetHeader";
+    const PACKAGE: &'static str = "astria_vendored.tendermint.types";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria_vendored.tendermint.types.{}", Self::NAME)
+    }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Header {
+    /// basic block info
+    #[prost(message, optional, tag = "1")]
+    pub version: ::core::option::Option<super::version::Consensus>,
+    #[prost(string, tag = "2")]
+    pub chain_id: ::prost::alloc::string::String,
+    #[prost(int64, tag = "3")]
+    pub height: i64,
+    #[prost(message, optional, tag = "4")]
+    pub time: ::core::option::Option<::pbjson_types::Timestamp>,
+    /// prev block info
+    #[prost(message, optional, tag = "5")]
+    pub last_block_id: ::core::option::Option<BlockId>,
+    /// hashes of block data
+    #[prost(bytes = "vec", tag = "6")]
+    pub last_commit_hash: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "7")]
+    pub data_hash: ::prost::alloc::vec::Vec<u8>,
+    /// hashes from the app output from the prev block
+    #[prost(bytes = "vec", tag = "8")]
+    pub validators_hash: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "9")]
+    pub next_validators_hash: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "10")]
+    pub consensus_hash: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "11")]
+    pub app_hash: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "12")]
+    pub last_results_hash: ::prost::alloc::vec::Vec<u8>,
+    /// consensus info
+    #[prost(bytes = "vec", tag = "13")]
+    pub evidence_hash: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "14")]
+    pub proposer_address: ::prost::alloc::vec::Vec<u8>,
+}
+impl ::prost::Name for Header {
+    const NAME: &'static str = "Header";
+    const PACKAGE: &'static str = "astria_vendored.tendermint.types";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria_vendored.tendermint.types.{}", Self::NAME)
+    }
+}

--- a/crates/astria-core/src/generated/astria_vendored.tendermint.types.serde.rs
+++ b/crates/astria-core/src/generated/astria_vendored.tendermint.types.serde.rs
@@ -1,0 +1,578 @@
+impl serde::Serialize for BlockId {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.hash.is_empty() {
+            len += 1;
+        }
+        if self.part_set_header.is_some() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria_vendored.tendermint.types.BlockID", len)?;
+        if !self.hash.is_empty() {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("hash", pbjson::private::base64::encode(&self.hash).as_str())?;
+        }
+        if let Some(v) = self.part_set_header.as_ref() {
+            struct_ser.serialize_field("partSetHeader", v)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for BlockId {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "hash",
+            "part_set_header",
+            "partSetHeader",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Hash,
+            PartSetHeader,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "hash" => Ok(GeneratedField::Hash),
+                            "partSetHeader" | "part_set_header" => Ok(GeneratedField::PartSetHeader),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = BlockId;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria_vendored.tendermint.types.BlockID")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<BlockId, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut hash__ = None;
+                let mut part_set_header__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Hash => {
+                            if hash__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("hash"));
+                            }
+                            hash__ = 
+                                Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::PartSetHeader => {
+                            if part_set_header__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("partSetHeader"));
+                            }
+                            part_set_header__ = map_.next_value()?;
+                        }
+                    }
+                }
+                Ok(BlockId {
+                    hash: hash__.unwrap_or_default(),
+                    part_set_header: part_set_header__,
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria_vendored.tendermint.types.BlockID", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for Header {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.version.is_some() {
+            len += 1;
+        }
+        if !self.chain_id.is_empty() {
+            len += 1;
+        }
+        if self.height != 0 {
+            len += 1;
+        }
+        if self.time.is_some() {
+            len += 1;
+        }
+        if self.last_block_id.is_some() {
+            len += 1;
+        }
+        if !self.last_commit_hash.is_empty() {
+            len += 1;
+        }
+        if !self.data_hash.is_empty() {
+            len += 1;
+        }
+        if !self.validators_hash.is_empty() {
+            len += 1;
+        }
+        if !self.next_validators_hash.is_empty() {
+            len += 1;
+        }
+        if !self.consensus_hash.is_empty() {
+            len += 1;
+        }
+        if !self.app_hash.is_empty() {
+            len += 1;
+        }
+        if !self.last_results_hash.is_empty() {
+            len += 1;
+        }
+        if !self.evidence_hash.is_empty() {
+            len += 1;
+        }
+        if !self.proposer_address.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria_vendored.tendermint.types.Header", len)?;
+        if let Some(v) = self.version.as_ref() {
+            struct_ser.serialize_field("version", v)?;
+        }
+        if !self.chain_id.is_empty() {
+            struct_ser.serialize_field("chainId", &self.chain_id)?;
+        }
+        if self.height != 0 {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("height", ToString::to_string(&self.height).as_str())?;
+        }
+        if let Some(v) = self.time.as_ref() {
+            struct_ser.serialize_field("time", v)?;
+        }
+        if let Some(v) = self.last_block_id.as_ref() {
+            struct_ser.serialize_field("lastBlockId", v)?;
+        }
+        if !self.last_commit_hash.is_empty() {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("lastCommitHash", pbjson::private::base64::encode(&self.last_commit_hash).as_str())?;
+        }
+        if !self.data_hash.is_empty() {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("dataHash", pbjson::private::base64::encode(&self.data_hash).as_str())?;
+        }
+        if !self.validators_hash.is_empty() {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("validatorsHash", pbjson::private::base64::encode(&self.validators_hash).as_str())?;
+        }
+        if !self.next_validators_hash.is_empty() {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("nextValidatorsHash", pbjson::private::base64::encode(&self.next_validators_hash).as_str())?;
+        }
+        if !self.consensus_hash.is_empty() {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("consensusHash", pbjson::private::base64::encode(&self.consensus_hash).as_str())?;
+        }
+        if !self.app_hash.is_empty() {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("appHash", pbjson::private::base64::encode(&self.app_hash).as_str())?;
+        }
+        if !self.last_results_hash.is_empty() {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("lastResultsHash", pbjson::private::base64::encode(&self.last_results_hash).as_str())?;
+        }
+        if !self.evidence_hash.is_empty() {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("evidenceHash", pbjson::private::base64::encode(&self.evidence_hash).as_str())?;
+        }
+        if !self.proposer_address.is_empty() {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("proposerAddress", pbjson::private::base64::encode(&self.proposer_address).as_str())?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for Header {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "version",
+            "chain_id",
+            "chainId",
+            "height",
+            "time",
+            "last_block_id",
+            "lastBlockId",
+            "last_commit_hash",
+            "lastCommitHash",
+            "data_hash",
+            "dataHash",
+            "validators_hash",
+            "validatorsHash",
+            "next_validators_hash",
+            "nextValidatorsHash",
+            "consensus_hash",
+            "consensusHash",
+            "app_hash",
+            "appHash",
+            "last_results_hash",
+            "lastResultsHash",
+            "evidence_hash",
+            "evidenceHash",
+            "proposer_address",
+            "proposerAddress",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Version,
+            ChainId,
+            Height,
+            Time,
+            LastBlockId,
+            LastCommitHash,
+            DataHash,
+            ValidatorsHash,
+            NextValidatorsHash,
+            ConsensusHash,
+            AppHash,
+            LastResultsHash,
+            EvidenceHash,
+            ProposerAddress,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "version" => Ok(GeneratedField::Version),
+                            "chainId" | "chain_id" => Ok(GeneratedField::ChainId),
+                            "height" => Ok(GeneratedField::Height),
+                            "time" => Ok(GeneratedField::Time),
+                            "lastBlockId" | "last_block_id" => Ok(GeneratedField::LastBlockId),
+                            "lastCommitHash" | "last_commit_hash" => Ok(GeneratedField::LastCommitHash),
+                            "dataHash" | "data_hash" => Ok(GeneratedField::DataHash),
+                            "validatorsHash" | "validators_hash" => Ok(GeneratedField::ValidatorsHash),
+                            "nextValidatorsHash" | "next_validators_hash" => Ok(GeneratedField::NextValidatorsHash),
+                            "consensusHash" | "consensus_hash" => Ok(GeneratedField::ConsensusHash),
+                            "appHash" | "app_hash" => Ok(GeneratedField::AppHash),
+                            "lastResultsHash" | "last_results_hash" => Ok(GeneratedField::LastResultsHash),
+                            "evidenceHash" | "evidence_hash" => Ok(GeneratedField::EvidenceHash),
+                            "proposerAddress" | "proposer_address" => Ok(GeneratedField::ProposerAddress),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = Header;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria_vendored.tendermint.types.Header")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Header, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut version__ = None;
+                let mut chain_id__ = None;
+                let mut height__ = None;
+                let mut time__ = None;
+                let mut last_block_id__ = None;
+                let mut last_commit_hash__ = None;
+                let mut data_hash__ = None;
+                let mut validators_hash__ = None;
+                let mut next_validators_hash__ = None;
+                let mut consensus_hash__ = None;
+                let mut app_hash__ = None;
+                let mut last_results_hash__ = None;
+                let mut evidence_hash__ = None;
+                let mut proposer_address__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Version => {
+                            if version__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("version"));
+                            }
+                            version__ = map_.next_value()?;
+                        }
+                        GeneratedField::ChainId => {
+                            if chain_id__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("chainId"));
+                            }
+                            chain_id__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Height => {
+                            if height__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("height"));
+                            }
+                            height__ = 
+                                Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::Time => {
+                            if time__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("time"));
+                            }
+                            time__ = map_.next_value()?;
+                        }
+                        GeneratedField::LastBlockId => {
+                            if last_block_id__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("lastBlockId"));
+                            }
+                            last_block_id__ = map_.next_value()?;
+                        }
+                        GeneratedField::LastCommitHash => {
+                            if last_commit_hash__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("lastCommitHash"));
+                            }
+                            last_commit_hash__ = 
+                                Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::DataHash => {
+                            if data_hash__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("dataHash"));
+                            }
+                            data_hash__ = 
+                                Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::ValidatorsHash => {
+                            if validators_hash__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("validatorsHash"));
+                            }
+                            validators_hash__ = 
+                                Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::NextValidatorsHash => {
+                            if next_validators_hash__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("nextValidatorsHash"));
+                            }
+                            next_validators_hash__ = 
+                                Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::ConsensusHash => {
+                            if consensus_hash__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("consensusHash"));
+                            }
+                            consensus_hash__ = 
+                                Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::AppHash => {
+                            if app_hash__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("appHash"));
+                            }
+                            app_hash__ = 
+                                Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::LastResultsHash => {
+                            if last_results_hash__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("lastResultsHash"));
+                            }
+                            last_results_hash__ = 
+                                Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::EvidenceHash => {
+                            if evidence_hash__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("evidenceHash"));
+                            }
+                            evidence_hash__ = 
+                                Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::ProposerAddress => {
+                            if proposer_address__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("proposerAddress"));
+                            }
+                            proposer_address__ = 
+                                Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
+                            ;
+                        }
+                    }
+                }
+                Ok(Header {
+                    version: version__,
+                    chain_id: chain_id__.unwrap_or_default(),
+                    height: height__.unwrap_or_default(),
+                    time: time__,
+                    last_block_id: last_block_id__,
+                    last_commit_hash: last_commit_hash__.unwrap_or_default(),
+                    data_hash: data_hash__.unwrap_or_default(),
+                    validators_hash: validators_hash__.unwrap_or_default(),
+                    next_validators_hash: next_validators_hash__.unwrap_or_default(),
+                    consensus_hash: consensus_hash__.unwrap_or_default(),
+                    app_hash: app_hash__.unwrap_or_default(),
+                    last_results_hash: last_results_hash__.unwrap_or_default(),
+                    evidence_hash: evidence_hash__.unwrap_or_default(),
+                    proposer_address: proposer_address__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria_vendored.tendermint.types.Header", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for PartSetHeader {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.total != 0 {
+            len += 1;
+        }
+        if !self.hash.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria_vendored.tendermint.types.PartSetHeader", len)?;
+        if self.total != 0 {
+            struct_ser.serialize_field("total", &self.total)?;
+        }
+        if !self.hash.is_empty() {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("hash", pbjson::private::base64::encode(&self.hash).as_str())?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for PartSetHeader {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "total",
+            "hash",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Total,
+            Hash,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "total" => Ok(GeneratedField::Total),
+                            "hash" => Ok(GeneratedField::Hash),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = PartSetHeader;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria_vendored.tendermint.types.PartSetHeader")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<PartSetHeader, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut total__ = None;
+                let mut hash__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Total => {
+                            if total__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("total"));
+                            }
+                            total__ = 
+                                Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::Hash => {
+                            if hash__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("hash"));
+                            }
+                            hash__ = 
+                                Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
+                            ;
+                        }
+                    }
+                }
+                Ok(PartSetHeader {
+                    total: total__.unwrap_or_default(),
+                    hash: hash__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria_vendored.tendermint.types.PartSetHeader", FIELDS, GeneratedVisitor)
+    }
+}

--- a/crates/astria-core/src/generated/astria_vendored.tendermint.version.rs
+++ b/crates/astria-core/src/generated/astria_vendored.tendermint.version.rs
@@ -1,0 +1,15 @@
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Consensus {
+    #[prost(uint64, tag = "1")]
+    pub block: u64,
+    #[prost(uint64, tag = "2")]
+    pub app: u64,
+}
+impl ::prost::Name for Consensus {
+    const NAME: &'static str = "Consensus";
+    const PACKAGE: &'static str = "astria_vendored.tendermint.version";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria_vendored.tendermint.version.{}", Self::NAME)
+    }
+}

--- a/crates/astria-core/src/generated/astria_vendored.tendermint.version.serde.rs
+++ b/crates/astria-core/src/generated/astria_vendored.tendermint.version.serde.rs
@@ -1,0 +1,114 @@
+impl serde::Serialize for Consensus {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.block != 0 {
+            len += 1;
+        }
+        if self.app != 0 {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria_vendored.tendermint.version.Consensus", len)?;
+        if self.block != 0 {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("block", ToString::to_string(&self.block).as_str())?;
+        }
+        if self.app != 0 {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("app", ToString::to_string(&self.app).as_str())?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for Consensus {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "block",
+            "app",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Block,
+            App,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "block" => Ok(GeneratedField::Block),
+                            "app" => Ok(GeneratedField::App),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = Consensus;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria_vendored.tendermint.version.Consensus")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Consensus, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut block__ = None;
+                let mut app__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Block => {
+                            if block__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("block"));
+                            }
+                            block__ = 
+                                Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::App => {
+                            if app__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("app"));
+                            }
+                            app__ = 
+                                Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                    }
+                }
+                Ok(Consensus {
+                    block: block__.unwrap_or_default(),
+                    app: app__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria_vendored.tendermint.version.Consensus", FIELDS, GeneratedVisitor)
+    }
+}

--- a/crates/astria-core/src/generated/mod.rs
+++ b/crates/astria-core/src/generated/mod.rs
@@ -4,13 +4,39 @@
     clippy::needless_borrows_for_generic_args,
     clippy::arithmetic_side_effects
 )]
+//! Files generated using [`tonic-build`] and [`buf`] via the [`tools/protobuf-compiler`]
+//! build tool.
+//!
+//! [`tonic-build`]: https://docs.rs/tonic-build
+//! [`buf`]: https://buf.build
+//! [`tools/protobuf-compiler`]: ../../../../tools/protobuf-compiler
 
-/// Files generated using [`tonic-build`] and [`buf`] via the [`tools/protobuf-compiler`]
-/// build tool.
-///
-/// [`tonic-build`]: https://docs.rs/tonic-build
-/// [`buf`]: https://buf.build
-/// [`tools/protobuf-compiler`]: ../../../../tools/protobuf-compiler
+#[path = ""]
+pub mod astria_vendored {
+    #[path = ""]
+    pub mod tendermint {
+        pub mod abci {
+            include!("astria_vendored.tendermint.abci.rs");
+
+            #[cfg(feature = "serde")]
+            mod _serde_impl {
+                use super::*;
+                include!("astria_vendored.tendermint.abci.serde.rs");
+            }
+        }
+
+        pub mod crypto {
+            include!("astria_vendored.tendermint.crypto.rs");
+
+            #[cfg(feature = "serde")]
+            mod _serde_impl {
+                use super::*;
+                include!("astria_vendored.tendermint.crypto.serde.rs");
+            }
+        }
+    }
+}
+
 #[path = ""]
 pub mod execution {
     #[path = "astria.execution.v1alpha1.rs"]
@@ -59,8 +85,15 @@ pub mod protocol {
     }
     #[path = ""]
     pub mod transaction {
-        #[path = "astria.protocol.transactions.v1alpha1.rs"]
-        pub mod v1alpha1;
+        pub mod v1alpha1 {
+            include!("astria.protocol.transactions.v1alpha1.rs");
+
+            #[cfg(feature = "serde")]
+            mod _serde_impl {
+                use super::*;
+                include!("astria.protocol.transactions.v1alpha1.serde.rs");
+            }
+        }
     }
 }
 

--- a/crates/astria-core/src/protocol/transaction/v1alpha1/action.rs
+++ b/crates/astria-core/src/protocol/transaction/v1alpha1/action.rs
@@ -24,10 +24,15 @@ use crate::{
 };
 
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(::serde::Deserialize, ::serde::Serialize))]
+#[cfg_attr(
+    feature = "serde",
+    serde(into = "raw::Action", try_from = "raw::Action")
+)]
 pub enum Action {
     Sequence(SequenceAction),
     Transfer(TransferAction),
-    ValidatorUpdate(tendermint::validator::Update),
+    ValidatorUpdate(ValidatorUpdate),
     SudoAddressChange(SudoAddressChangeAction),
     Ibc(IbcRelay),
     Ics20Withdrawal(Ics20Withdrawal),
@@ -47,7 +52,7 @@ impl Action {
         let kind = match self {
             Action::Sequence(act) => Value::SequenceAction(act.into_raw()),
             Action::Transfer(act) => Value::TransferAction(act.into_raw()),
-            Action::ValidatorUpdate(act) => Value::ValidatorUpdateAction(act.into()),
+            Action::ValidatorUpdate(act) => Value::ValidatorUpdateAction(act.into_raw()),
             Action::SudoAddressChange(act) => Value::SudoAddressChangeAction(act.into_raw()),
             Action::Ibc(act) => Value::IbcAction(act.into()),
             Action::Ics20Withdrawal(act) => Value::Ics20Withdrawal(act.into_raw()),
@@ -70,7 +75,7 @@ impl Action {
         let kind = match self {
             Action::Sequence(act) => Value::SequenceAction(act.to_raw()),
             Action::Transfer(act) => Value::TransferAction(act.to_raw()),
-            Action::ValidatorUpdate(act) => Value::ValidatorUpdateAction(act.clone().into()),
+            Action::ValidatorUpdate(act) => Value::ValidatorUpdateAction(act.to_raw()),
             Action::SudoAddressChange(act) => {
                 Value::SudoAddressChangeAction(act.clone().into_raw())
             }
@@ -110,9 +115,9 @@ impl Action {
             Value::TransferAction(act) => {
                 Self::Transfer(TransferAction::try_from_raw(act).map_err(ActionError::transfer)?)
             }
-            Value::ValidatorUpdateAction(act) => {
-                Self::ValidatorUpdate(act.try_into().map_err(ActionError::validator_update)?)
-            }
+            Value::ValidatorUpdateAction(act) => Self::ValidatorUpdate(
+                ValidatorUpdate::try_from_raw(act).map_err(ActionError::validator_update)?,
+            ),
             Value::SudoAddressChangeAction(act) => Self::SudoAddressChange(
                 SudoAddressChangeAction::try_from_raw(act)
                     .map_err(ActionError::sudo_address_change)?,
@@ -240,6 +245,20 @@ impl From<FeeChangeAction> for Action {
     }
 }
 
+impl From<Action> for raw::Action {
+    fn from(value: Action) -> Self {
+        value.into_raw()
+    }
+}
+
+impl TryFrom<raw::Action> for Action {
+    type Error = ActionError;
+
+    fn try_from(value: raw::Action) -> Result<Self, Self::Error> {
+        Self::try_from_raw(value)
+    }
+}
+
 #[allow(clippy::module_name_repetitions)]
 #[derive(Debug, thiserror::Error)]
 #[error(transparent)]
@@ -258,7 +277,7 @@ impl ActionError {
         Self(ActionErrorKind::Transfer(inner))
     }
 
-    fn validator_update(inner: tendermint::error::Error) -> Self {
+    fn validator_update(inner: ValidatorUpdateError) -> Self {
         Self(ActionErrorKind::ValidatorUpdate(inner))
     }
 
@@ -312,7 +331,7 @@ enum ActionErrorKind {
     #[error("transfer action was not valid")]
     Transfer(#[source] TransferActionError),
     #[error("validator update action was not valid")]
-    ValidatorUpdate(#[source] tendermint::error::Error),
+    ValidatorUpdate(#[source] ValidatorUpdateError),
     #[error("sudo address change action was not valid")]
     SudoAddressChange(#[source] SudoAddressChangeActionError),
     #[error("ibc action was not valid")]
@@ -531,6 +550,138 @@ enum TransferActionErrorKind {
     Asset(#[source] asset::ParseDenomError),
     #[error("`fee_asset` field did not contain a valid asset ID")]
     FeeAsset(#[source] asset::ParseDenomError),
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub struct ValidatorUpdateError(ValidatorUpdateErrorKind);
+
+impl ValidatorUpdateError {
+    fn negative_power(power: i64) -> Self {
+        Self(ValidatorUpdateErrorKind::NegativePower {
+            power,
+        })
+    }
+
+    fn public_key_not_set() -> Self {
+        Self(ValidatorUpdateErrorKind::PublicKeyNotSet)
+    }
+
+    fn secp256k1_not_supported() -> Self {
+        Self(ValidatorUpdateErrorKind::Secp256k1NotSupported)
+    }
+
+    fn verification_key(source: crate::crypto::Error) -> Self {
+        Self(ValidatorUpdateErrorKind::VerificationKey {
+            source,
+        })
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum ValidatorUpdateErrorKind {
+    #[error("field .power had negative value `{power}`, which is not permitted")]
+    NegativePower { power: i64 },
+    #[error(".pub_key field was not set")]
+    PublicKeyNotSet,
+    #[error(".pub_key field was set to secp256k1, but only ed25519 keys are supported")]
+    Secp256k1NotSupported,
+    #[error("bytes stored in the .pub_key field could not be read as an ed25519 verification key")]
+    VerificationKey { source: crate::crypto::Error },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(
+    feature = "serde",
+    serde(
+        into = "crate::generated::astria_vendored::tendermint::abci::ValidatorUpdate",
+        try_from = "crate::generated::astria_vendored::tendermint::abci::ValidatorUpdate",
+    )
+)]
+pub struct ValidatorUpdate {
+    pub power: u32,
+    pub verification_key: crate::crypto::VerificationKey,
+}
+
+impl ValidatorUpdate {
+    pub fn try_from_raw(
+        value: crate::generated::astria_vendored::tendermint::abci::ValidatorUpdate,
+    ) -> Result<Self, ValidatorUpdateError> {
+        use crate::generated::astria_vendored::tendermint::crypto::{
+            public_key,
+            PublicKey,
+        };
+        let crate::generated::astria_vendored::tendermint::abci::ValidatorUpdate {
+            pub_key,
+            power,
+        } = value;
+        let power = power
+            .try_into()
+            .map_err(|_| ValidatorUpdateError::negative_power(power))?;
+        let verification_key = match pub_key {
+            None
+            | Some(PublicKey {
+                sum: None,
+            }) => Err(ValidatorUpdateError::public_key_not_set()),
+            Some(PublicKey {
+                sum: Some(public_key::Sum::Secp256k1(..)),
+            }) => Err(ValidatorUpdateError::secp256k1_not_supported()),
+
+            Some(PublicKey {
+                sum: Some(public_key::Sum::Ed25519(bytes)),
+            }) => crate::crypto::VerificationKey::try_from(&*bytes)
+                .map_err(ValidatorUpdateError::verification_key),
+        }?;
+        Ok(Self {
+            power,
+            verification_key,
+        })
+    }
+
+    pub fn into_raw(self) -> crate::generated::astria_vendored::tendermint::abci::ValidatorUpdate {
+        self.to_raw()
+    }
+
+    pub fn to_raw(&self) -> crate::generated::astria_vendored::tendermint::abci::ValidatorUpdate {
+        use crate::generated::astria_vendored::tendermint::crypto::{
+            public_key,
+            PublicKey,
+        };
+        let Self {
+            power,
+            verification_key,
+        } = self;
+
+        crate::generated::astria_vendored::tendermint::abci::ValidatorUpdate {
+            power: (*power).into(),
+            pub_key: Some(PublicKey {
+                sum: Some(public_key::Sum::Ed25519(
+                    verification_key.to_bytes().to_vec(),
+                )),
+            }),
+        }
+    }
+}
+
+impl From<ValidatorUpdate>
+    for crate::generated::astria_vendored::tendermint::abci::ValidatorUpdate
+{
+    fn from(value: ValidatorUpdate) -> Self {
+        value.into_raw()
+    }
+}
+
+impl TryFrom<crate::generated::astria_vendored::tendermint::abci::ValidatorUpdate>
+    for ValidatorUpdate
+{
+    type Error = ValidatorUpdateError;
+
+    fn try_from(
+        value: crate::generated::astria_vendored::tendermint::abci::ValidatorUpdate,
+    ) -> Result<Self, Self::Error> {
+        Self::try_from_raw(value)
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/crates/astria-core/src/protocol/transaction/v1alpha1/action.rs
+++ b/crates/astria-core/src/protocol/transaction/v1alpha1/action.rs
@@ -605,6 +605,14 @@ pub struct ValidatorUpdate {
 }
 
 impl ValidatorUpdate {
+    /// Create a validator update by verifying a raw protobuf-decoded
+    /// [`crate::generated::astria_vendored::tendermint::abci::ValidatorUpdate`].
+    ///
+    /// # Errors
+    /// Returns an error if the `.power` field is negative, if `.pub_key`
+    /// is not set, or if `.pub_key` contains a non-ed25519 variant, or
+    /// if the ed25519 has invalid bytes (that is, bytes from which an
+    /// ed25519 public key cannot be constructed).
     pub fn try_from_raw(
         value: crate::generated::astria_vendored::tendermint::abci::ValidatorUpdate,
     ) -> Result<Self, ValidatorUpdateError> {
@@ -639,10 +647,12 @@ impl ValidatorUpdate {
         })
     }
 
+    #[must_use]
     pub fn into_raw(self) -> crate::generated::astria_vendored::tendermint::abci::ValidatorUpdate {
         self.to_raw()
     }
 
+    #[must_use]
     pub fn to_raw(&self) -> crate::generated::astria_vendored::tendermint::abci::ValidatorUpdate {
         use crate::generated::astria_vendored::tendermint::crypto::{
             public_key,

--- a/crates/astria-core/src/protocol/transaction/v1alpha1/action.rs
+++ b/crates/astria-core/src/protocol/transaction/v1alpha1/action.rs
@@ -24,9 +24,9 @@ use crate::{
 };
 
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "serde", derive(::serde::Deserialize, ::serde::Serialize))]
 #[cfg_attr(
     feature = "serde",
+    derive(::serde::Deserialize, ::serde::Serialize),
     serde(into = "raw::Action", try_from = "raw::Action")
 )]
 pub enum Action {
@@ -591,9 +591,9 @@ enum ValidatorUpdateErrorKind {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(
     feature = "serde",
+    derive(::serde::Deserialize, ::serde::Serialize),
     serde(
         into = "crate::generated::astria_vendored::tendermint::abci::ValidatorUpdate",
         try_from = "crate::generated::astria_vendored::tendermint::abci::ValidatorUpdate",

--- a/crates/astria-sequencer/Cargo.toml
+++ b/crates/astria-sequencer/Cargo.toml
@@ -70,6 +70,7 @@ config = { package = "astria-config", path = "../astria-config", features = [
   "tests",
 ] }
 insta = { workspace = true, features = ["json"] }
+rand_chacha = "0.3.1"
 tokio = { workspace = true, features = ["test-util"] }
 
 [build-dependencies]

--- a/crates/astria-sequencer/src/app/mod.rs
+++ b/crates/astria-sequencer/src/app/mod.rs
@@ -24,6 +24,7 @@ use astria_core::{
     protocol::{
         abci::AbciErrorCode,
         transaction::v1alpha1::{
+            action::ValidatorUpdate,
             Action,
             SignedTransaction,
         },
@@ -209,7 +210,7 @@ impl App {
         &mut self,
         storage: Storage,
         genesis_state: astria_core::sequencer::GenesisState,
-        genesis_validators: Vec<tendermint::validator::Update>,
+        genesis_validators: Vec<ValidatorUpdate>,
         chain_id: String,
     ) -> anyhow::Result<AppHash> {
         let mut state_tx = self
@@ -1087,7 +1088,9 @@ impl App {
 
         let events = self.apply(state_tx);
         Ok(abci::response::EndBlock {
-            validator_updates: validator_updates.into_tendermint_validator_updates(),
+            validator_updates: validator_updates
+                .try_into_cometbft()
+                .context("failed converting astria validators to cometbft compatible type")?,
             events,
             ..Default::default()
         })

--- a/crates/astria-sequencer/src/app/test_utils.rs
+++ b/crates/astria-sequencer/src/app/test_utils.rs
@@ -6,7 +6,10 @@ use astria_core::{
         ADDRESS_LEN,
     },
     protocol::transaction::v1alpha1::{
-        action::SequenceAction,
+        action::{
+            SequenceAction,
+            ValidatorUpdate,
+        },
         SignedTransaction,
         TransactionParams,
         UnsignedTransaction,
@@ -116,7 +119,7 @@ pub(crate) fn genesis_state() -> GenesisState {
 
 pub(crate) async fn initialize_app_with_storage(
     genesis_state: Option<GenesisState>,
-    genesis_validators: Vec<tendermint::validator::Update>,
+    genesis_validators: Vec<ValidatorUpdate>,
 ) -> (App, Storage) {
     let storage = cnidarium::TempStorage::new()
         .await
@@ -143,7 +146,7 @@ pub(crate) async fn initialize_app_with_storage(
 
 pub(crate) async fn initialize_app(
     genesis_state: Option<GenesisState>,
-    genesis_validators: Vec<tendermint::validator::Update>,
+    genesis_validators: Vec<ValidatorUpdate>,
 ) -> App {
     let (app, _storage) = initialize_app_with_storage(genesis_state, genesis_validators).await;
     app

--- a/crates/astria-sequencer/src/app/tests_breaking_changes.rs
+++ b/crates/astria-sequencer/src/app/tests_breaking_changes.rs
@@ -24,6 +24,7 @@ use astria_core::{
             IbcRelayerChangeAction,
             SequenceAction,
             TransferAction,
+            ValidatorUpdate,
         },
         Action,
         TransactionParams,
@@ -198,10 +199,9 @@ async fn app_execute_transaction_with_every_action_snapshot() {
     let (mut app, storage) = initialize_app_with_storage(Some(genesis_state), vec![]).await;
 
     // setup for ValidatorUpdate action
-    let pub_key = tendermint::public_key::PublicKey::from_raw_ed25519(&[1u8; 32]).unwrap();
-    let update = tendermint::validator::Update {
-        pub_key,
-        power: 100u32.into(),
+    let update = ValidatorUpdate {
+        power: 100,
+        verification_key: crate::test_utils::verification_key(1),
     };
 
     let rollup_id = RollupId::from_unhashed_bytes(b"testchainid");

--- a/crates/astria-sequencer/src/app/tests_execute_transaction.rs
+++ b/crates/astria-sequencer/src/app/tests_execute_transaction.rs
@@ -14,6 +14,7 @@ use astria_core::{
             SequenceAction,
             SudoAddressChangeAction,
             TransferAction,
+            ValidatorUpdate,
         },
         Action,
         TransactionParams,
@@ -312,10 +313,9 @@ async fn app_execute_transaction_validator_update() {
 
     let mut app = initialize_app(Some(genesis_state()), vec![]).await;
 
-    let pub_key = tendermint::public_key::PublicKey::from_raw_ed25519(&[1u8; 32]).unwrap();
-    let update = tendermint::validator::Update {
-        pub_key,
-        power: 100u32.into(),
+    let update = ValidatorUpdate {
+        power: 100,
+        verification_key: crate::test_utils::verification_key(1),
     };
 
     let tx = UnsignedTransaction {
@@ -332,7 +332,10 @@ async fn app_execute_transaction_validator_update() {
 
     let validator_updates = app.state.get_validator_updates().await.unwrap();
     assert_eq!(validator_updates.len(), 1);
-    assert_eq!(validator_updates.get(&pub_key.into()).unwrap(), &update);
+    assert_eq!(
+        validator_updates.get(crate::test_utils::verification_key(1).address_bytes()),
+        Some(&update)
+    );
 }
 
 #[tokio::test]

--- a/crates/astria-sequencer/src/authority/action.rs
+++ b/crates/astria-sequencer/src/authority/action.rs
@@ -10,9 +10,9 @@ use astria_core::{
         FeeChange,
         FeeChangeAction,
         SudoAddressChangeAction,
+        ValidatorUpdate,
     },
 };
-use tendermint::account;
 use tracing::instrument;
 
 use crate::{
@@ -24,7 +24,7 @@ use crate::{
 };
 
 #[async_trait::async_trait]
-impl ActionHandler for tendermint::validator::Update {
+impl ActionHandler for ValidatorUpdate {
     async fn check_stateful<S: StateReadExt + 'static>(
         &self,
         state: &S,
@@ -39,14 +39,14 @@ impl ActionHandler for tendermint::validator::Update {
 
         // ensure that we're not removing the last validator or a validator
         // that doesn't exist, these both cause issues in cometBFT
-        if self.power.is_zero() {
+        if self.power == 0 {
             let validator_set = state
                 .get_validator_set()
                 .await
                 .context("failed to get validator set from state")?;
             // check that validator exists
             if validator_set
-                .get(&account::Id::from(self.pub_key))
+                .get(self.verification_key.address_bytes())
                 .is_none()
             {
                 bail!("cannot remove a non-existing validator");
@@ -64,7 +64,9 @@ impl ActionHandler for tendermint::validator::Update {
             .get_validator_updates()
             .await
             .context("failed getting validator updates from state")?;
-        validator_updates.push_update(self.clone());
+        validator_updates
+            .push_update(self.clone())
+            .context("failed adding validator to update-list of validators")?;
         state
             .put_validator_updates(validator_updates)
             .context("failed to put validator updates in state")?;

--- a/crates/astria-sequencer/src/authority/action.rs
+++ b/crates/astria-sequencer/src/authority/action.rs
@@ -64,9 +64,7 @@ impl ActionHandler for ValidatorUpdate {
             .get_validator_updates()
             .await
             .context("failed getting validator updates from state")?;
-        validator_updates
-            .push_update(self.clone())
-            .context("failed adding validator to update-list of validators")?;
+        validator_updates.push_update(self.clone());
         state
             .put_validator_updates(validator_updates)
             .context("failed to put validator updates in state")?;

--- a/crates/astria-sequencer/src/authority/state_ext.rs
+++ b/crates/astria-sequencer/src/authority/state_ext.rs
@@ -36,7 +36,6 @@ struct SudoAddress([u8; ADDRESS_LEN]);
 ///
 /// Contains a map of hex-encoded public keys to validator updates.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-// #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct ValidatorSet(BTreeMap<ValidatorSetKey, ValidatorUpdate>);
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Ord, PartialOrd)]

--- a/crates/astria-sequencer/src/authority/state_ext.rs
+++ b/crates/astria-sequencer/src/authority/state_ext.rs
@@ -5,9 +5,13 @@ use anyhow::{
     Context,
     Result,
 };
-use astria_core::primitive::v1::{
-    Address,
-    ADDRESS_LEN,
+use astria_core::{
+    crypto::VerificationKey,
+    primitive::v1::{
+        Address,
+        ADDRESS_LEN,
+    },
+    protocol::transaction::v1alpha1::action::ValidatorUpdate,
 };
 use async_trait::async_trait;
 use borsh::{
@@ -22,10 +26,6 @@ use serde::{
     Deserialize,
     Serialize,
 };
-use tendermint::{
-    account,
-    validator,
-};
 use tracing::instrument;
 
 /// Newtype wrapper to read and write an address from rocksdb.
@@ -36,32 +36,49 @@ struct SudoAddress([u8; ADDRESS_LEN]);
 ///
 /// Contains a map of hex-encoded public keys to validator updates.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub(crate) struct ValidatorSet(BTreeMap<account::Id, validator::Update>);
+// #[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ValidatorSet(BTreeMap<ValidatorSetKey, ValidatorUpdate>);
+
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Ord, PartialOrd)]
+pub(crate) struct ValidatorSetKey(#[serde(with = "::hex::serde")] [u8; ADDRESS_LEN]);
+
+impl From<[u8; ADDRESS_LEN]> for ValidatorSetKey {
+    fn from(value: [u8; ADDRESS_LEN]) -> Self {
+        Self(value)
+    }
+}
+
+impl From<VerificationKey> for ValidatorSetKey {
+    fn from(value: VerificationKey) -> Self {
+        Self(value.address_bytes())
+    }
+}
 
 impl ValidatorSet {
-    pub(crate) fn new_from_updates(updates: Vec<validator::Update>) -> Self {
-        let validator_set = updates
-            .into_iter()
-            .map(|update| (account::Id::from(update.pub_key), update))
-            .collect::<BTreeMap<_, _>>();
-        Self(validator_set)
+    pub(crate) fn new_from_updates(updates: Vec<ValidatorUpdate>) -> Self {
+        Self(
+            updates
+                .into_iter()
+                .map(|update| (update.verification_key.into(), update))
+                .collect::<BTreeMap<_, _>>(),
+        )
     }
 
     pub(crate) fn len(&self) -> usize {
         self.0.len()
     }
 
-    pub(crate) fn get(&self, address: &account::Id) -> Option<&validator::Update> {
-        self.0.get(address)
+    pub(crate) fn get<T: Into<ValidatorSetKey>>(&self, address: T) -> Option<&ValidatorUpdate> {
+        self.0.get(&address.into())
     }
 
-    pub(crate) fn push_update(&mut self, update: validator::Update) {
-        let address = tendermint::account::Id::from(update.pub_key);
-        self.0.insert(address, update);
+    pub(crate) fn push_update(&mut self, update: ValidatorUpdate) -> anyhow::Result<()> {
+        self.0.insert(update.verification_key.into(), update);
+        Ok(())
     }
 
-    pub(crate) fn remove(&mut self, address: &account::Id) {
-        self.0.remove(address);
+    pub(crate) fn remove<T: Into<ValidatorSetKey>>(&mut self, address: T) {
+        self.0.remove(&address.into());
     }
 
     /// Apply updates to the validator set.
@@ -70,15 +87,19 @@ impl ValidatorSet {
     /// Otherwise, update the validator's power.
     pub(crate) fn apply_updates(&mut self, validator_updates: ValidatorSet) {
         for (address, update) in validator_updates.0 {
-            match update.power.value() {
+            match update.power {
                 0 => self.0.remove(&address),
                 _ => self.0.insert(address, update),
             };
         }
     }
 
-    pub(crate) fn into_tendermint_validator_updates(self) -> Vec<validator::Update> {
-        self.0.into_values().collect::<Vec<_>>()
+    pub(crate) fn try_into_cometbft(self) -> anyhow::Result<Vec<tendermint::validator::Update>> {
+        self.0
+            .into_values()
+            .map(crate::utils::sequencer_to_cometbft_validator)
+            .collect::<Result<Vec<_>, _>>()
+            .context("failed to map one or more astria validators to cometbft validators")
     }
 }
 
@@ -179,18 +200,19 @@ impl<T: StateWrite> StateWriteExt for T {}
 
 #[cfg(test)]
 mod test {
+    use astria_core::protocol::transaction::v1alpha1::action::ValidatorUpdate;
     use cnidarium::StateDelta;
-    use tendermint::{
-        validator,
-        vote,
-        PublicKey,
-    };
 
     use super::{
         StateReadExt as _,
         StateWriteExt as _,
         ValidatorSet,
     };
+    use crate::test_utils::verification_key;
+
+    fn empty_validator_set() -> ValidatorSet {
+        ValidatorSet::new_from_updates(vec![])
+    }
 
     #[tokio::test]
     async fn sudo_address() {
@@ -252,10 +274,9 @@ mod test {
         let snapshot = storage.latest_snapshot();
         let mut state = StateDelta::new(snapshot);
 
-        let initial = vec![validator::Update {
-            pub_key: PublicKey::from_raw_ed25519(&[1u8; 32])
-                .expect("creating ed25519 key should not fail"),
-            power: vote::Power::from(10u32),
+        let initial = vec![ValidatorUpdate {
+            power: 10,
+            verification_key: verification_key(1),
         }];
         let initial_validator_set = ValidatorSet::new_from_updates(initial);
 
@@ -273,10 +294,9 @@ mod test {
         );
 
         // can update
-        let updates = vec![validator::Update {
-            pub_key: PublicKey::from_raw_ed25519(&[2u8; 32])
-                .expect("creating ed25519 key should not fail"),
-            power: vote::Power::from(20u32),
+        let updates = vec![ValidatorUpdate {
+            power: 20,
+            verification_key: verification_key(2),
         }];
         let updated_validator_set = ValidatorSet::new_from_updates(updates);
         state
@@ -298,16 +318,13 @@ mod test {
         let snapshot = storage.latest_snapshot();
         let state = StateDelta::new(snapshot);
 
-        // create update validator set
-        let empty_validator_set = ValidatorSet::new_from_updates(vec![]);
-
         // querying for empty validator set is ok
         assert_eq!(
             state
                 .get_validator_updates()
                 .await
                 .expect("if no updates have been written return empty set"),
-            empty_validator_set,
+            empty_validator_set(),
             "returned empty validator set different than expected"
         );
     }
@@ -320,15 +337,13 @@ mod test {
 
         // create update validator set
         let mut updates = vec![
-            validator::Update {
-                pub_key: PublicKey::from_raw_ed25519(&[1u8; 32])
-                    .expect("creating ed25519 key should not fail"),
-                power: vote::Power::from(10u32),
+            ValidatorUpdate {
+                power: 10,
+                verification_key: verification_key(1),
             },
-            validator::Update {
-                pub_key: PublicKey::from_raw_ed25519(&[2u8; 32])
-                    .expect("creating ed25519 key should not fail"),
-                power: vote::Power::from(0u32),
+            ValidatorUpdate {
+                power: 0,
+                verification_key: verification_key(2),
             },
         ];
         let mut validator_set_updates = ValidatorSet::new_from_updates(updates);
@@ -348,15 +363,13 @@ mod test {
 
         // create different updates
         updates = vec![
-            validator::Update {
-                pub_key: PublicKey::from_raw_ed25519(&[1u8; 32])
-                    .expect("creating ed25519 key should not fail"),
-                power: vote::Power::from(22u32),
+            ValidatorUpdate {
+                power: 22,
+                verification_key: verification_key(1),
             },
-            validator::Update {
-                pub_key: PublicKey::from_raw_ed25519(&[3u8; 32])
-                    .expect("creating ed25519 key should not fail"),
-                power: vote::Power::from(10u32),
+            ValidatorUpdate {
+                power: 10,
+                verification_key: verification_key(3),
             },
         ];
 
@@ -383,10 +396,9 @@ mod test {
         let mut state = StateDelta::new(snapshot);
 
         // create update validator set
-        let updates = vec![validator::Update {
-            pub_key: PublicKey::from_raw_ed25519(&[1u8; 32])
-                .expect("creating ed25519 key should not fail"),
-            power: vote::Power::from(10u32),
+        let updates = vec![ValidatorUpdate {
+            power: 10,
+            verification_key: verification_key(1),
         }];
         let validator_set_updates = ValidatorSet::new_from_updates(updates);
 
@@ -407,13 +419,12 @@ mod test {
         state.clear_validator_updates();
 
         // check that clear worked
-        let empty_validator_set = ValidatorSet::new_from_updates(vec![]);
         assert_eq!(
             state
                 .get_validator_updates()
                 .await
                 .expect("if no updates have been written return empty set"),
-            empty_validator_set,
+            empty_validator_set(),
             "returned validator set different than expected"
         );
     }
@@ -430,39 +441,32 @@ mod test {
 
     #[tokio::test]
     async fn execute_validator_updates() {
-        let key_0 =
-            PublicKey::from_raw_ed25519(&[1u8; 32]).expect("creating ed25519 key should not fail");
-        let key_1 =
-            PublicKey::from_raw_ed25519(&[2u8; 32]).expect("creating ed25519 key should not fail");
-        let key_2 =
-            PublicKey::from_raw_ed25519(&[3u8; 32]).expect("creating ed25519 key should not fail");
-
         // create initial validator set
         let initial = vec![
-            validator::Update {
-                pub_key: key_0,
-                power: vote::Power::from(1u32),
+            ValidatorUpdate {
+                power: 1,
+                verification_key: verification_key(0),
             },
-            validator::Update {
-                pub_key: key_1,
-                power: vote::Power::from(2u32),
+            ValidatorUpdate {
+                power: 2,
+                verification_key: verification_key(1),
             },
-            validator::Update {
-                pub_key: key_2,
-                power: vote::Power::from(3u32),
+            ValidatorUpdate {
+                power: 3,
+                verification_key: verification_key(2),
             },
         ];
         let mut initial_validator_set = ValidatorSet::new_from_updates(initial);
 
         // create set of updates (update key_0, remove key_1)
         let updates = vec![
-            validator::Update {
-                pub_key: key_0,
-                power: vote::Power::from(5u32),
+            ValidatorUpdate {
+                power: 5,
+                verification_key: verification_key(0),
             },
-            validator::Update {
-                pub_key: key_1,
-                power: vote::Power::from(0u32),
+            ValidatorUpdate {
+                power: 0,
+                verification_key: verification_key(1),
             },
         ];
 
@@ -473,13 +477,13 @@ mod test {
 
         // create end state
         let updates = vec![
-            validator::Update {
-                pub_key: key_0,
-                power: vote::Power::from(5u32),
+            ValidatorUpdate {
+                power: 5,
+                verification_key: verification_key(0),
             },
-            validator::Update {
-                pub_key: key_2,
-                power: vote::Power::from(3u32),
+            ValidatorUpdate {
+                power: 3,
+                verification_key: verification_key(2),
             },
         ];
         let validator_set_endstate = ValidatorSet::new_from_updates(updates);

--- a/crates/astria-sequencer/src/authority/state_ext.rs
+++ b/crates/astria-sequencer/src/authority/state_ext.rs
@@ -72,9 +72,8 @@ impl ValidatorSet {
         self.0.get(&address.into())
     }
 
-    pub(crate) fn push_update(&mut self, update: ValidatorUpdate) -> anyhow::Result<()> {
+    pub(crate) fn push_update(&mut self, update: ValidatorUpdate) {
         self.0.insert(update.verification_key.into(), update);
-        Ok(())
     }
 
     pub(crate) fn remove<T: Into<ValidatorSetKey>>(&mut self, address: T) {

--- a/crates/astria-sequencer/src/lib.rs
+++ b/crates/astria-sequencer/src/lib.rs
@@ -19,6 +19,8 @@ mod sequencer;
 pub(crate) mod service;
 pub(crate) mod state_ext;
 pub(crate) mod storage_keys;
+#[cfg(test)]
+pub(crate) mod test_utils;
 pub(crate) mod transaction;
 mod utils;
 

--- a/crates/astria-sequencer/src/service/consensus.rs
+++ b/crates/astria-sequencer/src/service/consensus.rs
@@ -137,7 +137,15 @@ impl Consensus {
             .init_chain(
                 self.storage.clone(),
                 genesis_state,
-                init_chain.validators.clone(),
+                init_chain
+                    .validators
+                    .iter()
+                    .cloned()
+                    .map(crate::utils::cometbft_to_sequencer_validator)
+                    .collect::<Result<_, _>>()
+                    .context(
+                        "failed converting cometbft genesis validators to astria validators",
+                    )?,
                 init_chain.chain_id,
             )
             .await

--- a/crates/astria-sequencer/src/test_utils.rs
+++ b/crates/astria-sequencer/src/test_utils.rs
@@ -1,0 +1,11 @@
+use astria_core::crypto::{
+    SigningKey,
+    VerificationKey,
+};
+
+pub(crate) fn verification_key(seed: u64) -> VerificationKey {
+    use rand::SeedableRng as _;
+    let rng = rand_chacha::ChaChaRng::seed_from_u64(seed);
+    let signing_key = SigningKey::new(rng);
+    signing_key.verification_key()
+}

--- a/crates/astria-sequencer/src/utils.rs
+++ b/crates/astria-sequencer/src/utils.rs
@@ -1,3 +1,9 @@
+use anyhow::Context as _;
+use astria_core::{
+    generated::astria_vendored::tendermint::abci as raw,
+    protocol::transaction::v1alpha1::action::ValidatorUpdate,
+};
+
 pub(crate) struct Hex<'a>(pub(crate) &'a [u8]);
 
 impl<'a> std::fmt::Display for Hex<'a> {
@@ -6,5 +12,73 @@ impl<'a> std::fmt::Display for Hex<'a> {
             f.write_fmt(format_args!("{byte:02x}"))?;
         }
         Ok(())
+    }
+}
+
+pub(crate) fn cometbft_to_sequencer_validator(
+    value: tendermint::validator::Update,
+) -> anyhow::Result<ValidatorUpdate> {
+    let tendermint_proto::abci::ValidatorUpdate {
+        pub_key,
+        power,
+    } = value.into();
+    ValidatorUpdate::try_from_raw(raw::ValidatorUpdate {
+        power,
+        pub_key: pub_key.map(pubkey::cometbft_to_astria),
+    })
+    .context("failed converting cometbft validator update to astria validator update")
+}
+
+pub(crate) fn sequencer_to_cometbft_validator(
+    value: ValidatorUpdate,
+) -> anyhow::Result<tendermint::validator::Update> {
+    let astria_core::generated::astria_vendored::tendermint::abci::ValidatorUpdate {
+        pub_key,
+        power,
+    } = value.into_raw();
+    tendermint_proto::abci::ValidatorUpdate {
+        pub_key: pub_key.map(pubkey::astria_to_cometbft),
+        power,
+    }
+    .try_into()
+    .context("failed converting astria validator update to cometbft validator update")
+}
+
+mod pubkey {
+    use astria_core::generated::astria_vendored::tendermint::crypto::{
+        public_key::Sum as AstriaSum,
+        PublicKey as AstriaKey,
+    };
+    use tendermint_proto::crypto::{
+        public_key::Sum as CometbftSum,
+        PublicKey as CometbftKey,
+    };
+
+    pub(super) fn astria_to_cometbft(key: AstriaKey) -> CometbftKey {
+        let AstriaKey {
+            sum,
+        } = key;
+        let sum = match sum {
+            Some(AstriaSum::Ed25519(bytes)) => Some(CometbftSum::Ed25519(bytes)),
+            Some(AstriaSum::Secp256k1(bytes)) => Some(CometbftSum::Secp256k1(bytes)),
+            None => None,
+        };
+        CometbftKey {
+            sum,
+        }
+    }
+
+    pub(super) fn cometbft_to_astria(key: CometbftKey) -> AstriaKey {
+        let CometbftKey {
+            sum,
+        } = key;
+        let sum = match sum {
+            Some(CometbftSum::Ed25519(bytes)) => Some(AstriaSum::Ed25519(bytes)),
+            Some(CometbftSum::Secp256k1(bytes)) => Some(AstriaSum::Secp256k1(bytes)),
+            None => None,
+        };
+        AstriaKey {
+            sum,
+        }
     }
 }

--- a/tools/protobuf-compiler/src/main.rs
+++ b/tools/protobuf-compiler/src/main.rs
@@ -73,23 +73,11 @@ fn main() {
         ])
         .client_mod_attribute(".", "#[cfg(feature=\"client\")]")
         .server_mod_attribute(".", "#[cfg(feature=\"server\")]")
-        .extern_path(
-            ".astria_vendored.tendermint.abci",
-            "::tendermint-proto::abci",
-        )
-        .extern_path(
-            ".astria_vendored.tendermint.crypto",
-            "::tendermint-proto::crypto",
-        )
-        .extern_path(
-            ".astria_vendored.tendermint.version",
-            "::tendermint-proto::version",
-        )
-        .extern_path(
-            ".astria_vendored.tendermint.types",
-            "::tendermint-proto::types",
-        )
         .extern_path(".astria_vendored.penumbra", "::penumbra-proto")
+        .extern_path(
+            ".astria_vendored.tendermint.abci.ValidatorUpdate",
+            "crate::generated::astria_vendored::tendermint::abci::ValidatorUpdate",
+        )
         .type_attribute(".astria.primitive.v1.Uint128", "#[derive(Copy)]")
         .use_arc_self(true)
         // override prost-types with pbjson-types
@@ -109,9 +97,8 @@ fn main() {
         .unwrap()
         .out_dir(&out_dir)
         .build(&[
-            ".astria.execution.v1alpha2",
-            ".astria.primitive.v1",
-            ".astria.sequencerblock.v1alpha1",
+            ".astria",
+            ".astria_vendored",
             ".celestia",
             ".cosmos",
             ".tendermint",
@@ -150,6 +137,7 @@ fn clean_non_astria_code(generated: &mut ContentMap) {
         .keys()
         .filter(|name| {
             !name.starts_with("astria.")
+                && !name.starts_with("astria_vendored.")
                 && !name.starts_with("celestia.")
                 && !name.starts_with("cosmos.")
                 && !name.starts_with("tendermint.")


### PR DESCRIPTION
## Summary
This patch ensures extends our generated serde `Deserialize` and `Serialize` trait implementations to all protobuf messages defined in `astria.protocol`.

## Background
So far the protocol-specs did not have serde traits generated, but these are necessary to write out bridge-withdrawer actions as JSON.

A side-effect of this patch is that all of `proto/protocolapis/astria_vendored` is now also commited to the repository (they were previously filtered). Very likely this is not desired but should be addressed in a followup. It is not clear to the author of this patch in how far these types might be necessary.

## Changes
- Generate serde `Deserialize` and `Serialize` impls for Rust types generated from `astria.protocol` and `astria_vendored` protobufs
- Use a vendored `astria_vendored::tendermint::abci::ValidatorUpdate` instead of `tendermint_proto`: `tendermint_proto@v0.34` does not yet have serde impls for its types, which blocks us from having an easy way to use `pbjson` generated serde impls
- Introduce a new `ValidatorUpdate` action to replace `tendermint::validator::Update` to transform to/from the vendored protobuf type (again necessary to implement serde and foreign type restrictions)
- Update sequencer to use  the new `ValidatorUpdate` type

## Testing
All tests have been upgraded and still pass. Specifically, ingestion of validator updates happens through cometbft, which were already tested end-to-end.

## Breaking Changelist
- Marked as breaking even though none of the breaking change tests are affected: the serialization shape of the validator updates has changed. As they are commited to state using json, this should be breaking.
