### PR TITLE
fix(test): use correct conditions to dermine smoke test success

### DIFF
--- a/charts/deploy.just
+++ b/charts/deploy.just
@@ -257,7 +257,7 @@ run-smoke-test:
   just init rollup-bridge
   CHECKS=0
   EXPECTED_BALANCE=$(echo "{{sequencer_transfer_amount}} * {{sequencer_base_amount}} * {{rollup_multiplier}}" | bc)
-  while [ $CHECKS -lt $MAX_CHECKS ]; do
+  while (( $CHECKS < $MAX_CHECKS )); do
     CHECKS=$((CHECKS+1))
     BALANCE=$(just evm-get-balance {{evm_destination_address}})
     echo "Check $CHECKS, Balance: $BALANCE, Expected: $EXPECTED_BALANCE"
@@ -268,7 +268,7 @@ run-smoke-test:
       sleep 1
     fi
   done
-  if [ $CHECKS -eq $MAX_CHECKS ]; then
+  if (( $CHECKS >= $MAX_CHECKS )); then
     echo "Bridge In failure"
     exit 1
   fi
@@ -278,7 +278,7 @@ run-smoke-test:
   TRANSFERED_BALANCE=$(echo "1 * {{sequencer_base_amount}} * {{rollup_multiplier}}" | bc)
   EXPECTED_BALANCE=$(echo "$EXPECTED_BALANCE - $TRANSFERED_BALANCE" | bc)
   CHECKS=0
-  while [ $CHECKS -lt $MAX_CHECKS ]; do
+  while (( $CHECKS < $MAX_CHECKS )); do
     CHECKS=$((CHECKS+1))
     BALANCE=$(just evm-get-balance {{evm_destination_address}})
     echo "Check $CHECKS, Balance: $BALANCE, Expected: $EXPECTED_BALANCE"
@@ -289,13 +289,13 @@ run-smoke-test:
       sleep 1
     fi
   done
-  if [ $CHECKS -eq $MAX_CHECKS ]; then
+  if (( $CHECKS >= $MAX_CHECKS )); then
     echo "Bridge Out EVM failure"
     exit 1
   fi
   CHECKS=0
   EXPECTED_BALANCE=$(echo "1 * {{sequencer_base_amount}}" | bc)
-  while [ $CHECKS -lt $MAX_CHECKS ]; do
+  while (( $CHECKS < $MAX_CHECKS )); do
     CHECKS=$((CHECKS+1))
     BALANCE=$(astria-cli sequencer account balance astria17w0adeg64ky0daxwd2ugyuneellmjgnxl39504 --sequencer-url {{sequencer_rpc_url}}  | awk '/nria/{print $(NF-1)}')
     echo "Check $CHECKS, Balance: $BALANCE, Expected: $EXPECTED_BALANCE"
@@ -306,7 +306,7 @@ run-smoke-test:
       sleep 1
     fi
   done
-  if [ $CHECKS -gt $MAX_CHECKS ]; then
+  if (( $CHECKS >= $MAX_CHECKS )); then
     echo "Bridge Out Sequencer failure"
     exit 1
   fi
@@ -315,7 +315,7 @@ run-smoke-test:
   CHECKS=0
   BLOCK_NUM_HEX=$(just evm-get-transaction-receipt {{bridge_tx_hash}} | jq -r '.blockNumber')
   BLOCK_NUM=$(just hex-to-dec $BLOCK_NUM_HEX)
-  while [ $CHECKS -lt $MAX_CHECKS ]; do
+  while (( $CHECKS < $MAX_CHECKS )); do
     CHECKS=$((CHECKS+1))
     FINALIZED_BLOCK=$(just evm-get-block-by-number finalized | jq -r '.number')
     FINALIZED_BLOCK=$(just hex-to-dec $FINALIZED_BLOCK)
@@ -327,7 +327,7 @@ run-smoke-test:
       sleep 1
     fi
   done
-  if [ $CHECKS -gt $MAX_CHECKS ]; then
+  if (( $CHECKS >= $MAX_CHECKS )); then
     echo "Finalization failure"
     exit 1
   fi
