### PR TITLE
Refactor(charts): move celestia-node dependency up a level

### DIFF
--- a/charts/celestia-node/files/scripts/start-node.sh
+++ b/charts/celestia-node/files/scripts/start-node.sh
@@ -10,6 +10,8 @@ function set_token() {
 
   mkdir -p /celestia/token
   echo "$TOKEN" > /celestia/token/token.key
+  mkdir -p /celestia/token-server
+  echo "$TOKEN" > /celestia/token-server/index.html
 }
 
 if [ ! -f /celestia/token/token.key ]; then

--- a/charts/celestia-node/templates/statefulset.yaml
+++ b/charts/celestia-node/templates/statefulset.yaml
@@ -72,6 +72,24 @@ spec:
               subPath: {{ $secret.filename }}
             {{- end }}
             {{- end }}
+        {{- if .Values.config.tokenAuthLevel }}
+        - name: token-server
+          image: {{ .Values.images.tokenServer }}
+          command: [ "/bin/httpd", "-v", "-f", "-p", "{{ .Values.ports.tokenServer }}", "-h", "/celestia/token-server/" ]
+          ports:
+            - containerPort: {{ .Values.ports.tokenServer }}
+              name: token-svc
+          volumeMounts:
+            - mountPath: /celestia
+              name: {{ $label }}-vol
+              readOnly: true
+          startupProbe:
+            httpGet:
+              path: /
+              port: token-svc
+            failureThreshold: 30
+            periodSeconds: 5
+        {{- end }}
       volumes:
         # ------------ Startup scripts -------------
         - name: {{ $label }}-scripts-vol

--- a/charts/celestia-node/values.yaml
+++ b/charts/celestia-node/values.yaml
@@ -19,6 +19,7 @@ config:
 
 images:
   pullPolicy: IfNotPresent
+  tokenServer: "busybox:1.35.0-musl"
   node: ghcr.io/celestiaorg/celestia-node:v0.13.6
 
 ports:

--- a/charts/evm-rollup/Chart.lock
+++ b/charts/evm-rollup/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: celestia-node
-  repository: file://../celestia-node
-  version: 0.3.2
-digest: sha256:dbd9dbd2cc6b97947ab7612bcb69a092d324d53a637c04cdf7b727db5a1a04fb
-generated: "2024-05-20T17:12:32.402994-07:00"

--- a/charts/evm-rollup/Chart.yaml
+++ b/charts/evm-rollup/Chart.yaml
@@ -23,12 +23,6 @@ version: 0.25.1
 # It is recommended to use it with quotes.
 appVersion: "0.14.0"
 
-dependencies:
-  - name: celestia-node
-    version: "0.3.2"
-    repository: "file://../celestia-node"
-    condition: celestia-node.enabled
-
 maintainers:
   - name: wafflesvonmaple
     url: astria.org

--- a/charts/evm-rollup/files/scripts/start-conductor.sh
+++ b/charts/evm-rollup/files/scripts/start-conductor.sh
@@ -2,19 +2,26 @@
 
 set -o errexit -o nounset -o pipefail
 
-# Request Celestia token if connecting to celestia
-BEARER_TOKEN=""
-if [ "$ASTRIA_CONDUCTOR_EXECUTION_COMMIT_LEVEL" != "SoftOnly" ]; then
-    BEARER_TOKEN=$(wget -qO- "$TOKEN_SERVER_URL")
+# Check if ASTRIA_CONDUCTOR_CELESTIA_BEARER_TOKEN is already defined
+if [ -z "${ASTRIA_CONDUCTOR_CELESTIA_BEARER_TOKEN:-}" ]; then
+    echo "ASTRIA_CONDUCTOR_CELESTIA_BEARER_TOKEN is not defined. Fetching the token..."
+    
+    # Request Celestia token if connecting to celestia
+    BEARER_TOKEN=""
+    if [ "$ASTRIA_CONDUCTOR_EXECUTION_COMMIT_LEVEL" != "SoftOnly" ]; then
+        BEARER_TOKEN=$(wget --timeout=10 --tries=1 -O - "$TOKEN_SERVER_URL")
 
