### PR TITLE
fix(ci): use rust 1.76.0 to run clippy tests

### DIFF
--- a/.github/workflows/reusable-run-checker.yml
+++ b/.github/workflows/reusable-run-checker.yml
@@ -17,7 +17,7 @@ on:
         value: ${{ github.event_name != 'pull_request' || jobs.changes.outputs.lint_workflow == 'true' || jobs.changes.outputs.proto == 'true' }}
       run_lint_rust:
         description: If lint for rust needs to be run, will be 'true'
-        value: ${{ github.event_name != 'pull_request' || jobs.changes.outputs.lint_workflow == 'true' || jobs.changes.outputs.rust == 'true' || jobs.changes.outputs.rustfmt == 'true' }}
+        value: ${{ github.event_name != 'pull_request' || jobs.changes.outputs.lint_workflow == 'true' || jobs.changes.outputs.rust == 'true' || jobs.changes.outputs.rustfmt == 'true' || jobs.changes.output.test_workflow == 'true' }}
       run_lint_toml:
         description: If lint for toml needs to be run, will be 'true'
         value: ${{ github.event_name != 'pull_request' || jobs.changes.outputs.lint_workflow == 'true' || jobs.changes.outputs.toml == 'true' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -198,7 +198,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: 'true'
-      - uses: dtolnay/rust-toolchain@1.78.0
+      - uses: dtolnay/rust-toolchain@1.76.0
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2.7.3


### PR DESCRIPTION
## Summary
Changes the clippy CI job to use Rust 1.76.0, matching all other rust versions.

## Background

All rust related jobs must use the same Rust version.

## Related Issues
Closes https://github.com/astriaorg/astria/issues/1396