### PR TITLE
chore(chart): Update EVM-Rollup Geth devTag

### DIFF
--- a/charts/evm-rollup/Chart.yaml
+++ b/charts/evm-rollup/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.25.0
+version: 0.26.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/evm-rollup/Chart.yaml
+++ b/charts/evm-rollup/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.26.0
+version: 0.25.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/evm-rollup/values.yaml
+++ b/charts/evm-rollup/values.yaml
@@ -10,7 +10,7 @@ images:
   geth:
     repo: ghcr.io/astriaorg/astria-geth
     tag: 0.13.0
-    devTag: pr-38
+    devTag: latest
   conductor:
     repo: ghcr.io/astriaorg/conductor
     tag: "0.18.0"

--- a/charts/evm-stack/Chart.lock
+++ b/charts/evm-stack/Chart.lock
@@ -17,5 +17,5 @@ dependencies:
 - name: blockscout-stack
   repository: https://blockscout.github.io/helm-charts
   version: 1.6.2
-digest: sha256:0ff9226aede13d1e76e583a32b2902483dc06b3df81ac7940d3c2e9ae360cdf0
-generated: "2024-07-23T19:34:13.143403-05:00"
+digest: sha256:086d6a6ca254f7da8d5d33b1812ca81cdf712f55a4cff657598d9f13157ef16d
+generated: "2024-07-25T16:35:09.580512-05:00"

--- a/charts/evm-stack/Chart.lock
+++ b/charts/evm-stack/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: evm-rollup
   repository: file://../evm-rollup
-  version: 0.26.0
+  version: 0.25.1
 - name: composer
   repository: file://../composer
   version: 0.1.0
@@ -17,5 +17,5 @@ dependencies:
 - name: blockscout-stack
   repository: https://blockscout.github.io/helm-charts
   version: 1.6.2
-digest: sha256:086d6a6ca254f7da8d5d33b1812ca81cdf712f55a4cff657598d9f13157ef16d
-generated: "2024-07-25T16:35:09.580512-05:00"
+digest: sha256:ff21c9da378275fdffee8af268a64a0b846893699c334082305e8487dde93ede
+generated: "2024-07-25T16:40:06.411653-05:00"

--- a/charts/evm-stack/Chart.lock
+++ b/charts/evm-stack/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: evm-rollup
   repository: file://../evm-rollup
-  version: 0.25.0
+  version: 0.26.0
 - name: composer
   repository: file://../composer
   version: 0.1.0

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -15,11 +15,11 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.2.1
 
 dependencies:
   - name: evm-rollup
-    version: 0.26.0
+    version: 0.25.1
     repository: "file://../evm-rollup"
   - name: composer
     version: 0.1.0

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -15,11 +15,11 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.3.0
 
 dependencies:
   - name: evm-rollup
-    version: 0.25.0
+    version: 0.26.0
     repository: "file://../evm-rollup"
   - name: composer
     version: 0.1.0


### PR DESCRIPTION
## Summary
Update EVM-Rollup Geth `devTag` after #1291 and astria-geth [#38](https://github.com/astriaorg/astria-geth/pull/38).

## Background
#1291 relied on astria-geth PR [#38](https://github.com/astriaorg/astria-geth/pull/38) for `evm-rollup` chart. Now that both PRs have been merged, the `devTag` can be updated to `latest`.

## Changes
- Updated geth `devTag` to `latest` in `evm-rollup` `values.yaml`. 
- Updated `evm-rollup` and `evm-stack` versions.

## Testing
Passing e2e tests.