-    if [ -z "$BEARER_TOKEN" ]; then
-        echo "Failed to fetch the Celestia bearer token."
-        exit 1
+        if [ -z "$BEARER_TOKEN" ]; then
+            echo "Failed to fetch the Celestia bearer token."
+            exit 1
+        fi
+
+        echo "Celestia Bearer token fetched successfully."
     fi
 
-    echo "Celestia Bearer token fetched successfully."
+    export ASTRIA_CONDUCTOR_CELESTIA_BEARER_TOKEN="$BEARER_TOKEN"
+else
+    echo "ASTRIA_CONDUCTOR_CELESTIA_BEARER_TOKEN is already defined. Skipping token fetch."
 fi
-
-export ASTRIA_CONDUCTOR_CELESTIA_BEARER_TOKEN="$BEARER_TOKEN"
 
 exec /usr/local/bin/astria-conductor

--- a/charts/evm-rollup/templates/configmap.yaml
+++ b/charts/evm-rollup/templates/configmap.yaml
@@ -38,7 +38,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "rollup.namespace" .  }}-conductor-scripts
+  name: {{ include "rollup.name" .  }}-conductor-scripts
   namespace: {{ include "rollup.namespace" .  }}
 data:
   start-conductor.sh: |

--- a/charts/evm-rollup/templates/configmap.yaml
+++ b/charts/evm-rollup/templates/configmap.yaml
@@ -38,6 +38,15 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  name: {{ .Values.config.rollup.name }}-conductor-scripts
+  namespace: {{ include "rollup.namespace" .  }}
+data:
+  start-conductor.sh: |
+    {{- .Files.Get "files/scripts/start-conductor.sh" | nindent 4 }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
   name: {{ include "rollup.name" . }}-geth-env
   namespace: {{ include "rollup.namespace" .  }}
 data:

--- a/charts/evm-rollup/templates/configmap.yaml
+++ b/charts/evm-rollup/templates/configmap.yaml
@@ -5,7 +5,11 @@ metadata:
   namespace: {{ include "rollup.namespace" . }}
 data:
   ASTRIA_CONDUCTOR_LOG: "astria_conductor={{ .Values.config.logLevel }}"
+  {{- if .Values.config.celestia.node.enabled }}
   TOKEN_SERVER_URL: "{{ .Values.config.celestia.token }}"
+  {{- else }}
+  ASTRIA_CONDUCTOR_CELESTIA_BEARER_TOKEN: "{{ .Values.config.celestia.token }}"
+  {{- end }}
   ASTRIA_CONDUCTOR_CELESTIA_NODE_HTTP_URL: "{{ .Values.config.celestia.rpc }}"
   ASTRIA_CONDUCTOR_CELESTIA_BLOCK_TIME_MS: "12000"
   ASTRIA_CONDUCTOR_EXECUTION_RPC_URL: "http://127.0.0.1:{{ .Values.ports.executionGRPC }}"
@@ -20,7 +24,6 @@ data:
   ASTRIA_CONDUCTOR_PRETTY_PRINT: "{{ .Values.global.useTTY }}"
   NO_COLOR: "{{ .Values.global.useTTY }}"
   ASTRIA_CONDUCTOR_NO_OTEL: "{{ not .Values.otel.enabled }}"
-  ASTRIA_CONDUCTOR_CELESTIA_BEARER_TOKEN: "{{ .Values.config.celestia.token }}"
   OTEL_EXPORTER_OTLP_ENDPOINT: "{{ .Values.otel.endpoint }}"
   OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: "{{ .Values.otel.tracesEndpoint }}"
   OTEL_EXPORTER_OTLP_TRACES_TIMEOUT: "{{ .Values.otel.tracesTimeout }}"

--- a/charts/evm-rollup/templates/configmap.yaml
+++ b/charts/evm-rollup/templates/configmap.yaml
@@ -38,7 +38,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.config.rollup.name }}-conductor-scripts
+  name: {{ include "rollup.namespace" .  }}-conductor-scripts
   namespace: {{ include "rollup.namespace" .  }}
 data:
   start-conductor.sh: |

