### PR TITLE
feat(sequencer): various updates to mempool PR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -803,7 +803,6 @@ dependencies = [
  "penumbra-ibc",
  "penumbra-proto",
  "penumbra-tower-trace",
- "priority-queue",
  "prost",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -5854,17 +5853,6 @@ dependencies = [
  "impl-serde",
  "scale-info",
  "uint",
-]
-
-[[package]]
-name = "priority-queue"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509354d8a769e8d0b567d6821b84495c60213162761a732d68ce87c964bd347f"
-dependencies = [
- "autocfg",
- "equivalent",
- "indexmap 2.2.6",
 ]
 
 [[package]]

--- a/crates/astria-sequencer/.gitignore
+++ b/crates/astria-sequencer/.gitignore
@@ -1,1 +1,0 @@
-app-genesis-state.json

--- a/crates/astria-sequencer/Cargo.toml
+++ b/crates/astria-sequencer/Cargo.toml
@@ -31,7 +31,6 @@ cnidarium = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.7
 cnidarium-component = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.78.0" }
 ibc-proto = { version = "0.41.0", features = ["server"] }
 matchit = "0.7.2"
-priority-queue = "2.0.2"
 tower = "0.4"
 tower-abci = "0.12.0"
 tower-actor = "0.1.0"

--- a/crates/astria-sequencer/src/app/test_utils.rs
+++ b/crates/astria-sequencer/src/app/test_utils.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use astria_core::{
     crypto::SigningKey,
     primitive::v1::RollupId,
@@ -137,30 +139,11 @@ pub(crate) async fn initialize_app(
     app
 }
 
-pub(crate) fn get_mock_tx(nonce: u32) -> SignedTransaction {
-    let tx = UnsignedTransaction {
-        params: TransactionParams::builder()
-            .nonce(nonce)
-            .chain_id("test")
-            .build(),
-        actions: vec![
-            SequenceAction {
-                rollup_id: RollupId::from_unhashed_bytes([0; 32]),
-                data: vec![0x99],
-                fee_asset: "astria".parse().unwrap(),
-            }
-            .into(),
-        ],
-    };
-
-    tx.into_signed(&get_alice_signing_key())
-}
-
-pub(crate) fn get_mock_tx_parameterized(
+pub(crate) fn mock_tx(
     nonce: u32,
     signer: &SigningKey,
-    data_bytes: [u8; 32],
-) -> SignedTransaction {
+    rollup_name: &str,
+) -> Arc<SignedTransaction> {
     let tx = UnsignedTransaction {
         params: TransactionParams::builder()
             .nonce(nonce)
@@ -168,7 +151,7 @@ pub(crate) fn get_mock_tx_parameterized(
             .build(),
         actions: vec![
             SequenceAction {
-                rollup_id: RollupId::from_unhashed_bytes(data_bytes),
+                rollup_id: RollupId::from_unhashed_bytes(rollup_name.as_bytes()),
                 data: vec![0x99],
                 fee_asset: "astria".parse().unwrap(),
             }
@@ -176,5 +159,5 @@ pub(crate) fn get_mock_tx_parameterized(
         ],
     };
 
-    tx.into_signed(signer)
+    Arc::new(tx.into_signed(signer))
 }

--- a/crates/astria-sequencer/src/app/tests_app.rs
+++ b/crates/astria-sequencer/src/app/tests_app.rs
@@ -449,7 +449,7 @@ async fn app_execution_results_match_proposal_vs_after_proposal() {
     // don't commit the result, now call prepare_proposal with the same data.
     // this will reset the app state.
     // this simulates executing the same block as a validator (specifically the proposer).
-    app.mempool.insert(signed_tx, 0).await.unwrap();
+    app.mempool.insert(Arc::new(signed_tx), 0).await.unwrap();
 
     let proposer_address = [88u8; 20].to_vec().try_into().unwrap();
     let prepare_proposal = PrepareProposal {
@@ -474,8 +474,7 @@ async fn app_execution_results_match_proposal_vs_after_proposal() {
     let current_account_nonce_getter = |address: [u8; 20]| app.state.get_account_nonce(address);
     app.mempool
         .run_maintenance(current_account_nonce_getter)
-        .await
-        .unwrap();
+        .await;
 
     assert_eq!(app.mempool.len().await, 0);
 
@@ -565,8 +564,8 @@ async fn app_prepare_proposal_cometbft_max_bytes_overflow_ok() {
     }
     .into_signed(&alice);
 
-    app.mempool.insert(tx_pass, 0).await.unwrap();
-    app.mempool.insert(tx_overflow, 0).await.unwrap();
+    app.mempool.insert(Arc::new(tx_pass), 0).await.unwrap();
+    app.mempool.insert(Arc::new(tx_overflow), 0).await.unwrap();
 
     // send to prepare_proposal
     let prepare_args = abci::request::PrepareProposal {
@@ -589,9 +588,7 @@ async fn app_prepare_proposal_cometbft_max_bytes_overflow_ok() {
     let current_account_nonce_getter = |address: [u8; 20]| app.state.get_account_nonce(address);
     app.mempool
         .run_maintenance(current_account_nonce_getter)
-        .await
-        .unwrap();
-
+        .await;
     // see only first tx made it in
     assert_eq!(
         result.txs.len(),
@@ -645,8 +642,8 @@ async fn app_prepare_proposal_sequencer_max_bytes_overflow_ok() {
     }
     .into_signed(&alice);
 
-    app.mempool.insert(tx_pass, 0).await.unwrap();
-    app.mempool.insert(tx_overflow, 0).await.unwrap();
+    app.mempool.insert(Arc::new(tx_pass), 0).await.unwrap();
+    app.mempool.insert(Arc::new(tx_overflow), 0).await.unwrap();
 
     // send to prepare_proposal
     let prepare_args = abci::request::PrepareProposal {
@@ -669,8 +666,7 @@ async fn app_prepare_proposal_sequencer_max_bytes_overflow_ok() {
     let current_account_nonce_getter = |address: [u8; 20]| app.state.get_account_nonce(address);
     app.mempool
         .run_maintenance(current_account_nonce_getter)
-        .await
-        .unwrap();
+        .await;
 
     // see only first tx made it in
     assert_eq!(

--- a/crates/astria-sequencer/src/grpc/sequencer.rs
+++ b/crates/astria-sequencer/src/grpc/sequencer.rs
@@ -261,12 +261,12 @@ mod test {
         let alice = get_alice_signing_key();
         let alice_address = astria_address(&alice.address_bytes());
         let nonce = 99;
-        let tx = crate::app::test_utils::get_mock_tx(nonce);
+        let tx = crate::app::test_utils::mock_tx(nonce, &get_alice_signing_key(), "test");
         mempool.insert(tx, 0).await.unwrap();
 
-        // insert tx into pending
-        let nonce = 0;
-        let tx = crate::app::test_utils::get_mock_tx(nonce);
+        // insert a tx with lower nonce also, but we should get the highest nonce
+        let lower_nonce = 98;
+        let tx = crate::app::test_utils::mock_tx(lower_nonce, &get_alice_signing_key(), "test");
         mempool.insert(tx, 0).await.unwrap();
 
         let server = Arc::new(SequencerServer::new(storage.clone(), mempool));

--- a/crates/astria-sequencer/src/mempool/transactions_container.rs
+++ b/crates/astria-sequencer/src/mempool/transactions_container.rs
@@ -1,40 +1,42 @@
 use std::{
     cmp::Ordering,
     collections::{
+        hash_map,
         BTreeMap,
         HashMap,
-        HashSet,
     },
     fmt,
     future::Future,
+    mem,
     sync::Arc,
 };
 
 use anyhow::Context;
 use astria_core::protocol::transaction::v1alpha1::SignedTransaction;
-use priority_queue::PriorityQueue;
 use tokio::time::{
     Duration,
     Instant,
 };
+use tracing::error;
 
 use super::RemovalReason;
 
-/// [`TimemarkedTransaction`] is a wrapper around a signed transaction
-/// used to keep track of when that transaction was first seen in the mempool.
-///
-/// Note: `PartialEq` was implemented for this struct to only take into account
-/// the signed transaction's hash.  
-#[derive(Debug)]
-pub(crate) struct TimemarkedTransaction {
-    signed_tx: SignedTransaction,
+pub(super) type PendingTransactions = TransactionsContainer<PendingTransactionsForAccount>;
+pub(super) type ParkedTransactions<const MAX_TX_COUNT: usize> =
+    TransactionsContainer<ParkedTransactionsForAccount<MAX_TX_COUNT>>;
+
+/// `TimemarkedTransaction` is a wrapper around a signed transaction used to keep track of when that
+/// transaction was first seen in the mempool.
+#[derive(Clone, Debug)]
+pub(super) struct TimemarkedTransaction {
+    signed_tx: Arc<SignedTransaction>,
     tx_hash: [u8; 32],
     time_first_seen: Instant,
     address: [u8; 20],
 }
 
 impl TimemarkedTransaction {
-    pub(crate) fn new(signed_tx: SignedTransaction) -> Self {
+    pub(super) fn new(signed_tx: Arc<SignedTransaction>) -> Self {
         Self {
             tx_hash: signed_tx.sha256_of_proto_encoding(),
             address: signed_tx.verification_key().address_bytes(),
@@ -57,41 +59,35 @@ impl TimemarkedTransaction {
         })
     }
 
-    pub(crate) fn time_first_seen(&self) -> Instant {
-        self.time_first_seen
+    fn is_expired(&self, now: Instant, ttl: Duration) -> bool {
+        now.saturating_duration_since(self.time_first_seen) > ttl
     }
 
-    pub(crate) fn signed_tx(&self) -> &SignedTransaction {
-        &self.signed_tx
+    pub(super) fn nonce(&self) -> u32 {
+        self.signed_tx.nonce()
     }
 
-    pub(crate) fn tx_hash(&self) -> [u8; 32] {
-        self.tx_hash
-    }
-
-    pub(crate) fn address(&self) -> &[u8; 20] {
+    pub(super) fn address(&self) -> &[u8; 20] {
         &self.address
     }
 }
 
-/// Only consider `self.tx_hash` for equality. This is consistent with the impl for std `Hash`.
-impl PartialEq for TimemarkedTransaction {
-    fn eq(&self, other: &Self) -> bool {
-        self.tx_hash == other.tx_hash
+impl fmt::Display for TimemarkedTransaction {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "tx_hash: {}, address: {}, signer: {}, nonce: {}, chain ID: {}",
+            telemetry::display::base64(&self.tx_hash),
+            telemetry::display::base64(&self.address),
+            self.signed_tx.verification_key(),
+            self.signed_tx.nonce(),
+            self.signed_tx.chain_id(),
+        )
     }
 }
 
-impl Eq for TimemarkedTransaction {}
-
-/// Only consider `self.tx_hash` when hashing. This is consistent with the impl for equality.
-impl std::hash::Hash for TimemarkedTransaction {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.tx_hash.hash(state);
-    }
-}
-
-#[derive(Clone, Debug)]
-pub(crate) struct TransactionPriority {
+#[derive(Clone, Copy, Debug)]
+struct TransactionPriority {
     nonce_diff: u32,
     time_first_seen: Instant,
 }
@@ -125,24 +121,7 @@ impl PartialOrd for TransactionPriority {
     }
 }
 
-/// [`BuilderQueue`] is a typed used to order transactions by the difference between a transaction
-/// nonce and the account nonce then by the time that a transaction was first seen by the mempool.
-pub(crate) type BuilderQueue = PriorityQueue<Arc<TimemarkedTransaction>, TransactionPriority>;
-
-/// [`AccountTransactionContainer`] is a container used for managing transactions belonging
-/// to a single account.
-///
-/// The `strict` mode defines if transaction nonces are allowed to be gapped or not. The
-/// `size_limit` is only enfored when the `strict` mode is false.
-#[derive(Clone, Debug)]
-struct AccountTransactionContainer {
-    txs: BTreeMap<u32, Arc<TimemarkedTransaction>>, // tracked transactions
-    strict: bool,                                   // if nonce gaps are allowed or not
-    size_limit: usize,                              /* max number of transactions stored, only
-                                                     * enforced if not strict */
-}
-
-#[derive(Debug, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub(crate) enum InsertionError {
     AlreadyPresent,
     NonceTooLow,
@@ -154,533 +133,530 @@ pub(crate) enum InsertionError {
 impl fmt::Display for InsertionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            InsertionError::AlreadyPresent => write!(f, "AlreadyPresent"),
-            InsertionError::NonceTooLow => write!(f, "NonceTooLow"),
-            InsertionError::NonceTaken => write!(f, "NonceTaken"),
-            InsertionError::NonceGap => write!(f, "NonceGap"),
-            InsertionError::AccountSizeLimit => write!(f, "AccountSizeLimit"),
+            InsertionError::AlreadyPresent => {
+                write!(f, "transaction already exists in the mempool")
+            }
+            InsertionError::NonceTooLow => {
+                write!(f, "given nonce has already been used previously")
+            }
+            InsertionError::NonceTaken => write!(f, "given nonce already exists in the mempool"),
+            InsertionError::NonceGap => write!(f, "gap in the pending nonce sequence"),
+            InsertionError::AccountSizeLimit => write!(
+                f,
+                "maximum number of pending transactions has been reached for the given account"
+            ),
         }
     }
 }
 
-impl AccountTransactionContainer {
-    fn new(strict: bool, size_limit: usize) -> Self {
-        AccountTransactionContainer {
-            txs: BTreeMap::<u32, Arc<TimemarkedTransaction>>::new(),
-            strict,
-            size_limit,
-        }
+/// Transactions for a single account where the sequence of nonces must not have any gaps.
+#[derive(Clone, Default, Debug)]
+pub(super) struct PendingTransactionsForAccount {
+    txs: BTreeMap<u32, TimemarkedTransaction>,
+}
+
+impl PendingTransactionsForAccount {
+    fn highest_nonce(&self) -> Option<u32> {
+        self.txs.last_key_value().map(|(nonce, _)| *nonce)
+    }
+}
+
+impl TransactionsForAccount for PendingTransactionsForAccount {
+    fn txs(&self) -> &BTreeMap<u32, TimemarkedTransaction> {
+        &self.txs
     }
 
-    /// Adds transaction to the container. Note: does NOT allow for nonce replacement.
-    /// Will fail if `strict` is true and adding the transaction would create a nonce gap.
+    fn txs_mut(&mut self) -> &mut BTreeMap<u32, TimemarkedTransaction> {
+        &mut self.txs
+    }
+
+    fn is_at_tx_limit(&self) -> bool {
+        false
+    }
+
+    fn is_sequential_nonce_precondition_met(&self, ttx: &TimemarkedTransaction) -> bool {
+        // If the `ttx` nonce is 0, precondition is met iff there are no other existing txs.
+        let Some(previous_nonce) = ttx.signed_tx.nonce().checked_sub(1) else {
+            return self.txs().is_empty();
+        };
+
+        // Precondition is met if the previous nonce is in the existing txs, or if there are no
+        // existing txs.
+        self.txs().contains_key(&previous_nonce) || self.txs().is_empty()
+    }
+}
+
+/// Transactions for a single account where gaps are allowed in the sequence of nonces, and with an
+/// upper bound on the number of transactions.
+#[derive(Clone, Default, Debug)]
+pub(super) struct ParkedTransactionsForAccount<const MAX_TX_COUNT: usize> {
+    txs: BTreeMap<u32, TimemarkedTransaction>,
+}
+
+impl<const MAX_TX_COUNT: usize> ParkedTransactionsForAccount<MAX_TX_COUNT> {
+    /// Returns contiguous transactions from front of queue starting from target nonce, removing the
+    /// transactions in the process.
     ///
-    /// `current_account_nonce` should be the nonce that the current accounts state is at.
+    /// Note: this function only operates on the front of the queue. If the target nonce is not at
+    /// the front, an error will be logged and nothing will be returned.
+    fn pop_front_contiguous(
+        &mut self,
+        mut target_nonce: u32,
+    ) -> impl Iterator<Item = TimemarkedTransaction> {
+        let mut split_at = 0;
+        for nonce in self.txs.keys() {
+            if *nonce == target_nonce {
+                let Some(next_target) = target_nonce.checked_add(1) else {
+                    // We've got contiguous nonces up to `u32::MAX`; return everything.
+                    return mem::take(&mut self.txs).into_values();
+                };
+                target_nonce = next_target;
+                split_at = next_target;
+            } else {
+                break;
+            }
+        }
+
+        if split_at == 0 {
+            error!(target_nonce, "expected nonce to be present");
+        }
+
+        let mut split_off = self.txs.split_off(&split_at);
+        // The higher nonces are returned in `split_off`, but we want to keep these in `self.txs`,
+        // so swap the two collections.
+        mem::swap(&mut split_off, &mut self.txs);
+        split_off.into_values()
+    }
+}
+
+impl<const MAX_TX_COUNT: usize> TransactionsForAccount
+    for ParkedTransactionsForAccount<MAX_TX_COUNT>
+{
+    fn txs(&self) -> &BTreeMap<u32, TimemarkedTransaction> {
+        &self.txs
+    }
+
+    fn txs_mut(&mut self) -> &mut BTreeMap<u32, TimemarkedTransaction> {
+        &mut self.txs
+    }
+
+    fn is_at_tx_limit(&self) -> bool {
+        self.txs.len() >= MAX_TX_COUNT
+    }
+
+    fn is_sequential_nonce_precondition_met(&self, _: &TimemarkedTransaction) -> bool {
+        true
+    }
+}
+
+/// `TransactionsForAccount` is a trait for a collection of transactions belonging to a single
+/// account.
+pub(super) trait TransactionsForAccount: Default {
+    fn new() -> Self
+    where
+        Self: Sized + Default,
+    {
+        Self::default()
+    }
+
+    fn txs(&self) -> &BTreeMap<u32, TimemarkedTransaction>;
+
+    fn txs_mut(&mut self) -> &mut BTreeMap<u32, TimemarkedTransaction>;
+
+    fn is_at_tx_limit(&self) -> bool;
+
+    /// Returns `Ok` if adding `ttx` would not break the nonce precondition, i.e. sequential
+    /// nonces with no gaps if in `SequentialNonces` mode.
+    fn is_sequential_nonce_precondition_met(&self, ttx: &TimemarkedTransaction) -> bool;
+
+    /// Adds transaction to the container. Note: does NOT allow for nonce replacement.
+    /// Will fail if in `SequentialNonces` mode and adding the transaction would create a nonce gap.
+    ///
+    /// `current_account_nonce` should be the account's nonce in the latest chain state.
+    ///
     /// Note: if the account `current_account_nonce` ever decreases, this is a logic error
-    /// and could mess up the validity of strict containers.
+    /// and could mess up the validity of `SequentialNonces` containers.
     fn add(
         &mut self,
-        ttx: Arc<TimemarkedTransaction>,
+        ttx: TimemarkedTransaction,
         current_account_nonce: u32,
-    ) -> anyhow::Result<(), InsertionError> {
-        if !self.strict && self.txs.len() >= self.size_limit {
+    ) -> Result<(), InsertionError> {
+        if self.is_at_tx_limit() {
             return Err(InsertionError::AccountSizeLimit);
         }
 
-        if ttx.signed_tx().nonce() < current_account_nonce {
+        if ttx.nonce() < current_account_nonce {
             return Err(InsertionError::NonceTooLow);
         }
 
-        if self.txs.contains_key(&ttx.signed_tx.nonce()) {
-            return Err(InsertionError::NonceTaken);
+        if let Some(existing_ttx) = self.txs().get(&ttx.signed_tx.nonce()) {
+            return Err(if existing_ttx.tx_hash == ttx.tx_hash {
+                InsertionError::AlreadyPresent
+            } else {
+                InsertionError::NonceTaken
+            });
         }
 
-        // ensure that if strict mode is on that the previous nonce is already in the list
-        if self.strict
-            && ttx.signed_tx.nonce() != 0
-            && ttx.signed_tx.nonce() != current_account_nonce
-            && !self.txs.contains_key(
-                &ttx.signed_tx
-                    .nonce()
-                    .checked_sub(1)
-                    .expect("Error subtracting from non zero nonce"),
-            )
-        {
-            // nonce is gapped
+        if !self.is_sequential_nonce_precondition_met(&ttx) {
             return Err(InsertionError::NonceGap);
         }
 
-        // add to internal structure
-        self.txs.insert(ttx.signed_tx.nonce(), ttx);
+        self.txs_mut().insert(ttx.signed_tx.nonce(), ttx);
 
         Ok(())
     }
 
-    /// Removes transaction from the container. If `remove_higher` is true, will
-    /// remove all higher nonces from account as well. Returns a vector of removed transactions.
-    fn remove(&mut self, nonce: u32, remove_higher: bool) -> Vec<Arc<TimemarkedTransaction>> {
-        let mut result = Vec::<Arc<TimemarkedTransaction>>::new();
-        if !self.txs.contains_key(&nonce) {
-            // doesn't contain requested nonce
-            return result;
-        }
-
-        if remove_higher {
-            // remove from end till all higher nonces removed
-            loop {
-                let (key, value) = self
-                    .txs
-                    .pop_last()
-                    .expect("Error popping values that should exist");
-                result.push(value);
-                if key == nonce {
-                    break;
-                }
-            }
-        } else {
-            // remove single element
-            result.push(
-                self.txs
-                    .remove(&nonce)
-                    .expect("Error removing value that should exist"),
-            );
-        }
-        result
-    }
-
-    /// Returns a copy of all of the contained transactions.
-    fn all_transactions_copy(&self) -> Vec<Arc<TimemarkedTransaction>> {
-        self.txs.clone().into_values().collect()
-    }
-
-    /// Returns all transactions, consuming them in the process.
-    fn pop_all_transactions(&mut self) -> Vec<Arc<TimemarkedTransaction>> {
-        let mut popped_txs = Vec::<Arc<TimemarkedTransaction>>::new();
-        while let Some((_, tx)) = self.txs.pop_first() {
-            popped_txs.push(tx);
-        }
-        popped_txs
-    }
-
-    /// Returns contiguous transactions from front of queue starting from target nonce, removing the
-    /// transactions in the process. Used when need to promote transactions from parked to
-    /// pending.
+    /// Removes transactions with the given nonce and higher.
     ///
-    /// Note: this function only operates on the front of the queue. If the target nonce
-    /// is not at the front, nothing will be returned.
-    fn pop_front_multiple(&mut self, mut target_nonce: u32) -> Vec<Arc<TimemarkedTransaction>> {
-        assert!(!self.strict, "shouldn't be popping from strict queue");
-        let mut popped_txs = Vec::<Arc<TimemarkedTransaction>>::new();
-
-        while let Some((nonce, _)) = self.txs.first_key_value() {
-            if *nonce == target_nonce {
-                let (_, tx) = self
-                    .txs
-                    .pop_first()
-                    .expect("popped value should exist in pop_front");
-                popped_txs.push(tx);
-                target_nonce = target_nonce
-                    .checked_add(1)
-                    .expect("failed while incrementing nonce");
-            } else {
-                // not target nonce
-                break;
-            }
+    /// Note: the given nonce is expected to be present. If it's absent, an error is logged and no
+    /// transactions are removed.
+    ///
+    /// Returns the hashes of the removed transactions.
+    fn remove(&mut self, nonce: u32) -> Vec<[u8; 32]> {
+        if !self.txs().contains_key(&nonce) {
+            error!(nonce, "transaction with given nonce not found");
+            return Vec::new();
         }
-        popped_txs
+
+        self.txs_mut()
+            .split_off(&nonce)
+            .values()
+            .map(|ttx| ttx.tx_hash)
+            .collect()
     }
 
-    /// Pops the lowest transaction.
-    fn pop_front_single(&mut self) -> Option<Arc<TimemarkedTransaction>> {
-        if let Some((_, tx)) = self.txs.pop_first() {
-            Some(tx)
-        } else {
-            None
-        }
+    /// Returns the transaction with the lowest nonce.
+    fn front(&self) -> Option<&TimemarkedTransaction> {
+        self.txs().first_key_value().map(|(_, ttx)| ttx)
     }
 
-    /// Returns the highest nonce value.
-    fn peek_end(&self) -> Option<u32> {
-        if let Some((nonce, _)) = self.txs.last_key_value() {
-            Some(*nonce)
-        } else {
-            None
-        }
+    /// Removes transactions below the given nonce. Returns the hashes of the removed transactions.
+    fn register_latest_account_nonce(
+        &mut self,
+        current_account_nonce: u32,
+    ) -> impl Iterator<Item = [u8; 32]> {
+        let mut split_off = self.txs_mut().split_off(&current_account_nonce);
+        mem::swap(&mut split_off, self.txs_mut());
+        split_off.into_values().map(|ttx| ttx.tx_hash)
     }
 
-    /// Returns a copy of the lowest transaction.
-    fn peek_front(&self) -> Option<Arc<TimemarkedTransaction>> {
-        if let Some((_, tx)) = self.txs.first_key_value() {
-            Some(tx.clone())
-        } else {
-            None
-        }
-    }
-
-    /// Remove transactions below the current account nonce. Used for
-    /// clearing out stale nonces. Returns the transactions that were removed.
-    fn fast_forward(&mut self, current_account_nonce: u32) -> Vec<Arc<TimemarkedTransaction>> {
-        let mut removed_txs = Vec::<Arc<TimemarkedTransaction>>::new();
-        while let Some((nonce, _)) = self.txs.first_key_value() {
-            if *nonce < current_account_nonce {
-                let (_, tx) = self
-                    .txs
-                    .pop_first()
-                    .expect("popped value should exist in fast_forward");
-                removed_txs.push(tx);
-            } else {
-                // cleared out stale nonces
-                break;
-            }
-        }
-        removed_txs
-    }
-
-    /// Returns the number of transactions in container.
-    fn size(&self) -> usize {
-        self.txs.len()
+    #[cfg(test)]
+    fn contains_tx(&self, tx_hash: &[u8; 32]) -> bool {
+        self.txs().values().any(|ttx| ttx.tx_hash == *tx_hash)
     }
 }
 
-/// [`AccountTransactionContainer`] is a container used for mananging transactions for
-/// multiple accounts.
-///
-/// The `strict` mode defines if transaction nonces are allowed to be gapped or not for the managed
-/// accounts. The `size_limit` is only enfored when the `strict` mode is false.
+/// `TransactionsContainer` is a container used for managing transactions for multiple accounts.
 #[derive(Clone, Debug)]
-pub(crate) struct TransactionContainer {
-    accounts: HashMap<[u8; 20], AccountTransactionContainer>,
-    all: HashSet<[u8; 32]>,
-    strict: bool,
-    size_limit: usize,
+pub(super) struct TransactionsContainer<T> {
+    /// A map of collections of transactions, indexed by the account address.
+    txs: HashMap<[u8; 20], T>,
     tx_ttl: Duration,
 }
 
-impl TransactionContainer {
-    pub(crate) fn new(strict: bool, size_limit: usize, tx_ttl: Duration) -> Self {
-        assert!(
-            (!strict && size_limit != 0) || (strict && size_limit == 0),
-            "pending shouldn't have size restrictions and parked should"
-        );
-        TransactionContainer {
-            accounts: HashMap::<[u8; 20], AccountTransactionContainer>::new(),
-            all: HashSet::<[u8; 32]>::new(),
-            strict,
-            size_limit,
+impl<T: TransactionsForAccount> TransactionsContainer<T> {
+    pub(super) fn new(tx_ttl: Duration) -> Self {
+        TransactionsContainer::<T> {
+            txs: HashMap::new(),
             tx_ttl,
         }
     }
 
-    #[cfg(test)]
-    /// Returns the number of transactions in the container.
-    pub(crate) fn size(&self) -> usize {
-        self.all.len()
-    }
-
-    /// Returns the highest nonce for an account.
-    pub(crate) fn pending_nonce(&self, address: [u8; 20]) -> Option<u32> {
-        if let Some(account) = self.accounts.get(&address) {
-            account.peek_end()
-        } else {
-            None
-        }
-    }
-
-    /// Adds the transaction to the container. If failed,
-    /// returns the reason why.
+    /// Adds the transaction to the container.
     ///
-    /// `current_account_nonce` should be the current nonce
-    /// of the account associated with the transaction. If this
-    /// ever decreases, the strict containers could become messed up.
-    pub(crate) fn add(
+    /// `current_account_nonce` should be the current nonce of the account associated with the
+    /// transaction. If this ever decreases, the `TransactionsContainer` containers could become
+    /// invalid.
+    pub(super) fn add(
         &mut self,
-        ttx: Arc<TimemarkedTransaction>,
+        ttx: TimemarkedTransaction,
         current_account_nonce: u32,
-    ) -> anyhow::Result<(), InsertionError> {
-        // already tracked
-        if self.all.contains(&ttx.tx_hash()) {
-            return Err(InsertionError::AlreadyPresent);
-        }
-
-        // create account map if necessary
-        let mut account_created = false;
-        if !self.accounts.contains_key(ttx.address()) {
-            account_created = true;
-            self.accounts.insert(
-                *ttx.address(),
-                AccountTransactionContainer::new(self.strict, self.size_limit),
-            );
-        }
-
-        // try to add transaction
-        let address_cache = *ttx.address();
-        let hash_cache = ttx.tx_hash();
-        let success = self
-            .accounts
-            .get_mut(ttx.address())
-            .expect("AccountTransactionsContainer for account should exist")
-            .add(ttx, current_account_nonce);
-
-        if success.is_ok() {
-            // add to all tracked if successfully added to account
-            self.all.insert(hash_cache);
-        } else if account_created {
-            // remove freshly created account if insertion failed
-            self.accounts.remove(&address_cache);
-        }
-
-        success
-    }
-
-    /// Removes the target transaction and any transactions with higher
-    /// nonces if `remove_higher` is set to true. Returns all removed transactions.
-    ///
-    /// Note: operates on the account<>nonce pair of the target transaction instead of the
-    /// transaction's hash.
-    pub(crate) fn remove(
-        &mut self,
-        ttx: &Arc<TimemarkedTransaction>,
-        remove_higher: bool,
-    ) -> Vec<Arc<TimemarkedTransaction>> {
-        let address = ttx.signed_tx.verification_key().address_bytes();
-
-        // return if no tracked account
-        if !self.accounts.contains_key(&address) {
-            return Vec::<Arc<TimemarkedTransaction>>::new();
-        }
-
-        // remove transactions
-        let removed_txs = self
-            .accounts
-            .get_mut(&address)
-            .expect("AccountTransactionsContainer for account should exist")
-            .remove(ttx.signed_tx.nonce(), remove_higher);
-
-        // remove transactions from all tracked
-        for tx in &removed_txs {
-            self.all.remove(&tx.tx_hash);
-        }
-
-        // remove account if out of transactions
-        if self
-            .accounts
-            .get(&address)
-            .expect("AccountTransactionsContainer for account should still exist")
-            .size()
-            == 0
-        {
-            self.accounts.remove(&address);
-        }
-
-        removed_txs
-    }
-
-    /// Removes all of the transactions from an account and deletes the account entry.
-    /// Returns the removed transactions.
-    pub(crate) fn clear_account(&mut self, address: &[u8; 20]) -> Vec<Arc<TimemarkedTransaction>> {
-        let mut removed_txs = Vec::<Arc<TimemarkedTransaction>>::new();
-        if let Some(account) = self.accounts.get_mut(address) {
-            removed_txs.append(&mut account.pop_all_transactions());
-
-            // remove from all
-            for tx in &removed_txs {
-                self.all.remove(&tx.tx_hash());
+    ) -> Result<(), InsertionError> {
+        match self.txs.entry(*ttx.address()) {
+            hash_map::Entry::Occupied(entry) => {
+                entry.into_mut().add(ttx, current_account_nonce)?;
             }
-            // remove account
-            self.accounts.remove(address);
+            hash_map::Entry::Vacant(entry) => {
+                let mut txs = T::new();
+                txs.add(ttx, current_account_nonce)?;
+                entry.insert(txs);
+            }
         }
-        removed_txs
+        Ok(())
     }
 
-    /// Cleans all of the accounts in the container. Will remove any transactions with stale nonces
-    /// and will evict all transactions from accounts whose lowest transaction has expired.
+    /// Removes the given transaction and any transactions with higher nonces for the relevant
+    /// account.
+    ///
+    /// If `signed_tx` existed, returns `Ok` with the hashes of the removed transactions. If
+    /// `signed_tx` was not in the collection, it is returned via `Err`.
+    pub(super) fn remove(
+        &mut self,
+        signed_tx: Arc<SignedTransaction>,
+    ) -> Result<Vec<[u8; 32]>, Arc<SignedTransaction>> {
+        let address = signed_tx.verification_key().address_bytes();
+
+        // Take the collection for this account out of `self` temporarily.
+        let Some(mut account_txs) = self.txs.remove(&address) else {
+            return Err(signed_tx);
+        };
+
+        let removed = account_txs.remove(signed_tx.nonce());
+
+        // Re-add the collection to `self` if it's not empty.
+        if !account_txs.txs().is_empty() {
+            let _ = self.txs.insert(address, account_txs);
+        }
+
+        if removed.is_empty() {
+            return Err(signed_tx);
+        }
+
+        Ok(removed)
+    }
+
+    /// Removes all of the transactions for the given account and returns the hashes of the removed
+    /// transactions.
+    pub(super) fn clear_account(&mut self, address: &[u8; 20]) -> Vec<[u8; 32]> {
+        self.txs
+            .remove(address)
+            .map(|account_txs| account_txs.txs().values().map(|ttx| ttx.tx_hash).collect())
+            .unwrap_or_default()
+    }
+
+    /// Cleans all of the accounts in the container. Removes any transactions with stale nonces and
+    /// evicts all transactions from accounts whose lowest transaction has expired.
     ///
     /// Returns all transactions that have been removed with the reason why they have been removed.
-    pub(crate) async fn clean_accounts<F, O>(
+    pub(super) async fn clean_accounts<F, O>(
         &mut self,
         current_account_nonce_getter: &F,
-    ) -> anyhow::Result<Vec<(Arc<TimemarkedTransaction>, RemovalReason)>>
+    ) -> Vec<([u8; 32], RemovalReason)>
     where
         F: Fn([u8; 20]) -> O,
         O: Future<Output = anyhow::Result<u32>>,
     {
         // currently just removes stale nonces and will clear accounts if the
         // transactions are older than the TTL
-        let mut accounts_to_remove = Vec::<[u8; 20]>::new();
-        let mut removed_txs = Vec::<(Arc<TimemarkedTransaction>, RemovalReason)>::new();
-        for (address, account_txs) in &mut self.accounts {
+        let mut accounts_to_remove = Vec::new();
+        let mut removed_txs = Vec::new();
+        let now = Instant::now();
+        for (address, account_txs) in &mut self.txs {
             // check if first tx is older than the TTL, if so, remove all transactions
-            if let Some(first_tx) = account_txs.peek_front() {
-                if first_tx.time_first_seen().elapsed() > self.tx_ttl {
+            if let Some(first_tx) = account_txs.front() {
+                if first_tx.is_expired(now, self.tx_ttl) {
                     // first is stale, rest popped for invalidation
-                    removed_txs.push((
+                    removed_txs.push((first_tx.tx_hash, RemovalReason::Expired));
+                    removed_txs.extend(
                         account_txs
-                            .pop_front_single()
-                            .expect("first tx should exist"),
-                        RemovalReason::Expired,
-                    ));
-                    for tx in account_txs.pop_all_transactions() {
-                        println!("other nonce: {}", tx.signed_tx().nonce());
-                        removed_txs.push((tx, RemovalReason::LowerNonceInvalidated));
-                    }
+                            .txs()
+                            .values()
+                            .skip(1)
+                            .map(|ttx| (ttx.tx_hash, RemovalReason::LowerNonceInvalidated)),
+                    );
+                    account_txs.txs_mut().clear();
                 } else {
                     // clean to newest nonce
-                    let current_account_nonce = current_account_nonce_getter(*address)
-                        .await
-                        .context("failed to fetch account nonce for fast forward")?;
-                    for tx in account_txs.fast_forward(current_account_nonce) {
-                        removed_txs.push((tx, RemovalReason::NonceStale));
-                    }
+                    let current_account_nonce = match current_account_nonce_getter(*address).await {
+                        Ok(nonce) => nonce,
+                        Err(error) => {
+                            error!(
+                                address = %telemetry::display::base64(address),
+                                "failed to fetch nonce from state when cleaning accounts: {error:#}"
+                            );
+                            continue;
+                        }
+                    };
+                    removed_txs.extend(
+                        account_txs
+                            .register_latest_account_nonce(current_account_nonce)
+                            .map(|tx_hash| (tx_hash, RemovalReason::NonceStale)),
+                    );
                 }
             }
 
-            if account_txs.size() == 0 {
+            if account_txs.txs().is_empty() {
                 accounts_to_remove.push(*address);
             }
         }
 
         // remove empty accounts
         for account in accounts_to_remove {
-            // remove empty accounts
-            self.accounts.remove(&account);
+            self.txs.remove(&account);
         }
 
-        // untrack transactions
-        for (tx, _) in &removed_txs {
-            self.all.remove(&tx.tx_hash());
-        }
-
-        Ok(removed_txs)
+        removed_txs
     }
 
-    /// Removes and returns transactions that are lower than or equal to the current nonce of
-    /// accounts. This is helpful when needing to promote transactions from parked to pending
-    /// during mempool maintenance.
-    pub(crate) async fn find_promotables<F, O>(
-        &mut self,
-        current_account_nonce_getter: &F,
-    ) -> anyhow::Result<Vec<Arc<TimemarkedTransaction>>>
+    /// Returns the number of transactions in the container.
+    pub(super) fn len(&self) -> usize {
+        self.txs
+            .values()
+            .map(|account_txs| account_txs.txs().len())
+            .sum()
+    }
+
+    #[cfg(test)]
+    fn contains_tx(&self, tx_hash: &[u8; 32]) -> bool {
+        self.txs
+            .values()
+            .any(|account_txs| account_txs.contains_tx(tx_hash))
+    }
+}
+
+impl TransactionsContainer<PendingTransactionsForAccount> {
+    /// Returns the highest nonce for an account.
+    pub(super) fn pending_nonce(&self, address: [u8; 20]) -> Option<u32> {
+        self.txs
+            .get(&address)
+            .and_then(PendingTransactionsForAccount::highest_nonce)
+    }
+
+    /// Returns a copy of transactions and their hashes sorted by nonce difference and then time
+    /// first seen.
+    pub(super) async fn builder_queue<F, O>(
+        &self,
+        current_account_nonce_getter: F,
+    ) -> anyhow::Result<Vec<([u8; 32], Arc<SignedTransaction>)>>
     where
         F: Fn([u8; 20]) -> O,
         O: Future<Output = anyhow::Result<u32>>,
     {
-        assert!(!self.strict, "should not be promoting from pending");
-        let mut accounts_to_remove = Vec::<[u8; 20]>::new();
-        let mut promoted_txs = Vec::<Arc<TimemarkedTransaction>>::new();
+        // Used to hold the values in Vec for sorting.
+        struct QueueEntry {
+            tx: Arc<SignedTransaction>,
+            tx_hash: [u8; 32],
+            priority: TransactionPriority,
+        }
 
-        for (address, account_txs) in &mut self.accounts {
+        let mut queue = Vec::with_capacity(self.len());
+        // Add all transactions to the queue.
+        for (address, account_txs) in &self.txs {
             let current_account_nonce = current_account_nonce_getter(*address)
                 .await
-                .context("failed to fetch account nonce for pop front")?;
+                .context("failed to fetch account nonce for builder queue")?;
+            for ttx in account_txs.txs.values() {
+                let priority = match ttx.priority(current_account_nonce) {
+                    Ok(priority) => priority,
+                    Err(error) => {
+                        // mempool could be off due to node connectivity issues
+                        error!(
+                            tx_hash = %telemetry::display::base64(&ttx.tx_hash),
+                            "failed to add pending tx to builder queue: {error:#}"
+                        );
+                        continue;
+                    }
+                };
+                queue.push(QueueEntry {
+                    tx: ttx.signed_tx.clone(),
+                    tx_hash: ttx.tx_hash,
+                    priority,
+                });
+            }
+        }
+
+        // Sort the queue and return the relevant data. Note that the sorted queue will be ordered
+        // from lowest to highest priority, so we need to reverse the order before returning.
+        queue.sort_unstable_by_key(|entry| entry.priority);
+        Ok(queue
+            .into_iter()
+            .rev()
+            .map(|entry| (entry.tx_hash, entry.tx))
+            .collect())
+    }
+}
+
+impl<const MAX_TX_COUNT: usize> TransactionsContainer<ParkedTransactionsForAccount<MAX_TX_COUNT>> {
+    /// Removes and returns the transactions from the front of an account, similar to
+    /// `find_promotables`. Useful for when needing to promote transactions from a specific
+    /// account instead of all accounts.
+    pub(super) fn pop_front_account(
+        &mut self,
+        account: &[u8; 20],
+        target_nonce: u32,
+    ) -> Vec<TimemarkedTransaction> {
+        // Take the collection for this account out of `self` temporarily.
+        let Some(mut account_txs) = self.txs.remove(account) else {
+            return Vec::new();
+        };
+
+        let removed = account_txs.pop_front_contiguous(target_nonce);
+
+        // Re-add the collection to `self` if it's not empty.
+        if !account_txs.txs().is_empty() {
+            let _ = self.txs.insert(*account, account_txs);
+        }
+        removed.collect()
+    }
+
+    /// Removes and returns transactions along with their account's current nonce that are lower
+    /// than or equal to that nonce. This is helpful when needing to promote transactions from
+    /// parked to pending during mempool maintenance.
+    pub(super) async fn find_promotables<F, O>(
+        &mut self,
+        current_account_nonce_getter: &F,
+    ) -> Vec<(TimemarkedTransaction, u32)>
+    where
+        F: Fn([u8; 20]) -> O,
+        O: Future<Output = anyhow::Result<u32>>,
+    {
+        let mut accounts_to_remove = Vec::new();
+        let mut promoted_txs = Vec::new();
+
+        for (address, account_txs) in &mut self.txs {
+            let current_account_nonce = match current_account_nonce_getter(*address).await {
+                Ok(nonce) => nonce,
+                Err(error) => {
+                    error!(
+                        address = %telemetry::display::base64(address),
+                        "failed to fetch nonce from state when finding promotables: {error:#}"
+                    );
+                    continue;
+                }
+            };
 
             // find transactions that can be promoted
             // note: can use current account nonce as target because this logic
             // is only handling the case where transactions we didn't have in our
             // local mempool were ran that would enable the parked transactions to
             // be valid
-            promoted_txs.append(&mut account_txs.pop_front_multiple(current_account_nonce));
+            promoted_txs.extend(
+                account_txs
+                    .pop_front_contiguous(current_account_nonce)
+                    .map(|ttx| (ttx, current_account_nonce)),
+            );
 
-            if account_txs.size() == 0 {
+            if account_txs.txs.is_empty() {
                 accounts_to_remove.push(*address);
             }
         }
 
         // remove empty accounts
         for account in accounts_to_remove {
-            // remove empty accounts
-            self.accounts.remove(&account);
+            self.txs.remove(&account);
         }
 
-        // untrack transactions
-        for tx in &promoted_txs {
-            self.all.remove(&tx.tx_hash());
-        }
-
-        Ok(promoted_txs)
-    }
-
-    /// Removes and returns the transactions from the front of an account, similar to
-    /// `find_promotables()`. Useful for when needing to promote transactions from a specific
-    /// account instead of all accounts.
-    pub(crate) fn pop_front_account(
-        &mut self,
-        account: &[u8; 20],
-        target_nonce: u32,
-    ) -> Vec<Arc<TimemarkedTransaction>> {
-        if let Some(account_txs) = self.accounts.get_mut(account) {
-            let removed_txs = account_txs.pop_front_multiple(target_nonce);
-            for tx in &removed_txs {
-                // remove popped transactions from all
-                self.all.remove(&tx.tx_hash());
-            }
-
-            if account_txs.size() == 0 {
-                // remove empty account
-                self.accounts.remove(account);
-            }
-
-            removed_txs
-        } else {
-            Vec::<Arc<TimemarkedTransaction>>::new()
-        }
-    }
-
-    /// Returns a copy of transactions sorted by nonce difference and then time first seen.
-    pub(crate) async fn builder_queue<F, O>(
-        &self,
-        current_account_nonce_getter: F,
-    ) -> anyhow::Result<BuilderQueue>
-    where
-        F: Fn([u8; 20]) -> O,
-        O: Future<Output = anyhow::Result<u32>>,
-    {
-        assert!(
-            self.strict,
-            "shouldn't be calling build on gapped container"
-        );
-
-        let mut builder_queue = BuilderQueue::new();
-        for (address, account_txs) in &self.accounts {
-            let current_account_nonce = current_account_nonce_getter(*address)
-                .await
-                .context("failed to fetch account nonce for builder queue")?;
-
-            let txs = account_txs.all_transactions_copy();
-            for tx in txs {
-                match tx.priority(current_account_nonce) {
-                    Ok(tx_priority) => {
-                        builder_queue.push(tx.clone(), tx_priority);
-                    }
-                    Err(_) => continue, // mempool could be off due to node connectivity issues
-                }
-            }
-        }
-        Ok(builder_queue)
+        promoted_txs
     }
 }
 
 #[cfg(test)]
 mod test {
-    use std::{
-        hash::{
-            Hash,
-            Hasher,
-        },
-        time::Duration,
-    };
-
     use astria_core::crypto::SigningKey;
 
     use super::*;
-    use crate::app::test_utils::get_mock_tx_parameterized;
+    use crate::app::test_utils::mock_tx;
 
-    const STRICT_SIZE_LIMIT: usize = 0;
-    const UNSTRICT_SIZE_LIMIT: usize = 15;
+    const MAX_PARKED_TXS_PER_ACCOUNT: usize = 15;
+    const TX_TTL: Duration = Duration::from_secs(2);
+
+    fn mock_ttx(nonce: u32, signer: &SigningKey) -> TimemarkedTransaction {
+        TimemarkedTransaction::new(mock_tx(nonce, signer, "test"))
+    }
 
     #[test]
     fn transaction_priority_should_error_if_invalid() {
-        let ttx =
-            TimemarkedTransaction::new(get_mock_tx_parameterized(0, &[1; 32].into(), [1; 32]));
+        let ttx = TimemarkedTransaction::new(mock_tx(0, &[1; 32].into(), "test"));
         let priority = ttx.priority(1);
 
         assert!(
@@ -792,902 +768,532 @@ mod test {
     }
 
     #[test]
-    // From https://doc.rust-lang.org/std/hash/trait.Hash.html#hash-and-eq
-    fn timemarked_tx_hash_and_eq_should_be_consistent() {
-        // Check timemarked txs compare equal if and only if their tx hashes are equal.
-        let signed_tx_0_a = get_mock_tx_parameterized(0, &[1; 32].into(), [1; 32]);
-        let tx0 = TimemarkedTransaction {
-            tx_hash: [0; 32],
-            signed_tx: signed_tx_0_a.clone(),
-            address: signed_tx_0_a.verification_key().address_bytes(),
-
-            time_first_seen: Instant::now(),
-        };
-        let signed_tx_0_b = get_mock_tx_parameterized(1, &[1; 32].into(), [1; 32]);
-        let other_tx0 = TimemarkedTransaction {
-            tx_hash: [0; 32],
-            signed_tx: signed_tx_0_b.clone(),
-            address: signed_tx_0_b.verification_key().address_bytes(),
-
-            time_first_seen: Instant::now(),
-        };
-        let signed_tx_1 = get_mock_tx_parameterized(1, &[1; 32].into(), [1; 32]);
-        let tx1 = TimemarkedTransaction {
-            tx_hash: [1; 32],
-            signed_tx: signed_tx_1.clone(),
-            address: signed_tx_1.verification_key().address_bytes(),
-            time_first_seen: Instant::now(),
-        };
-        assert!(tx0 == other_tx0);
-        assert!(tx0 != tx1);
-
-        // Check timemarked txs' std hashes compare equal if and only if their tx hashes are equal.
-        let std_hash = |ttx: &TimemarkedTransaction| -> u64 {
-            let mut hasher = std::hash::DefaultHasher::new();
-            ttx.hash(&mut hasher);
-            hasher.finish()
-        };
-        assert!(std_hash(&tx0) == std_hash(&other_tx0));
-        assert!(std_hash(&tx0) != std_hash(&tx1));
-    }
-
-    #[test]
-    fn account_trasaction_container_non_strict_add() {
-        let mut account_container = AccountTransactionContainer::new(false, UNSTRICT_SIZE_LIMIT);
+    fn parked_transactions_for_account_add() {
+        let mut parked_txs = ParkedTransactionsForAccount::<MAX_PARKED_TXS_PER_ACCOUNT>::new();
 
         // transactions to add
-        let ttx_1 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            1,
-            &[1; 32].into(),
-            [1; 32],
-        )));
-        let ttx_3 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            3,
-            &[1; 32].into(),
-            [1; 32],
-        )));
-        let ttx_5 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            5,
-            &[1; 32].into(),
-            [1; 32],
-        )));
+        let ttx_1 = mock_ttx(1, &[1; 32].into());
+        let ttx_3 = mock_ttx(3, &[1; 32].into());
+        let ttx_5 = mock_ttx(5, &[1; 32].into());
 
         let current_account_nonce = 2;
-        assert!(matches!(
-            account_container.add(ttx_3.clone(), current_account_nonce),
-            Ok(())
-        ));
-        assert!(matches!(
-            account_container.add(ttx_3, current_account_nonce),
-            Err(InsertionError::NonceTaken)
-        ));
+        parked_txs
+            .add(ttx_3.clone(), current_account_nonce)
+            .unwrap();
+        assert!(parked_txs.contains_tx(&ttx_3.tx_hash));
+        assert_eq!(
+            parked_txs.add(ttx_3, current_account_nonce).unwrap_err(),
+            InsertionError::AlreadyPresent
+        );
 
         // add gapped transaction
-        assert!(matches!(
-            account_container.add(ttx_5, current_account_nonce),
-            Ok(())
-        ));
+        parked_txs.add(ttx_5, current_account_nonce).unwrap();
 
         // fail adding too low nonce
-        assert!(matches!(
-            account_container.add(ttx_1, current_account_nonce),
-            Err(InsertionError::NonceTooLow)
-        ));
+        assert_eq!(
+            parked_txs.add(ttx_1, current_account_nonce).unwrap_err(),
+            InsertionError::NonceTooLow
+        );
     }
 
     #[test]
-    fn account_trasaction_container_non_strict_size_limit() {
-        let mut account_container = AccountTransactionContainer::new(false, 2);
+    fn parked_transactions_for_account_size_limit() {
+        let mut parked_txs = ParkedTransactionsForAccount::<2>::new();
 
         // transactions to add
-        let ttx_1 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            1,
-            &[1; 32].into(),
-            [1; 32],
-        )));
-        let ttx_3 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            3,
-            &[1; 32].into(),
-            [1; 32],
-        )));
-        let ttx_5 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            5,
-            &[1; 32].into(),
-            [1; 32],
-        )));
+        let ttx_1 = mock_ttx(1, &[1; 32].into());
+        let ttx_3 = mock_ttx(3, &[1; 32].into());
+        let ttx_5 = mock_ttx(5, &[1; 32].into());
 
         let current_account_nonce = 0;
-        assert!(matches!(
-            account_container.add(ttx_3.clone(), current_account_nonce),
-            Ok(())
-        ));
-        assert!(matches!(
-            account_container.add(ttx_5, current_account_nonce),
-            Ok(())
-        ));
+        parked_txs
+            .add(ttx_3.clone(), current_account_nonce)
+            .unwrap();
+        parked_txs.add(ttx_5, current_account_nonce).unwrap();
 
         // fail with size limit hit
-        assert!(matches!(
-            account_container.add(ttx_1, current_account_nonce),
-            Err(InsertionError::AccountSizeLimit)
-        ));
+        assert_eq!(
+            parked_txs.add(ttx_1, current_account_nonce).unwrap_err(),
+            InsertionError::AccountSizeLimit
+        );
     }
 
     #[test]
-    fn account_trasaction_container_strict_add() {
-        let mut account_container = AccountTransactionContainer::new(true, STRICT_SIZE_LIMIT);
+    fn pending_transactions_for_account_add() {
+        let mut pending_txs = PendingTransactionsForAccount::new();
 
         // transactions to add
-        let ttx_0 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            0,
-            &[1; 32].into(),
-            [1; 32],
-        )));
-        let ttx_1 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            1,
-            &[1; 32].into(),
-            [1; 32],
-        )));
-        let ttx_2 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            2,
-            &[1; 32].into(),
-            [1; 32],
-        )));
-        let ttx_3 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            3,
-            &[1; 32].into(),
-            [1; 32],
-        )));
+        let ttx_0 = mock_ttx(0, &[1; 32].into());
+        let ttx_1 = mock_ttx(1, &[1; 32].into());
+        let ttx_2 = mock_ttx(2, &[1; 32].into());
+        let ttx_3 = mock_ttx(3, &[1; 32].into());
 
         let current_account_nonce = 1;
 
         // too low nonces not added
-        assert!(matches!(
-            account_container.add(ttx_0, current_account_nonce),
-            Err(InsertionError::NonceTooLow)
-        ));
+        assert_eq!(
+            pending_txs.add(ttx_0, current_account_nonce).unwrap_err(),
+            InsertionError::NonceTooLow
+        );
+        assert!(pending_txs.txs().is_empty());
 
         // add ok
-        assert!(matches!(
-            account_container.add(ttx_1.clone(), current_account_nonce),
-            Ok(())
-        ));
-        assert!(matches!(
-            account_container.add(ttx_1, current_account_nonce),
-            Err(InsertionError::NonceTaken)
-        ));
+        pending_txs
+            .add(ttx_1.clone(), current_account_nonce)
+            .unwrap();
+        assert_eq!(
+            pending_txs.add(ttx_1, current_account_nonce).unwrap_err(),
+            InsertionError::AlreadyPresent
+        );
 
         // gapped transaction not allowed
-        assert!(matches!(
-            account_container.add(ttx_3, current_account_nonce),
-            Err(InsertionError::NonceGap)
-        ));
+        assert_eq!(
+            pending_txs.add(ttx_3, current_account_nonce).unwrap_err(),
+            InsertionError::NonceGap
+        );
 
         // can add consecutive
-        assert!(matches!(
-            account_container.add(ttx_2, current_account_nonce),
-            Ok(())
-        ));
+        pending_txs.add(ttx_2, current_account_nonce).unwrap();
     }
 
     #[test]
-    fn account_trasaction_container_remove() {
-        let mut account_container = AccountTransactionContainer::new(true, STRICT_SIZE_LIMIT);
+    fn transactions_for_account_remove() {
+        let mut account_txs = PendingTransactionsForAccount::new();
 
         // transactions to add
-        let ttx_0 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            0,
-            &[1; 32].into(),
-            [1; 32],
-        )));
-        let ttx_1 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            1,
-            &[1; 32].into(),
-            [1; 32],
-        )));
-        let ttx_2 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            2,
-            &[1; 32].into(),
-            [1; 32],
-        )));
-        let ttx_3 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            3,
-            &[1; 32].into(),
-            [1; 32],
-        )));
+        let ttx_0 = mock_ttx(0, &[1; 32].into());
+        let ttx_1 = mock_ttx(1, &[1; 32].into());
+        let ttx_2 = mock_ttx(2, &[1; 32].into());
+        let ttx_3 = mock_ttx(3, &[1; 32].into());
 
-        account_container.add(ttx_0, 0).unwrap();
-        account_container.add(ttx_1, 0).unwrap();
-        account_container.add(ttx_2, 0).unwrap();
-        account_container.add(ttx_3, 0).unwrap();
-
-        // non-remove-higher remove ok
-        assert_eq!(
-            account_container.remove(1, false).len(),
-            1,
-            "tranasction should've been removed"
-        );
-        assert_eq!(account_container.size(), 3);
-
-        // remove same again return nothing
-        assert_eq!(
-            account_container.remove(1, true).len(),
-            0,
-            "no transaction should be removed"
-        );
+        account_txs.add(ttx_0.clone(), 0).unwrap();
+        account_txs.add(ttx_1.clone(), 0).unwrap();
+        account_txs.add(ttx_2.clone(), 0).unwrap();
+        account_txs.add(ttx_3.clone(), 0).unwrap();
 
         // remove from end will only remove end
         assert_eq!(
-            account_container.remove(3, true).len(),
-            1,
+            account_txs.remove(3),
+            vec![ttx_3.tx_hash],
             "only one transaction should've been removed"
         );
-        assert_eq!(account_container.size(), 2);
+        assert_eq!(account_txs.txs().len(), 3);
 
-        // remove higher from start will remove all
+        // remove same again return nothing
         assert_eq!(
-            account_container.remove(0, true).len(),
-            2,
-            "two transactions should've been removed"
+            account_txs.remove(3).len(),
+            0,
+            "no transaction should be removed"
         );
-        assert_eq!(account_container.size(), 0);
+        assert_eq!(account_txs.txs().len(), 3);
+
+        // remove from start will remove all
+        assert_eq!(
+            account_txs.remove(0),
+            vec![ttx_0.tx_hash, ttx_1.tx_hash, ttx_2.tx_hash,],
+            "three transactions should've been removed"
+        );
+        assert!(account_txs.txs().is_empty());
     }
 
     #[test]
-    fn account_trasaction_pop_front_multiple() {
-        let mut account_container = AccountTransactionContainer::new(false, UNSTRICT_SIZE_LIMIT);
+    fn parked_transactions_for_account_pop_front_contiguous() {
+        let mut parked_txs = ParkedTransactionsForAccount::<MAX_PARKED_TXS_PER_ACCOUNT>::new();
 
         // transactions to add
-        let ttx_0 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            0,
-            &[1; 32].into(),
-            [1; 32],
-        )));
-        let ttx_2 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            2,
-            &[1; 32].into(),
-            [1; 32],
-        )));
-        let ttx_3 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            3,
-            &[1; 32].into(),
-            [1; 32],
-        )));
-        let ttx_4 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            4,
-            &[1; 32].into(),
-            [1; 32],
-        )));
+        let ttx_0 = mock_ttx(0, &[1; 32].into());
+        let ttx_2 = mock_ttx(2, &[1; 32].into());
+        let ttx_3 = mock_ttx(3, &[1; 32].into());
+        let ttx_4 = mock_ttx(4, &[1; 32].into());
 
