### PR TITLE
chore(test): use a temporary file to not pollute the workspace

### DIFF
--- a/charts/deploy.just
+++ b/charts/deploy.just
@@ -383,6 +383,12 @@ run-smoke-cli:
   CURRENT_BLOCK=$(just hex-to-dec $CURRENT_BLOCK_HEX)
   echo {{sequencer_bridge_pkey}} > test_se
 
+  withdrawals_dst="$(mktemp)"
+  # uncomment this line if you want to inspect `withdrawals_dst`
+  trap "rm -f ${withdrawals_dst@Q}" EXIT
+
+  echo "passing ${withdrawals_dst} to astria-cli"
+
   astria-cli bridge collect-withdrawals \
     --rollup-endpoint {{eth_ws_url}} \
     --contract-address {{evm_contract_address}} \
@@ -390,13 +396,12 @@ run-smoke-cli:
     --to-rollup-height $CURRENT_BLOCK \
     --rollup-asset-denom nria \
     --bridge-address {{sequencer_bridge_address}} \
-    --output ./withdrawals.json
+    --output "${withdrawals_dst}"
    astria-cli bridge submit-withdrawals \
     --signing-key <(printf "%s" "{{sequencer_bridge_pkey}}") \
     --sequencer-chain-id {{sequencer_chain_id}} \
     --sequencer-url {{sequencer_rpc_url}} \
-    --input ./withdrawals.json
-
+    --input "${withdrawals_dst}"
 
   CHECKS=0
   EXPECTED_BALANCE=$(echo "1 * {{sequencer_base_amount}}" | bc)

--- a/charts/deploy.just
+++ b/charts/deploy.just
@@ -381,7 +381,6 @@ run-smoke-cli:
 
   CURRENT_BLOCK_HEX=$(just evm-get-block-by-number latest | jq -r '.number')
   CURRENT_BLOCK=$(just hex-to-dec $CURRENT_BLOCK_HEX)
-  echo {{sequencer_bridge_pkey}} > test_se
 
   withdrawals_dst="$(mktemp)"
   # uncomment this line if you want to inspect `withdrawals_dst`


### PR DESCRIPTION
## Summary
Uses a temporary file instead of writing to the workspace during smoke tests.

## Background
It's bad practice to pollute the workspace when running tests. This change writes the output to a temporary file instead, and ensures that it is cleaned up after exit.

## Changes
- Update the `run-smoke-cli` recipe in `charts/deploy.just` to write to a temporary generated by `mktemp` (without arguments to not run into differences between Darwin/BSD and GNU/Linux)
- Use a trap to clean up the temporary on `EXIT`.

## Testing
Run `just run-smoke-cli`, observe that the workspace is clean.