### PR TITLE
chore: remove spurious entry in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,3 @@ target/
 
 # We don't want to commit the dependency directory of charts
 charts/*/charts
-
-crates/astria-bridge-withdrawer/src/withdrawer/ethereum/generated/


### PR DESCRIPTION
## Summary
Removed a gitignore entry that had no relevance to the repo.

