### PR TITLE
chore(charts): fix charts production templates

### DIFF
--- a/charts/composer/Chart.yaml
+++ b/charts/composer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/composer/templates/configmap.yaml
+++ b/charts/composer/templates/configmap.yaml
@@ -38,7 +38,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   namespace: {{ include "composer.namespace" .  }}
-  name: sequencer-private-key
+  name: composer-private-key
 data:
   {{ .Values.config.privateKey.secret.filename }}: |
     {{ .Values.config.privateKey.devContent }}

--- a/charts/composer/templates/deployment.yaml
+++ b/charts/composer/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
                 name: composer-env
           volumeMounts:
             - mountPath: "/var/secrets"
-              name: sequencer-private-key
+              name: composer-private-key
           startupProbe:
             httpGet:
               path: /readyz
@@ -47,14 +47,14 @@ spec:
           resources:
             {{- toYaml .Values.resources | trim | nindent 12 }}
       volumes:
-        - name: sequencer-private-key
+        - name: composer-private-key
           {{- if .Values.secretProvider.enabled }}
           csi:
             driver: secrets-store.csi.k8s.io
             readOnly: true
             volumeAttributes:
-              secretProviderClass: sequencer-private-key
+              secretProviderClass: composer-private-key
           {{- else }}
           configMap:
-            name: sequencer-private-key
+            name: composer-private-key
               {{- end }}

--- a/charts/composer/templates/secretproviderclass.yaml
+++ b/charts/composer/templates/secretproviderclass.yaml
@@ -3,7 +3,7 @@
 apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
-  name: sequencer-private-key
+  name: composer-private-key
 spec:
   provider: {{ .Values.secretProvider.provider }}
   parameters:

