### PR TITLE
feat(cli): add bridge cmd to submit withdrawal events

### DIFF
--- a/crates/astria-cli/src/cli/bridge.rs
+++ b/crates/astria-cli/src/cli/bridge.rs
@@ -2,16 +2,21 @@ use clap::Subcommand;
 use color_eyre::eyre;
 
 /// Interact with a Sequencer node
+// allow: these are one-shot variants. the size doesn't matter as they are
+// passed around only once.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Subcommand)]
-pub enum Command {
+pub(crate) enum Command {
     /// Commands for interacting with Sequencer accounts
-    CollectWithdrawalEvents(crate::commands::bridge::CollectWithdrawalEvents),
+    CollectWithdrawals(crate::commands::bridge::collect::WithdrawalEvents),
+    SubmitWithdrawals(crate::commands::bridge::submit::WithdrawalEvents),
 }
 
 impl Command {
-    pub async fn run(self) -> eyre::Result<()> {
+    pub(crate) async fn run(self) -> eyre::Result<()> {
         match self {
-            Command::CollectWithdrawalEvents(args) => args.run().await,
+            Command::CollectWithdrawals(args) => args.run().await,
+            Command::SubmitWithdrawals(args) => args.run().await,
         }
     }
 }

--- a/crates/astria-cli/src/cli/mod.rs
+++ b/crates/astria-cli/src/cli/mod.rs
@@ -17,7 +17,7 @@ const DEFAULT_SEQUENCER_CHAIN_ID: &str = "astria-dusk-7";
 #[command(name = "astria-cli", version)]
 pub struct Cli {
     #[command(subcommand)]
-    pub command: Option<Command>,
+    pub(crate) command: Option<Command>,
 }
 
 impl Cli {
@@ -34,7 +34,7 @@ impl Cli {
 
 /// Commands that can be run
 #[derive(Debug, Subcommand)]
-pub enum Command {
+pub(crate) enum Command {
     Bridge {
         #[command(subcommand)]
         command: bridge::Command,

--- a/crates/astria-cli/src/cli/sequencer.rs
+++ b/crates/astria-cli/src/cli/sequencer.rs
@@ -7,7 +7,7 @@ use clap::{
 
 /// Interact with a Sequencer node
 #[derive(Debug, Subcommand)]
-pub(crate)enum Command {
+pub(crate) enum Command {
     /// Commands for interacting with Sequencer accounts
     Account {
         #[command(subcommand)]
@@ -43,7 +43,7 @@ pub(crate)enum Command {
 }
 
 #[derive(Debug, Subcommand)]
-pub(crate)enum AccountCommand {
+pub(crate) enum AccountCommand {
     /// Create a new Sequencer account
     Create,
     Balance(BasicAccountArgs),
@@ -51,19 +51,19 @@ pub(crate)enum AccountCommand {
 }
 
 #[derive(Debug, Subcommand)]
-pub(crate)enum AddressCommand {
+pub(crate) enum AddressCommand {
     /// Construct a bech32m Sequencer address given a public key
     Bech32m(Bech32mAddressArgs),
 }
 
 #[derive(Debug, Subcommand)]
-pub(crate)enum BalanceCommand {
+pub(crate) enum BalanceCommand {
     /// Get the balance of a Sequencer account
     Get(BasicAccountArgs),
 }
 
 #[derive(Debug, Subcommand)]
-pub(crate)enum SudoCommand {
+pub(crate) enum SudoCommand {
     IbcRelayer {
         #[command(subcommand)]
         command: IbcRelayerChangeCommand,
@@ -77,7 +77,7 @@ pub(crate)enum SudoCommand {
 }
 
 #[derive(Debug, Subcommand)]
-pub(crate)enum IbcRelayerChangeCommand {
+pub(crate) enum IbcRelayerChangeCommand {
     /// Add IBC Relayer
     Add(IbcRelayerChangeArgs),
     /// Remove IBC Relayer
@@ -85,7 +85,7 @@ pub(crate)enum IbcRelayerChangeCommand {
 }
 
 #[derive(Debug, Subcommand)]
-pub(crate)enum FeeAssetChangeCommand {
+pub(crate) enum FeeAssetChangeCommand {
     /// Add Fee Asset
     Add(FeeAssetChangeArgs),
     /// Remove Fee Asset
@@ -93,7 +93,7 @@ pub(crate)enum FeeAssetChangeCommand {
 }
 
 #[derive(Args, Debug)]
-pub(crate)struct BasicAccountArgs {
+pub(crate) struct BasicAccountArgs {
     /// The url of the Sequencer node
     #[arg(
         long,
@@ -106,7 +106,7 @@ pub(crate)struct BasicAccountArgs {
 }
 
 #[derive(Args, Debug)]
-pub(crate)struct Bech32mAddressArgs {
+pub(crate) struct Bech32mAddressArgs {
     /// The hex formatted byte part of the bech32m address
     #[arg(long)]
     pub(crate) bytes: String,
@@ -116,7 +116,7 @@ pub(crate)struct Bech32mAddressArgs {
 }
 
 #[derive(Args, Debug)]
-pub(crate)struct TransferArgs {
+pub(crate) struct TransferArgs {
     // The address of the Sequencer account to send amount to
     pub(crate) to_address: Address,
     // The amount being sent
@@ -145,17 +145,17 @@ pub(crate)struct TransferArgs {
         env = "ROLLUP_SEQUENCER_CHAIN_ID",
         default_value = crate::cli::DEFAULT_SEQUENCER_CHAIN_ID
     )]
-    pub(crate)sequencer_chain_id: String,
+    pub(crate) sequencer_chain_id: String,
     /// The asset to transer.
     #[arg(long, default_value = "nria")]
-    pub(crate)asset: asset::Denom,
+    pub(crate) asset: asset::Denom,
     /// The asset to pay the transfer fees with.
     #[arg(long, default_value = "nria")]
-    pub(crate)fee_asset: asset::Denom,
+    pub(crate) fee_asset: asset::Denom,
 }
 
 #[derive(Args, Debug)]
-pub(crate)struct FeeAssetChangeArgs {
+pub(crate) struct FeeAssetChangeArgs {
     /// The bech32m prefix that will be used for constructing addresses using the private key
     #[arg(long, default_value = "astria")]
     pub(crate) prefix: String,
@@ -178,14 +178,14 @@ pub(crate)struct FeeAssetChangeArgs {
         env = "ROLLUP_SEQUENCER_CHAIN_ID",
         default_value = crate::cli::DEFAULT_SEQUENCER_CHAIN_ID
     )]
-    pub(crate)sequencer_chain_id: String,
+    pub(crate) sequencer_chain_id: String,
     /// Asset's denomination string
     #[arg(long)]
     pub(crate) asset: asset::Denom,
 }
 
 #[derive(Args, Debug)]
-pub(crate)struct IbcRelayerChangeArgs {
+pub(crate) struct IbcRelayerChangeArgs {
     /// The prefix to construct a bech32m address given the private key.
     #[arg(long, default_value = "astria")]
     pub(crate) prefix: String,
@@ -208,14 +208,14 @@ pub(crate)struct IbcRelayerChangeArgs {
         env = "ROLLUP_SEQUENCER_CHAIN_ID",
         default_value = crate::cli::DEFAULT_SEQUENCER_CHAIN_ID
     )]
-    pub(crate)sequencer_chain_id: String,
+    pub(crate) sequencer_chain_id: String,
     /// The address to add or remove as an IBC relayer
     #[arg(long)]
     pub(crate) address: Address,
 }
 
 #[derive(Args, Debug)]
-pub(crate)struct InitBridgeAccountArgs {
+pub(crate) struct InitBridgeAccountArgs {
     /// The bech32m prefix that will be used for constructing addresses using the private key
     #[arg(long, default_value = "astria")]
     pub(crate) prefix: String,
@@ -238,21 +238,21 @@ pub(crate)struct InitBridgeAccountArgs {
         env = "ROLLUP_SEQUENCER_CHAIN_ID",
         default_value = crate::cli::DEFAULT_SEQUENCER_CHAIN_ID
     )]
-    pub(crate)sequencer_chain_id: String,
+    pub(crate) sequencer_chain_id: String,
     /// Plaintext rollup name (to be hashed into a rollup ID)
     /// to initialize the bridge account with.
     #[arg(long)]
     pub(crate) rollup_name: String,
     /// The asset to transer.
     #[arg(long, default_value = "nria")]
-    pub(crate)asset: asset::Denom,
+    pub(crate) asset: asset::Denom,
     /// The asset to pay the transfer fees with.
     #[arg(long, default_value = "nria")]
-    pub(crate)fee_asset: asset::Denom,
+    pub(crate) fee_asset: asset::Denom,
 }
 
 #[derive(Args, Debug)]
-pub(crate)struct BridgeLockArgs {
+pub(crate) struct BridgeLockArgs {
     /// The address of the Sequencer account to lock amount to
     pub(crate) to_address: Address,
     /// The amount being locked
@@ -282,23 +282,23 @@ pub(crate)struct BridgeLockArgs {
         env = "ROLLUP_SEQUENCER_CHAIN_ID",
         default_value = crate::cli::DEFAULT_SEQUENCER_CHAIN_ID
     )]
-    pub(crate)sequencer_chain_id: String,
+    pub(crate) sequencer_chain_id: String,
     /// The asset to lock.
     #[arg(long, default_value = "nria")]
-    pub(crate)asset: asset::Denom,
+    pub(crate) asset: asset::Denom,
     /// The asset to pay the transfer fees with.
     #[arg(long, default_value = "nria")]
-    pub(crate)fee_asset: asset::Denom,
+    pub(crate) fee_asset: asset::Denom,
 }
 
 #[derive(Debug, Subcommand)]
-pub(crate)enum BlockHeightCommand {
+pub(crate) enum BlockHeightCommand {
     /// Get the current block height of the Sequencer node
     Get(BlockHeightGetArgs),
 }
 
 #[derive(Args, Debug)]
-pub(crate)struct BlockHeightGetArgs {
+pub(crate) struct BlockHeightGetArgs {
     /// The url of the Sequencer node
     #[arg(
         long,
@@ -312,11 +312,11 @@ pub(crate)struct BlockHeightGetArgs {
         env = "ROLLUP_SEQUENCER_CHAIN_ID",
         default_value = crate::cli::DEFAULT_SEQUENCER_CHAIN_ID
     )]
-    pub(crate)sequencer_chain_id: String,
+    pub(crate) sequencer_chain_id: String,
 }
 
 #[derive(Args, Debug)]
-pub(crate)struct SudoAddressChangeArgs {
+pub(crate) struct SudoAddressChangeArgs {
     /// The bech32m prefix that will be used for constructing addresses using the private key
     #[arg(long, default_value = "astria")]
     pub(crate) prefix: String,
@@ -339,14 +339,14 @@ pub(crate)struct SudoAddressChangeArgs {
         env = "ROLLUP_SEQUENCER_CHAIN_ID",
         default_value = crate::cli::DEFAULT_SEQUENCER_CHAIN_ID
     )]
-    pub(crate)sequencer_chain_id: String,
+    pub(crate) sequencer_chain_id: String,
     /// The new address to take over sudo privileges
     #[arg(long)]
     pub(crate) address: Address,
 }
 
 #[derive(Args, Debug)]
-pub(crate)struct ValidatorUpdateArgs {
+pub(crate) struct ValidatorUpdateArgs {
     /// The url of the Sequencer node
     #[arg(
         long,
@@ -360,7 +360,7 @@ pub(crate)struct ValidatorUpdateArgs {
         env = "ROLLUP_SEQUENCER_CHAIN_ID",
         default_value = crate::cli::DEFAULT_SEQUENCER_CHAIN_ID
     )]
-    pub(crate)sequencer_chain_id: String,
+    pub(crate) sequencer_chain_id: String,
     /// The bech32m prefix that will be used for constructing addresses using the private key
     #[arg(long, default_value = "astria")]
     pub(crate) prefix: String,

--- a/crates/astria-cli/src/cli/sequencer.rs
+++ b/crates/astria-cli/src/cli/sequencer.rs
@@ -7,7 +7,7 @@ use clap::{
 
 /// Interact with a Sequencer node
 #[derive(Debug, Subcommand)]
-pub enum Command {
+pub(crate)enum Command {
     /// Commands for interacting with Sequencer accounts
     Account {
         #[command(subcommand)]
@@ -43,7 +43,7 @@ pub enum Command {
 }
 
 #[derive(Debug, Subcommand)]
-pub enum AccountCommand {
+pub(crate)enum AccountCommand {
     /// Create a new Sequencer account
     Create,
     Balance(BasicAccountArgs),
@@ -51,19 +51,19 @@ pub enum AccountCommand {
 }
 
 #[derive(Debug, Subcommand)]
-pub enum AddressCommand {
+pub(crate)enum AddressCommand {
     /// Construct a bech32m Sequencer address given a public key
     Bech32m(Bech32mAddressArgs),
 }
 
 #[derive(Debug, Subcommand)]
-pub enum BalanceCommand {
+pub(crate)enum BalanceCommand {
     /// Get the balance of a Sequencer account
     Get(BasicAccountArgs),
 }
 
 #[derive(Debug, Subcommand)]
-pub enum SudoCommand {
+pub(crate)enum SudoCommand {
     IbcRelayer {
         #[command(subcommand)]
         command: IbcRelayerChangeCommand,
@@ -77,7 +77,7 @@ pub enum SudoCommand {
 }
 
 #[derive(Debug, Subcommand)]
-pub enum IbcRelayerChangeCommand {
+pub(crate)enum IbcRelayerChangeCommand {
     /// Add IBC Relayer
     Add(IbcRelayerChangeArgs),
     /// Remove IBC Relayer
@@ -85,7 +85,7 @@ pub enum IbcRelayerChangeCommand {
 }
 
 #[derive(Debug, Subcommand)]
-pub enum FeeAssetChangeCommand {
+pub(crate)enum FeeAssetChangeCommand {
     /// Add Fee Asset
     Add(FeeAssetChangeArgs),
     /// Remove Fee Asset
@@ -93,7 +93,7 @@ pub enum FeeAssetChangeCommand {
 }
 
 #[derive(Args, Debug)]
-pub struct BasicAccountArgs {
+pub(crate)struct BasicAccountArgs {
     /// The url of the Sequencer node
     #[arg(
         long,
@@ -106,7 +106,7 @@ pub struct BasicAccountArgs {
 }
 
 #[derive(Args, Debug)]
-pub struct Bech32mAddressArgs {
+pub(crate)struct Bech32mAddressArgs {
     /// The hex formatted byte part of the bech32m address
     #[arg(long)]
     pub(crate) bytes: String,
@@ -116,7 +116,7 @@ pub struct Bech32mAddressArgs {
 }
 
 #[derive(Args, Debug)]
-pub struct TransferArgs {
+pub(crate)struct TransferArgs {
     // The address of the Sequencer account to send amount to
     pub(crate) to_address: Address,
     // The amount being sent
@@ -145,17 +145,17 @@ pub struct TransferArgs {
         env = "ROLLUP_SEQUENCER_CHAIN_ID",
         default_value = crate::cli::DEFAULT_SEQUENCER_CHAIN_ID
     )]
-    pub sequencer_chain_id: String,
+    pub(crate)sequencer_chain_id: String,
     /// The asset to transer.
     #[arg(long, default_value = "nria")]
-    pub asset: asset::Denom,
+    pub(crate)asset: asset::Denom,
     /// The asset to pay the transfer fees with.
     #[arg(long, default_value = "nria")]
-    pub fee_asset: asset::Denom,
+    pub(crate)fee_asset: asset::Denom,
 }
 
 #[derive(Args, Debug)]
-pub struct FeeAssetChangeArgs {
+pub(crate)struct FeeAssetChangeArgs {
     /// The bech32m prefix that will be used for constructing addresses using the private key
     #[arg(long, default_value = "astria")]
     pub(crate) prefix: String,
@@ -178,14 +178,14 @@ pub struct FeeAssetChangeArgs {
         env = "ROLLUP_SEQUENCER_CHAIN_ID",
         default_value = crate::cli::DEFAULT_SEQUENCER_CHAIN_ID
     )]
-    pub sequencer_chain_id: String,
+    pub(crate)sequencer_chain_id: String,
     /// Asset's denomination string
     #[arg(long)]
     pub(crate) asset: asset::Denom,
 }
 
 #[derive(Args, Debug)]
-pub struct IbcRelayerChangeArgs {
+pub(crate)struct IbcRelayerChangeArgs {
     /// The prefix to construct a bech32m address given the private key.
     #[arg(long, default_value = "astria")]
     pub(crate) prefix: String,
@@ -208,14 +208,14 @@ pub struct IbcRelayerChangeArgs {
         env = "ROLLUP_SEQUENCER_CHAIN_ID",
         default_value = crate::cli::DEFAULT_SEQUENCER_CHAIN_ID
     )]
-    pub sequencer_chain_id: String,
+    pub(crate)sequencer_chain_id: String,
     /// The address to add or remove as an IBC relayer
     #[arg(long)]
     pub(crate) address: Address,
 }
 
 #[derive(Args, Debug)]
-pub struct InitBridgeAccountArgs {
+pub(crate)struct InitBridgeAccountArgs {
     /// The bech32m prefix that will be used for constructing addresses using the private key
     #[arg(long, default_value = "astria")]
     pub(crate) prefix: String,
@@ -238,21 +238,21 @@ pub struct InitBridgeAccountArgs {
         env = "ROLLUP_SEQUENCER_CHAIN_ID",
         default_value = crate::cli::DEFAULT_SEQUENCER_CHAIN_ID
     )]
-    pub sequencer_chain_id: String,
+    pub(crate)sequencer_chain_id: String,
     /// Plaintext rollup name (to be hashed into a rollup ID)
     /// to initialize the bridge account with.
     #[arg(long)]
     pub(crate) rollup_name: String,
     /// The asset to transer.
     #[arg(long, default_value = "nria")]
-    pub asset: asset::Denom,
+    pub(crate)asset: asset::Denom,
     /// The asset to pay the transfer fees with.
     #[arg(long, default_value = "nria")]
-    pub fee_asset: asset::Denom,
+    pub(crate)fee_asset: asset::Denom,
 }
 
 #[derive(Args, Debug)]
-pub struct BridgeLockArgs {
+pub(crate)struct BridgeLockArgs {
     /// The address of the Sequencer account to lock amount to
     pub(crate) to_address: Address,
     /// The amount being locked
@@ -282,23 +282,23 @@ pub struct BridgeLockArgs {
         env = "ROLLUP_SEQUENCER_CHAIN_ID",
         default_value = crate::cli::DEFAULT_SEQUENCER_CHAIN_ID
     )]
-    pub sequencer_chain_id: String,
+    pub(crate)sequencer_chain_id: String,
     /// The asset to lock.
     #[arg(long, default_value = "nria")]
-    pub asset: asset::Denom,
+    pub(crate)asset: asset::Denom,
     /// The asset to pay the transfer fees with.
     #[arg(long, default_value = "nria")]
-    pub fee_asset: asset::Denom,
+    pub(crate)fee_asset: asset::Denom,
 }
 
 #[derive(Debug, Subcommand)]
-pub enum BlockHeightCommand {
+pub(crate)enum BlockHeightCommand {
     /// Get the current block height of the Sequencer node
     Get(BlockHeightGetArgs),
 }
 
 #[derive(Args, Debug)]
-pub struct BlockHeightGetArgs {
+pub(crate)struct BlockHeightGetArgs {
     /// The url of the Sequencer node
     #[arg(
         long,
@@ -312,11 +312,11 @@ pub struct BlockHeightGetArgs {
         env = "ROLLUP_SEQUENCER_CHAIN_ID",
         default_value = crate::cli::DEFAULT_SEQUENCER_CHAIN_ID
     )]
-    pub sequencer_chain_id: String,
+    pub(crate)sequencer_chain_id: String,
 }
 
 #[derive(Args, Debug)]
-pub struct SudoAddressChangeArgs {
+pub(crate)struct SudoAddressChangeArgs {
     /// The bech32m prefix that will be used for constructing addresses using the private key
     #[arg(long, default_value = "astria")]
     pub(crate) prefix: String,
@@ -339,14 +339,14 @@ pub struct SudoAddressChangeArgs {
         env = "ROLLUP_SEQUENCER_CHAIN_ID",
         default_value = crate::cli::DEFAULT_SEQUENCER_CHAIN_ID
     )]
-    pub sequencer_chain_id: String,
+    pub(crate)sequencer_chain_id: String,
     /// The new address to take over sudo privileges
     #[arg(long)]
     pub(crate) address: Address,
 }
 
 #[derive(Args, Debug)]
-pub struct ValidatorUpdateArgs {
+pub(crate)struct ValidatorUpdateArgs {
     /// The url of the Sequencer node
     #[arg(
         long,
@@ -360,7 +360,7 @@ pub struct ValidatorUpdateArgs {
         env = "ROLLUP_SEQUENCER_CHAIN_ID",
         default_value = crate::cli::DEFAULT_SEQUENCER_CHAIN_ID
     )]
-    pub sequencer_chain_id: String,
+    pub(crate)sequencer_chain_id: String,
     /// The bech32m prefix that will be used for constructing addresses using the private key
     #[arg(long, default_value = "astria")]
     pub(crate) prefix: String,

--- a/crates/astria-cli/src/commands/bridge/mod.rs
+++ b/crates/astria-cli/src/commands/bridge/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod collect;
+pub(crate) mod submit;

--- a/crates/astria-cli/src/commands/bridge/submit.rs
+++ b/crates/astria-cli/src/commands/bridge/submit.rs
@@ -1,0 +1,134 @@
+use std::path::{
+    Path,
+    PathBuf,
+};
+
+use astria_core::{
+    crypto::SigningKey,
+    protocol::transaction::v1alpha1::{
+        Action,
+        TransactionParams,
+        UnsignedTransaction,
+    },
+};
+use astria_sequencer_client::{
+    tendermint_rpc::endpoint,
+    Address,
+    HttpClient,
+    SequencerClientExt as _,
+};
+use clap::Args;
+use color_eyre::eyre::{
+    self,
+    ensure,
+    WrapErr as _,
+};
+use tracing::info;
+
+#[derive(Args, Debug)]
+pub(crate) struct WithdrawalEvents {
+    #[arg(long, short)]
+    input: PathBuf,
+    #[arg(long)]
+    signing_key: PathBuf,
+    #[arg(long, default_value = "astria")]
+    sequencer_address_prefix: String,
+    #[arg(long)]
+    sequencer_chain_id: String,
+    #[arg(long)]
+    sequencer_url: String,
+}
+
+impl WithdrawalEvents {
+    pub(crate) async fn run(self) -> eyre::Result<()> {
+        let signing_key = read_signing_key(&self.signing_key).wrap_err_with(|| {
+            format!(
+                "failed reading signing key from file: {}",
+                self.signing_key.display()
+            )
+        })?;
+
+        let actions_by_rollup_number = read_actions(&self.input).wrap_err_with(|| {
+            format!("failed reading actions from file: {}", self.input.display())
+        })?;
+
+        let sequencer_client = HttpClient::new(&*self.sequencer_url)
+            .wrap_err("failed constructing http sequencer client")?;
+
+        for (rollup_height, actions) in actions_by_rollup_number.into_inner() {
+            let response = submit_transaction(
+                sequencer_client.clone(),
+                &self.sequencer_chain_id,
+                &self.sequencer_address_prefix,
+                &signing_key,
+                actions,
+            )
+            .await
+            .wrap_err_with(move || {
+                "failed withdrawal actions for rollup height `{rollup_height}`"
+            })?;
+            info!(
+                sequencer_height = %response.height,
+                rollup_height,
+                "actions derived from rollup succesfully submitted to sequencer"
+            );
+        }
+        Ok(())
+    }
+}
+
+fn read_actions<P: AsRef<Path>>(path: P) -> eyre::Result<super::collect::ActionsByRollupHeight> {
+    let s = std::fs::read_to_string(path).wrap_err("failed buffering file contents as string")?;
+    serde_json::from_str(&s)
+        .wrap_err("failed deserializing file contents height-to-sequencer-actions serde object")
+}
+
+fn read_signing_key<P: AsRef<Path>>(path: P) -> eyre::Result<SigningKey> {
+    let hex =
+        std::fs::read_to_string(&path).wrap_err("failed to read file contents into buffer")?;
+    let bytes = hex::decode(hex.trim()).wrap_err("failed to decode file contents as hex")?;
+    SigningKey::try_from(&*bytes).wrap_err("failed to construct signing key hex-decoded bytes")
+}
+
+async fn submit_transaction(
+    client: HttpClient,
+    chain_id: &str,
+    prefix: &str,
+    signing_key: &SigningKey,
+    actions: Vec<Action>,
+) -> eyre::Result<endpoint::broadcast::tx_commit::Response> {
+    let from_address = Address::builder()
+        .array(signing_key.verification_key().address_bytes())
+        .prefix(prefix)
+        .try_build()
+        .wrap_err("failed constructing a valid from address from the provided prefix")?;
+
+    let nonce_res = client
+        .get_latest_nonce(from_address)
+        .await
+        .wrap_err("failed to get nonce")?;
+
+    let tx = UnsignedTransaction {
+        params: TransactionParams::builder()
+            .nonce(nonce_res.nonce)
+            .chain_id(chain_id)
+            .build(),
+        actions,
+    }
+    .into_signed(signing_key);
+    let res = client
+        .submit_transaction_commit(tx)
+        .await
+        .wrap_err("failed to submit transaction")?;
+    ensure!(
+        res.check_tx.code.is_ok(),
+        "failed to check tx: {}",
+        res.check_tx.log
+    );
+    ensure!(
+        res.tx_result.code.is_ok(),
+        "failed to execute tx: {}",
+        res.tx_result.log
+    );
+    Ok(res)
+}


### PR DESCRIPTION
## Summary
Adds a subcommand to submit previously collected withdrawal events.

## Background
https://github.com/astriaorg/astria/pull/1261 provides a subcommand to listen to and collect withdrawal events that come form a rollup's astria contracts. This patch now provides the ability to also submit the events.

## Changes
- Added a `bridge submit-withdrawals` subcommand to `astria-cli`
- Renamed `bridge collect-withdrawal-events` to `bridge collect-withdrawals`
- Adjusted the object written and read to be a json object `rollup_height -> [actions]`.

## Testing
TBD