### PR TITLE
fix(proto)!: ics20 withdrawal return address is string

### DIFF
--- a/crates/astria-bridge-withdrawer/src/bridge_withdrawer/ethereum/watcher.rs
+++ b/crates/astria-bridge-withdrawer/src/bridge_withdrawer/ethereum/watcher.rs
@@ -75,7 +75,6 @@ pub(crate) struct Builder {
     pub(crate) rollup_asset_denom: Denom,
     pub(crate) bridge_address: Address,
     pub(crate) submitter_handle: submitter::Handle,
-    pub(crate) sequencer_address_prefix: String,
 }
 
 impl Builder {
@@ -89,7 +88,6 @@ impl Builder {
             rollup_asset_denom,
             bridge_address,
             submitter_handle,
-            sequencer_address_prefix,
         } = self;
 
         let contract_address = address_from_string(&ethereum_contract_address)
@@ -114,7 +112,6 @@ impl Builder {
             shutdown_token: shutdown_token.clone(),
             startup_handle,
             submitter_handle,
-            sequencer_address_prefix,
         })
     }
 }
@@ -129,7 +126,6 @@ pub(crate) struct Watcher {
     rollup_asset_denom: Denom,
     bridge_address: Address,
     state: Arc<State>,
-    sequencer_address_prefix: String,
 }
 
 impl Watcher {
@@ -145,7 +141,6 @@ impl Watcher {
             state,
             shutdown_token,
             submitter_handle,
-            sequencer_address_prefix,
             ..
         } = self;
 
@@ -154,7 +149,6 @@ impl Watcher {
             rollup_asset_denom,
             bridge_address,
             asset_withdrawal_divisor,
-            sequencer_address_prefix,
         };
 
         state.set_watcher_ready();
@@ -497,7 +491,6 @@ struct EventToActionConvertConfig {
     rollup_asset_denom: Denom,
     bridge_address: Address,
     asset_withdrawal_divisor: u128,
-    sequencer_address_prefix: String,
 }
 
 impl EventToActionConvertConfig {
@@ -508,7 +501,6 @@ impl EventToActionConvertConfig {
             self.rollup_asset_denom.clone(),
             self.asset_withdrawal_divisor,
             self.bridge_address,
-            &self.sequencer_address_prefix,
         )
     }
 }
@@ -670,7 +662,6 @@ mod tests {
             state: Arc::new(State::new()),
             rollup_asset_denom: denom.clone(),
             bridge_address,
-            sequencer_address_prefix: crate::ASTRIA_ADDRESS_PREFIX.into(),
         }
         .build()
         .unwrap();
@@ -686,15 +677,8 @@ mod tests {
             block_number: receipt.block_number.unwrap(),
             transaction_hash: receipt.transaction_hash,
         };
-        let expected_action = event_to_action(
-            expected_event,
-            denom.clone(),
-            denom,
-            1,
-            bridge_address,
-            crate::ASTRIA_ADDRESS_PREFIX,
-        )
-        .unwrap();
+        let expected_action =
+            event_to_action(expected_event, denom.clone(), denom, 1, bridge_address).unwrap();
         let Action::BridgeUnlock(expected_action) = expected_action else {
             panic!("expected action to be BridgeUnlock, got {expected_action:?}");
         };
