### PR TITLE
chore(core): remove ed25519_consensus from public API

### DIFF
--- a/crates/astria-core/src/crypto.rs
+++ b/crates/astria-core/src/crypto.rs
@@ -214,7 +214,7 @@ impl TryFrom<&[u8]> for VerificationKey {
     type Error = Error;
 
     fn try_from(slice: &[u8]) -> Result<Self, Error> {
-        let key = Ed25519VerificationKey::try_from(slice)?;
+        let key = Ed25519VerificationKey::try_from(slice).map_err(Error)?;
         Ok(Self {
             key,
         })
@@ -225,7 +225,7 @@ impl TryFrom<[u8; 32]> for VerificationKey {
     type Error = Error;
 
     fn try_from(bytes: [u8; 32]) -> Result<Self, Self::Error> {
-        let key = Ed25519VerificationKey::try_from(bytes)?;
+        let key = Ed25519VerificationKey::try_from(bytes).map_err(Error)?;
         Ok(Self {
             key,
         })
@@ -266,7 +266,7 @@ impl TryFrom<&[u8]> for Signature {
     type Error = Error;
 
     fn try_from(slice: &[u8]) -> Result<Self, Error> {
-        let signature = Ed25519Signature::try_from(slice)?;
+        let signature = Ed25519Signature::try_from(slice).map_err(Error)?;
         Ok(Self(signature))
     }
 }
@@ -274,7 +274,7 @@ impl TryFrom<&[u8]> for Signature {
 /// An error related to Ed25519 signing.
 #[derive(Copy, Clone, Eq, PartialEq, thiserror::Error, Debug)]
 #[error(transparent)]
-pub struct Error(#[from] Ed25519Error);
+pub struct Error(Ed25519Error);
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Summary
Ensures that ed25519_consensus is not part of the public `astria-core` API.

## Background
The definition `struct astria_core::crypto::Error(#[from] ed25519_consensus::Error)` leaks `ed25519_consensus::Error` into the public API of `astria-core`. This patch removes the `#[from]` attribute and updates a few lines by explicit constructors, `map_err(Error)`.

## Changes
* Remove the `From<ed25519_consensus::Error> for crypto::Error` impl, removing `ed25519_consensus` from `astria-core`'s public API. 

## Breaking Changelist
This is a breaking change in `astria-core` but not in any of our services. Because we don't yet publish `astria-core`, this is not a breaking change at this moment but would be breaking in the future.

## Related Issues
Closes https://github.com/astriaorg/astria/issues/1221

