### PR TITLE
fix: cargo audit warning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1441,9 +1441,9 @@ checksum = "e1e5f035d16fc623ae5f74981db80a439803888314e3a555fd6f04acd51a3205"
 
 [[package]]
 name = "bytemuck"
-version = "1.15.0"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d68c57235a3a081186990eca2867354726650f42f7516ca50c28d6281fd15"
+checksum = "102087e286b4677862ea56cf8fc58bb2cdfa8725c40ffb80fe3a008eb7f2fc83"
 
 [[package]]
 name = "byteorder"


### PR DESCRIPTION
## Summary
Updated the version of `bytemuck`.

## Background
Running `cargo audit` yields a non-critical warning that bytemuck v1.15.0 has been yanked.

## Changes
Ran `cargo update -p bytemuck` to increase the version.

## Testing
Ran normal test suite, no additional tests added.