### PR TITLE
fix(cli, tests): add force flag to overwrite withdrawal target path

### DIFF
--- a/charts/deploy.just
+++ b/charts/deploy.just
@@ -407,7 +407,8 @@ run-smoke-cli:
     --to-rollup-height $CURRENT_BLOCK \
     --sequencer-asset-to-withdraw nria \
     --bridge-address {{sequencer_bridge_address}} \
-    --output "${withdrawals_dst}"
+    --output "${withdrawals_dst}" \
+    --force
    astria-cli bridge submit-withdrawals \
     --signing-key <(printf "%s" "{{sequencer_bridge_pkey}}") \
     --sequencer-chain-id {{sequencer_chain_id}} \


### PR DESCRIPTION
## Summary
Adds a flag `--force`/`-f` to `astria-cli bridge collect-withdrawals` to overwrite the output target if it exists.

## Background
When running the [smoke CLI test](https://github.com/astriaorg/astria/blob/acff940abd2dd9857e038323ed6eb8aa88016a87/charts/deploy.just#L342-L435) a temporary file is created to pass to `astria-cli bridge collect-withdrawals`, which immediately fails because it refuses to overwrite an existing file. This patch adds a flag to overwrite it.

## Changes
- Add a flag `-f/--force` to the `astria-cli bridge collect-withdrawals` subcommand to overwrite the file passed to it

## Testing
This fixes a broken test.

## Related Issues
Partially addresses https://github.com/astriaorg/astria/issues/1392
