### PR TITLE
Chore(Charts): seq-faucet bech32m chart update

### DIFF
--- a/charts/sequencer-faucet/Chart.yaml
+++ b/charts/sequencer-faucet/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.1
+version: 0.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.6.0"
+appVersion: "0.8.0"
 
 maintainers:
   - name: wafflesvonmaple
@@ -29,4 +29,6 @@ maintainers:
   - name: steezeburger
     url: astria.org
   - name: joroshiba
+    url: astria.org
+  - name: quasystaty1
     url: astria.org

--- a/charts/sequencer-faucet/templates/configmap.yaml
+++ b/charts/sequencer-faucet/templates/configmap.yaml
@@ -11,6 +11,7 @@ data:
   SEQUENCER_FAUCET_MINUTE: "{{ .Values.config.minutesBetweenRequests }}"
   SEQUENCER_CHAIN_ID: "{{ .Values.config.sequencerChainId }}"
   SEQUENCER_ADDRESS_PREFIX: "{{ .Values.config.addressPrefix }}"
+  SEQUENCER_NATIVE_DENOM: "{{ .Values.config.sequencerNativeDenom }}"
   {{- if not .Values.secretProvider.enabled }}
   SEQUENCER_FAUCET_PRIVATE_KEY: "{{ .Values.config.fundingPrivateKey.devContent }}"
   {{- end }}

--- a/charts/sequencer-faucet/templates/configmap.yaml
+++ b/charts/sequencer-faucet/templates/configmap.yaml
@@ -8,7 +8,9 @@ data:
   SEQUENCER_FAUCET_PROXYCOUNT: "{{ .Values.config.proxyCount }}"
   SEQUENCER_FAUCET_SEQUENCER_RPC_URL: "{{ .Values.config.sequencerRpcUrl}}"
   SEQUENCER_FAUCET_AMOUNT: "{{ .Values.config.amount }}"
+  SEQUENCER_FAUCET_MINUTE: "{{ .Values.config.minutesBetweenRequests }}"
   SEQUENCER_CHAIN_ID: "{{ .Values.config.sequencerChainId }}"
+  SEQUENCER_ADDRESS_PREFIX: "{{ .Values.config.addressPrefix }}"
   {{- if not .Values.secretProvider.enabled }}
   SEQUENCER_FAUCET_PRIVATE_KEY: "{{ .Values.config.fundingPrivateKey.devContent }}"
   {{- end }}

--- a/charts/sequencer-faucet/templates/deployment.yaml
+++ b/charts/sequencer-faucet/templates/deployment.yaml
@@ -25,8 +25,10 @@ spec:
             - -wallet.provider=$(SEQUENCER_FAUCET_SEQUENCER_RPC_URL)
             - -wallet.privkey=$(SEQUENCER_FAUCET_PRIVATE_KEY)
             - -faucet.amount=$(SEQUENCER_FAUCET_AMOUNT)
+            - -faucet.minutes=$(SEQUENCER_FAUCET_MINUTE)
             - -proxycount=$(SEQUENCER_FAUCET_PROXYCOUNT)
             - -sequencer.chainId=$(SEQUENCER_CHAIN_ID)
+            - -bech32.prefix=$(SEQUENCER_ADDRESS_PREFIX)
           envFrom:
             - configMapRef:
                 name: sequencer-faucet-env

--- a/charts/sequencer-faucet/templates/deployment.yaml
+++ b/charts/sequencer-faucet/templates/deployment.yaml
@@ -26,6 +26,7 @@ spec:
             - -wallet.privkey=$(SEQUENCER_FAUCET_PRIVATE_KEY)
             - -faucet.amount=$(SEQUENCER_FAUCET_AMOUNT)
             - -faucet.minutes=$(SEQUENCER_FAUCET_MINUTE)
+            - -faucet.asset=$(SEQUENCER_NATIVE_DENOM)
             - -proxycount=$(SEQUENCER_FAUCET_PROXYCOUNT)
             - -sequencer.chainId=$(SEQUENCER_CHAIN_ID)
             - -bech32.prefix=$(SEQUENCER_ADDRESS_PREFIX)

--- a/charts/sequencer-faucet/values.yaml
+++ b/charts/sequencer-faucet/values.yaml
@@ -21,6 +21,7 @@ config:
   amount: 1800
   minutesBetweenRequests: 1440
   addressPrefix: "astria"
+  sequencerNativeDenom: "nria"
 
 images:
   sequencerFaucet: "ghcr.io/astriaorg/seq-faucet:sha-5c9d64c"

--- a/charts/sequencer-faucet/values.yaml
+++ b/charts/sequencer-faucet/values.yaml
@@ -19,6 +19,8 @@ config:
       key: token
   # The amount of token to give per request
   amount: 1800
+  minutesBetweenRequests: 1440
+  addressPrefix: "astria"
 
 images:
   sequencerFaucet: "ghcr.io/astriaorg/seq-faucet:sha-5c9d64c"

--- a/charts/sequencer-faucet/values.yaml
+++ b/charts/sequencer-faucet/values.yaml
@@ -24,7 +24,7 @@ config:
   sequencerNativeDenom: "nria"
 
 images:
-  sequencerFaucet: "ghcr.io/astriaorg/seq-faucet:sha-5c9d64c"
+  sequencerFaucet: "ghcr.io/astriaorg/seq-faucet:0.8.0"
 
 # When deploying in a production environment should use a secret provider
 # This is configured for use with GCP, need to set own resource names


### PR DESCRIPTION
## Summary
Updates `sequencer-faucet` chart to support the changes made to the sequencer faucet image for bech32m compatibility.

## Background
With the introduction of bech32m prefixed addresses, an update to the sequencer faucet was required. This PR updates the `sequencer-faucet` helm chart to use the new faucet.

## Changes
* ADDED `SEQUENCER_FAUCET_MINUTE` - rate limit on requests, default `1 day`
* ADDED `SEQUENCER_ADDRESS_PREFIX` - sequencer prefix address, default `astria`
* ADDED `SEQUENCER_NATIVE_DENOM` - asset to transfer upon request, default `nria`

## Testing
Tested locally against the latest kubernetes cluster
