### PR TITLE
chore(sequencer): init chain from only genesis state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -920,6 +920,8 @@ dependencies = [
  "itertools 0.12.1",
  "predicates",
  "prost",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rlp",
  "serde",
  "serde_json",

--- a/crates/astria-core/src/sequencer.rs
+++ b/crates/astria-core/src/sequencer.rs
@@ -1,12 +1,15 @@
 //! Sequencer specific types that are needed outside of it.
 pub use penumbra_ibc::params::IBCParameters;
 
-use crate::primitive::v1::{
-    asset::{
-        self,
-        TracePrefixed,
+use crate::{
+    primitive::v1::{
+        asset::{
+            self,
+            TracePrefixed,
+        },
+        Address,
     },
-    Address,
+    protocol::transaction::v1alpha1::action::ValidatorUpdate,
 };
 
 /// The genesis state of Astria's Sequencer.
@@ -33,6 +36,8 @@ pub struct GenesisState {
     ibc_params: IBCParameters,
     allowed_fee_assets: Vec<asset::Denom>,
     fees: Fees,
+    validators: Vec<ValidatorUpdate>,
+    chain_id: String,
 }
 
 impl GenesisState {
@@ -80,6 +85,16 @@ impl GenesisState {
     pub fn fees(&self) -> &Fees {
         &self.fees
     }
+
+    #[must_use]
+    pub fn validators(&self) -> &Vec<ValidatorUpdate> {
+        &self.validators
+    }
+
+    #[must_use]
+    pub fn chain_id(&self) -> &str {
+        &self.chain_id
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -118,6 +133,8 @@ impl TryFrom<UncheckedGenesisState> for GenesisState {
             ibc_params,
             allowed_fee_assets,
             fees,
+            validators,
+            chain_id,
         } = value;
 
         Ok(Self {
@@ -130,6 +147,8 @@ impl TryFrom<UncheckedGenesisState> for GenesisState {
             ibc_params,
             allowed_fee_assets,
             fees,
+            validators,
+            chain_id,
         })
     }
 }
@@ -147,6 +166,8 @@ pub struct UncheckedGenesisState {
     pub ibc_params: IBCParameters,
     pub allowed_fee_assets: Vec<asset::Denom>,
     pub fees: Fees,
+    pub validators: Vec<ValidatorUpdate>,
+    pub chain_id: String,
 }
 
 impl UncheckedGenesisState {
@@ -197,6 +218,8 @@ impl From<GenesisState> for UncheckedGenesisState {
             ibc_params,
             allowed_fee_assets,
             fees,
+            validators,
+            chain_id,
         } = value;
         Self {
             address_prefixes,
@@ -208,6 +231,8 @@ impl From<GenesisState> for UncheckedGenesisState {
             ibc_params,
             allowed_fee_assets,
             fees,
+            validators,
+            chain_id,
         }
     }
 }
@@ -314,6 +339,8 @@ mod tests {
                 bridge_sudo_change_fee: 24,
                 ics20_withdrawal_base_fee: 24,
             },
+            validators: vec![],
+            chain_id: "astria-test".into(),
         }
     }
 

--- a/crates/astria-core/src/snapshots/astria_core__sequencer__tests__genesis_state_is_unchanged.snap
+++ b/crates/astria-core/src/snapshots/astria_core__sequencer__tests__genesis_state_is_unchanged.snap
@@ -57,5 +57,7 @@ expression: genesis_state()
     "bridge_lock_byte_cost_multiplier": 1,
     "bridge_sudo_change_fee": 24,
     "ics20_withdrawal_base_fee": 24
-  }
+  },
+  "validators": [],
+  "chain_id": "astria-test"
 }

--- a/crates/astria-sequencer-utils/Cargo.toml
+++ b/crates/astria-sequencer-utils/Cargo.toml
@@ -25,6 +25,8 @@ prost = { workspace = true }
 rlp = "0.5.2"
 serde = { workspace = true }
 serde_json = { workspace = true }
