### PR TITLE
fix(sequencer): update mempool benchmarks (ENG-733)

### DIFF
--- a/crates/astria-sequencer/src/benchmark_utils.rs
+++ b/crates/astria-sequencer/src/benchmark_utils.rs
@@ -82,11 +82,11 @@ fn sequence_actions() -> Vec<Arc<SignedTransaction>> {
             let (nonce, chain_id) = nonces_and_chain_ids
                 .entry(verification_key)
                 .or_insert_with(|| (0_u32, format!("chain-{}", signing_key.verification_key())));
-            *nonce = (*nonce).wrapping_add(1);
             let params = TransactionParams::builder()
                 .nonce(*nonce)
                 .chain_id(chain_id.as_str())
                 .build();
+            *nonce = (*nonce).wrapping_add(1);
             let sequence_action = SequenceAction {
                 rollup_id: RollupId::new([1; 32]),
                 data: vec![2; 1000].into(),


### PR DESCRIPTION
## Summary
Recent changes to the mempool broke the benchmarks.  This PR fixes that.

## Background
Specifically, the benchmarks tests were failing in two ways: the limit on number of parked txs per account was causing the addition of txs to fail, and the pending nonce was returning `None` in the tests.

This was all due to the current account nonce being provided as 0, but the txs started from nonce 1, meaning they weren't eligible for adding to the pending queue.

## Changes
- Ensure the txs all end up in the pending queue by having the txs start from nonce 0.

## Testing
Ran the benchmark and observed the full suite passing.

## Related Issues
Closes #1384.