### PR TITLE
fix(ci): enable bridge withdrawer building with tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
     with:
       package-name: 'conductor'
       tag: ${{ inputs.tag }}
-  
+
   composer:
     uses: './.github/workflows/reusable-build.yml'
     with:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -49,7 +49,7 @@ jobs:
     with:
       depot-project-id: mhgvgvsjnx
       package-name: composer
-      target-binary: astria-composer
+      binary-name: composer
       tag: ${{ inputs.tag }}
     secrets: inherit
 
@@ -64,7 +64,7 @@ jobs:
     with:
       depot-project-id: zrh9t1d84s
       package-name: conductor
-      target-binary: astria-conductor
+      binary-name: conductor
       tag: ${{ inputs.tag }}
     secrets: inherit
 
@@ -79,7 +79,7 @@ jobs:
     with:
       depot-project-id: brzhxfbv9b
       package-name: sequencer
-      target-binary: astria-sequencer
+      binary-name: sequencer
       tag: ${{ inputs.tag }}
     secrets: inherit
 
@@ -94,7 +94,7 @@ jobs:
     with:
       depot-project-id: 86q4kz4wfs
       package-name: sequencer-relayer
-      target-binary: astria-sequencer-relayer
+      binary-name: sequencer-relayer
       tag: ${{ inputs.tag }}
     secrets: inherit
 
@@ -109,7 +109,7 @@ jobs:
     with:
       depot-project-id: dl81f3fc6x
       package-name: evm-bridge-withdrawer
-      target-binary: astria-bridge-withdrawer
+      binary-name: bridge-withdrawer
       tag: ${{ inputs.tag }}
     secrets: inherit
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,6 @@ jobs:
     uses: ./.github/workflows/reusable-release-cargo.yml
     with:
       package-name: 'conductor'
-      target-binary: 'astria-conductor'
       display-name: 'Conductor'
 
   composer:
@@ -81,7 +80,6 @@ jobs:
     uses: ./.github/workflows/reusable-release-cargo.yml
     with:
       package-name: 'composer'
-      target-binary: 'astria-composer'
       display-name: 'Composer'
 
   sequencer:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,7 @@ jobs:
     uses: ./.github/workflows/reusable-release-cargo.yml
     with:
       package-name: 'conductor'
+      target-binary: 'astria-conductor'
       display-name: 'Conductor'
 
   composer:
@@ -80,6 +81,7 @@ jobs:
     uses: ./.github/workflows/reusable-release-cargo.yml
     with:
       package-name: 'composer'
+      target-binary: 'astria-composer'
       display-name: 'Composer'
 
   sequencer:

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -9,9 +9,12 @@ on:
       package-name:
         required: true
         type: string
-      target-binary:
+      binary-name:
         required: true
         type: string
+      binary-prefix:
+        type: string
+        default: astria
       tag:
         required: false
         type: string
@@ -23,7 +26,7 @@ on:
 env:
   REGISTRY: ghcr.io
   FULL_REF: ${{ inputs.tag && format('refs/tags/{0}', inputs.tag) || github.ref }}
-
+  FULL_BINARY_NAME: ${{ inputs.binary-prefix }}-${{ inputs.binary-name }}
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
@@ -31,7 +34,7 @@ jobs:
       contents: read
       id-token: write
       packages: write
-    if: startsWith(inputs.tag, inputs.package-name) || !inputs.tag && (startsWith(github.ref, format('refs/tags/{0}-v', inputs.package-name)) || github.ref == 'refs/heads/main' || github.event_name == 'pull_request' || github.event_name == 'merge_group')
+    if: startsWith(inputs.tag, inputs.binary-name) || !inputs.tag && (startsWith(github.ref, format('refs/tags/{0}-v', inputs.binary-name)) || github.ref == 'refs/heads/main' || github.event_name == 'pull_request' || github.event_name == 'merge_group')
     steps:
       # Checking out the repo
       - uses: actions/checkout@v4
@@ -72,7 +75,7 @@ jobs:
           context: .
           file: containerfiles/Dockerfile
           build-args: |
-            TARGETBINARY=${{ inputs.target-binary }}
+            TARGETBINARY=${{ env.FULL_BINARY_NAME }}
           platforms: "linux/amd64,linux/arm64"
           push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'astriaorg/astria' }}
           tags: ${{ steps.metadata.outputs.tags }}

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -62,7 +62,7 @@ jobs:
           images: ${{ format('ghcr.io/astriaorg/{0}', inputs.package-name) }}
           tags: |
             type=ref,event=pr
-            type=match,pattern=refs/tags/${{ inputs.package-name }}-v(.*),group=1,enable=${{ startsWith(env.FULL_REF, 'refs/tags/') }},value=${{ env.FULL_REF }}
+            type=match,pattern=refs/tags/${{ inputs.binary-name }}-v(.*),group=1,enable=${{ startsWith(env.FULL_REF, 'refs/tags/') }},value=${{ env.FULL_REF }}
             type=sha
             # set latest tag for `main` branch
             type=raw,value=latest,enable=${{ env.FULL_REF == format('refs/heads/{0}', 'main') }}


### PR DESCRIPTION
## Summary
Updates the image build to work on a specific tag when binary name and image name don't match

## Background
The `astria-bridge-withdrawer` binary is pushed to an `evm-bridge-withdrawer` docker package and the tag used is `bridge-withdrawer-v<semantic version>` for releases. This is potentially suboptimal but has already been done. Our image build script doesn't work with this setup.

## Changes
- update image build to consider `binary-name` without `astria` prefix and take a separate `package-name` for most instances these are the same but for when they are not it supports it. There is also a `binary-prefix` which can be set to provide more flexibility for the future.

## Testing
CI/CD tests

## Related Issues

closes https://github.com/astriaorg/astria/issues/1373
