### PR TITLE
feat(conductor)!: add sequencer and celestia chain ID verification

### DIFF
--- a/crates/astria-conductor/local.env.example
+++ b/crates/astria-conductor/local.env.example
@@ -56,6 +56,12 @@ ASTRIA_CONDUCTOR_SEQUENCER_GRPC_URL="http://127.0.0.1:8080"
 # 127.0.0.1:26657 is the default socket address in comebft's `rpc.laddr` setting.
 ASTRIA_CONDUCTOR_SEQUENCER_COMETBFT_URL="http://127.0.0.1:26657"
 
+# The expected chain ID of the sequencer the conductor is communicating with
+ASTRIA_CONDUCTOR_SEQUENCER_CHAIN_ID="test_sequencer-1000"
+
+# The expected chain ID of the Celstia netowrk the conductor is communicating with
+ASTRIA_CONDUCTOR_CELESTIA_CHAIN_ID="test_celestia-1000"
+
 # The duration in milliseconds that conductor waits between requests for the latest
 # block height from sequencer.
 # A block time of 2000 is the default for sequencer.

--- a/crates/astria-conductor/local.env.example
+++ b/crates/astria-conductor/local.env.example
@@ -59,7 +59,7 @@ ASTRIA_CONDUCTOR_SEQUENCER_COMETBFT_URL="http://127.0.0.1:26657"
 # The expected chain ID of the sequencer the conductor is communicating with
 ASTRIA_CONDUCTOR_SEQUENCER_CHAIN_ID="test_sequencer-1000"
 
-# The expected chain ID of the Celstia netowrk the conductor is communicating with
+# The expected chain ID of the Celstia network the conductor is communicating with
 ASTRIA_CONDUCTOR_CELESTIA_CHAIN_ID="test_celestia-1000"
 
 # The duration in milliseconds that conductor waits between requests for the latest

--- a/crates/astria-conductor/src/celestia/builder.rs
+++ b/crates/astria-conductor/src/celestia/builder.rs
@@ -56,7 +56,10 @@ impl Builder {
     }
 }
 
-fn create_celestia_client(endpoint: String, bearer_token: &str) -> eyre::Result<CelestiaClient> {
+pub(crate) fn create_celestia_client(
+    endpoint: String,
+    bearer_token: &str,
+) -> eyre::Result<CelestiaClient> {
     use jsonrpsee::http_client::{
         HeaderMap,
         HttpClientBuilder,

--- a/crates/astria-conductor/src/celestia/mod.rs
+++ b/crates/astria-conductor/src/celestia/mod.rs
@@ -65,7 +65,7 @@ use crate::{
 };
 
 mod block_verifier;
-mod builder;
+pub(crate) mod builder;
 mod convert;
 mod fetch;
 mod latest_height_stream;
@@ -125,7 +125,7 @@ pub(crate) struct Reader {
     celestia_block_time: Duration,
 
     /// Client to fetch heights and blocks from Celestia.
-    celestia_client: CelestiaClient,
+    pub(crate) celestia_client: CelestiaClient,
 
     /// The channel used to send messages to the executor task.
     executor: executor::Handle,

--- a/crates/astria-conductor/src/config.rs
+++ b/crates/astria-conductor/src/config.rs
@@ -58,6 +58,12 @@ pub struct Config {
     /// The number of requests per second that will be sent to Sequencer.
     pub sequencer_requests_per_second: u32,
 
+    /// Configured sequencer chain ID
+    pub sequencer_chain_id: String,
+
+    /// Configured Celestia chain ID
+    pub celestia_chain_id: String,
+
     /// Address of the RPC server for execution
     pub execution_rpc_url: String,
 

--- a/crates/astria-conductor/tests/blackbox/helpers/macros.rs
+++ b/crates/astria-conductor/tests/blackbox/helpers/macros.rs
@@ -15,7 +15,7 @@ macro_rules! block {
 
 #[macro_export]
 macro_rules! celestia_network_head {
-    (height: $height:expr) => {
+    (height: $height:expr,chain_id: $chain_id:expr) => {
         ::celestia_types::ExtendedHeader {
             header: ::celestia_tendermint::block::header::Header {
                 height: $height.into(),
@@ -23,7 +23,7 @@ macro_rules! celestia_network_head {
                     block: 0,
                     app: 0,
                 },
-                chain_id: "test_celestia-1000".try_into().unwrap(),
+                chain_id: $chain_id.try_into().unwrap(),
                 time: ::celestia_tendermint::Time::from_unix_timestamp(1, 1).unwrap(),
                 last_block_id: None,
                 last_commit_hash: ::celestia_tendermint::Hash::Sha256([0; 32]),
@@ -138,11 +138,12 @@ macro_rules! mount_celestia_blobs {
 macro_rules! mount_celestia_header_network_head {
     (
         $test_env:ident,
-        height: $height:expr $(,)?
+        height: $height:expr,
+        chain_id: $chain_id:expr $(,)?
     ) => {
         $test_env
             .mount_celestia_header_network_head(
-                $crate::celestia_network_head!(height: $height)
+                $crate::celestia_network_head!(height: $height, chain_id: $chain_id)
             )
             .await;
     }
@@ -320,8 +321,8 @@ macro_rules! mount_sequencer_validator_set {
 
 #[macro_export]
 macro_rules! mount_sequencer_genesis {
-    ($test_env:ident) => {
-        $test_env.mount_genesis().await;
+    ($test_env:ident,chain_id: $chain_id:expr $(,)?) => {
+        $test_env.mount_genesis({ $chain_id }).await;
     };
 }
 


### PR DESCRIPTION
## Summary
Added verification checks for sequencer and Celestia chain IDs against remote within conductor.

## Background
Previously, the conductor may have connected to the incorrect sequence or Celestia network. These changes are to ensure that the conductor is communicating with the expected network.

## Changes
* Added sequencer and Celestia chain ID environment variables.
* Implemented traits for sequencer and Celestia clients to get remote chain IDs.
* Added chain ID check function, which is called within initialization in conductor `run_until_stopped()`.
* Adjusted conductor `run_until_stopped()` to be able to return an error, allowing a failure in chain_id verification to be propagated.
* Added respective tests for failure in blackbox tests.

## Testing
Added 4 blackbox tests, with firm commitment levels testing for failure with Celestia chain ID mismatch, and soft commitment levels testing for failure with sequencer chain ID mismatch.

## Breaking Changelist
* Added `ASTRIA_CONDUCTOR_SEQUENCER_CHAIN_ID`
* Added `ASTRIA_CONDUCTOR_CELESTIA_CHAIN_ID`

## Related Issues
Part of #986