@@ -354,7 +354,7 @@ run-smoke-cli:
   just init rollup-bridge
   CHECKS=0
   EXPECTED_BALANCE=$(echo "{{sequencer_transfer_amount}} * {{sequencer_base_amount}} * {{rollup_multiplier}}" | bc)
-  while [ $CHECKS -lt $MAX_CHECKS ]; do
+  while (( $CHECKS < $MAX_CHECKS )); do
     CHECKS=$((CHECKS+1))
     BALANCE=$(just evm-get-balance {{evm_destination_address}})
     echo "Check $CHECKS, Balance: $BALANCE, Expected: $EXPECTED_BALANCE"
@@ -365,7 +365,7 @@ run-smoke-cli:
       sleep 1
     fi
   done
-  if [ $CHECKS -eq $MAX_CHECKS ]; then
+  if (( $CHECKS >= $MAX_CHECKS )); then
     echo "Bridge In failure"
     exit 1
   fi
@@ -375,7 +375,7 @@ run-smoke-cli:
   TRANSFERED_BALANCE=$(echo "1 * {{sequencer_base_amount}} * {{rollup_multiplier}}" | bc)
   EXPECTED_BALANCE=$(echo "$EXPECTED_BALANCE - $TRANSFERED_BALANCE" | bc)
   CHECKS=0
-  while [ $CHECKS -lt $MAX_CHECKS ]; do
+  while (( $CHECKS < $MAX_CHECKS )); do
     CHECKS=$((CHECKS+1))
     BALANCE=$(just evm-get-balance {{evm_destination_address}})
     echo "Check $CHECKS, Balance: $BALANCE, Expected: $EXPECTED_BALANCE"
@@ -386,7 +386,7 @@ run-smoke-cli:
       sleep 1
     fi
   done
-  if [ $CHECKS -eq $MAX_CHECKS ]; then
+  if (( $CHECKS >= $MAX_CHECKS )); then
     echo "Bridge Out EVM failure"
     exit 1
   fi
@@ -416,7 +416,7 @@ run-smoke-cli:
 
   CHECKS=0
   EXPECTED_BALANCE=$(echo "1 * {{sequencer_base_amount}}" | bc)
-  while [ $CHECKS -lt $MAX_CHECKS ]; do
+  while (( $CHECKS < $MAX_CHECKS )); do
     CHECKS=$((CHECKS+1))
     BALANCE=$(astria-cli sequencer account balance astria17w0adeg64ky0daxwd2ugyuneellmjgnxl39504 --sequencer-url {{sequencer_rpc_url}}  | awk '/nria/{print $(NF-1)}')
     echo "Check $CHECKS, Balance: $BALANCE, Expected: $EXPECTED_BALANCE"
@@ -427,7 +427,7 @@ run-smoke-cli:
       sleep 1
     fi
   done
-  if [ $CHECKS -gt $MAX_CHECKS ]; then
+  if (( $CHECKS >= $MAX_CHECKS )); then
     echo "Bridge Out Sequencer failure"
     exit 1
   fi


### PR DESCRIPTION
## Summary
Fixes the conditionals that determine whether a smoke test passes.

## Background
Many smoke tests incremented a fetch-counter as long as it was `counter < max`, but the test was for `counter > max`, which was never reached, and hence the test passed succesfully even though it actually failed. This was easily overlooked because so far the tests make use of the posix-compatible `[ $counter -lt $max_counter ]` and `[ $counter -gt $max_counter]`. But since all tests require bash this patch changes it to use `(( ))`.

## Changes
- Change all smoke test scripts to use the the bashism `(( $counter < $max_counter ))` for incrementing the counter, and `(( $counter >= $max_counter ))` to check for failure.

## Testing
This correctly fails tests if the conditions don't apply (tested offline and verified in CI).

## Related Issues
Partially addresses https://github.com/astriaorg/astria/issues/1392.
This patch will fail CI until after https://github.com/astriaorg/astria/pull/1393 is merged.