-        account_container.add(ttx_0, 0).unwrap();
-        account_container.add(ttx_2, 0).unwrap();
-        account_container.add(ttx_3, 0).unwrap();
-        account_container.add(ttx_4, 0).unwrap();
+        parked_txs.add(ttx_0.clone(), 0).unwrap();
+        parked_txs.add(ttx_2.clone(), 0).unwrap();
+        parked_txs.add(ttx_3.clone(), 0).unwrap();
+        parked_txs.add(ttx_4.clone(), 0).unwrap();
 
         // lowest nonce not target nonce is noop
         assert_eq!(
-            account_container.pop_front_multiple(2).len(),
+            parked_txs.pop_front_contiguous(2).count(),
             0,
             "no transaction should've been removed"
         );
-        assert_eq!(account_container.size(), 4);
+        assert_eq!(parked_txs.txs().len(), 4);
 
         // will remove single value
         assert_eq!(
-            account_container.pop_front_multiple(0).len(),
-            1,
+            parked_txs
+                .pop_front_contiguous(0)
+                .map(|ttx| ttx.tx_hash)
+                .collect::<Vec<_>>(),
+            vec![ttx_0.tx_hash],
             "single transaction should've been returned"
         );
-        assert_eq!(account_container.size(), 3);
+        assert_eq!(parked_txs.txs().len(), 3);
 
         // will remove multiple values
         assert_eq!(
-            account_container.pop_front_multiple(2).len(),
-            3,
+            parked_txs
+                .pop_front_contiguous(2)
+                .map(|ttx| ttx.tx_hash)
+                .collect::<Vec<_>>(),
+            vec![ttx_2.tx_hash, ttx_3.tx_hash, ttx_4.tx_hash],
             "multiple transaction should've been returned"
         );
