### PR TITLE
refactor(ci): execute ics20 test from statefulset celestia container

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -193,8 +193,6 @@ jobs:
           install_only: true
       - name: Install astria cli (rust)
         run: just install-cli
-      - name: Fetch and install celestia-appd
-        run: just get-celestia-appd v1.9.0 Linux x86_64
       - name: Log in to GHCR
         uses: docker/login-action@v2
         with:
@@ -211,7 +209,7 @@ jobs:
           just ibc-test deploy $TAG
       - name: Run IBC ICS20 Transfer test
         timeout-minutes: 3
-        run: just ibc-test run ./celestia ./celestia-appd
+        run: just ibc-test run
 
   docker:
     if: ${{ always() && !cancelled() }}

--- a/charts/celestia-local/Chart.yaml
+++ b/charts/celestia-local/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/celestia-local/templates/statefulsets.yaml
+++ b/charts/celestia-local/templates/statefulsets.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: celestia-local
   labels:

--- a/charts/deploy.just
+++ b/charts/deploy.just
@@ -93,7 +93,7 @@ delete-sequencer name=validatorName:
 delete-sequencers: (delete-sequencer "node0") (delete-sequencer "node1") (delete-sequencer "node2")
 
 wait-for-sequencer:
-  kubectl wait -n astria-dev-cluster deployment celestia-local --for=condition=Available=True --timeout=600s
+  kubectl rollout status --watch statefulset/celestia-local -n astria-dev-cluster --timeout=600s
   kubectl rollout status --watch statefulset/sequencer -n astria-dev-cluster --timeout=600s
 
 deploy-rollup: deploy-dev-rollup wait-for-rollup
@@ -235,7 +235,6 @@ init-ibc-bridge privateKey asset feeAsset rollupName=defaultRollupName:
     --sequencer-url {{ sequencer_rpc_url }} \
     --fee-asset {{ feeAsset }} \
     --asset {{ asset }}
-
 
 eth_rpc_url := "http://executor.astria.localdev.me/"
 eth_ws_url := "ws://ws-executor.astria.localdev.me/"

--- a/charts/ibc-test.just
+++ b/charts/ibc-test.just
@@ -32,7 +32,7 @@ delete:
   kubectl wait -n astria-dev-cluster deployment hermes-local-chart --for=condition=Available=True --timeout=300s
 
 [no-cd]
-run celestiaHome pathToCelestiaAppd=default_celestia_appd :
+run:
   #!/usr/bin/env bash
 
   initial_balance=$(just evm-get-balance {{evm_destination_address}})
@@ -40,11 +40,8 @@ run celestiaHome pathToCelestiaAppd=default_celestia_appd :
   # Create a bridge account on the sequencer
   just init-ibc-bridge {{ sequencer_tia_bridge_pkey }} transfer/channel-0/utia nria
 
-  # Load the private key of the Celestia dev account to issue transfers
-  just ibc-test _load-celestia-key "{{ celestiaHome}}" "{{ pathToCelestiaAppd }}"
-
   # Execute the transfer from Celestia to the Rollup
-  just ibc-test _do-ibc-transfer "{{ celestiaHome}}" "{{ pathToCelestiaAppd }}"
+  just ibc-test _do-ibc-transfer
 
   # Multiplication factor is 10^-6 (utia to tia) * 10^18 (rollup factor) = 10^12
   let expected_balance="$initial_balance + {{ transfer_amount }} * 10**12"
@@ -68,8 +65,6 @@ run celestiaHome pathToCelestiaAppd=default_celestia_appd :
 
 bridge_address := "astria1d7zjjljc0dsmxa545xkpwxym86g8uvvwhtezcr"
 celestia_dev_account_address := "celestia1m0ksdjl2p5nzhqy3p47fksv52at3ln885xvl96"
-celestia_dev_account_key_name := "dev"
-celestia_dev_account_mnemonic := "enrich avocado local net will avoid dizzy truth column excuse ready lesson"
 celestia_chain_id := "celestia-local-0"
 celestia_node_url := "http://rpc.app.celestia.localdev.me:80"
 sequencer_tia_bridge_pkey := "6015fbe1c365d3c5ef92dc891db8c5bb26ad454bec2db4762b96e9f8b2430285"
@@ -82,30 +77,22 @@ evm_destination_address := "0xaC21B97d35Bf75A7dAb16f35b111a50e78A72F30"
 transfer_amount := "53000"
 transfer_fees := "26000"
 