@@ -743,7 +727,6 @@ mod tests {
             denom.clone(),
             1,
             bridge_address,
-            crate::ASTRIA_ADDRESS_PREFIX,
         )
         .unwrap();
         let Action::BridgeUnlock(expected_action) = expected_action else {
@@ -768,7 +751,6 @@ mod tests {
             rollup_asset_denom: denom.clone(),
             bridge_address,
             submitter_handle: submitter::Handle::new(batch_tx),
-            sequencer_address_prefix: crate::ASTRIA_ADDRESS_PREFIX.into(),
         }
         .build()
         .unwrap();
@@ -849,7 +831,6 @@ mod tests {
             rollup_asset_denom: denom.clone(),
             bridge_address,
             submitter_handle: submitter::Handle::new(batch_tx),
-            sequencer_address_prefix: crate::ASTRIA_ADDRESS_PREFIX.into(),
         }
         .build()
         .unwrap();
@@ -874,7 +855,6 @@ mod tests {
             denom.clone(),
             1,
             bridge_address,
-            crate::ASTRIA_ADDRESS_PREFIX,
         )
         .unwrap() else {
             panic!("expected action to be Ics20Withdrawal");
@@ -976,7 +956,6 @@ mod tests {
             rollup_asset_denom: denom.clone(),
             bridge_address,
             submitter_handle: submitter::Handle::new(batch_tx),
-            sequencer_address_prefix: crate::ASTRIA_ADDRESS_PREFIX.into(),
         }
         .build()
         .unwrap();
@@ -999,7 +978,6 @@ mod tests {
             denom.clone(),
             1,
             bridge_address,
-            crate::ASTRIA_ADDRESS_PREFIX,
         )
         .unwrap();
         let Action::BridgeUnlock(expected_action) = expected_action else {
@@ -1078,7 +1056,6 @@ mod tests {
             rollup_asset_denom: denom.clone(),
             bridge_address,
             submitter_handle: submitter::Handle::new(batch_tx),
-            sequencer_address_prefix: crate::ASTRIA_ADDRESS_PREFIX.into(),
         }
         .build()
         .unwrap();
@@ -1107,7 +1084,6 @@ mod tests {
             denom.clone(),
             1,
             bridge_address,
-            crate::ASTRIA_ADDRESS_PREFIX,
         )
         .unwrap() else {
             panic!("expected action to be Ics20Withdrawal");

--- a/crates/astria-bridge-withdrawer/src/bridge_withdrawer/mod.rs
+++ b/crates/astria-bridge-withdrawer/src/bridge_withdrawer/mod.rs
@@ -124,7 +124,6 @@ impl BridgeWithdrawer {
                 .wrap_err("failed to parse ROLLUP_ASSET_DENOMINATION as Denom")?,
             bridge_address: sequencer_bridge_address,
             submitter_handle,
-            sequencer_address_prefix: sequencer_address_prefix.clone(),
         }
         .build()
         .wrap_err("failed to build ethereum watcher")?;
@@ -410,8 +409,6 @@ pub(crate) fn flatten_result<T>(res: Result<eyre::Result<T>, JoinError>) -> eyre
 }
 
 #[cfg(test)]
-pub(crate) const ASTRIA_ADDRESS_PREFIX: &str = "astria";
-
 /// Constructs an [`Address`] prefixed by `"astria"`.
 #[cfg(test)]
 pub(crate) fn astria_address(
@@ -419,7 +416,7 @@ pub(crate) fn astria_address(
 ) -> astria_core::primitive::v1::Address {
     astria_core::primitive::v1::Address::builder()
         .array(array)
-        .prefix(ASTRIA_ADDRESS_PREFIX)
+        .prefix("astria")
         .try_build()
         .unwrap()
 }

--- a/crates/astria-bridge-withdrawer/src/bridge_withdrawer/submitter/tests.rs
+++ b/crates/astria-bridge-withdrawer/src/bridge_withdrawer/submitter/tests.rs
@@ -185,7 +185,7 @@ fn make_ics20_withdrawal_action() -> Action {
     let inner = Ics20Withdrawal {
         denom: denom.clone(),
         destination_chain_address,
-        return_address: crate::astria_address([0u8; 20]),
+        rollup_return_address: ethers::types::Address::from([0u8; 20]).to_string(),
         amount: 99,
         memo: serde_json::to_string(&Ics20WithdrawalFromRollupMemo {
             memo: "hello".to_string(),

--- a/crates/astria-bridge-withdrawer/src/lib.rs
+++ b/crates/astria-bridge-withdrawer/src/lib.rs
@@ -4,11 +4,8 @@ mod build_info;
 pub(crate) mod config;
 pub(crate) mod metrics;
 
-pub use bridge_withdrawer::BridgeWithdrawer;
 #[cfg(test)]
-pub(crate) use bridge_withdrawer::{
-    astria_address,
-    ASTRIA_ADDRESS_PREFIX,
-};
+pub(crate) use bridge_withdrawer::astria_address;
+pub use bridge_withdrawer::BridgeWithdrawer;
 pub use build_info::BUILD_INFO;
 pub use config::Config;

--- a/crates/astria-core/src/generated/astria.protocol.transactions.v1alpha1.rs
+++ b/crates/astria-core/src/generated/astria.protocol.transactions.v1alpha1.rs
@@ -188,12 +188,10 @@ pub struct Ics20Withdrawal {
     /// to interpret it.
     #[prost(string, tag = "3")]
     pub destination_chain_address: ::prost::alloc::string::String,
-    /// an Astria address to use to return funds from this withdrawal
-    /// in the case it fails.
-    #[prost(message, optional, tag = "4")]
-    pub return_address: ::core::option::Option<
-        super::super::super::primitive::v1::Address,
-    >,
+    /// the address on the rollup to return funds to shold this withdrawal fail.
+    /// ideally formatted as a human-readable string in the convention of the rollup.
+    #[prost(string, tag = "4")]
+    pub rollup_return_address: ::prost::alloc::string::String,
     /// the height (on Astria) at which this transfer expires.
     #[prost(message, optional, tag = "5")]
     pub timeout_height: ::core::option::Option<IbcHeight>,

--- a/crates/astria-core/src/generated/astria.protocol.transactions.v1alpha1.serde.rs
+++ b/crates/astria-core/src/generated/astria.protocol.transactions.v1alpha1.serde.rs
@@ -1261,7 +1261,7 @@ impl serde::Serialize for Ics20Withdrawal {
         if !self.destination_chain_address.is_empty() {
             len += 1;
         }
-        if self.return_address.is_some() {
+        if !self.rollup_return_address.is_empty() {
             len += 1;
         }
         if self.timeout_height.is_some() {
@@ -1292,8 +1292,8 @@ impl serde::Serialize for Ics20Withdrawal {
         if !self.destination_chain_address.is_empty() {
             struct_ser.serialize_field("destinationChainAddress", &self.destination_chain_address)?;
         }
-        if let Some(v) = self.return_address.as_ref() {
-            struct_ser.serialize_field("returnAddress", v)?;
+        if !self.rollup_return_address.is_empty() {
+            struct_ser.serialize_field("rollupReturnAddress", &self.rollup_return_address)?;
         }
         if let Some(v) = self.timeout_height.as_ref() {
             struct_ser.serialize_field("timeoutHeight", v)?;
@@ -1328,8 +1328,8 @@ impl<'de> serde::Deserialize<'de> for Ics20Withdrawal {
             "denom",
             "destination_chain_address",
             "destinationChainAddress",
-            "return_address",
-            "returnAddress",
+            "rollup_return_address",
+            "rollupReturnAddress",
             "timeout_height",
             "timeoutHeight",
             "timeout_time",
@@ -1348,7 +1348,7 @@ impl<'de> serde::Deserialize<'de> for Ics20Withdrawal {
             Amount,
             Denom,
             DestinationChainAddress,
-            ReturnAddress,
+            RollupReturnAddress,
             TimeoutHeight,
             TimeoutTime,
             SourceChannel,
@@ -1379,7 +1379,7 @@ impl<'de> serde::Deserialize<'de> for Ics20Withdrawal {
                             "amount" => Ok(GeneratedField::Amount),
                             "denom" => Ok(GeneratedField::Denom),
                             "destinationChainAddress" | "destination_chain_address" => Ok(GeneratedField::DestinationChainAddress),
-                            "returnAddress" | "return_address" => Ok(GeneratedField::ReturnAddress),
+                            "rollupReturnAddress" | "rollup_return_address" => Ok(GeneratedField::RollupReturnAddress),
                             "timeoutHeight" | "timeout_height" => Ok(GeneratedField::TimeoutHeight),
                             "timeoutTime" | "timeout_time" => Ok(GeneratedField::TimeoutTime),
                             "sourceChannel" | "source_channel" => Ok(GeneratedField::SourceChannel),
@@ -1408,7 +1408,7 @@ impl<'de> serde::Deserialize<'de> for Ics20Withdrawal {
                 let mut amount__ = None;
                 let mut denom__ = None;
                 let mut destination_chain_address__ = None;
-                let mut return_address__ = None;
+                let mut rollup_return_address__ = None;
                 let mut timeout_height__ = None;
                 let mut timeout_time__ = None;
                 let mut source_channel__ = None;
@@ -1435,11 +1435,11 @@ impl<'de> serde::Deserialize<'de> for Ics20Withdrawal {
                             }
                             destination_chain_address__ = Some(map_.next_value()?);
                         }
-                        GeneratedField::ReturnAddress => {
-                            if return_address__.is_some() {
-                                return Err(serde::de::Error::duplicate_field("returnAddress"));
+                        GeneratedField::RollupReturnAddress => {
+                            if rollup_return_address__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("rollupReturnAddress"));
                             }
-                            return_address__ = map_.next_value()?;
+                            rollup_return_address__ = Some(map_.next_value()?);
                         }
                         GeneratedField::TimeoutHeight => {
                             if timeout_height__.is_some() {
@@ -1485,7 +1485,7 @@ impl<'de> serde::Deserialize<'de> for Ics20Withdrawal {
                     amount: amount__,
                     denom: denom__.unwrap_or_default(),
                     destination_chain_address: destination_chain_address__.unwrap_or_default(),
-                    return_address: return_address__,
+                    rollup_return_address: rollup_return_address__.unwrap_or_default(),
                     timeout_height: timeout_height__,
                     timeout_time: timeout_time__.unwrap_or_default(),
                     source_channel: source_channel__.unwrap_or_default(),

--- a/crates/astria-sequencer/src/ibc/ics20_withdrawal.rs
+++ b/crates/astria-sequencer/src/ibc/ics20_withdrawal.rs
@@ -102,8 +102,6 @@ impl ActionHandler for action::Ics20Withdrawal {
     async fn check_stateless(&self) -> Result<()> {
         ensure!(self.timeout_time() != 0, "timeout time must be non-zero",);
 
-        crate::address::ensure_base_prefix(&self.return_address)
-            .context("return address has an unsupported prefix")?;
         self.bridge_address
             .as_ref()
             .map(crate::address::ensure_base_prefix)
@@ -251,7 +249,7 @@ mod tests {
             denom: denom.clone(),
             bridge_address: None,
             destination_chain_address: "test".to_string(),
-            return_address: from,
+            rollup_return_address: "rollup_defined".to_string(),
             timeout_height: Height::new(1, 1).unwrap(),
             timeout_time: 1,
             source_channel: "channel-0".to_string().parse().unwrap(),
@@ -285,7 +283,7 @@ mod tests {
             denom: denom.clone(),
             bridge_address: None,
             destination_chain_address: "test".to_string(),
-            return_address: bridge_address,
+            rollup_return_address: "rollup_defined".to_string(),
             timeout_height: Height::new(1, 1).unwrap(),
             timeout_time: 1,
             source_channel: "channel-0".to_string().parse().unwrap(),
@@ -322,7 +320,7 @@ mod tests {
             denom: denom.clone(),
             bridge_address: None,
             destination_chain_address: "test".to_string(),
-            return_address: bridge_address,
+            rollup_return_address: "rollup_defined".to_string(),
             timeout_height: Height::new(1, 1).unwrap(),
             timeout_time: 1,
             source_channel: "channel-0".to_string().parse().unwrap(),
@@ -360,7 +358,7 @@ mod tests {
             denom: denom.clone(),
             bridge_address: Some(bridge_address),
             destination_chain_address: "test".to_string(),
-            return_address: bridge_address,
+            rollup_return_address: "rollup_defined".to_string(),
             timeout_height: Height::new(1, 1).unwrap(),
             timeout_time: 1,
             source_channel: "channel-0".to_string().parse().unwrap(),
@@ -394,7 +392,7 @@ mod tests {
             denom: denom.clone(),
             bridge_address: Some(bridge_address),
             destination_chain_address: "test".to_string(),
-            return_address: bridge_address,
+            rollup_return_address: "rollup_defined".to_string(),
             timeout_height: Height::new(1, 1).unwrap(),
             timeout_time: 1,
             source_channel: "channel-0".to_string().parse().unwrap(),
@@ -427,7 +425,7 @@ mod tests {
             denom: denom.clone(),
             bridge_address: Some(not_bridge_address),
             destination_chain_address: "test".to_string(),
-            return_address: not_bridge_address,
+            rollup_return_address: "rollup_defined".to_string(),
             timeout_height: Height::new(1, 1).unwrap(),
             timeout_time: 1,
             source_channel: "channel-0".to_string().parse().unwrap(),

--- a/proto/protocolapis/astria/protocol/transactions/v1alpha1/types.proto
+++ b/proto/protocolapis/astria/protocol/transactions/v1alpha1/types.proto
@@ -107,9 +107,9 @@ message Ics20Withdrawal {
   // this is not validated by Astria; it is up to the destination chain
   // to interpret it.
   string destination_chain_address = 3;
-  // an Astria address to use to return funds from this withdrawal
-  // in the case it fails.
-  astria.primitive.v1.Address return_address = 4;
+  // the address on the rollup to return funds to shold this withdrawal fail.
+  // ideally formatted as a human-readable string in the convention of the rollup.
+  string rollup_return_address = 4;
   // the height (on Astria) at which this transfer expires.
   IbcHeight timeout_height = 5;
   // the unix timestamp (in nanoseconds) at which this transfer expires.


### PR DESCRIPTION
## Summary
Changes the return address for ics20 withdrawal actions to be of type `string`. Also clarify its use by changing the field name from `return_address` to `rollup_return_address`.

## Background
The field `astria.protocol.transactions.v1alpha1.Ics20Withdrawal.return_address` was of type `astria.primitive.v1.Address`, but in fact it was supposed to be an address from the rollup. This is also how bridge-withdrawer was creating the return address (using an `"astria"` prefix but the sender bytes from a ethereum address, which is clearly wrong).

This patch changes to field to a human readable string which is opaque to sequncer (`string` was chosen over `bytes` to avoid the protobuf-to-json mapping from emitting the address as an unknown base64 string).

## Changes
- Change field `astria.protocol.transactions.v1alpha1.Ics20Withdrawal.return_address` of type `astria.primitive.v1.Address` to `astria.protocol.transactions.v1alpha1.Ics20Withdrawal.rollup_return_address` of type `string`
- Amend all tests and other code that uses it.

## Testing
No explicit tests, relying on blackbox tests to still work. A followup should add a smoketest to verify that failed ics20 transactions are returned to the rollup, but that is out of scope for this patch.

## Breaking Changelist
- This is a network-breaking change because the shape of an action changed.