-        assert_eq!(account_container.size(), 0);
+        assert!(parked_txs.txs().is_empty());
     }
 
     #[test]
-    fn account_trasaction_peek_end() {
-        let mut account_container = AccountTransactionContainer::new(false, UNSTRICT_SIZE_LIMIT);
+    fn pending_transactions_for_account_highest_nonce() {
+        let mut pending_txs = PendingTransactionsForAccount::new();
 
         // no transactions ok
-        assert_eq!(
-            account_container.peek_end(),
-            None,
+        assert!(
+            pending_txs.highest_nonce().is_none(),
             "no transactions will return None"
         );
 
         // transactions to add
-        let ttx_0 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            0,
-            &[1; 32].into(),
-            [1; 32],
-        )));
-        let ttx_2 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            2,
-            &[1; 32].into(),
-            [1; 32],
-        )));
+        let ttx_0 = mock_ttx(0, &[1; 32].into());
+        let ttx_1 = mock_ttx(1, &[1; 32].into());
+        let ttx_2 = mock_ttx(2, &[1; 32].into());
 
-        account_container.add(ttx_0, 0).unwrap();
-        account_container.add(ttx_2, 0).unwrap();
+        pending_txs.add(ttx_0, 0).unwrap();
+        pending_txs.add(ttx_1, 0).unwrap();
+        pending_txs.add(ttx_2, 0).unwrap();
 
         // will return last transaction
         assert_eq!(
-            account_container.peek_end(),
+            pending_txs.highest_nonce(),
             Some(2),
             "highest nonce should be returned"
         );
     }
 
     #[test]
