### PR TITLE
fix(relayer): change `reqwest` for `isahc` in relayer blackbox tests (ENG-699)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -874,6 +874,7 @@ dependencies = [
  "humantime",
  "humantime-serde",
  "hyper",
+ "isahc",
  "itertools 0.12.1",
  "itoa",
  "k256",
@@ -884,7 +885,6 @@ dependencies = [
  "prost",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
- "reqwest",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -1517,6 +1517,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "castaway"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2698f953def977c68f935bb0dfa959375ad4638570e969e2f1e9f433cbf1af6"
+
+[[package]]
 name = "cc"
 version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2142,6 +2148,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher 0.4.4",
+]
+
+[[package]]
+name = "curl"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e2161dd6eba090ff1594084e95fd67aeccf04382ffea77999ea94ed42ec67b6"
+dependencies = [
+ "curl-sys",
+ "libc",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "socket2",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "curl-sys"
+version = "0.4.74+curl-8.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8af10b986114528fcdc4b63b6f5f021b7057618411046a4de2ba0f0149a097bf"
+dependencies = [
+ "cc",
+ "libc",
+ "libnghttp2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4193,6 +4230,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "isahc"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "334e04b4d781f436dc315cb1e7515bd96826426345d498149e4bde36b67f8ee9"
+dependencies = [
+ "async-channel",
+ "castaway",
+ "crossbeam-utils",
+ "curl",
+ "curl-sys",
+ "encoding_rs",
+ "event-listener",
+ "futures-lite",
+ "http",
+ "log",
+ "mime",
+ "once_cell",
+ "polling",
+ "serde",
+ "serde_json",
+ "slab",
+ "sluice",
+ "tracing",
+ "tracing-futures",
+ "url",
+ "waker-fn",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4493,6 +4559,16 @@ name = "libm"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
+name = "libnghttp2-sys"
+version = "0.1.10+1.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "959c25552127d2e1fa72f0e52548ec04fc386e827ba71a7bd01db46a447dc135"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "libp2p-identity"
@@ -5709,6 +5785,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
+name = "polling"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "concurrent-queue",
+ "libc",
+ "log",
+ "pin-project-lite",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "poly1305"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5983,7 +6075,7 @@ checksum = "80b776a1b2dc779f5ee0641f8ade0125bc1298dd41a9a0c16d8bd57b42d222b1"
 dependencies = [
  "bytes",
  "heck 0.5.0",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -6003,7 +6095,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19de2de2a00075bf566bee3bd4db014b11587e84184d3f7a791bc17f1a8e9e48"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2 1.0.79",
  "quote",
  "syn 2.0.58",
@@ -7053,6 +7145,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "sluice"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d7400c0eff44aa2fcb5e31a5f24ba9716ed90138769e4977a2ba6014ae63eb5"
+dependencies = [
+ "async-channel",
+ "futures-core",
+ "futures-io",
 ]
 
 [[package]]

--- a/crates/astria-sequencer-relayer/Cargo.toml
+++ b/crates/astria-sequencer-relayer/Cargo.toml
@@ -80,7 +80,6 @@ hyper = { workspace = true }
 itertools = { workspace = true }
 once_cell = { workspace = true }
 rand_core = { version = "0.6", features = ["getrandom"] }
-reqwest = { workspace = true, features = ["json"] }
 tempfile = { workspace = true }
 tendermint-rpc = { workspace = true, features = ["http-client"] }
 tokio = { workspace = true, features = ["test-util"] }
@@ -88,9 +87,16 @@ tokio-stream = { workspace = true, features = ["net"] }
 wiremock = { workspace = true }
 
 assert-json-diff = "2.0.2"
+http = "0.2.7"
+isahc = { version = "1.7.2", features = ["json"] }
 tower = { version = "0.4.13" }
 tokio-test.workspace = true
 rand_chacha = "0.3.1"
 
 [build-dependencies]
 astria-build-info = { path = "../astria-build-info", features = ["build"] }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+  'cfg(dylint_lib, values("tracing_debug_field"))',
+] }

--- a/crates/astria-sequencer-relayer/tests/blackbox/main.rs
+++ b/crates/astria-sequencer-relayer/tests/blackbox/main.rs
@@ -12,7 +12,7 @@ use helpers::{
     SequencerBlockToMount,
     TestSequencerRelayerConfig,
 };
-use reqwest::StatusCode;
+use http::StatusCode;
 use tendermint::account::Id as AccountId;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/crates/astria-sequencer-relayer/tests/blackbox/main.rs
+++ b/crates/astria-sequencer-relayer/tests/blackbox/main.rs
@@ -273,7 +273,7 @@ async fn should_filter_rollup() {
         .await;
     sequencer_relayer
         .timeout_ms(
-            2_000,
+            10_000,
             "waiting for get tx guard",
             get_tx_guard.wait_until_satisfied(),
         )


### PR DESCRIPTION
## Summary
This is a straight swap of [`isahc`](https://github.com/sagebind/isahc) in place of `reqwest` in the relayer's blackbox tests.  Other than a single timeout being increased, no logic was changed.

## Background
Blackbox tests were failing on macOS due to the poor performance of the `reqwest` messages.  The timeout for a `GET` was set to 100ms, and using `reqwest` I was seeing times around 120ms.  By swapping to `isahc`, times dropped to 2ms.

## Changes
- Swapped `isahc` in place of `reqwest` in the realyer's blackbox tests.
- Increased the timeout on a flaky test from 2s to 10s (the test occasionally takes just over 2s, less than 3s from several attempts locally).
- Added `[lints.rust]` to the relayer's manifest to squash some warnings.

## Testing
No new tests required, existing ones now pass on macOS.

## Related Issues
Closes #1354.