+rand = { workspace = true }
+rand_chacha = "0.3.1"
 
 astria-core = { path = "../astria-core", features = ["brotli", "serde"] }
 astria-eyre = { path = "../astria-eyre" }

--- a/crates/astria-sequencer-utils/src/genesis_example.rs
+++ b/crates/astria-sequencer-utils/src/genesis_example.rs
@@ -5,7 +5,12 @@ use std::{
 };
 
 use astria_core::{
+    crypto::{
+        SigningKey,
+        VerificationKey,
+    },
     primitive::v1::Address,
+    protocol::transaction::v1alpha1::action::ValidatorUpdate,
     sequencer::{
         Account,
         AddressPrefixes,
@@ -46,6 +51,13 @@ fn charlie() -> Address {
         .unwrap()
 }
 
+fn verification_key(seed: u64) -> VerificationKey {
+    use rand::SeedableRng as _;
+    let rng = rand_chacha::ChaChaRng::seed_from_u64(seed);
+    let signing_key = SigningKey::new(rng);
+    signing_key.verification_key()
+}
+
 fn genesis_state() -> GenesisState {
     UncheckedGenesisState {
         accounts: vec![
@@ -84,6 +96,17 @@ fn genesis_state() -> GenesisState {
             bridge_sudo_change_fee: 24,
             ics20_withdrawal_base_fee: 24,
         },
+        validators: vec![
+            ValidatorUpdate {
+                power: 1u32,
+                verification_key: verification_key(0),
+            },
+            ValidatorUpdate {
+                power: 1u32,
+                verification_key: verification_key(1),
+            },
+        ],
+        chain_id: "test".to_string(),
     }
     .try_into()
     .unwrap()

--- a/crates/astria-sequencer/src/app/test_utils.rs
+++ b/crates/astria-sequencer/src/app/test_utils.rs
@@ -4,10 +4,7 @@ use astria_core::{
     crypto::SigningKey,
     primitive::v1::RollupId,
     protocol::transaction::v1alpha1::{
-        action::{
-            SequenceAction,
-            ValidatorUpdate,
-        },
+        action::SequenceAction,
         SignedTransaction,
         TransactionParams,
         UnsignedTransaction,
@@ -98,6 +95,8 @@ pub(crate) fn unchecked_genesis_state() -> UncheckedGenesisState {
         ibc_params: IBCParameters::default(),
         allowed_fee_assets: vec![crate::test_utils::nria().into()],
         fees: default_fees(),
+        validators: vec![],
+        chain_id: "test".to_string(),
     }
 }
 
@@ -107,7 +106,6 @@ pub(crate) fn genesis_state() -> GenesisState {
 
 pub(crate) async fn initialize_app_with_storage(
     genesis_state: Option<GenesisState>,
-    genesis_validators: Vec<ValidatorUpdate>,
 ) -> (App, Storage) {
     let storage = cnidarium::TempStorage::new()
         .await
@@ -119,24 +117,16 @@ pub(crate) async fn initialize_app_with_storage(
 
     let genesis_state = genesis_state.unwrap_or_else(self::genesis_state);
 
-    app.init_chain(
-        storage.clone(),
-        genesis_state,
-        genesis_validators,
-        "test".to_string(),
-    )
-    .await
-    .unwrap();
+    app.init_chain(storage.clone(), genesis_state)
+        .await
+        .unwrap();
     app.commit(storage.clone()).await;
 
     (app, storage.clone())
 }
 
-pub(crate) async fn initialize_app(
-    genesis_state: Option<GenesisState>,
-    genesis_validators: Vec<ValidatorUpdate>,
-) -> App {
-    let (app, _storage) = initialize_app_with_storage(genesis_state, genesis_validators).await;
+pub(crate) async fn initialize_app(genesis_state: Option<GenesisState>) -> App {
+    let (app, _storage) = initialize_app_with_storage(genesis_state).await;
     app
 }
 

--- a/crates/astria-sequencer/src/app/tests_breaking_changes.rs
+++ b/crates/astria-sequencer/src/app/tests_breaking_changes.rs
@@ -89,19 +89,21 @@ fn unchecked_genesis_state() -> UncheckedGenesisState {
         ibc_params: IBCParameters::default(),
         allowed_fee_assets: vec![nria().into()],
         fees: default_fees(),
+        validators: vec![],
+        chain_id: "test".to_string(),
     }
 }
 
 #[tokio::test]
 async fn app_genesis_snapshot() {
-    let app = initialize_app(None, vec![]).await;
+    let app = initialize_app(None).await;
     insta::assert_json_snapshot!(app.app_hash.as_bytes());
 }
 
 #[tokio::test]
 async fn app_finalize_block_snapshot() {
     let alice = get_alice_signing_key();
-    let (mut app, storage) = initialize_app_with_storage(None, vec![]).await;
+    let (mut app, storage) = initialize_app_with_storage(None).await;
 
     let bridge_address = astria_address(&[99; 20]);
     let rollup_id = RollupId::from_unhashed_bytes(b"testchainid");
@@ -204,7 +206,7 @@ async fn app_execute_transaction_with_every_action_snapshot() {
     }
     .try_into()
     .unwrap();
-    let (mut app, storage) = initialize_app_with_storage(Some(genesis_state), vec![]).await;
+    let (mut app, storage) = initialize_app_with_storage(Some(genesis_state)).await;
 
     // setup for ValidatorUpdate action
     let update = ValidatorUpdate {

--- a/crates/astria-sequencer/src/app/tests_execute_transaction.rs
+++ b/crates/astria-sequencer/src/app/tests_execute_transaction.rs
@@ -73,6 +73,8 @@ fn unchecked_genesis_state() -> UncheckedGenesisState {
         ibc_params: IBCParameters::default(),
         allowed_fee_assets: vec![crate::test_utils::nria().into()],
         fees: default_fees(),
+        validators: vec![],
+        chain_id: "test".to_string(),
     }
 }
 
@@ -86,7 +88,7 @@ fn test_asset() -> asset::Denom {
 
 #[tokio::test]
 async fn app_execute_transaction_transfer() {
-    let mut app = initialize_app(None, vec![]).await;
+    let mut app = initialize_app(None).await;
 
     // transfer funds from Alice to Bob
     let alice = get_alice_signing_key();
@@ -135,7 +137,7 @@ async fn app_execute_transaction_transfer() {
 async fn app_execute_transaction_transfer_not_native_token() {
     use crate::accounts::StateWriteExt as _;
 
-    let mut app = initialize_app(None, vec![]).await;
+    let mut app = initialize_app(None).await;
 
     // create some asset to be transferred and update Alice's balance of it
     let value = 333_333;
@@ -208,7 +210,7 @@ async fn app_execute_transaction_transfer_not_native_token() {
 async fn app_execute_transaction_transfer_balance_too_low_for_fee() {
     use rand::rngs::OsRng;
 
-    let mut app = initialize_app(None, vec![]).await;
+    let mut app = initialize_app(None).await;
 
     // create a new key; will have 0 balance
     let keypair = SigningKey::new(OsRng);
@@ -245,7 +247,7 @@ async fn app_execute_transaction_transfer_balance_too_low_for_fee() {
 async fn app_execute_transaction_sequence() {
     use crate::sequence::StateWriteExt as _;
 
-    let mut app = initialize_app(None, vec![]).await;
+    let mut app = initialize_app(None).await;
     let mut state_tx = StateDelta::new(app.state.clone());
     state_tx.put_sequence_action_base_fee(0);
     state_tx.put_sequence_action_byte_cost_multiplier(1);
@@ -286,7 +288,7 @@ async fn app_execute_transaction_sequence() {
 
 #[tokio::test]
 async fn app_execute_transaction_invalid_fee_asset() {
-    let mut app = initialize_app(None, vec![]).await;
+    let mut app = initialize_app(None).await;
 
     let alice = get_alice_signing_key();
     let data = Bytes::from_static(b"hello world");
@@ -315,7 +317,7 @@ async fn app_execute_transaction_validator_update() {
     let alice = get_alice_signing_key();
     let alice_address = astria_address(&alice.address_bytes());
 
-    let mut app = initialize_app(Some(genesis_state()), vec![]).await;
+    let mut app = initialize_app(Some(genesis_state())).await;
 
     let update = ValidatorUpdate {
         power: 100,
@@ -347,7 +349,7 @@ async fn app_execute_transaction_ibc_relayer_change_addition() {
     let alice = get_alice_signing_key();
     let alice_address = astria_address(&alice.address_bytes());
 
-    let mut app = initialize_app(Some(genesis_state()), vec![]).await;
+    let mut app = initialize_app(Some(genesis_state())).await;
 
     let tx = UnsignedTransaction {
         params: TransactionParams::builder()
@@ -374,7 +376,7 @@ async fn app_execute_transaction_ibc_relayer_change_deletion() {
     }
     .try_into()
     .unwrap();
-    let mut app = initialize_app(Some(genesis_state), vec![]).await;
+    let mut app = initialize_app(Some(genesis_state)).await;
 
     let tx = UnsignedTransaction {
         params: TransactionParams::builder()
@@ -401,7 +403,7 @@ async fn app_execute_transaction_ibc_relayer_change_invalid() {
     }
     .try_into()
     .unwrap();
-    let mut app = initialize_app(Some(genesis_state), vec![]).await;
+    let mut app = initialize_app(Some(genesis_state)).await;
 
     let tx = UnsignedTransaction {
         params: TransactionParams::builder()
@@ -420,7 +422,7 @@ async fn app_execute_transaction_sudo_address_change() {
     let alice = get_alice_signing_key();
     let alice_address = astria_address(&alice.address_bytes());
 
-    let mut app = initialize_app(Some(genesis_state()), vec![]).await;
+    let mut app = initialize_app(Some(genesis_state())).await;
 
     let new_address = astria_address_from_hex_string(BOB_ADDRESS);
 
@@ -455,7 +457,7 @@ async fn app_execute_transaction_sudo_address_change_error() {
     }
     .try_into()
     .unwrap();
-    let mut app = initialize_app(Some(genesis_state), vec![]).await;
+    let mut app = initialize_app(Some(genesis_state)).await;
 
     let tx = UnsignedTransaction {
         params: TransactionParams::builder()
@@ -484,7 +486,7 @@ async fn app_execute_transaction_fee_asset_change_addition() {
     let alice = get_alice_signing_key();
     let alice_address = astria_address(&alice.address_bytes());
 
-    let mut app = initialize_app(Some(genesis_state()), vec![]).await;
+    let mut app = initialize_app(Some(genesis_state())).await;
 
     let tx = UnsignedTransaction {
         params: TransactionParams::builder()
@@ -516,7 +518,7 @@ async fn app_execute_transaction_fee_asset_change_removal() {
     }
     .try_into()
     .unwrap();
-    let mut app = initialize_app(Some(genesis_state), vec![]).await;
+    let mut app = initialize_app(Some(genesis_state)).await;
 
     let tx = UnsignedTransaction {
         params: TransactionParams::builder()
@@ -541,7 +543,7 @@ async fn app_execute_transaction_fee_asset_change_invalid() {
 
     let alice = get_alice_signing_key();
 
-    let mut app = initialize_app(Some(genesis_state()), vec![]).await;
+    let mut app = initialize_app(Some(genesis_state())).await;
 
     let tx = UnsignedTransaction {
         params: TransactionParams::builder()
@@ -570,7 +572,7 @@ async fn app_execute_transaction_init_bridge_account_ok() {
     let alice = get_alice_signing_key();
     let alice_address = astria_address(&alice.address_bytes());
 
-    let mut app = initialize_app(None, vec![]).await;
+    let mut app = initialize_app(None).await;
     let mut state_tx = StateDelta::new(app.state.clone());
     let fee = 12; // arbitrary
     state_tx.put_init_bridge_account_base_fee(fee);
@@ -630,7 +632,7 @@ async fn app_execute_transaction_init_bridge_account_account_already_registered(
     use astria_core::protocol::transaction::v1alpha1::action::InitBridgeAccountAction;
 
     let alice = get_alice_signing_key();
-    let mut app = initialize_app(None, vec![]).await;
+    let mut app = initialize_app(None).await;
 
     let rollup_id = RollupId::from_unhashed_bytes(b"testchainid");
     let action = InitBridgeAccountAction {
@@ -675,7 +677,7 @@ async fn app_execute_transaction_init_bridge_account_account_already_registered(
 async fn app_execute_transaction_bridge_lock_action_ok() {
     let alice = get_alice_signing_key();
     let alice_address = astria_address(&alice.address_bytes());
-    let mut app = initialize_app(None, vec![]).await;
+    let mut app = initialize_app(None).await;
 
     let bridge_address = astria_address(&[99; 20]);
     let rollup_id = RollupId::from_unhashed_bytes(b"testchainid");
@@ -759,7 +761,7 @@ async fn app_execute_transaction_bridge_lock_action_invalid_for_eoa() {
     use astria_core::protocol::transaction::v1alpha1::action::BridgeLockAction;
 
     let alice = get_alice_signing_key();
-    let mut app = initialize_app(None, vec![]).await;
+    let mut app = initialize_app(None).await;
 
     // don't actually register this address as a bridge address
     let bridge_address = astria_address(&[99; 20]);
@@ -786,7 +788,7 @@ async fn app_execute_transaction_bridge_lock_action_invalid_for_eoa() {
 
 #[tokio::test]
 async fn app_execute_transaction_invalid_nonce() {
-    let mut app = initialize_app(None, vec![]).await;
+    let mut app = initialize_app(None).await;
 
     let alice = get_alice_signing_key();
     let alice_address = astria_address(&alice.address_bytes());
@@ -833,7 +835,7 @@ async fn app_execute_transaction_invalid_nonce() {
 
 #[tokio::test]
 async fn app_execute_transaction_invalid_chain_id() {
-    let mut app = initialize_app(None, vec![]).await;
+    let mut app = initialize_app(None).await;
 
     let alice = get_alice_signing_key();
     let alice_address = astria_address(&alice.address_bytes());
@@ -882,7 +884,7 @@ async fn app_execute_transaction_invalid_chain_id() {
 async fn app_stateful_check_fails_insufficient_total_balance() {
     use rand::rngs::OsRng;
 
-    let mut app = initialize_app(None, vec![]).await;
+    let mut app = initialize_app(None).await;
 
     let alice = get_alice_signing_key();
 
@@ -979,7 +981,7 @@ async fn app_execute_transaction_bridge_lock_unlock_action_ok() {
     let alice = get_alice_signing_key();
     let alice_address = astria_address(&alice.address_bytes());
 
-    let mut app = initialize_app(None, vec![]).await;
+    let mut app = initialize_app(None).await;
     let mut state_tx = StateDelta::new(app.state.clone());
 
     let bridge = get_bridge_signing_key();
@@ -1055,7 +1057,7 @@ async fn app_execute_transaction_bridge_lock_unlock_action_ok() {
 
 #[tokio::test]
 async fn transaction_execution_records_fee_event() {
-    let mut app = initialize_app(None, vec![]).await;
+    let mut app = initialize_app(None).await;
 
     // transfer funds from Alice to Bob
     let alice = get_alice_signing_key();


### PR DESCRIPTION
## Summary
Enabled chain to be initialized solely based on the genesis state.

## Background
The Sequencer ABCI consensus service was passing in a chain ID and initial validator set through `init_chain()` in addition to the genesis state. With only the genesis state, it's a closed collection of settings with no need for external input.

## Changes
- Removed `genesis_validators` and `chain_id` as arguments from `init_chain()`.
- Added `validators` and `chain_id` to `GenesisState` and `UncheckedGenesisState`.
- Fixed all the tests which broke as a result.
- Updated example genesis state and snapshot.

## Testing
Passing all tests, snapshot had to be regenerated.

## Related Issues
closes #1348