-    fn account_trasaction_peek_front() {
-        let mut account_container = AccountTransactionContainer::new(false, UNSTRICT_SIZE_LIMIT);
+    fn transactions_for_account_front() {
+        let mut parked_txs = ParkedTransactionsForAccount::<MAX_PARKED_TXS_PER_ACCOUNT>::new();
 
         // no transactions ok
-        assert_eq!(
-            account_container.peek_front(),
-            None,
+        assert!(
+            parked_txs.front().is_none(),
             "no transactions will return None"
         );
 
         // transactions to add
-        let ttx_0 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            0,
-            &[1; 32].into(),
-            [1; 32],
-        )));
-        let ttx_2 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            2,
-            &[1; 32].into(),
-            [1; 32],
-        )));
+        let ttx_0 = mock_ttx(0, &[1; 32].into());
+        let ttx_2 = mock_ttx(2, &[1; 32].into());
 
-        account_container.add(ttx_0.clone(), 0).unwrap();
-        account_container.add(ttx_2, 0).unwrap();
+        parked_txs.add(ttx_0.clone(), 0).unwrap();
+        parked_txs.add(ttx_2, 0).unwrap();
 
-        // will return last transaction
+        // will return first transaction
         assert_eq!(
-            account_container.peek_front(),
-            Some(ttx_0),
+            parked_txs.front().unwrap().tx_hash,
+            ttx_0.tx_hash,
             "lowest transaction should be returned"
         );
     }
 
     #[test]
