### PR TITLE
chore: update `bytes` and `ics23` crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3986,9 +3986,9 @@ dependencies = [
 
 [[package]]
 name = "ics23"
-version = "0.11.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc3b8be84e7285c73b88effdc3294b552277d6b0ec728ee016c861b7b9a2c19c"
+checksum = "18798160736c1e368938ba6967dbcb3c7afb3256b442a5506ba5222eebb68a5a"
 dependencies = [
  "anyhow",
  "blake2",
@@ -5967,7 +5967,7 @@ checksum = "80b776a1b2dc779f5ee0641f8ade0125bc1298dd41a9a0c16d8bd57b42d222b1"
 dependencies = [
  "bytes",
  "heck 0.5.0",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -5987,7 +5987,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19de2de2a00075bf566bee3bd4db014b11587e84184d3f7a791bc17f1a8e9e48"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "proc-macro2 1.0.79",
  "quote",
  "syn 2.0.58",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1447,9 +1447,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
 dependencies = [
  "serde",
 ]


### PR DESCRIPTION
## Summary
Updated the `bytes` and `ics23` crates.

## Background
The version of `bytes` we currently use has been yanked due to [a bug](https://github.com/tokio-rs/bytes/pull/718).  Running `cargo audit` exposed this as an allowed warning.

We also got a report of an issue with the `ics23` crate and a recommendation to update to v0.11.3.

## Changes
- Ran `cargo update -p bytes` and `cargo update -p ics23`.

## Testing
No additional tests required.