### PR TITLE
fix(proto): fix import name mismatch

### DIFF
--- a/crates/astria-bridge-withdrawer/src/bridge_withdrawer/startup.rs
+++ b/crates/astria-bridge-withdrawer/src/bridge_withdrawer/startup.rs
@@ -284,16 +284,16 @@ impl Startup {
         );
 
         let proto_tx =
-            astria_core::generated::protocol::transaction::v1alpha1::SignedTransaction::decode(
+            astria_core::generated::protocol::transactions::v1alpha1::SignedTransaction::decode(
                 &*last_transaction.tx,
             )
             .wrap_err_with(|| format!(
-                            "failed to decode data in Sequencer CometBFT transaction as `{}`",
-                            astria_core::generated::protocol::transaction::v1alpha1::SignedTransaction::full_name(),
+                "failed to decode data in Sequencer CometBFT transaction as `{}`",
+                astria_core::generated::protocol::transactions::v1alpha1::SignedTransaction::full_name(),
                         ))?;
 
         let tx = SignedTransaction::try_from_raw(proto_tx)
-            .wrap_err_with(|| format!("failed to verify {}", astria_core::generated::protocol::transaction::v1alpha1::SignedTransaction::full_name()))?;
+            .wrap_err_with(|| format!("failed to verify {}", astria_core::generated::protocol::transactions::v1alpha1::SignedTransaction::full_name()))?;
 
         info!(
             last_bridge_account_tx.hash = %telemetry::display::hex(&tx_hash),

--- a/crates/astria-bridge-withdrawer/tests/blackbox/helpers/mock_cometbft.rs
+++ b/crates/astria-bridge-withdrawer/tests/blackbox/helpers/mock_cometbft.rs
@@ -341,7 +341,7 @@ fn prepare_broadcast_tx_commit_response(response: tx_commit::Response) -> Mock {
 
 /// Convert a `Request` object to a `SignedTransaction`
 pub fn signed_tx_from_request(request: &wiremock::Request) -> SignedTransaction {
-    use astria_core::generated::protocol::transaction::v1alpha1::SignedTransaction as RawSignedTransaction;
+    use astria_core::generated::protocol::transactions::v1alpha1::SignedTransaction as RawSignedTransaction;
     use prost::Message as _;
 
     let wrapped_tx_sync_req: tendermint_rpc::request::Wrapper<tx_sync::Request> =

--- a/crates/astria-composer/src/executor/tests.rs
+++ b/crates/astria-composer/src/executor/tests.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use astria_core::{
-    generated::protocol::account::v1alpha1::NonceResponse,
+    generated::protocol::accounts::v1alpha1::NonceResponse,
     primitive::v1::{
         RollupId,
         ROLLUP_ID_LEN,
@@ -174,7 +174,7 @@ async fn mount_default_nonce_query_mock(server: &MockServer) -> MockGuard {
 
 /// Convert a `Request` object to a `SignedTransaction`
 fn signed_tx_from_request(request: &Request) -> SignedTransaction {
-    use astria_core::generated::protocol::transaction::v1alpha1::SignedTransaction as RawSignedTransaction;
+    use astria_core::generated::protocol::transactions::v1alpha1::SignedTransaction as RawSignedTransaction;
     use prost::Message as _;
 
     let wrapped_tx_sync_req: request::Wrapper<tx_sync::Request> =

--- a/crates/astria-composer/tests/blackbox/geth_collector.rs
+++ b/crates/astria-composer/tests/blackbox/geth_collector.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use astria_core::{
-    generated::protocol::account::v1alpha1::NonceResponse,
+    generated::protocol::accounts::v1alpha1::NonceResponse,
     primitive::v1::RollupId,
 };
 use ethers::types::Transaction;

--- a/crates/astria-composer/tests/blackbox/grpc_collector.rs
+++ b/crates/astria-composer/tests/blackbox/grpc_collector.rs
@@ -6,7 +6,7 @@ use astria_core::{
             grpc_collector_service_client::GrpcCollectorServiceClient,
             SubmitRollupTransactionRequest,
         },
-        protocol::account::v1alpha1::NonceResponse,
+        protocol::accounts::v1alpha1::NonceResponse,
     },
     primitive::v1::RollupId,
 };

--- a/crates/astria-composer/tests/blackbox/helper/mock_sequencer.rs
+++ b/crates/astria-composer/tests/blackbox/helper/mock_sequencer.rs
@@ -29,7 +29,7 @@ use wiremock::{
 };
 
 pub async fn start() -> (MockServer, MockGuard) {
-    use astria_core::generated::protocol::account::v1alpha1::NonceResponse;
+    use astria_core::generated::protocol::accounts::v1alpha1::NonceResponse;
     let server = MockServer::start().await;
     let startup_guard = mount_abci_query_mock(
         &server,

--- a/crates/astria-composer/tests/blackbox/helper/mod.rs
+++ b/crates/astria-composer/tests/blackbox/helper/mod.rs
@@ -153,7 +153,7 @@ pub async fn loop_until_composer_is_ready(addr: SocketAddr) {
 }
 
 fn signed_tx_from_request(request: &Request) -> SignedTransaction {
-    use astria_core::generated::protocol::transaction::v1alpha1::SignedTransaction as RawSignedTransaction;
+    use astria_core::generated::protocol::transactions::v1alpha1::SignedTransaction as RawSignedTransaction;
     use prost::Message as _;
 
     let wrapped_tx_sync_req: request::Wrapper<tx_sync::Request> =

--- a/crates/astria-core/src/generated/mod.rs
+++ b/crates/astria-core/src/generated/mod.rs
@@ -69,7 +69,7 @@ pub mod primitive {
 #[path = ""]
 pub mod protocol {
     #[path = ""]
-    pub mod account {
+    pub mod accounts {
         #[path = "astria.protocol.accounts.v1alpha1.rs"]
         pub mod v1alpha1;
     }
@@ -96,7 +96,7 @@ pub mod protocol {
         }
     }
     #[path = ""]
-    pub mod transaction {
+    pub mod transactions {
         pub mod v1alpha1 {
             include!("astria.protocol.transactions.v1alpha1.rs");
 

--- a/crates/astria-core/src/protocol/account/mod.rs
+++ b/crates/astria-core/src/protocol/account/mod.rs
@@ -1,3 +1,3 @@
 pub mod v1alpha1;
 
-use crate::generated::protocol::account::v1alpha1 as raw;
+use crate::generated::protocol::accounts::v1alpha1 as raw;

--- a/crates/astria-core/src/protocol/transaction/mod.rs
+++ b/crates/astria-core/src/protocol/transaction/mod.rs
@@ -1,3 +1,3 @@
 pub mod v1alpha1;
 
-use crate::generated::protocol::transaction::v1alpha1 as raw;
+use crate::generated::protocol::transactions::v1alpha1 as raw;

--- a/crates/astria-core/src/sequencerblock/v1alpha1/block.rs
+++ b/crates/astria-core/src/sequencerblock/v1alpha1/block.rs
@@ -727,7 +727,7 @@ impl SequencerBlock {
         let mut rollup_datas = IndexMap::new();
         for elem in data_list {
             let raw_tx =
-                crate::generated::protocol::transaction::v1alpha1::SignedTransaction::decode(
+                crate::generated::protocol::transactions::v1alpha1::SignedTransaction::decode(
                     &*elem,
                 )
                 .map_err(SequencerBlockError::signed_transaction_protobuf_decode)?;

--- a/crates/astria-sequencer-client/src/extension_trait.rs
+++ b/crates/astria-sequencer-client/src/extension_trait.rs
@@ -448,7 +448,7 @@ pub trait SequencerClientExt: Client {
             .map_err(|e| Error::tendermint_rpc("abci_query", e))?;
 
         let proto_response =
-            astria_core::generated::protocol::account::v1alpha1::BalanceResponse::decode(
+            astria_core::generated::protocol::accounts::v1alpha1::BalanceResponse::decode(
                 &*response.value,
             )
             .map_err(|e| {
@@ -530,7 +530,7 @@ pub trait SequencerClientExt: Client {
             .map_err(|e| Error::tendermint_rpc("abci_query", e))?;
 
         let proto_response =
-            astria_core::generated::protocol::account::v1alpha1::NonceResponse::decode(
+            astria_core::generated::protocol::accounts::v1alpha1::NonceResponse::decode(
                 &*response.value,
             )
             .map_err(|e| {
@@ -627,7 +627,7 @@ pub trait SequencerClientExt: Client {
             .map_err(|e| Error::tendermint_rpc("abci_query", e))?;
 
         let proto_response =
-            astria_core::generated::protocol::transaction::v1alpha1::TransactionFeeResponse::decode(
+            astria_core::generated::protocol::transactions::v1alpha1::TransactionFeeResponse::decode(
                 &*response.value,
             )
             .map_err(|e| {

--- a/crates/astria-sequencer-client/src/tests/http.rs
+++ b/crates/astria-sequencer-client/src/tests/http.rs
@@ -163,7 +163,7 @@ fn create_signed_transaction() -> SignedTransaction {
 
 #[tokio::test]
 async fn get_latest_nonce() {
-    use astria_core::generated::protocol::account::v1alpha1::NonceResponse;
+    use astria_core::generated::protocol::accounts::v1alpha1::NonceResponse;
     let MockSequencer {
         server,
         client,
@@ -190,7 +190,7 @@ async fn get_latest_nonce() {
 
 #[tokio::test]
 async fn get_latest_balance() {
-    use astria_core::generated::protocol::account::v1alpha1::{
+    use astria_core::generated::protocol::accounts::v1alpha1::{
         AssetBalance,
         BalanceResponse,
     };
@@ -317,7 +317,7 @@ async fn get_bridge_account_last_transaction_hash() {
 
 #[tokio::test]
 async fn get_transaction_fee() {
-    use astria_core::generated::protocol::transaction::v1alpha1::{
+    use astria_core::generated::protocol::transactions::v1alpha1::{
         TransactionFee,
         TransactionFeeResponse,
     };

--- a/crates/astria-sequencer/src/app/mod.rs
+++ b/crates/astria-sequencer/src/app/mod.rs
@@ -20,7 +20,7 @@ use anyhow::{
     Context,
 };
 use astria_core::{
-    generated::protocol::transaction::v1alpha1 as raw,
+    generated::protocol::transactions::v1alpha1 as raw,
     protocol::{
         abci::AbciErrorCode,
         transaction::v1alpha1::{

--- a/crates/astria-sequencer/src/service/info/mod.rs
+++ b/crates/astria-sequencer/src/service/info/mod.rs
@@ -204,7 +204,7 @@ mod test {
     #[tokio::test]
     async fn handle_balance_query() {
         use astria_core::{
-            generated::protocol::account::v1alpha1 as raw,
+            generated::protocol::accounts::v1alpha1 as raw,
             protocol::account::v1alpha1::AssetBalance,
         };
 

--- a/crates/astria-sequencer/src/service/mempool.rs
+++ b/crates/astria-sequencer/src/service/mempool.rs
@@ -10,7 +10,7 @@ use std::{
 
 use anyhow::Context as _;
 use astria_core::{
-    generated::protocol::transaction::v1alpha1 as raw,
+    generated::protocol::transactions::v1alpha1 as raw,
     protocol::{
         abci::AbciErrorCode,
         transaction::v1alpha1::SignedTransaction,

--- a/crates/astria-sequencer/src/transaction/query.rs
+++ b/crates/astria-sequencer/src/transaction/query.rs
@@ -1,5 +1,5 @@
 use astria_core::{
-    generated::protocol::transaction::v1alpha1::UnsignedTransaction as RawUnsignedTransaction,
+    generated::protocol::transactions::v1alpha1::UnsignedTransaction as RawUnsignedTransaction,
     protocol::{
         abci::AbciErrorCode,
         transaction::v1alpha1::UnsignedTransaction,


### PR DESCRIPTION
## Summary
Updates the generated path names to match the actual proto dependency name.

## Background
Prost makes assumptions on how modules will be imported, where the proto and rust generated code modules match, but does not auto generate the module. We had a mismatch of singular -> plural in two places this resolves that. 

## Changes
- updates generated rust `account` and `transaction` modules to `accounts` and `transactions`

## Testing
test suite