-    fn account_trasaction_fast_forward() {
-        let mut account_container = AccountTransactionContainer::new(false, UNSTRICT_SIZE_LIMIT);
+    fn transactions_for_account_register_latest_account_nonce() {
+        let mut parked_txs = ParkedTransactionsForAccount::<MAX_PARKED_TXS_PER_ACCOUNT>::new();
 
         // transactions to add
-        let ttx_0 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            0,
-            &[1; 32].into(),
-            [1; 32],
-        )));
-        let ttx_2 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            2,
-            &[1; 32].into(),
-            [1; 32],
-        )));
-        let ttx_3 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            3,
-            &[1; 32].into(),
-            [1; 32],
-        )));
-        let ttx_4 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            4,
-            &[1; 32].into(),
-            [1; 32],
-        )));
+        let ttx_0 = mock_ttx(0, &[1; 32].into());
+        let ttx_2 = mock_ttx(2, &[1; 32].into());
+        let ttx_3 = mock_ttx(3, &[1; 32].into());
+        let ttx_4 = mock_ttx(4, &[1; 32].into());
 
-        account_container.add(ttx_0, 0).unwrap();
-        account_container.add(ttx_2, 0).unwrap();
-        account_container.add(ttx_3, 0).unwrap();
-        account_container.add(ttx_4, 0).unwrap();
+        parked_txs.add(ttx_0.clone(), 0).unwrap();
+        parked_txs.add(ttx_2.clone(), 0).unwrap();
+        parked_txs.add(ttx_3.clone(), 0).unwrap();
+        parked_txs.add(ttx_4.clone(), 0).unwrap();
 
         // matching nonce will not be removed
         assert_eq!(
-            account_container.fast_forward(0).len(),
+            parked_txs.register_latest_account_nonce(0).count(),
             0,
             "no transaction should've been removed"
         );
-        assert_eq!(account_container.size(), 4);
+        assert_eq!(parked_txs.txs().len(), 4);
 
         // fast forwarding to non existing middle nonce ok
         assert_eq!(
-            account_container.fast_forward(1).len(),
-            1,
-            "one transaction should've been removed"
+            parked_txs
+                .register_latest_account_nonce(1)
+                .collect::<Vec<_>>(),
+            vec![ttx_0.tx_hash],
+            "ttx_0 should've been removed"
         );
-        assert_eq!(account_container.size(), 3);
+        assert_eq!(parked_txs.txs().len(), 3);
 
         // fast forwarding to existing nonce ok
         assert_eq!(
-            account_container.fast_forward(3).len(),
-            1,
+            parked_txs
+                .register_latest_account_nonce(3)
+                .collect::<Vec<_>>(),
+            vec![ttx_2.tx_hash],
             "one transaction should've been removed"
         );
-        assert_eq!(account_container.size(), 2);
+        assert_eq!(parked_txs.txs().len(), 2);
 
         // fast forwarding to much higher nonce ok
         assert_eq!(
-            account_container.fast_forward(10).len(),
-            2,
-            "two transaction should've been removed"
+            parked_txs
+                .register_latest_account_nonce(10)
+                .collect::<Vec<_>>(),
+            vec![ttx_3.tx_hash, ttx_4.tx_hash],
+            "two transactions should've been removed"
         );
-        assert_eq!(account_container.size(), 0);
+        assert!(parked_txs.txs().is_empty());
     }
 
     #[test]
-    fn transaction_container_pending_nonces() {
-        let mut transaction_container =
-            TransactionContainer::new(false, UNSTRICT_SIZE_LIMIT, Duration::from_secs(2));
+    fn transactions_container_add() {
+        let mut pending_txs = PendingTransactions::new(TX_TTL);
+
         let signing_key_0 = SigningKey::from([1; 32]);
-        let signing_address_0 = signing_key_0.clone().verification_key().address_bytes();
+        let signing_address_0 = signing_key_0.address_bytes();
 
         let signing_key_1 = SigningKey::from([2; 32]);
-        let signing_address_1 = signing_key_1.clone().verification_key().address_bytes();
-
-        // transactions to add for account 0
-        let ttx_s0_0 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            0,
-            &signing_key_0,
-            [1; 32],
-        )));
-        let ttx_s0_2 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            2,
-            &signing_key_0,
-            [1; 32],
-        )));
-
-        transaction_container.add(ttx_s0_0, 0).unwrap();
-        transaction_container.add(ttx_s0_2, 0).unwrap();
-
-        // empty account returns zero
-        assert_eq!(
-            transaction_container.pending_nonce(signing_address_1),
-            None,
-            "empty account should return None"
-        );
-
-        // non empty account returns highest nonce
-        assert_eq!(
-            transaction_container.pending_nonce(signing_address_0),
-            Some(2),
-            "should return highest nonce"
-        );
-    }
-
-    #[test]
-    #[allow(clippy::too_many_lines)]
-    fn transaction_container_add() {
-        let mut transaction_container =
-            TransactionContainer::new(true, STRICT_SIZE_LIMIT, Duration::from_secs(2));
-        let signing_key_0 = SigningKey::from([1; 32]);
-        let signing_address_0 = signing_key_0.clone().verification_key().address_bytes();
-
-        let signing_key_1 = SigningKey::from([2; 32]);
-        let signing_address_1 = signing_key_1.clone().verification_key().address_bytes();
+        let signing_address_1 = signing_key_1.address_bytes();
 
         // transactions to add to accounts
-        // account, nonce, hash
-        let ttx_s0_0_0 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            0,
-            &signing_key_0,
-            [1; 32],
-        )));
-        let ttx_s0_0_1 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            0,
-            &signing_key_0,
-            [2; 32],
-        )));
-        let ttx_s0_2_0 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            2,
-            &signing_key_0,
-            [2; 32],
-        )));
-        let ttx_s1_0_0 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            0,
-            &signing_key_1,
-            [1; 32],
-        )));
+        let ttx_s0_0_0 = mock_ttx(0, &signing_key_0);
+        // Same nonce and signer as `ttx_s0_0_0`, but different rollup name, hence different tx.
+        let ttx_s0_0_1 = TimemarkedTransaction::new(mock_tx(0, &signing_key_0, "other"));
+        let ttx_s0_2_0 = mock_ttx(2, &signing_key_0);
+        let ttx_s1_0_0 = mock_ttx(0, &signing_key_1);
 
         // transactions to add for account 1
 
         // initially no accounts should exist