--- a/charts/evm-rollup/templates/configmap.yaml
+++ b/charts/evm-rollup/templates/configmap.yaml
@@ -5,13 +5,8 @@ metadata:
   namespace: {{ include "rollup.namespace" . }}
 data:
   ASTRIA_CONDUCTOR_LOG: "astria_conductor={{ .Values.config.logLevel }}"
-  {{- if (index .Values "celestia-node").enabled }}
-  TOKEN_SERVER_URL: "{{ include "celestiaNode.service.addresses.token" (index .Subcharts "celestia-node") }}"
-  ASTRIA_CONDUCTOR_CELESTIA_NODE_HTTP_URL: "{{ include "celestiaNode.service.addresses.rpc" (index .Subcharts "celestia-node") }}"
-  {{- else }}
   TOKEN_SERVER_URL: "{{ .Values.config.celestia.token }}"
   ASTRIA_CONDUCTOR_CELESTIA_NODE_HTTP_URL: "{{ .Values.config.celestia.rpc }}"
-  {{- end }}
   ASTRIA_CONDUCTOR_CELESTIA_BLOCK_TIME_MS: "12000"
   ASTRIA_CONDUCTOR_EXECUTION_RPC_URL: "http://127.0.0.1:{{ .Values.ports.executionGRPC }}"
   ASTRIA_CONDUCTOR_EXECUTION_COMMIT_LEVEL: "{{ .Values.config.conductor.executionCommitLevel }}"

--- a/charts/evm-rollup/templates/statefulsets.yaml
+++ b/charts/evm-rollup/templates/statefulsets.yaml
@@ -73,9 +73,13 @@ spec:
             {{- toYaml .Values.resources.geth | trim | nindent 12 }}
         - name: conductor
           image: {{ include "conductor.image" . }}
-          command: [ "/usr/local/bin/astria-conductor" ]
+          command: [ "/scripts/start-conductor.sh" ]
           stdin: {{ .Values.global.useTTY }}
           tty: {{ .Values.global.useTTY }}
+          volumeMounts:
+            - mountPath: /scripts/
+              name: {{ .Values.config.rollup.name }}-conductor-scripts-volume
+              readOnly: true
           envFrom:
             - configMapRef:
                 name: {{ include "rollup.name" . }}-conductor-env
@@ -90,6 +94,10 @@ spec:
         - name: {{ include "rollup.name" . }}-executor-scripts-volume
           configMap:
             name: {{ include "rollup.name" . }}-executor-scripts
+            defaultMode: 0500
+        - name: {{ .Values.config.rollup.name }}-conductor-scripts-volume
+          configMap:
+            name: {{ .Values.config.rollup.name }}-conductor-scripts
             defaultMode: 0500
         - name: {{ include "rollup.name" $ }}-rollup-shared-storage-vol
           {{- if .Values.storage.enabled }}

--- a/charts/evm-rollup/templates/statefulsets.yaml
+++ b/charts/evm-rollup/templates/statefulsets.yaml
@@ -78,7 +78,7 @@ spec:
           tty: {{ .Values.global.useTTY }}
           volumeMounts:
             - mountPath: /scripts/
-              name: {{ include "rollup.namespace" .  }}-conductor-scripts-volume
+              name: {{ include "rollup.name" .  }}-conductor-scripts-volume
               readOnly: true
           envFrom:
             - configMapRef:
@@ -95,9 +95,9 @@ spec:
           configMap:
             name: {{ include "rollup.name" . }}-executor-scripts
             defaultMode: 0500
-        - name: {{ include "rollup.namespace" .  }}-conductor-scripts-volume
+        - name: {{ include "rollup.name" .  }}-conductor-scripts-volume
           configMap:
-            name: {{ include "rollup.namespace" .  }}-conductor-scripts
+            name: {{ include "rollup.name" .  }}-conductor-scripts
             defaultMode: 0500
         - name: {{ include "rollup.name" $ }}-rollup-shared-storage-vol
           {{- if .Values.storage.enabled }}

