### PR TITLE
Chore: Upgrade celestia-node to v0.14.1

### DIFF
--- a/charts/celestia-local/Chart.yaml
+++ b/charts/celestia-local/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.6.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.8.0"
+appVersion: "1.9.0"
 
 maintainers:
   - name: wafflesvonmaple

--- a/charts/celestia-local/values.yaml
+++ b/charts/celestia-local/values.yaml
@@ -16,7 +16,7 @@ storage:
       path: "/data/celestia-data"
 
 celestiaAppImage: "ghcr.io/celestiaorg/celestia-app:v1.9.0"
-celestiaNodeImage: "ghcr.io/celestiaorg/celestia-node:v0.13.4"
+celestiaNodeImage: "ghcr.io/celestiaorg/celestia-node:v0.14.1"
 
 podSecurityContext:
   runAsUser: 10001

--- a/charts/celestia-node/Chart.yaml
+++ b/charts/celestia-node/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.3
+version: 0.3.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/celestia-node/Chart.yaml
+++ b/charts/celestia-node/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.2
+version: 0.3.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.13.6"
+appVersion: "0.14.1"
 
 maintainers:
   - name: wafflesvonmaple

--- a/charts/celestia-node/values.yaml
+++ b/charts/celestia-node/values.yaml
@@ -19,7 +19,7 @@ config:
 
 images:
   pullPolicy: IfNotPresent
-  node: ghcr.io/celestiaorg/celestia-node:v0.13.6
+  node: ghcr.io/celestiaorg/celestia-node:v0.14.1
 
 ports:
   celestia:

--- a/charts/evm-rollup/Chart.lock
+++ b/charts/evm-rollup/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: celestia-node
   repository: file://../celestia-node
-  version: 0.3.3
-digest: sha256:627ac83a734e561e3947010518689f4f34ec7aa0ae33e9f09490781360b5c01b
-generated: "2024-08-09T15:21:21.590302+03:00"
+  version: 0.3.4
+digest: sha256:8389e87d7ce8a92d2af7a5c8177dbbf34d6471933b5c857bae88a44b860382b3
+generated: "2024-08-12T22:11:51.89263+03:00"

--- a/charts/evm-rollup/Chart.lock
+++ b/charts/evm-rollup/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: celestia-node
   repository: file://../celestia-node
-  version: 0.3.2
-digest: sha256:dbd9dbd2cc6b97947ab7612bcb69a092d324d53a637c04cdf7b727db5a1a04fb
-generated: "2024-05-20T17:12:32.402994-07:00"
+  version: 0.3.3
+digest: sha256:627ac83a734e561e3947010518689f4f34ec7aa0ae33e9f09490781360b5c01b
+generated: "2024-08-09T15:21:21.590302+03:00"

--- a/charts/evm-rollup/Chart.yaml
+++ b/charts/evm-rollup/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.25.2
+version: 0.25.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,7 +25,7 @@ appVersion: "0.14.0"
 
 dependencies:
   - name: celestia-node
-    version: "0.3.3"
+    version: "0.3.4"
     repository: "file://../celestia-node"
     condition: celestia-node.enabled
 

--- a/charts/evm-rollup/Chart.yaml
+++ b/charts/evm-rollup/Chart.yaml
@@ -25,7 +25,7 @@ appVersion: "0.14.0"
 
 dependencies:
   - name: celestia-node
-    version: "0.3.2"
+    version: "0.3.3"
     repository: "file://../celestia-node"
     condition: celestia-node.enabled
 

--- a/charts/evm-stack/Chart.lock
+++ b/charts/evm-stack/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: evm-rollup
   repository: file://../evm-rollup
-  version: 0.25.2
+  version: 0.25.3
 - name: composer
   repository: file://../composer
   version: 0.1.1
@@ -17,5 +17,5 @@ dependencies:
 - name: blockscout-stack
   repository: https://blockscout.github.io/helm-charts
   version: 1.6.2
-digest: sha256:2ceebf8976422c02bc200ad1ad636e1bd83a7b94931a024b5034212ef3fde8b3
-generated: "2024-08-11T18:04:44.817194+03:00"
+digest: sha256:75189d68ee2ddbb135ec487b4aee663fd2d096ae19608efc2d6ebfdec9d8c4a0
+generated: "2024-08-12T22:12:07.880246+03:00"

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -15,11 +15,11 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.3.2
 
 dependencies:
   - name: evm-rollup
-    version: 0.25.2
+    version: 0.25.3
     repository: "file://../evm-rollup"
   - name: composer
     version: 0.1.1


### PR DESCRIPTION
## Summary
celestia-node image update to v0.14.1 which fixes memory leaks
## Background
Image used per celestia-node is outdated
## Changes
- celestia-node image `v0.13.4 -> v0.14.1`

## Testing
locall kubernetes cluster with all services deployed and firm blocks confirmed