-        assert_eq!(
-            transaction_container.accounts.len(),
-            0,
+        assert!(
+            pending_txs.txs.is_empty(),
             "no accounts should exist at first"
         );
 
         // adding too low nonce shouldn't create account
-        assert!(
-            matches!(
-                transaction_container.add(ttx_s0_0_0.clone(), 1),
-                Err(InsertionError::NonceTooLow)
-            ),
+        assert_eq!(
+            pending_txs.add(ttx_s0_0_0.clone(), 1).unwrap_err(),
+            InsertionError::NonceTooLow,
             "shouldn't be able to add nonce too low transaction"
         );
-        assert_eq!(
-            transaction_container.accounts.len(),
-            0,
+        assert!(
+            pending_txs.txs.is_empty(),
             "failed adds to new accounts shouldn't create account"
         );
 
         // add one transaction
-        assert!(
-            matches!(transaction_container.add(ttx_s0_0_0.clone(), 0), Ok(())),
-            "should be able to add transaction"
-        );
-        assert_eq!(
-            transaction_container.accounts.len(),
-            1,
-            "one account should exist"
-        );
+        pending_txs.add(ttx_s0_0_0.clone(), 0).unwrap();
+        assert_eq!(pending_txs.txs.len(), 1, "one account should exist");
 
-        // readding transaction should fail
-        assert!(
-            matches!(
-                transaction_container.add(ttx_s0_0_0, 0),
-                Err(InsertionError::AlreadyPresent)
-            ),
-            "readding same transaction should fail"
+        // re-adding transaction should fail
+        assert_eq!(
+            pending_txs.add(ttx_s0_0_0, 0).unwrap_err(),
+            InsertionError::AlreadyPresent,
+            "re-adding same transaction should fail"
         );
 
         // nonce replacement fails
-        assert!(
-            matches!(
-                transaction_container.add(ttx_s0_0_1, 0),
-                Err(InsertionError::NonceTaken)
-            ),
+        assert_eq!(
+            pending_txs.add(ttx_s0_0_1, 0).unwrap_err(),
+            InsertionError::NonceTaken,
             "nonce replacement not supported"
         );
 
         // nonce gaps not supported
-        assert!(
-            matches!(
-                transaction_container.add(ttx_s0_2_0, 0),
-                Err(InsertionError::NonceGap)
-            ),
-            "gapped nonces in strict not allowed"
+        assert_eq!(
+            pending_txs.add(ttx_s0_2_0, 0).unwrap_err(),
+            InsertionError::NonceGap,
+            "gapped nonces in pending transactions not allowed"
         );
 
         // add transactions for account 2
-        assert!(
-            matches!(transaction_container.add(ttx_s1_0_0, 0), Ok(())),
-            "should be able to add transaction to second account"
-        );
+        pending_txs.add(ttx_s1_0_0, 0).unwrap();
 
         // check internal structures
+        assert_eq!(pending_txs.txs.len(), 2, "two accounts should exist");
         assert_eq!(
-            transaction_container.accounts.len(),
-            2,
-            "two accounts should exist"
-        );
-        assert_eq!(
-            transaction_container
-                .accounts
-                .get(&signing_address_0)
-                .unwrap()
-                .size(),
+            pending_txs.txs.get(&signing_address_0).unwrap().txs().len(),
             1,
             "one transaction should be in the original account"
         );
         assert_eq!(
-            transaction_container
-                .accounts
-                .get(&signing_address_1)
-                .unwrap()
-                .size(),
+            pending_txs.txs.get(&signing_address_1).unwrap().txs().len(),
             1,
             "one transaction should be in the second account"
         );
         assert_eq!(
-            transaction_container.size(),
+            pending_txs.len(),
             2,
             "should only have two transactions tracked"
         );
     }
 
     #[test]
-    fn transaction_container_remove() {
-        let mut transaction_container =
-            TransactionContainer::new(true, STRICT_SIZE_LIMIT, Duration::from_secs(2));
+    fn transactions_container_remove() {
+        let mut pending_txs = PendingTransactions::new(TX_TTL);
         let signing_key_0 = SigningKey::from([1; 32]);
-        let signing_address_0 = signing_key_0.clone().verification_key().address_bytes();
-
         let signing_key_1 = SigningKey::from([2; 32]);
-        let signing_address_1 = signing_key_1.clone().verification_key().address_bytes();
 
         // transactions to add to accounts
-        // account, nonce, hash
-        let ttx_s0_0 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            0,
-            &signing_key_0,
-            [1; 32],
-        )));
-        let ttx_s0_1 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            1,
-            &signing_key_0,
-            [2; 32],
-        )));
-        let ttx_s0_2 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            2,
-            &signing_key_0,
-            [2; 32],
-        )));
-        let ttx_s1_0 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            0,
-            &signing_key_1,
-            [1; 32],
-        )));
-        let ttx_s1_1 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            1,
-            &signing_key_1,
-            [1; 32],
-        )));
-        let ttx_s1_2 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            2,
-            &signing_key_1,
-            [1; 32],
-        )));
+        let ttx_s0_0 = mock_ttx(0, &signing_key_0);
+        let ttx_s0_1 = mock_ttx(1, &signing_key_0);
+        let ttx_s1_0 = mock_ttx(0, &signing_key_1);
+        let ttx_s1_1 = mock_ttx(1, &signing_key_1);
 
-        // remove on empty returns zero
-        assert_eq!(
-            transaction_container.remove(&ttx_s0_0, true).len(),
-            0,
+        // remove on empty returns the tx in Err variant.
+        assert!(
+            pending_txs.remove(ttx_s0_0.signed_tx.clone()).is_err(),
             "zero transactions should be removed from non existing accounts"
         );
 
         // add transactions
-        transaction_container.add(ttx_s0_0.clone(), 0).unwrap();
-        transaction_container.add(ttx_s0_1.clone(), 0).unwrap();
-        transaction_container.add(ttx_s0_2.clone(), 0).unwrap();
-        transaction_container.add(ttx_s1_0.clone(), 0).unwrap();
-        transaction_container.add(ttx_s1_1.clone(), 0).unwrap();
-        transaction_container.add(ttx_s1_2.clone(), 0).unwrap();
+        pending_txs.add(ttx_s0_0.clone(), 0).unwrap();
+        pending_txs.add(ttx_s0_1.clone(), 0).unwrap();
+        pending_txs.add(ttx_s1_0.clone(), 0).unwrap();
+        pending_txs.add(ttx_s1_1.clone(), 0).unwrap();
 
-        // remove with remove_higher to false should only remove one
+        // remove should remove tx and higher
         assert_eq!(
-            transaction_container.remove(&ttx_s0_0, false).len(),
-            1,
-            "single transactions should be removed when remove_higher is false"
+            pending_txs.remove(ttx_s0_0.signed_tx.clone()).unwrap(),
+            vec![ttx_s0_0.tx_hash, ttx_s0_1.tx_hash],
+            "rest of transactions for account should be removed when targeting bottom nonce"
         );
+        assert_eq!(pending_txs.txs.len(), 1, "empty account should be removed");
         assert_eq!(
-            transaction_container
-                .accounts
-                .get(&signing_address_0)
-                .unwrap()
-                .size(),
+            pending_txs.len(),
             2,
-            "two transactions should be in the original account"
+            "should only have two transactions tracked"
         );
-
-        // remove with remove_higher set to true should remove rest
-        assert_eq!(
-            transaction_container.remove(&ttx_s0_1, true).len(),
-            2,
-            "rest of transactions should be removed when remove_higher is true and targeting \
-             bottom nonce"
+        assert!(
+            pending_txs.contains_tx(&ttx_s1_0.tx_hash),
+            "other account should be untouched"
         );
-        assert_eq!(
-            transaction_container.accounts.len(),
-            1,
-            "empty account should be removed"
-        );
-        assert_eq!(
-            transaction_container.size(),
-            3,
-            "should only have three transactions tracked"
-        );
-        assert_eq!(
-            transaction_container
-                .accounts
-                .get(&signing_address_1)
-                .unwrap()
-                .size(),
-            3,
+        assert!(
+            pending_txs.contains_tx(&ttx_s1_1.tx_hash),
             "other account should be untouched"
         );
     }
 
     #[test]
-    fn transaction_container_clear_account() {
-        let mut transaction_container =
-            TransactionContainer::new(true, STRICT_SIZE_LIMIT, Duration::from_secs(2));
+    fn transactions_container_clear_account() {
+        let mut pending_txs = PendingTransactions::new(TX_TTL);
         let signing_key_0 = SigningKey::from([1; 32]);
-        let signing_address_0 = signing_key_0.clone().verification_key().address_bytes();
+        let signing_address_0 = signing_key_0.address_bytes();
 
         let signing_key_1 = SigningKey::from([2; 32]);
-        let signing_address_1 = signing_key_1.clone().verification_key().address_bytes();
 
         // transactions to add to accounts
-        // account, nonce, hash
-        let ttx_s0_0 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            0,
-            &signing_key_0,
-            [1; 32],
-        )));
-        let ttx_s0_1 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            1,
-            &signing_key_0,
-            [2; 32],
-        )));
-        let ttx_s1_0 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            0,
-            &signing_key_1,
-            [1; 32],
-        )));
+        let ttx_s0_0 = mock_ttx(0, &signing_key_0);
+        let ttx_s0_1 = mock_ttx(1, &signing_key_0);
+        let ttx_s1_0 = mock_ttx(0, &signing_key_1);
 
         // clear all on empty returns zero
-        assert_eq!(
-            transaction_container
-                .clear_account(&signing_address_0)
-                .len(),
-            0,
+        assert!(
+            pending_txs.clear_account(&signing_address_0).is_empty(),
             "zero transactions should be removed from clearing non existing accounts"
         );
 
         // add transactions
-        transaction_container.add(ttx_s0_0.clone(), 0).unwrap();
-        transaction_container.add(ttx_s0_1.clone(), 0).unwrap();
-        transaction_container.add(ttx_s1_0.clone(), 0).unwrap();
+        pending_txs.add(ttx_s0_0.clone(), 0).unwrap();
+        pending_txs.add(ttx_s0_1.clone(), 0).unwrap();
+        pending_txs.add(ttx_s1_0.clone(), 0).unwrap();
 
         // clear should return all transactions
         assert_eq!(
-            transaction_container
-                .clear_account(&signing_address_0)
-                .len(),
-            2,
+            pending_txs.clear_account(&signing_address_0),
+            vec![ttx_s0_0.tx_hash, ttx_s0_1.tx_hash],
             "all transactions should be returned from clearing account"
         );
 
+        assert_eq!(pending_txs.txs.len(), 1, "empty account should be removed");
         assert_eq!(
-            transaction_container.accounts.len(),
-            1,
-            "empty account should be removed"
-        );
-        assert_eq!(
-            transaction_container.size(),
+            pending_txs.len(),
             1,
             "should only have one transaction tracked"
         );
-        assert_eq!(
-            transaction_container
-                .accounts
-                .get(&signing_address_1)
-                .unwrap()
-                .size(),
-            1,
+        assert!(
+            pending_txs.contains_tx(&ttx_s1_0.tx_hash),
             "other account should be untouched"
         );
     }
 
     #[tokio::test]
-    #[allow(clippy::too_many_lines)]
-    async fn transaction_container_clean_accounts_nonce() {
-        let mut transaction_container =
-            TransactionContainer::new(true, STRICT_SIZE_LIMIT, Duration::from_secs(2));
+    async fn transactions_container_clean_accounts() {
+        let mut pending_txs = PendingTransactions::new(TX_TTL);
         let signing_key_0 = SigningKey::from([1; 32]);
-        let signing_address_0 = signing_key_0.clone().verification_key().address_bytes();
+        let signing_address_0 = signing_key_0.address_bytes();
         let signing_key_1 = SigningKey::from([2; 32]);
-        let signing_address_1 = signing_key_1.clone().verification_key().address_bytes();
+        let signing_address_1 = signing_key_1.address_bytes();
         let signing_key_2 = SigningKey::from([3; 32]);
-        let signing_address_2 = signing_key_2.clone().verification_key().address_bytes();
+        let signing_address_2 = signing_key_2.address_bytes();
 
         // transactions to add to accounts
-        // account, nonce, hash
-        let ttx_s0_0 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            0,
-            &signing_key_0,
-            [1; 32],
-        )));
-        let ttx_s0_1 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            1,
-            &signing_key_0,
-            [2; 32],
-        )));
-        let ttx_s0_2 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            2,
-            &signing_key_0,
-            [2; 32],
-        )));
-        let ttx_s1_0 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            0,
-            &signing_key_1,
-            [1; 32],
-        )));
-        let ttx_s1_1 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            1,
-            &signing_key_1,
-            [1; 32],
-        )));
-        let ttx_s1_2 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            2,
-            &signing_key_1,
-            [1; 32],
-        )));
-        let ttx_s2_0 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            0,
-            &signing_key_2,
-            [1; 32],
-        )));
-        let ttx_s2_1 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            1,
-            &signing_key_2,
-            [1; 32],
-        )));
-        let ttx_s2_2 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            2,
-            &signing_key_2,
-            [1; 32],
-        )));
+        let ttx_s0_0 = mock_ttx(0, &signing_key_0);
+        let ttx_s0_1 = mock_ttx(1, &signing_key_0);
+        let ttx_s0_2 = mock_ttx(2, &signing_key_0);
+        let ttx_s1_0 = mock_ttx(0, &signing_key_1);
+        let ttx_s1_1 = mock_ttx(1, &signing_key_1);
+        let ttx_s1_2 = mock_ttx(2, &signing_key_1);
+        let ttx_s2_0 = mock_ttx(0, &signing_key_2);
+        let ttx_s2_1 = mock_ttx(1, &signing_key_2);
+        let ttx_s2_2 = mock_ttx(2, &signing_key_2);
 
         // add transactions
-        transaction_container.add(ttx_s0_0.clone(), 0).unwrap();
-        transaction_container.add(ttx_s0_1.clone(), 0).unwrap();
-        transaction_container.add(ttx_s0_2.clone(), 0).unwrap();
-        transaction_container.add(ttx_s1_0.clone(), 0).unwrap();
-        transaction_container.add(ttx_s1_1.clone(), 0).unwrap();
-        transaction_container.add(ttx_s1_2.clone(), 0).unwrap();
-        transaction_container.add(ttx_s2_0.clone(), 0).unwrap();
-        transaction_container.add(ttx_s2_1.clone(), 0).unwrap();
-        transaction_container.add(ttx_s2_2.clone(), 0).unwrap();
+        pending_txs.add(ttx_s0_0.clone(), 0).unwrap();
+        pending_txs.add(ttx_s0_1.clone(), 0).unwrap();
+        pending_txs.add(ttx_s0_2.clone(), 0).unwrap();
+        pending_txs.add(ttx_s1_0.clone(), 0).unwrap();
+        pending_txs.add(ttx_s1_1.clone(), 0).unwrap();
+        pending_txs.add(ttx_s1_2.clone(), 0).unwrap();
+        pending_txs.add(ttx_s2_0.clone(), 0).unwrap();
+        pending_txs.add(ttx_s2_1.clone(), 0).unwrap();
+        pending_txs.add(ttx_s2_2.clone(), 0).unwrap();
 
         // current nonce getter
         // should pop none from signing_address_0, one from signing_address_1, and all from
         // signing_address_2
         let current_account_nonce_getter = |address: [u8; 20]| async move {
             if address == signing_address_0 {
-                return Ok(0);
+                Ok(0)
+            } else if address == signing_address_1 {
+                Ok(1)
+            } else if address == signing_address_2 {
+                Ok(4)
+            } else {
+                Err(anyhow::anyhow!("invalid address"))
             }
-            if address == signing_address_1 {
-                return Ok(1);
-            }
-            if address == signing_address_2 {
-                return Ok(4);
-            }
-            Err(anyhow::anyhow!("invalid address"))
         };
 
