### PR TITLE
fix(test): fail smoke test scripts eagerly if a command fails

### DIFF
--- a/charts/deploy.just
+++ b/charts/deploy.just
@@ -209,6 +209,8 @@ sequencer_bridge_pkey := "dfa7108e38ab71f89f356c72afc38600d5758f11a8c337164713e4
 sequencer_chain_id := "sequencer-test-chain-0"
 init-rollup-bridge rollupName=defaultRollupName evmDestinationAddress=evm_destination_address transferAmount=sequencer_transfer_amount:
   #!/usr/bin/env bash
+  set -e
+
   SEQUENCER_FUNDS_PKEY="934ab488f9e1900f6a08f50605ce1409ca9d95ebdc400dafc2e8a4306419fd52"
   ASSET="nria"
   FEE_ASSET="nria"
@@ -226,7 +228,7 @@ init-rollup-bridge rollupName=defaultRollupName evmDestinationAddress=evm_destin
     --private-key $SEQUENCER_FUNDS_PKEY \
     --sequencer.chain-id {{sequencer_chain_id}} \
     --sequencer-url {{sequencer_rpc_url}} \
-    --fee-asset=$FEE_ASSET --asset=$ASSET || exit 1
+    --fee-asset=$FEE_ASSET --asset=$ASSET
 
 
 init-ibc-bridge privateKey asset feeAsset rollupName=defaultRollupName:
@@ -244,6 +246,8 @@ bridge_tx_bytes := "0xf8f280843c54e7f182898594a58639fb5458e65e4fa917ff951c390292
 bridge_tx_hash := "0x67db5b0825e8f60b926234e209d54e0336cd94defe6720e7acadf871e0377150"
 run-smoke-test:
   #!/usr/bin/env bash
+  set -e
+
   MAX_CHECKS=30
 
   # Checking starting balance
@@ -341,6 +345,8 @@ delete-smoke-test:
 evm_contract_address := "0xA58639fB5458e65E4fA917FF951C390292C24A15"
 run-smoke-cli:
   #!/usr/bin/env bash
+  set -e
+
   MAX_CHECKS=30
 
   # Checking starting balance

--- a/charts/ibc-test.just
+++ b/charts/ibc-test.just
@@ -34,6 +34,7 @@ delete:
 [no-cd]
 run:
   #!/usr/bin/env bash
+  set -e
 
   initial_balance=$(just evm-get-balance {{evm_destination_address}})
 


### PR DESCRIPTION
## Summary
Fail smoke tests eagerly if one command fails.

## Background
Smoke test scripts kept executing even though some of their commands failed. This patch uses the bash built-in `set -e` to immediately exit tests with non-zero exit code.

## Changes
- Use `set -e` in all smoke tests.

## Testing
This correctly fails tests if the conditions don't apply (tested offline and verified in CI).

## Related Issues
Partially addresses https://github.com/astriaorg/astria/issues/1392.
This patch will fail CI until after https://github.com/astriaorg/astria/pull/1393 is merged.