--- a/charts/evm-rollup/templates/statefulsets.yaml
+++ b/charts/evm-rollup/templates/statefulsets.yaml
@@ -78,7 +78,7 @@ spec:
           tty: {{ .Values.global.useTTY }}
           volumeMounts:
             - mountPath: /scripts/
-              name: {{ .Values.config.rollup.name }}-conductor-scripts-volume
+              name: {{ include "rollup.namespace" .  }}-conductor-scripts-volume
               readOnly: true
           envFrom:
             - configMapRef:
@@ -95,9 +95,9 @@ spec:
           configMap:
             name: {{ include "rollup.name" . }}-executor-scripts
             defaultMode: 0500
-        - name: {{ .Values.config.rollup.name }}-conductor-scripts-volume
+        - name: {{ include "rollup.namespace" .  }}-conductor-scripts-volume
           configMap:
-            name: {{ .Values.config.rollup.name }}-conductor-scripts
+            name: {{ include "rollup.namespace" .  }}-conductor-scripts
             defaultMode: 0500
         - name: {{ include "rollup.name" $ }}-rollup-shared-storage-vol
           {{- if .Values.storage.enabled }}

--- a/charts/evm-rollup/values.yaml
+++ b/charts/evm-rollup/values.yaml
@@ -182,7 +182,7 @@ config:
 
   celestia:
     node:
-      enabled: true
+      enabled: false
     # if config.rollup.executionLevel is NOT 'SoftOnly' AND celestia-node is not enabled
     # the rpc, ws, and token fields must be set to access celestia network.
     rpc: ""

--- a/charts/evm-rollup/values.yaml
+++ b/charts/evm-rollup/values.yaml
@@ -186,24 +186,6 @@ config:
     rpc: ""
     token: ""
 
-celestia-node:
-  # Strongly recommend leaving enabled when not doing `SoftOnly` execution
-  enabled: true
-  # By default the celestia node deploys on top of the Celestia testnet mocha network
-  config:
-    labelPrefix: astria
-    type: light
-    tokenAuthLevel: false  # Set to false to disable auth
-    # You can deploy on top of a custom celestia network, uncomment below and
-    # update fields with notes
-    # network: custom
-    # chainId: test
-    # # The below information will depend on your local celestia deployment,
-    # # using the default generated when deploying "celestia-local" chart
-    # coreIp: celestia-service.astria-dev-cluster.svc.cluster.local
-    # # The custom info below must be grabbed from the custom network bridge on startup
-    # customInfo: "<GENESIS_HASH>:<BRIDGE_MULTIADDRESS>"
-
 metrics:
   # set to enable prometheus metrics
   enabled: false

--- a/charts/evm-rollup/values.yaml
+++ b/charts/evm-rollup/values.yaml
@@ -181,6 +181,8 @@ config:
     sequencerRequestsPerSecond: 500
 
   celestia:
+    node:
+      enabled: true
     # if config.rollup.executionLevel is NOT 'SoftOnly' AND celestia-node is not enabled
     # the rpc, ws, and token fields must be set to access celestia network.
     rpc: ""

--- a/charts/evm-stack/Chart.lock
+++ b/charts/evm-stack/Chart.lock
@@ -1,4 +1,7 @@
 dependencies:
+- name: celestia-node
+  repository: file://../celestia-node
+  version: 0.3.2
 - name: evm-rollup
   repository: file://../evm-rollup
   version: 0.25.1
@@ -17,5 +20,5 @@ dependencies:
 - name: blockscout-stack
   repository: https://blockscout.github.io/helm-charts
   version: 1.6.2
-digest: sha256:d337fa8fa4f7c8986527bf03bc7a1511bd1ac196214b35b8c2cf8d99d8e0358b
-generated: "2024-07-30T09:09:11.244761-07:00"
+digest: sha256:d614fb17d7892c02357cd27fccf44711a5738c810cb83184a59e984cbb4ddd20
+generated: "2024-08-12T15:27:19.38204+03:00"