--- a/charts/evm-bridge-withdrawer/Chart.yaml
+++ b/charts/evm-bridge-withdrawer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/evm-bridge-withdrawer/templates/servicemonitor.yaml
+++ b/charts/evm-bridge-withdrawer/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.serviceMonitor.enabled .Values.config.relayer.metrics.enabled }}
+{{- if and .Values.serviceMonitor.enabled .Values.metrics.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/evm-faucet/Chart.yaml
+++ b/charts/evm-faucet/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/evm-faucet/templates/deployment.yaml
+++ b/charts/evm-faucet/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: evm-faucet-private-key
-                  key: {{ .Values.privateKey.secret.key }}
+                  key: {{ .Values.config.privateKey.secret.key }}
           {{- end }}
           volumeMounts:
             - mountPath: /home/faucet
@@ -43,7 +43,7 @@ spec:
               subPath: {{tpl .Values.config.rollupName . }}/faucet
             {{- if .Values.secretProvider.enabled }}
             - mountPath: /var/secrets
-              name: faucet-private-key
+              name: evm-faucet-private-key
             {{- end }}
           ports:
             - containerPort: {{ .Values.ports.faucet }}

--- a/charts/evm-rollup/Chart.yaml
+++ b/charts/evm-rollup/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.25.1
+version: 0.25.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/evm-rollup/templates/configmap.yaml
+++ b/charts/evm-rollup/templates/configmap.yaml
@@ -26,12 +26,12 @@ data:
   NO_COLOR: "{{ .Values.global.useTTY }}"
   ASTRIA_CONDUCTOR_NO_OTEL: "{{ not .Values.otel.enabled }}"
   ASTRIA_CONDUCTOR_CELESTIA_BEARER_TOKEN: "{{ .Values.config.celestia.token }}"
-  OTEL_EXPORTER_OTLP_ENDPOINT: "{{ .Values.otel.endpoint }}"
-  OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: "{{ .Values.otel.tracesEndpoint }}"
-  OTEL_EXPORTER_OTLP_TRACES_TIMEOUT: "{{ .Values.otel.tracesTimeout }}"
-  OTEL_EXPORTER_OTLP_TRACES_COMPRESSION: "{{ .Values.otel.tracesCompression }}"
-  OTEL_EXPORTER_OTLP_HEADERS: "{{ .Values.otel.otlpHeaders }}"
-  OTEL_EXPORTER_OTLP_TRACE_HEADERS: "{{ .Values.otel.traceHeaders }}"
+  OTEL_EXPORTER_OTLP_ENDPOINT: "{{ tpl .Values.otel.endpoint . }}"
+  OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: "{{ tpl .Values.otel.tracesEndpoint . }}"
+  OTEL_EXPORTER_OTLP_TRACES_TIMEOUT: "{{ tpl .Values.otel.tracesTimeout . }}"
+  OTEL_EXPORTER_OTLP_TRACES_COMPRESSION: "{{ tpl .Values.otel.tracesCompression . }}"
+  OTEL_EXPORTER_OTLP_HEADERS: "{{ tpl .Values.otel.otlpHeaders . }}"
+  OTEL_EXPORTER_OTLP_TRACE_HEADERS: "{{ tpl .Values.otel.traceHeaders .}}"
   OTEL_SERVICE_NAME: "{{ tpl .Values.otel.serviceNamePrefix . }}-conductor"
   {{- if not .Values.global.dev }}
   {{- else }}

--- a/charts/evm-rollup/values.yaml
+++ b/charts/evm-rollup/values.yaml
@@ -211,12 +211,12 @@ metrics:
 otel:
   enabled: false
   serviceNamePrefix: '{{ include "rollup.name" . }}'
-  endpoint:
-  tracesEndpoint:
-  tracesCompression: gzip
-  tracesTimeout: 10
-  otlpHeaders:
-  traceHeaders:
+  endpoint: ""
+  tracesEndpoint: ""
+  tracesCompression: "gzip"
+  tracesTimeout: "10"
+  otlpHeaders: ""
+  traceHeaders: ""
 
 serviceMonitor:
   # set to enable port svc and service monitor

--- a/charts/evm-stack/Chart.lock
+++ b/charts/evm-stack/Chart.lock
@@ -1,21 +1,21 @@
 dependencies:
 - name: evm-rollup
   repository: file://../evm-rollup
-  version: 0.25.1
+  version: 0.25.2
 - name: composer
   repository: file://../composer
-  version: 0.1.0
+  version: 0.1.1
 - name: evm-faucet
   repository: file://../evm-faucet
-  version: 0.1.0
+  version: 0.1.1
 - name: evm-bridge-withdrawer
   repository: file://../evm-bridge-withdrawer
-  version: 0.1.1
+  version: 0.1.2
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 15.2.4
 - name: blockscout-stack
   repository: https://blockscout.github.io/helm-charts
   version: 1.6.2
-digest: sha256:d337fa8fa4f7c8986527bf03bc7a1511bd1ac196214b35b8c2cf8d99d8e0358b
-generated: "2024-07-30T09:09:11.244761-07:00"
+digest: sha256:2ceebf8976422c02bc200ad1ad636e1bd83a7b94931a024b5034212ef3fde8b3
+generated: "2024-08-11T18:04:44.817194+03:00"

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -19,18 +19,18 @@ version: 0.3.0
 
 dependencies:
   - name: evm-rollup
-    version: 0.25.1
+    version: 0.25.2
     repository: "file://../evm-rollup"
   - name: composer
-    version: 0.1.0
+    version: 0.1.1
     repository: "file://../composer"
     condition: composer.enabled
   - name: evm-faucet
-    version: 0.1.0
+    version: 0.1.1
     repository: "file://../evm-faucet"
     condition: evm-faucet.enabled
   - name: evm-bridge-withdrawer
-    version: 0.1.1
+    version: 0.1.2
     repository: "file://../evm-bridge-withdrawer"
     condition: evm-bridge-withdrawer.enabled
   - name: postgresql

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 
 dependencies:
   - name: evm-rollup

--- a/charts/sequencer-faucet/Chart.yaml
+++ b/charts/sequencer-faucet/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.0
+version: 0.7.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sequencer-faucet/values.yaml
+++ b/charts/sequencer-faucet/values.yaml
@@ -21,7 +21,7 @@ config:
   amount: 1800
 
 images:
-  sequencerFaucet: "ghcr.io/astriaorg/seq-faucet:0.6.0"
+  sequencerFaucet: "ghcr.io/astriaorg/seq-faucet:sha-5c9d64c"
 
 # When deploying in a production environment should use a secret provider
 # This is configured for use with GCP, need to set own resource names


### PR DESCRIPTION
## Summary
Changes to production templates of the charts, namely secrets, volumes, configmap and deployment
## Background
Production deployments through GCP provider has small template errors
## Changes
- composer secret private key naming
- evm-bridge-withdrawer condition
- sequencer-faucet now uses fixed image
- evm-faucet condition and secret naming
- evm-rollup otel values templating

## Testing
- deployed a local kubernetes cluster with all services
- this changes were originally made while deploying dusk-9 production network

## Related Issues
closes #1358 