-default_celestia_appd := "celestia-appd"
+# TODO: move this to deploy.just so that defaultNamespace need not be redefined
+defaultNamespace := "astria-dev-cluster"
 [no-cd]
-_load-celestia-key celestiaHome pathToCelestiaAppd=default_celestia_appd:
-  #!/usr/bin/env bash
-  pwd
-  "{{pathToCelestiaAppd}}" keys add {{ celestia_dev_account_key_name }} \
-    --home "{{celestiaHome}}" \
-    --keyring-backend="{{ keyring_backend }}" \
-    --recover <<< "{{ celestia_dev_account_mnemonic }}"
-
-[no-cd]
-_do-ibc-transfer celestiaHome pathToCelestiaAppd=default_celestia_appd:
+_do-ibc-transfer namespace=defaultNamespace:
   echo "Performing IBC transfer..."
-  "{{pathToCelestiaAppd}}" tx ibc-transfer transfer \
+  kubectl exec -n {{ namespace }} pods/celestia-local-0 celestia-app -- /bin/bash -c \
+  'celestia-appd tx ibc-transfer transfer \
     transfer \
     channel-0 \
     {{ bridge_address }} \
     "{{ transfer_amount }}utia" \
     --memo="{\"rollupDepositAddress\":\"{{ evm_destination_address }}\"}" \
     --chain-id="{{ celestia_chain_id }}" \
-    --node="{{ celestia_node_url }}" \
     --from="{{ celestia_dev_account_address }}" \
     --fees="{{ transfer_fees }}utia" \
     --yes \
     --log_level=debug \
-    --home "{{celestiaHome}}" \
-    --keyring-backend="{{ keyring_backend }}"
+    --home /home/celestia \
+    --keyring-backend="{{ keyring_backend }}"'

--- a/justfile
+++ b/justfile
@@ -13,22 +13,6 @@ docker-build crate tag=default_docker_tag:
 install-cli:
   cargo install --path ./crates/astria-cli --locked
 
-# version is a celestia-app release. Example: v1.9.0
-# operatingSystem is Linux or Darwin
-# machineHardwareName is arm64 or x86_64
-celestia_default_appd_dst := "."
-get-celestia-appd version operatingSystem machineHardwareName dst=celestia_default_appd_dst:
-  #!/usr/bin/env bash
-  src="celestia-app_{{operatingSystem}}_{{machineHardwareName}}.tar.gz"
-  curl -LOsS -q --output-dir "{{dst}}" \
-    https://github.com/celestiaorg/celestia-app/releases/download/{{version}}/"$src"
-  curl -LOsS -q --output-dir "{{dst}}" \
-    https://github.com/celestiaorg/celestia-app/releases/download/{{version}}/checksums.txt
-  cd "{{dst}}"
-  sha256sum --ignore-missing -c checksums.txt
-  cd -
-  tar --directory "{{dst}}" -xvzf "{{dst}}"/"$src" celestia-appd
-
 # Compiles the generated rust code from protos which are used in crates.
 compile-protos:
   cargo run --manifest-path tools/protobuf-compiler/Cargo.toml


### PR DESCRIPTION
## Summary
Updates the `charts/celestia-local` to spin up `celestia-appd` in a stateful set. Executes the ics20 transfer inside the celestia-app container inside the set.

## Background
https://github.com/astriaorg/astria/pull/1285 updates the ibc ics20 transfer test to require `celestia-appd` and an initialized celestia keystore to be present on the machine running the test. This is undesirable because it pollutes the host environment and creates potential for collisions. Turning `celestia-local` from a kubernetes deployment to a stateful set allows executing the ics20 transfer from inside the container.

## Changes
- Rename `charts/celestia-local/templates/deployment.yaml -> charts/celestia-local/templates/statefulsets.yaml`
- Changes `kind: Deployment -> kind: StatefulSet` in that file
- Update recipes in `charts/deploy.just` to use `kubectl rollout status` instead of `kubectl wait` (the latter does not seem to work with stateful sets)
- Use `kubectl exec` against the celestia-app container in the stateful set to initialize the transfer instead of a locally present `celestia-appd`

## Testing
This is an update to the ibc ics20 smoke test flow. The test still passes with the expected result.

## Related Issues
Closes #1296
Closes #1295