--- a/charts/evm-stack/Chart.lock
+++ b/charts/evm-stack/Chart.lock
@@ -20,5 +20,5 @@ dependencies:
 - name: blockscout-stack
   repository: https://blockscout.github.io/helm-charts
   version: 1.6.2
-digest: sha256:d614fb17d7892c02357cd27fccf44711a5738c810cb83184a59e984cbb4ddd20
-generated: "2024-08-12T15:27:19.38204+03:00"
+digest: sha256:3dc36f5826a94728cf8249a504a33c1c19c6b1eba96ccdacdc6ca41bd13805b6
+generated: "2024-08-13T14:57:56.473718+03:00"

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -18,6 +18,9 @@ type: application
 version: 0.3.0
 
 dependencies:
+  - name: celestia-node
+    version: 0.3.2
+    repository: "file://../celestia-node"
   - name: evm-rollup
     version: 0.25.1
     repository: "file://../evm-rollup"

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -21,6 +21,7 @@ dependencies:
   - name: celestia-node
     version: 0.3.2
     repository: "file://../celestia-node"
+    condition: celestia-node.enabled
   - name: evm-rollup
     version: 0.25.1
     repository: "file://../evm-rollup"

--- a/charts/evm-stack/values.yaml
+++ b/charts/evm-stack/values.yaml
@@ -39,6 +39,26 @@ evm-rollup:
     otlpHeaders: "{{ .Values.global.otel.otlpHeaders }}"
     traceHeaders: "{{ .Values.global.otel.traceHeaders }}"
 
+celestia-node:
+  # Strongly recommend leaving enabled when not doing `SoftOnly` execution
+  enabled: false
+  # By default the celestia node deploys on top of the Celestia testnet mocha network
+  config:
+    coreIp: "full.consensus.mocha-4.celestia-mocha.com"
+    type: light
+    tokenAuthLevel: read  # can set to nil or false to disable rpc auth
+    startHeight: "2469374"
+    trustedHash: "672FE0EC073C31CE7302837EE11AFECB798CE11D031042DE1ADF0734E7F8DC0D"
+    # You can deploy on top of a custom celestia network, uncomment below and
+    # update fields with notes
+    # network: custom
+    # chainId: test
+    # # The below information will depend on your local celestia deployment,
+    # # using the default generated when deploying "celestia-local" chart
+    # coreIp: celestia-service.astria-dev-cluster.svc.cluster.local
+    # # The custom info below must be grabbed from the custom network bridge on startup
+    # customInfo: "<GENESIS_HASH>:<BRIDGE_MULTIADDRESS>"
+
 composer:
   enabled: false
   config:

--- a/dev/values/rollup/dev.yaml
+++ b/dev/values/rollup/dev.yaml
@@ -99,6 +99,8 @@ evm-rollup:
       sequencerRequestsPerSecond: 500
 
     celestia:
+      node:
+        enabled: false
       rpc: "http://celestia-service.astria-dev-cluster.svc.cluster.local:26658"
       token: "http://celestia-service.astria-dev-cluster.svc.cluster.local:5353"
 

--- a/dev/values/rollup/dev.yaml
+++ b/dev/values/rollup/dev.yaml
@@ -118,9 +118,6 @@ evm-rollup:
         cpu: 2
         memory: 1Gi
 
-  celestia-node:
-    enabled: false
-
   storage:
     enabled: false
 
@@ -131,6 +128,9 @@ evm-rollup:
         enabled: true
       ws:
         enabled: true
+
+celestia-node:
+  enabled: false
 
 composer:
   enabled: true


### PR DESCRIPTION
## Summary
Moves `celestia-node` chart to be a direct dependency of the `evm-stack` 
## Background
With the new `evm-stack` wrapper chart, deploying a celestia-node failed duo to a dependency level issue.
## Changes
- moved `celestia-node` chart up a level from `evm-rollup -> evm-stack`
- now uses an HTTP server to share auth token with conductor service
- conductor script running within the pod

## Testing
- tested against a local kubernetes cluster with the latest components
- tested against devdev remote cluster, using a mocha-4 celestia-node

## Related Issues
closes #1362 
