### PR TITLE
chore(bridge-withdrawer): Add instrumentation to bridge-withdrawer

### DIFF
--- a/crates/astria-bridge-withdrawer/src/api.rs
+++ b/crates/astria-bridge-withdrawer/src/api.rs
@@ -20,6 +20,7 @@ use http::status::StatusCode;
 use hyper::server::conn::AddrIncoming;
 use serde::Serialize;
 use tokio::sync::watch;
+use tracing::instrument;
 
 use crate::bridge_withdrawer::StateSnapshot;
 
@@ -51,6 +52,7 @@ pub(crate) fn start(socket_addr: SocketAddr, withdrawer_state: WithdrawerState) 
 }
 
 #[allow(clippy::unused_async)] // Permit because axum handlers must be async
+#[instrument(skip_all)]
 async fn get_healthz(State(withdrawer_state): State<WithdrawerState>) -> Healthz {
     if withdrawer_state.borrow().is_healthy() {
         Healthz::Ok
@@ -66,6 +68,7 @@ async fn get_healthz(State(withdrawer_state): State<WithdrawerState>) -> Healthz
 /// + there is a current sequencer height (implying a block from sequencer was received)
 /// + there is a current data availability height (implying a height was received from the DA)
 #[allow(clippy::unused_async)] // Permit because axum handlers must be async
+#[instrument(skip_all)]
 async fn get_readyz(State(withdrawer_state): State<WithdrawerState>) -> Readyz {
     let is_withdrawer_online = withdrawer_state.borrow().is_ready();
     if is_withdrawer_online {
@@ -76,6 +79,7 @@ async fn get_readyz(State(withdrawer_state): State<WithdrawerState>) -> Readyz {
 }
 
 #[allow(clippy::unused_async)] // Permit because axum handlers must be async
+#[instrument(skip_all)]
 async fn get_status(State(withdrawer_state): State<WithdrawerState>) -> Json<StateSnapshot> {
     Json(withdrawer_state.borrow().clone())
 }

--- a/crates/astria-bridge-withdrawer/src/bridge_withdrawer/startup.rs
+++ b/crates/astria-bridge-withdrawer/src/bridge_withdrawer/startup.rs
@@ -47,6 +47,7 @@ use tracing::{
     instrument,
     warn,
     Instrument as _,
+    Level,
     Span,
 };
 use tryhard::backoff_strategies::ExponentialBackoff;
@@ -120,6 +121,7 @@ impl InfoHandle {
         }
     }
 
+    #[instrument(skip_all, err)]
     pub(super) async fn get_info(&mut self) -> eyre::Result<Info> {
         let state = self
             .rx
@@ -202,6 +204,7 @@ impl Startup {
     /// - `self.chain_id` does not match the value returned from the sequencer node
     /// - `self.fee_asset` is not a valid fee asset on the sequencer node
     /// - `self.sequencer_bridge_address` does not have a sufficient balance of `self.fee_asset`.
+    #[instrument(skip_all, err)]
     async fn confirm_sequencer_config(&self) -> eyre::Result<()> {
         // confirm the sequencer chain id
         let actual_chain_id =
@@ -250,6 +253,7 @@ impl Startup {
     ///   in the sequencer logic).
     /// 5. Failing to convert the transaction data from bytes to proto.
     /// 6. Failing to convert the transaction data from proto to `SignedTransaction`.
+    #[instrument(skip_all, err)]
     async fn get_last_transaction(&self) -> eyre::Result<Option<SignedTransaction>> {
         // get last transaction hash by the bridge account, if it exists
         let last_transaction_hash_resp = get_bridge_account_last_transaction_hash(
@@ -323,6 +327,7 @@ impl Startup {
     ///    the sequencer logic)
     /// 3. The last transaction by the bridge account did not contain a withdrawal action
     /// 4. The memo of the last transaction by the bridge account could not be parsed
+    #[instrument(skip_all, err)]
     async fn get_starting_rollup_height(&mut self) -> eyre::Result<u64> {
         let signed_transaction = self
             .get_last_transaction()
@@ -347,6 +352,7 @@ impl Startup {
     }
 }
 
+#[instrument(skip_all, err(level = Level::WARN))]
 async fn ensure_mempool_empty(
     cometbft_client: sequencer_client::HttpClient,
     sequencer_client: sequencer_service_client::SequencerServiceClient<Channel>,
@@ -391,6 +397,7 @@ async fn ensure_mempool_empty(
 /// 2. Failing to get the latest nonce from cometBFT's mempool.
 /// 3. The pending nonce from the Sequencer's app-side mempool does not match the latest nonce from
 ///    cometBFT's mempool after the exponential backoff times out.
+#[instrument(skip_all, err)]
 async fn wait_for_empty_mempool(
     cometbft_client: sequencer_client::HttpClient,
     sequencer_grpc_endpoint: String,
@@ -485,7 +492,7 @@ fn rollup_height_from_signed_transaction(
     Ok(last_batch_rollup_height)
 }
 
-#[instrument(skip_all)]
+#[instrument(skip_all, err)]
 async fn get_bridge_account_last_transaction_hash(
     client: sequencer_client::HttpClient,
     state: Arc<State>,
@@ -507,7 +514,7 @@ async fn get_bridge_account_last_transaction_hash(
     res
 }
 
-#[instrument(skip_all)]
+#[instrument(skip_all, err)]
 async fn get_sequencer_transaction_at_hash(
     client: sequencer_client::HttpClient,
     state: Arc<State>,
@@ -525,7 +532,7 @@ async fn get_sequencer_transaction_at_hash(
     res
 }
 
-#[instrument(skip_all)]
+#[instrument(skip_all, err)]
 async fn get_sequencer_chain_id(
     client: sequencer_client::HttpClient,
     state: Arc<State>,
@@ -542,7 +549,7 @@ async fn get_sequencer_chain_id(
     Ok(genesis.chain_id)
 }
 
-#[instrument(skip_all)]
+#[instrument(skip_all, err)]
 async fn get_allowed_fee_assets(
     client: sequencer_client::HttpClient,
     state: Arc<State>,
@@ -559,7 +566,7 @@ async fn get_allowed_fee_assets(
     res
 }
 
-#[instrument(skip_all)]
+#[instrument(skip_all, err)]
 async fn get_latest_nonce(
     client: sequencer_client::HttpClient,
     state: Arc<State>,

--- a/crates/astria-bridge-withdrawer/src/bridge_withdrawer/submitter/builder.rs
+++ b/crates/astria-bridge-withdrawer/src/bridge_withdrawer/submitter/builder.rs
@@ -6,7 +6,10 @@ use astria_eyre::eyre::{
 };
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
-use tracing::info;
+use tracing::{
+    info,
+    instrument,
+};
 
 use super::state::State;
 use crate::{
@@ -30,6 +33,7 @@ impl Handle {
         }
     }
 
+    #[instrument(skip_all, err)]
     pub(crate) async fn send_batch(&self, batch: Batch) -> eyre::Result<()> {
         self.batches_tx
             .send(batch)

--- a/crates/astria-bridge-withdrawer/src/bridge_withdrawer/submitter/mod.rs
+++ b/crates/astria-bridge-withdrawer/src/bridge_withdrawer/submitter/mod.rs
@@ -134,7 +134,7 @@ impl Submitter {
         Ok(())
     }
 
-    #[instrument(skip_all)]
+    #[instrument(skip_all, err)]
     async fn process_batch(
         &self,
         sequencer_grpc_client: SequencerServiceClient<Channel>,
@@ -224,7 +224,8 @@ impl Submitter {
     fields(
         nonce = tx.nonce(),
         transaction.hash = %telemetry::display::hex(&tx.sha256_of_proto_encoding()),
-    )
+    ),
+    err
 )]
 async fn submit_tx(
     client: sequencer_client::HttpClient,
@@ -279,6 +280,7 @@ async fn submit_tx(
     res
 }
 
+#[instrument(skip_all, err)]
 pub(crate) async fn get_pending_nonce(
     client: sequencer_service_client::SequencerServiceClient<Channel>,
     address: Address,


### PR DESCRIPTION
## Summary
Added instrumentation to `bridge-withdrawer`

## Background
Adding instrumentation to all async calls will aid in tracing since spans will be emitted even if no events happen under them.

## Changes
- Added instrumentation to all async function calls that are not long-lived.

## Related Issues
Part of #1321 