-        let removed_txs = transaction_container
+        let removed_txs = pending_txs
             .clean_accounts(&current_account_nonce_getter)
-            .await
-            .unwrap();
+            .await;
 
         assert_eq!(
             removed_txs.len(),
             4,
             "four transactions should've been popped"
         );
+        assert_eq!(pending_txs.txs.len(), 2, "empty accounts should be removed");
         assert_eq!(
-            transaction_container.accounts.len(),
-            2,
-            "empty accounts should be removed"
-        );
-        assert_eq!(
-            transaction_container.size(),
+            pending_txs.len(),
             5,
             "5 transactions should be remaining from original 9"
         );
+        assert!(pending_txs.contains_tx(&ttx_s0_0.tx_hash));
+        assert!(pending_txs.contains_tx(&ttx_s0_1.tx_hash));
+        assert!(pending_txs.contains_tx(&ttx_s0_2.tx_hash));
+        assert!(pending_txs.contains_tx(&ttx_s1_1.tx_hash));
+        assert!(pending_txs.contains_tx(&ttx_s1_2.tx_hash));
+
         assert_eq!(
-            transaction_container
-                .accounts
-                .get(&signing_address_0)
-                .unwrap()
-                .size(),
+            pending_txs.txs.get(&signing_address_0).unwrap().txs().len(),
             3
         );
         assert_eq!(
-            transaction_container
-                .accounts
-                .get(&signing_address_1)
-                .unwrap()
-                .size(),
+            pending_txs.txs.get(&signing_address_1).unwrap().txs().len(),
             2
         );
         for (_, reason) in removed_txs {
@@ -1699,322 +1305,133 @@ mod test {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn transaction_container_clean_accounts_expired_transactions() {
-        let mut transaction_container =
-            TransactionContainer::new(true, STRICT_SIZE_LIMIT, Duration::from_secs(2));
+    async fn transactions_container_clean_accounts_expired_transactions() {
+        let mut pending_txs = PendingTransactions::new(TX_TTL);
         let signing_key_0 = SigningKey::from([1; 32]);
-        let signing_address_0 = signing_key_0.clone().verification_key().address_bytes();
+        let signing_address_0 = signing_key_0.address_bytes();
         let signing_key_1 = SigningKey::from([2; 32]);
-        let signing_address_1 = signing_key_1.clone().verification_key().address_bytes();
+        let signing_address_1 = signing_key_1.address_bytes();
 
         // transactions to add to accounts
-        // account, nonce, hash
-        let ttx_s0_0 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            0,
-            &signing_key_0,
-            [1; 32],
-        )));
+        let ttx_s0_0 = mock_ttx(0, &signing_key_0);
 
         // pass time to make first transaction stale
-        tokio::time::advance(Duration::from_secs(5)).await;
+        tokio::time::advance(TX_TTL.saturating_add(Duration::from_nanos(1))).await;
 
-        let ttx_s0_1 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            1,
-            &signing_key_0,
-            [2; 32],
-        )));
-        let ttx_s1_0 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            0,
-            &signing_key_1,
-            [1; 32],
-        )));
+        let ttx_s0_1 = mock_ttx(1, &signing_key_0);
+        let ttx_s1_0 = mock_ttx(0, &signing_key_1);
 
         // add transactions
-        transaction_container.add(ttx_s0_0.clone(), 0).unwrap();
-        transaction_container.add(ttx_s0_1.clone(), 0).unwrap();
-        transaction_container.add(ttx_s1_0.clone(), 0).unwrap();
+        pending_txs.add(ttx_s0_0.clone(), 0).unwrap();
+        pending_txs.add(ttx_s0_1.clone(), 0).unwrap();
+        pending_txs.add(ttx_s1_0.clone(), 0).unwrap();
 
         // current nonce getter
         // all nonces should be valid
         let current_account_nonce_getter = |address: [u8; 20]| async move {
-            if address == signing_address_0 {
-                return Ok(0);
-            }
-            if address == signing_address_1 {
+            if address == signing_address_0 || address == signing_address_1 {
                 return Ok(0);
             }
             Err(anyhow::anyhow!("invalid address"))
         };
 
-        let mut removed_txs = transaction_container
+        let removed_txs = pending_txs
             .clean_accounts(&current_account_nonce_getter)
-            .await
-            .unwrap();
+            .await;
 
         assert_eq!(
             removed_txs.len(),
             2,
             "two transactions should've been popped"
         );
+        assert_eq!(pending_txs.txs.len(), 1, "empty accounts should be removed");
         assert_eq!(
-            transaction_container.accounts.len(),
-            1,
-            "empty accounts should be removed"
-        );
-        assert_eq!(
-            transaction_container.size(),
+            pending_txs.len(),
             1,
             "1 transaction should be remaining from original 3"
         );
-        assert_eq!(
-            transaction_container
-                .accounts
-                .get(&signing_address_1)
-                .unwrap()
-                .size(),
-            1,
-            "not expired account should have expected transactions"
+        assert!(
+            pending_txs.contains_tx(&ttx_s1_0.tx_hash),
+            "not expired account should be untouched"
         );
 
         // check removal reasons
-        let first_pop = removed_txs.pop().expect("should have tx to pop");
         assert_eq!(
-            first_pop.0.tx_hash(),
-            ttx_s0_1.tx_hash(),
-            "first pop should be last pushed tx, which should be the second tx"
+            removed_txs[0],
+            (ttx_s0_0.tx_hash, RemovalReason::Expired),
+            "first should be first pushed tx with removal reason as expired"
         );
+        assert_eq!(
+            removed_txs[1],
+            (ttx_s0_1.tx_hash, RemovalReason::LowerNonceInvalidated),
+            "second should be second added tx with removal reason as lower nonce invalidation"
+        );
+    }
+
+    #[test]
+    fn pending_transactions_pending_nonce() {
+        let mut pending_txs = PendingTransactions::new(TX_TTL);
+        let signing_key_0 = SigningKey::from([1; 32]);
+        let signing_address_0 = signing_key_0.address_bytes();
+
+        let signing_key_1 = SigningKey::from([2; 32]);
+        let signing_address_1 = signing_key_1.address_bytes();
+
+        // transactions to add for account 0
+        let ttx_s0_0 = mock_ttx(0, &signing_key_0);
+        let ttx_s0_1 = mock_ttx(1, &signing_key_0);
+
+        pending_txs.add(ttx_s0_0, 0).unwrap();
+        pending_txs.add(ttx_s0_1, 0).unwrap();
+
+        // empty account returns zero
         assert!(
-            matches!(first_pop.1, RemovalReason::LowerNonceInvalidated),
-            "first transaction's removal reason should be lower nonce invalidation"
+            pending_txs.pending_nonce(signing_address_1).is_none(),
+            "empty account should return None"
         );
-        let second_pop = removed_txs.pop().expect("should have another tx to pop");
+
+        // non empty account returns highest nonce
         assert_eq!(
-            second_pop.0.tx_hash(),
-            ttx_s0_0.tx_hash(),
-            "second pop should be first added tx, to verify for next check"
-        );
-        assert!(
-            matches!(second_pop.1, RemovalReason::Expired),
-            "first transaction's removal reason should be expiration"
+            pending_txs.pending_nonce(signing_address_0),
+            Some(1),
+            "should return highest nonce"
         );
     }
 
     #[tokio::test]
-    async fn transaction_container_find_promotables() {
-        let mut transaction_container =
-            TransactionContainer::new(false, UNSTRICT_SIZE_LIMIT, Duration::from_secs(2));
+    async fn pending_transactions_builder_queue() {
+        let mut pending_txs = PendingTransactions::new(TX_TTL);
         let signing_key_0 = SigningKey::from([1; 32]);
-        let signing_address_0 = signing_key_0.clone().verification_key().address_bytes();
+        let signing_address_0 = signing_key_0.address_bytes();
         let signing_key_1 = SigningKey::from([2; 32]);
-        let signing_address_1 = signing_key_1.clone().verification_key().address_bytes();
+        let signing_address_1 = signing_key_1.address_bytes();
 
         // transactions to add to accounts
-        // account, nonce, hash
-        let ttx_s0_1 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            1,
-            &signing_key_0,
-            [1; 32],
-        )));
-        let ttx_s0_2 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            2,
-            &signing_key_0,
-            [2; 32],
-        )));
-        let ttx_s0_3 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            3,
-            &signing_key_0,
-            [2; 32],
-        )));
-        let ttx_s1_1 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            1,
-            &signing_key_1,
-            [1; 32],
-        )));
-        let ttx_s1_2 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            2,
-            &signing_key_1,
-            [1; 32],
-        )));
-        let ttx_s1_4 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            4,
-            &signing_key_1,
-            [1; 32],
-        )));
+        let ttx_s0_1 = mock_ttx(1, &signing_key_0);
+        let ttx_s1_1 = mock_ttx(1, &signing_key_1);
+        let ttx_s1_2 = mock_ttx(2, &signing_key_1);
+        let ttx_s1_3 = mock_ttx(3, &signing_key_1);
 
         // add transactions
-        transaction_container.add(ttx_s0_1.clone(), 0).unwrap();
-        transaction_container.add(ttx_s0_2.clone(), 0).unwrap();
-        transaction_container.add(ttx_s0_3.clone(), 0).unwrap();
-        transaction_container.add(ttx_s1_1.clone(), 0).unwrap();
-        transaction_container.add(ttx_s1_2.clone(), 0).unwrap();
-        transaction_container.add(ttx_s1_4.clone(), 0).unwrap();
-
-        // current nonce getter
-        // should pop all from signing_address_0 and two from signing_address_1
-        let current_account_nonce_getter = |address: [u8; 20]| async move {
-            if address == signing_address_0 {
-                return Ok(1);
-            }
-            if address == signing_address_1 {
-                return Ok(1);
-            }
-            Err(anyhow::anyhow!("invalid address"))
-        };
-
-        assert_eq!(
-            transaction_container
-                .find_promotables(&current_account_nonce_getter)
-                .await
-                .expect("find promotables should work")
-                .len(),
-            5,
-            "five transactions should've been popped"
-        );
-        assert_eq!(
-            transaction_container.accounts.len(),
-            1,
-            "empty accounts should be removed"
-        );
-        assert_eq!(
-            transaction_container.size(),
-            1,
-            "1 transactions should be remaining from original 6"
-        );
-        assert_eq!(
-            transaction_container
-                .accounts
-                .get(&signing_address_1)
-                .unwrap()
-                .size(),
-            1
-        );
-    }
-
-    #[tokio::test]
-    async fn transaction_container_pop_front_account() {
-        let mut transaction_container =
-            TransactionContainer::new(false, UNSTRICT_SIZE_LIMIT, Duration::from_secs(2));
-        let signing_key_0 = SigningKey::from([1; 32]);
-        let signing_address_0 = signing_key_0.clone().verification_key().address_bytes();
-        let signing_key_1 = SigningKey::from([2; 32]);
-        let signing_address_1 = signing_key_1.clone().verification_key().address_bytes();
-
-        // transactions to add to accounts
-        // account, nonce, hash
-        let ttx_s0_1 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            1,
-            &signing_key_0,
-            [1; 32],
-        )));
-        let ttx_s1_1 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            1,
-            &signing_key_1,
-            [1; 32],
-        )));
-        let ttx_s1_2 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            2,
-            &signing_key_1,
-            [1; 32],
-        )));
-        let ttx_s1_4 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            4,
-            &signing_key_1,
-            [1; 32],
-        )));
-
-        // add transactions
-        transaction_container.add(ttx_s0_1.clone(), 0).unwrap();
-        transaction_container.add(ttx_s1_1.clone(), 0).unwrap();
-        transaction_container.add(ttx_s1_2.clone(), 0).unwrap();
-        transaction_container.add(ttx_s1_4.clone(), 0).unwrap();
-
-        // pop from account 1
-        assert_eq!(
-            transaction_container
-                .pop_front_account(&signing_address_0, 1)
-                .len(),
-            1,
-            "one transactions should've been popped"
-        );
-        assert_eq!(
-            transaction_container.accounts.len(),
-            1,
-            "empty accounts should be removed"
-        );
-
-        // pop from account 2
-        assert_eq!(
-            transaction_container
-                .pop_front_account(&signing_address_1, 1)
-                .len(),
-            2,
-            "two transactions should've been popped"
-        );
-        assert_eq!(
-            transaction_container.accounts.len(),
-            1,
-            "non empty accounts should not be removed"
-        );
-
-        assert_eq!(
-            transaction_container.size(),
-            1,
-            "1 transactions should be remaining from original 4"
-        );
-    }
-
-    #[tokio::test]
-    async fn transaction_container_builder_queue() {
-        let mut transaction_container =
-            TransactionContainer::new(true, STRICT_SIZE_LIMIT, Duration::from_secs(2));
-        let signing_key_0 = SigningKey::from([1; 32]);
-        let signing_address_0 = signing_key_0.clone().verification_key().address_bytes();
-        let signing_key_1 = SigningKey::from([2; 32]);
-        let signing_address_1 = signing_key_1.clone().verification_key().address_bytes();
-
-        // transactions to add to accounts
-        // account, nonce, hash
-        let ttx_s0_1 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            1,
-            &signing_key_0,
-            [1; 32],
-        )));
-        let ttx_s1_1 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            1,
-            &signing_key_1,
-            [1; 32],
-        )));
-        let ttx_s1_2 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            2,
-            &signing_key_1,
-            [1; 32],
-        )));
-        let ttx_s1_3 = Arc::new(TimemarkedTransaction::new(get_mock_tx_parameterized(
-            3,
-            &signing_key_1,
-            [1; 32],
-        )));
-
-        // add transactions
-        transaction_container.add(ttx_s0_1.clone(), 1).unwrap();
-        transaction_container.add(ttx_s1_1.clone(), 1).unwrap();
-        transaction_container.add(ttx_s1_2.clone(), 1).unwrap();
-        transaction_container.add(ttx_s1_3.clone(), 1).unwrap();
+        pending_txs.add(ttx_s0_1.clone(), 1).unwrap();
+        pending_txs.add(ttx_s1_1.clone(), 1).unwrap();
+        pending_txs.add(ttx_s1_2.clone(), 1).unwrap();
+        pending_txs.add(ttx_s1_3.clone(), 1).unwrap();
 
         // current nonce getter
         // should return all transactions from signing_key_0 and last two from signing_key_1
         let current_account_nonce_getter = |address: [u8; 20]| async move {
             if address == signing_address_0 {
-                return Ok(1);
+                Ok(1)
+            } else if address == signing_address_1 {
+                Ok(2)
+            } else {
+                Err(anyhow::anyhow!("invalid address"))
             }
-            if address == signing_address_1 {
-                return Ok(2);
-            }
-            Err(anyhow::anyhow!("invalid address"))
         };
 
         // get builder queue
