### PR TITLE
chore(sequencer-relayer): Add instrumentation

### DIFF
--- a/crates/astria-sequencer-relayer/src/api.rs
+++ b/crates/astria-sequencer-relayer/src/api.rs
@@ -20,6 +20,7 @@ use http::status::StatusCode;
 use hyper::server::conn::AddrIncoming;
 use serde::Serialize;
 use tokio::sync::watch;
+use tracing::instrument;
 
 use crate::relayer;
 
@@ -51,6 +52,7 @@ pub(crate) fn start(socket_addr: SocketAddr, relayer_state: RelayerState) -> Api
 }
 
 #[allow(clippy::unused_async)] // Permit because axum handlers must be async
+#[instrument(skip_all)]
 async fn get_healthz(State(relayer_state): State<RelayerState>) -> Healthz {
     if relayer_state.borrow().is_healthy() {
         Healthz::Ok
@@ -66,6 +68,7 @@ async fn get_healthz(State(relayer_state): State<RelayerState>) -> Healthz {
 /// + there is a current sequencer height (implying a block from sequencer was received)
 /// + there is a current data availability height (implying a height was received from the DA)
 #[allow(clippy::unused_async)] // Permit because axum handlers must be async
+#[instrument(skip_all)]
 async fn get_readyz(State(relayer_state): State<RelayerState>) -> Readyz {
     let is_relayer_online = relayer_state.borrow().is_ready();
     if is_relayer_online {
@@ -76,6 +79,7 @@ async fn get_readyz(State(relayer_state): State<RelayerState>) -> Readyz {
 }
 
 #[allow(clippy::unused_async)] // Permit because axum handlers must be async
+#[instrument(skip_all)]
 async fn get_status(State(relayer_state): State<RelayerState>) -> Json<relayer::StateSnapshot> {
     Json(*relayer_state.borrow())
 }

--- a/crates/astria-sequencer-relayer/src/relayer/celestia_client/builder.rs
+++ b/crates/astria-sequencer-relayer/src/relayer/celestia_client/builder.rs
@@ -19,6 +19,7 @@ use tonic::transport::{
 };
 use tracing::{
     info,
+    instrument,
     trace,
 };
 
@@ -98,6 +99,7 @@ impl Builder {
     }
 
     /// Returns a new `CelestiaClient` initialized with info retrieved from the Celestia app.
+    #[instrument(skip_all, err)]
     pub(in crate::relayer) async fn try_build(self) -> Result<CelestiaClient, BuilderError> {
         let received_celestia_chain_id = self.fetch_celestia_chain_id().await?;
 
@@ -129,6 +131,7 @@ impl Builder {
         })
     }
 
+    #[instrument(skip_all, err)]
     async fn fetch_celestia_chain_id(&self) -> Result<String, BuilderError> {
         let mut node_info_client = NodeInfoClient::new(self.grpc_channel.clone());
         let response = node_info_client.get_node_info(GetNodeInfoRequest {}).await;

--- a/crates/astria-sequencer-relayer/src/relayer/mod.rs
+++ b/crates/astria-sequencer-relayer/src/relayer/mod.rs
@@ -234,7 +234,7 @@ impl Relayer {
     }
 
     #[instrument(skip_all)]
-    fn latest_height_stream_handler(
+    fn handle_latest_height(
         &self,
         res: Result<SequencerHeight, Error>,
         block_stream: &mut read::BlockStream,
@@ -259,7 +259,7 @@ impl Relayer {
     }
 
     #[instrument(skip_all)]
-    async fn submitter_shutdown_handler(&self, submitter_task: Fuse<JoinHandle<eyre::Result<()>>>) {
+    async fn handle_submitter_shutdown(&self, submitter_task: Fuse<JoinHandle<eyre::Result<()>>>) {
         if !submitter_task.is_terminated() {
             debug!("waiting for Celestia submission task to exit");
             self.submitter_shutdown_token.cancel();

--- a/crates/astria-sequencer-relayer/src/relayer/mod.rs
+++ b/crates/astria-sequencer-relayer/src/relayer/mod.rs
@@ -25,7 +25,10 @@ use futures::{
 };
 use sequencer_client::{
     tendermint::block::Height as SequencerHeight,
-    tendermint_rpc,
+    tendermint_rpc::{
+        self,
+        Error,
+    },
     HttpClient as SequencerClient,
 };
 use tokio::{
@@ -41,12 +44,14 @@ use tokio_util::sync::CancellationToken;
 use tonic::transport::Channel;
 use tracing::{
     debug,
+    debug_span,
     error,
     info,
     instrument,
     trace,
     warn,
     Instrument,
+    Level,
     Span,
 };
 
@@ -123,7 +128,6 @@ impl Relayer {
     ///
     /// Returns errors if sequencer block fetch or celestia blob submission
     /// failed catastrophically (after `u32::MAX` retries).
-    #[instrument(skip_all)]
     pub(crate) async fn run(self) -> eyre::Result<()> {
         // No need to add `wrap_err` as `new_from_path` already reports the path on error.
         let submission_state_at_startup =
@@ -175,7 +179,6 @@ impl Relayer {
                 biased;
 
                 () = self.relayer_shutdown_token.cancelled() => {
-                    info!("received shutdown signal");
                     break Ok("shutdown signal received");
                 }
 
@@ -188,25 +191,11 @@ impl Relayer {
                         break Err(eyre!("submitter exited unexpectedly while trying to forward block"));
                     }
                     block_stream.resume();
-                    debug!("block stream resumed");
+                    debug_span!("sequencer-relayer::Relayer::run").in_scope(|| debug!("block stream resumed"));
                 }
 
                 Some(res) = latest_height_stream.next() => {
-                    match res {
-                        Ok(height) => {
-                            self.state.set_latest_observed_sequencer_height(height.value());
-                            debug!(%height, "received latest height from sequencer");
-                            block_stream.set_latest_sequencer_height(height);
-                        }
-                        Err(error) => {
-                            self.metrics.increment_sequencer_height_fetch_failure_count();
-                            self.state.set_sequencer_connected(false);
-                            warn!(
-                                %error,
-                                "failed fetching latest height from sequencer; waiting until next tick",
-                            );
-                        }
-                    }
+                    self.latest_height_stream_handler(res, &mut block_stream);
                 }
 
                 Some((height, fetch_result)) = block_stream.next() => {
@@ -237,11 +226,40 @@ impl Relayer {
             );
         };
 
-        match &reason {
-            Ok(reason) => info!(reason, "starting shutdown"),
-            Err(reason) => error!(%reason, "starting shutdown"),
-        }
+        report_shutdown(&reason);
 
+        self.submitter_shutdown_handler(submitter_task).await;
+
+        reason.map(|_| ())
+    }
+
+    #[instrument(skip_all)]
+    fn latest_height_stream_handler(
+        &self,
+        res: Result<SequencerHeight, Error>,
+        block_stream: &mut read::BlockStream,
+    ) {
+        match res {
+            Ok(height) => {
+                self.state
+                    .set_latest_observed_sequencer_height(height.value());
+                debug!(%height, "received latest height from sequencer");
+                block_stream.set_latest_sequencer_height(height);
+            }
+            Err(error) => {
+                self.metrics
+                    .increment_sequencer_height_fetch_failure_count();
+                self.state.set_sequencer_connected(false);
+                warn!(
+                    %error,
+                    "failed fetching latest height from sequencer; waiting until next tick",
+                );
+            }
+        }
+    }
+
+    #[instrument(skip_all)]
+    async fn submitter_shutdown_handler(&self, submitter_task: Fuse<JoinHandle<eyre::Result<()>>>) {
         if !submitter_task.is_terminated() {
             debug!("waiting for Celestia submission task to exit");
             self.submitter_shutdown_token.cancel();
@@ -252,8 +270,6 @@ impl Relayer {
                 );
             }
         }
-
-        reason.map(|_| ())
     }
 
     #[instrument(skip_all, fields(%height))]
@@ -294,7 +310,7 @@ impl Relayer {
     }
 }
 
-#[instrument(skip_all)]
+#[instrument(skip_all, err)]
 async fn confirm_sequencer_chain_id(
     configured_sequencer_chain_id: String,
     sequencer_cometbft_client: SequencerClient,
@@ -336,6 +352,7 @@ async fn confirm_sequencer_chain_id(
     Ok(())
 }
 
+#[instrument(skip_all, err(level = Level::WARN))]
 async fn fetch_sequencer_chain_id(
     sequencer_cometbft_client: SequencerClient,
 ) -> Result<String, tendermint_rpc::Error> {
@@ -370,4 +387,12 @@ fn spawn_submitter(
         metrics,
     );
     (tokio::spawn(submitter.run()).fuse(), handle)
+}
+
+#[instrument(skip_all)]
+fn report_shutdown(reason: &eyre::Result<&str>) {
+    match reason {
+        Ok(reason) => info!(reason, "starting shutdown"),
+        Err(reason) => error!(%reason, "starting shutdown"),
+    }
 }

--- a/crates/astria-sequencer-relayer/src/relayer/mod.rs
+++ b/crates/astria-sequencer-relayer/src/relayer/mod.rs
@@ -195,7 +195,7 @@ impl Relayer {
                 }
 
                 Some(res) = latest_height_stream.next() => {
-                    self.latest_height_stream_handler(res, &mut block_stream);
+                    self.handle_latest_height(res, &mut block_stream);
                 }
 
                 Some((height, fetch_result)) = block_stream.next() => {
@@ -228,7 +228,7 @@ impl Relayer {
 
         report_shutdown(&reason);
 
-        self.submitter_shutdown_handler(submitter_task).await;
+        self.handle_submitter_shutdown(submitter_task).await;
 
         reason.map(|_| ())
     }

--- a/crates/astria-sequencer-relayer/src/relayer/read.rs
+++ b/crates/astria-sequencer-relayer/src/relayer/read.rs
@@ -183,7 +183,7 @@ impl Stream for BlockStream {
 ///
 /// If fetching the block fails, then a new fetch is scheduled with exponential backoff,
 /// up to a maximum of `block_time` duration between subsequent requests.
-#[instrument(skip_all, fields(%height))]
+#[instrument(skip_all, fields(%height), err)]
 async fn fetch_block(
     client: SequencerServiceClient<tonic::transport::Channel>,
     height: Height,

--- a/crates/astria-sequencer-relayer/src/relayer/write/mod.rs
+++ b/crates/astria-sequencer-relayer/src/relayer/write/mod.rs
@@ -600,6 +600,7 @@ async fn try_confirm_submission_from_failed_attempt(
 
 type OngoingSubmission =
     Fuse<Pin<Box<dyn Future<Output = Result<StartedSubmission, Report>> + Send>>>;
+
 #[instrument(skip_all)]
 async fn ongoing_submission_termination(ongoing_submission: OngoingSubmission) {
     if ongoing_submission.is_terminated() {

--- a/crates/astria-sequencer-relayer/src/relayer/write/mod.rs
+++ b/crates/astria-sequencer-relayer/src/relayer/write/mod.rs
@@ -9,6 +9,8 @@
 //! another task sends sequencer blocks ordered by their heights, then
 //! they will be written in that order.
 use std::{
+    future::Future,
+    pin::Pin,
     sync::Arc,
     time::Duration,
 };
@@ -16,6 +18,7 @@ use std::{
 use astria_eyre::eyre::{
     self,
     bail,
+    eyre,
     Report,
     WrapErr as _,
 };
@@ -48,9 +51,11 @@ use tracing::{
     debug,
     error,
     info,
+    info_span,
     instrument,
     warn,
     Instrument,
+    Level,
     Span,
 };
 
@@ -165,7 +170,7 @@ impl BlobSubmitter {
         );
         let client = init_result.map_err(|error| {
             let message = "failed to initialize celestia client";
-            error!(%error, message);
+            report_exit(&Err(eyre!(error.to_string())), message);
             error.wrap_err(message)
         })?;
 
@@ -198,7 +203,6 @@ impl BlobSubmitter {
                 biased;
 
                 () = self.submitter_shutdown_token.cancelled() => {
-                    info!("shutdown signal received");
                     break Ok("received shutdown signal");
                 }
 
@@ -242,10 +246,10 @@ impl BlobSubmitter {
                 // add new blocks to the next submission if there is space.
                 Some(block) = self.blocks.recv(), if self.has_capacity() => {
                     if block.height() <= started_submission.last_submission_sequencer_height() {
-                        info!(
+                        info_span!("sequencer-relayer::BlobSubmitter::run").in_scope(|| info!(
                             sequencer_height = %block.height(),
                             "skipping sequencer block as already included in previous submission"
-                        );
+                        ));
                     } else if let Err(error) = self.add_sequencer_block_to_next_submission(block) {
                         break Err(error).wrap_err(
                             "critically failed adding Sequencer block to next submission"
@@ -256,19 +260,10 @@ impl BlobSubmitter {
             );
         };
 
-        match &reason {
-            Ok(reason) => info!(reason, "starting shutdown"),
-            Err(reason) => error!(%reason, "starting shutdown"),
-        }
+        report_exit(&reason, "shutting down");
 
-        if ongoing_submission.is_terminated() {
-            info!("no submissions to Celestia were in flight, exiting now");
-        } else {
-            info!("a submission to Celestia is in flight; waiting for it to finish");
-            if let Err(error) = ongoing_submission.await {
-                error!(%error, "last submission to Celestia failed before exiting");
-            }
-        }
+        ongoing_submission_termination(ongoing_submission).await;
+
         reason.map(|_| ())
     }
 
@@ -309,7 +304,7 @@ impl BlobSubmitter {
 /// guaranteed to be in `Started` state, either holding the heights of the previously prepared
 /// submission if confirmed by Celestia, or holding the heights of the last known confirmed
 /// submission in the case of timing out.
-#[instrument(skip_all)]
+#[instrument(skip_all, err)]
 async fn try_confirm_submission_from_last_session(
     mut client: CelestiaClient,
     prepared_submission: PreparedSubmission,
@@ -401,7 +396,7 @@ async fn submit_blobs(
     Ok(new_state)
 }
 
-#[instrument(skip_all)]
+#[instrument(skip_all, err)]
 async fn init_with_retry(client_builder: CelestiaClientBuilder) -> eyre::Result<CelestiaClient> {
     let span = Span::current();
 
@@ -526,7 +521,7 @@ async fn submit_with_retry(
     Ok(final_state)
 }
 
-#[instrument(skip_all)]
+#[instrument(skip_all, err(level = Level::WARN))]
 async fn try_submit(
     mut client: CelestiaClient,
     blobs: Arc<Vec<Blob>>,
@@ -579,7 +574,7 @@ async fn try_submit(
 ///
 /// This should only be called where submission state is `Prepared`, meaning we don't yet
 /// know whether that previous submission attempt succeeded or not.
-#[instrument(skip_all)]
+#[instrument(skip_all, err)]
 async fn try_confirm_submission_from_failed_attempt(
     mut client: CelestiaClient,
     prepared_submission: PreparedSubmission,
@@ -601,4 +596,26 @@ async fn try_confirm_submission_from_failed_attempt(
 
     info!("previous attempt's last submission was not completed; starting resubmission");
     Ok(None)
+}
+
+type OngoingSubmission =
+    Fuse<Pin<Box<dyn Future<Output = Result<StartedSubmission, Report>> + Send>>>;
+#[instrument(skip_all)]
+async fn ongoing_submission_termination(ongoing_submission: OngoingSubmission) {
+    if ongoing_submission.is_terminated() {
+        info!("no submissions to Celestia were in flight, exiting now");
+    } else {
+        info!("a submission to Celestia is in flight; waiting for it to finish");
+        if let Err(error) = ongoing_submission.await {
+            error!(%error, "last submission to Celestia failed before exiting");
+        }
+    }
+}
+
+#[instrument(skip_all)]
+fn report_exit(reason: &eyre::Result<&str>, message: &str) {
+    match reason {
+        Ok(reason) => info!(reason, message),
+        Err(error) => error!(%error, message),
+    }
 }

--- a/crates/astria-sequencer-relayer/src/sequencer_relayer.rs
+++ b/crates/astria-sequencer-relayer/src/sequencer_relayer.rs
@@ -8,9 +8,18 @@ use astria_eyre::eyre::{
     self,
     WrapErr as _,
 };
+use axum::{
+    routing::IntoMakeService,
+    Router,
+    Server,
+};
+use hyper::server::conn::AddrIncoming;
 use tokio::{
     select,
-    sync::oneshot,
+    sync::oneshot::{
+        self,
+        Receiver,
+    },
     task::{
         JoinError,
         JoinHandle,
@@ -24,6 +33,7 @@ use tokio_util::sync::{
 use tracing::{
     error,
     info,
+    instrument,
 };
 
 use crate::{
@@ -110,18 +120,8 @@ impl SequencerRelayer {
         // Separate the API shutdown signal from the cancellation token because we want it to live
         // until the very end.
         let (api_shutdown_signal, api_shutdown_signal_rx) = oneshot::channel::<()>();
-        let mut api_task = tokio::spawn(async move {
-            api_server
-                .with_graceful_shutdown(async move {
-                    let _ = api_shutdown_signal_rx.await;
-                })
-                .await
-                .wrap_err("api server ended unexpectedly")
-        });
-        info!("spawned API server");
-
-        let mut relayer_task = tokio::spawn(relayer.run());
-        info!("spawned relayer task");
+        let (mut api_task, mut relayer_task) =
+            spawn_tasks(api_server, api_shutdown_signal_rx, relayer);
 
         let shutdown = select!(
             o = &mut api_task => {
@@ -136,6 +136,28 @@ impl SequencerRelayer {
         );
         shutdown.run().await;
     }
+}
+
+#[instrument(skip_all)]
+fn spawn_tasks(
+    api_server: Server<AddrIncoming, IntoMakeService<Router>>,
+    api_shutdown_signal_rx: Receiver<()>,
+    relayer: Relayer,
+) -> (JoinHandle<eyre::Result<()>>, JoinHandle<eyre::Result<()>>) {
+    let api_task = tokio::spawn(async move {
+        api_server
+            .with_graceful_shutdown(async move {
+                let _ = api_shutdown_signal_rx.await;
+            })
+            .await
+            .wrap_err("api server ended unexpectedly")
+    });
+    info!("spawned API server");
+
+    let relayer_task = tokio::spawn(relayer.run());
+    info!("spawned relayer task");
+
+    (api_task, relayer_task)
 }
 
 /// A handle for instructing the [`SequencerRelayer`] to shut down.
@@ -204,6 +226,7 @@ struct ShutDown {
 }
 
 impl ShutDown {
+    #[instrument(skip_all)]
     async fn run(self) {
         let Self {
             api_task,


### PR DESCRIPTION
## Summary
Added instrumentation to `astria-conductor`

## Background
Adding instrumentation to all async calls will aid in tracing since spans will be emitted even if no events happen under them.

## Changes
- Added instrumentation to all async function calls that are not long-lived.
- Removed instrumentation on long-lived functions.
- Minor refactoring of `run()` functions to ensure logging occurs within spans.

## Related Issues
Part of #1321 