-        let mut builder_queue = transaction_container
+        let builder_queue = pending_txs
             .builder_queue(&current_account_nonce_getter)
             .await
             .expect("building builders queue should work");
@@ -2025,32 +1442,125 @@ mod test {
         );
 
         // check that the transactions are in the expected order
-        let (first_tx, _) = builder_queue.pop().unwrap();
+        let (first_tx_hash, _) = builder_queue[0];
         assert_eq!(
-            first_tx.address(),
-            &signing_address_0,
-            "expected earliest transaction with lowest nonce difference to be first"
+            first_tx_hash, ttx_s0_1.tx_hash,
+            "expected earliest transaction with lowest nonce difference (0) to be first"
         );
-        let (second_tx, _) = builder_queue.pop().unwrap();
+        let (second_tx_hash, _) = builder_queue[1];
         assert_eq!(
-            second_tx.address(),
-            &signing_address_1,
-            "expected lower nonce diff to be second"
+            second_tx_hash, ttx_s1_2.tx_hash,
+            "expected other low nonce diff (0) to be second"
         );
-        assert_eq!(second_tx.signed_tx().nonce(), 2);
-        let (third_tx, _) = builder_queue.pop().unwrap();
+        let (third_tx_hash, _) = builder_queue[2];
         assert_eq!(
-            third_tx.address(),
-            &signing_address_1,
+            third_tx_hash, ttx_s1_3.tx_hash,
             "expected highest nonce diff to be last"
         );
-        assert_eq!(third_tx.signed_tx().nonce(), 3);
 
         // ensure transactions not removed
         assert_eq!(
-            transaction_container.size(),
+            pending_txs.len(),
             4,
             "no transactions should've been removed"
         );
+    }
+
+    #[tokio::test]
+    async fn parked_transactions_pop_front_account() {
+        let mut parked_txs = ParkedTransactions::<MAX_PARKED_TXS_PER_ACCOUNT>::new(TX_TTL);
+        let signing_key_0 = SigningKey::from([1; 32]);
+        let signing_address_0 = signing_key_0.address_bytes();
+        let signing_key_1 = SigningKey::from([2; 32]);
+        let signing_address_1 = signing_key_1.address_bytes();
+
+        // transactions to add to accounts
+        let ttx_s0_1 = mock_ttx(1, &signing_key_0);
+        let ttx_s1_1 = mock_ttx(1, &signing_key_1);
+        let ttx_s1_2 = mock_ttx(2, &signing_key_1);
+        let ttx_s1_4 = mock_ttx(4, &signing_key_1);
+
+        // add transactions
+        parked_txs.add(ttx_s0_1.clone(), 0).unwrap();
+        parked_txs.add(ttx_s1_1.clone(), 0).unwrap();
+        parked_txs.add(ttx_s1_2.clone(), 0).unwrap();
+        parked_txs.add(ttx_s1_4.clone(), 0).unwrap();
+
+        // pop from account 1
+        assert_eq!(
+            parked_txs.pop_front_account(&signing_address_0, 1).len(),
+            1,
+            "one transactions should've been popped"
+        );
+        assert_eq!(parked_txs.txs.len(), 1, "empty accounts should be removed");
+
+        // pop from account 2
+        assert_eq!(
+            parked_txs.pop_front_account(&signing_address_1, 1).len(),
+            2,
+            "two transactions should've been popped"
+        );
+        assert_eq!(
+            parked_txs.txs.len(),
+            1,
+            "non empty accounts should not be removed"
+        );
+
+        assert_eq!(
+            parked_txs.len(),
+            1,
+            "1 transactions should be remaining from original 4"
+        );
+        assert!(parked_txs.contains_tx(&ttx_s1_4.tx_hash));
+    }
+
+    #[tokio::test]
+    async fn parked_transactions_find_promotables() {
+        let mut parked_txs = ParkedTransactions::<MAX_PARKED_TXS_PER_ACCOUNT>::new(TX_TTL);
+        let signing_key_0 = SigningKey::from([1; 32]);
+        let signing_address_0 = signing_key_0.address_bytes();
+        let signing_key_1 = SigningKey::from([2; 32]);
+        let signing_address_1 = signing_key_1.address_bytes();
+
+        // transactions to add to accounts
+        let ttx_s0_1 = mock_ttx(1, &signing_key_0);
+        let ttx_s0_2 = mock_ttx(2, &signing_key_0);
+        let ttx_s0_3 = mock_ttx(3, &signing_key_0);
+        let ttx_s1_1 = mock_ttx(1, &signing_key_1);
+        let ttx_s1_2 = mock_ttx(2, &signing_key_1);
+        let ttx_s1_4 = mock_ttx(4, &signing_key_1);
+
+        // add transactions
+        parked_txs.add(ttx_s0_1.clone(), 0).unwrap();
+        parked_txs.add(ttx_s0_2.clone(), 0).unwrap();
+        parked_txs.add(ttx_s0_3.clone(), 0).unwrap();
+        parked_txs.add(ttx_s1_1.clone(), 0).unwrap();
+        parked_txs.add(ttx_s1_2.clone(), 0).unwrap();
+        parked_txs.add(ttx_s1_4.clone(), 0).unwrap();
+
+        // current nonce getter
+        // should pop all from signing_address_0 and two from signing_address_1
+        let current_account_nonce_getter = |address: [u8; 20]| async move {
+            if address == signing_address_0 || address == signing_address_1 {
+                return Ok(1);
+            }
+            Err(anyhow::anyhow!("invalid address"))
+        };
+
+        assert_eq!(
+            parked_txs
+                .find_promotables(&current_account_nonce_getter)
+                .await
+                .len(),
+            5,
+            "five transactions should've been popped"
+        );
+        assert_eq!(parked_txs.txs.len(), 1, "empty accounts should be removed");
+        assert_eq!(
+            parked_txs.len(),
+            1,
+            "1 transactions should be remaining from original 6"
+        );
+        assert!(parked_txs.contains_tx(&ttx_s1_4.tx_hash));
     }
 }

--- a/crates/astria-sequencer/src/service/consensus.rs
+++ b/crates/astria-sequencer/src/service/consensus.rs
@@ -202,6 +202,7 @@ mod test {
     use std::{
         collections::HashMap,
         str::FromStr,
+        sync::Arc,
     };
 
     use astria_core::{
@@ -287,12 +288,12 @@ mod test {
         let (mut consensus_service, mempool) =
             new_consensus_service(Some(signing_key.verification_key())).await;
         let tx = make_unsigned_tx();
-        let signed_tx = tx.into_signed(&signing_key);
-        let tx_bytes = signed_tx.clone().into_raw().encode_to_vec();
+        let signed_tx = Arc::new(tx.into_signed(&signing_key));
+        let tx_bytes = signed_tx.to_raw().encode_to_vec();
         let txs = vec![tx_bytes.into()];
         mempool.insert(signed_tx.clone(), 0).await.unwrap();
 
-        let res = generate_rollup_datas_commitment(&vec![signed_tx], HashMap::new());
+        let res = generate_rollup_datas_commitment(&vec![(*signed_tx).clone()], HashMap::new());
 
         let prepare_proposal = new_prepare_proposal_request();
         let prepare_proposal_response = consensus_service
@@ -492,10 +493,10 @@ mod test {
             new_consensus_service(Some(signing_key.verification_key())).await;
 
         let tx = make_unsigned_tx();
-        let signed_tx = tx.into_signed(&signing_key);
-        let tx_bytes = signed_tx.clone().into_raw().encode_to_vec();
+        let signed_tx = Arc::new(tx.into_signed(&signing_key));
+        let tx_bytes = signed_tx.to_raw().encode_to_vec();
         let txs = vec![tx_bytes.clone().into()];
-        let res = generate_rollup_datas_commitment(&vec![signed_tx.clone()], HashMap::new());
+        let res = generate_rollup_datas_commitment(&vec![(*signed_tx).clone()], HashMap::new());
 
         let block_data = res.into_transactions(txs.clone());
         let data_hash =


### PR DESCRIPTION
## Summary
This is effectively an update to the existing PR #1323.

## Background
While reviewing #1323, it seemed more expedient to open a PR against it rather than adding many GH comments (this was discussed with @Lilyjjo).

As always, there are more changes here than I initially expected.  The main thrust of the changes was to try and use the type system to avoid certain classes of errors, and to make things a little more canonical where possible.

## Changes
- At a high level, there are now separate types dealing with pending txs and parked txs: `PendingTransactionsForAccount`, `PendingTransactions`, `ParkedTransactionsForAccount` and `ParkedTransactions`.  For the ones dealing with a single account, much of their logic is common, so a trait `TransactionsForAccount` was introduced to express that shared logic.  For the ones dealing with collection of accounts' txs, a struct was introduced: `TransactionsContainer` generic over the type of the account-specific container `T: TransactionsForAccount`.  This allowed for the shared logic to be expressed on the generic impl, with methods which are only relevant to pending being added to only that specialization, and similarly for the parked impl.
- Extraneous fields were removed to avoid potential synchronization issues (e.g. `Mempool::all` and `TransactionContainer::all`)
- Reduced scope of several of the locks made on the `RwLock`s
- Various other smaller changes

## Testing
- No additional tests were added, the existing tests were modified.
- Benchmarks were run and reveal very promising results.  These are a reflection of the changes made in the original PR rather than this one.  Example output is included below, and for reference, the previous figures are available in the description of #1238.  Summary is that for a mempool with 100 txs, we're seeing roughly a two times speed increase, and at 100,000 txs, we're seeing roughly a ten times increase.

<details>

<summary>Example of running <code>cargo bench -qp astria-sequencer</code> on my Ryzen 7900X</summary>

```
Timer precision: 10 ns
astria_sequencer                     fastest       │ slowest       │ median        │ mean          │ samples │ iters
╰─ mempool                                         │               │               │               │         │
   ╰─ benchmarks                                   │               │               │               │         │
      ├─ check_removed_comet_bft     41.1 µs       │ 47.7 µs       │ 41.96 µs      │ 42.81 µs      │ 100     │ 100
      ├─ builder_queue                             │               │               │               │         │
      │  ├─ mempool_with_100000_txs  9.578 ms      │ 13.59 ms      │ 10.09 ms      │ 10.17 ms      │ 100     │ 100
      │  ├─ mempool_with_10000_txs   613 µs        │ 821.4 µs      │ 734.7 µs      │ 723.7 µs      │ 100     │ 100
      │  ├─ mempool_with_1000_txs    55.37 µs      │ 68.09 µs      │ 59.3 µs       │ 59.44 µs      │ 100     │ 100
      │  ╰─ mempool_with_100_txs     9.377 µs      │ 14.2 µs       │ 9.913 µs      │ 10.21 µs      │ 100     │ 100
      ├─ insert                                    │               │               │               │         │
      │  ├─ mempool_with_100000_txs  2.79 ms       │ 3.327 ms      │ 2.944 ms      │ 2.968 ms      │ 100     │ 100
      │  ├─ mempool_with_10000_txs   137.9 µs      │ 277.3 µs      │ 201.4 µs      │ 199.2 µs      │ 100     │ 100
      │  ├─ mempool_with_1000_txs    15.38 µs      │ 24.64 µs      │ 18.73 µs      │ 18.78 µs      │ 100     │ 100
      │  ╰─ mempool_with_100_txs     7.303 µs      │ 11.24 µs      │ 7.579 µs      │ 7.686 µs      │ 100     │ 100
      ├─ pending_nonce                             │               │               │               │         │
      │  ├─ mempool_with_100000_txs  2.727 ms      │ 3.524 ms      │ 2.896 ms      │ 2.92 ms       │ 100     │ 100
      │  ├─ mempool_with_10000_txs   124.4 µs      │ 275.7 µs      │ 198.2 µs      │ 194.4 µs      │ 100     │ 100
      │  ├─ mempool_with_1000_txs    12.56 µs      │ 22.14 µs      │ 17.16 µs      │ 16.97 µs      │ 100     │ 100
      │  ╰─ mempool_with_100_txs     6.001 µs      │ 11.11 µs      │ 6.176 µs      │ 6.262 µs      │ 100     │ 100
      ├─ remove_tx_invalid                         │               │               │               │         │
      │  ├─ mempool_with_100000_txs  2.76 ms       │ 3.832 ms      │ 2.945 ms      │ 3.02 ms       │ 100     │ 100
      │  ├─ mempool_with_10000_txs   120.5 µs      │ 288.1 µs      │ 199.2 µs      │ 201 µs        │ 100     │ 100
      │  ├─ mempool_with_1000_txs    14.76 µs      │ 31.87 µs      │ 18.22 µs      │ 18.35 µs      │ 100     │ 100
      │  ╰─ mempool_with_100_txs     7.593 µs      │ 18.72 µs      │ 7.824 µs      │ 8.123 µs      │ 100     │ 100
      ╰─ run_maintenance                           │               │               │               │         │
         ├─ mempool_with_100000_txs  3.209 ms      │ 3.877 ms      │ 3.424 ms      │ 3.456 ms      │ 100     │ 100
         ├─ mempool_with_10000_txs   423.5 µs      │ 765.5 µs      │ 497.7 µs      │ 505.3 µs      │ 100     │ 100
         ├─ mempool_with_1000_txs    81 µs         │ 125.8 µs      │ 88.26 µs      │ 88.84 µs      │ 100     │ 100
         ╰─ mempool_with_100_txs     14.14 µs      │ 24.13 µs      │ 14.64 µs      │ 15.04 µs      │ 100     │ 100
```

</details>
