### PR TITLE
chore: preview environment with astria-geth changes

### DIFF
--- a/charts/evm-rollup/Chart.yaml
+++ b/charts/evm-rollup/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.25.4
+version: 0.25.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/evm-rollup/templates/_helpers.tpl
+++ b/charts/evm-rollup/templates/_helpers.tpl
@@ -52,7 +52,8 @@ The log level represented as a number
 Full image paths for Astria built images
 */}}
 {{- define "rollup.image" -}}
-{{ .Values.images.geth.repo }}:{{ if .Values.global.dev }}{{ .Values.images.geth.devTag }}{{ else }}{{ .Values.images.geth.tag }}{{ end }}
+{{ .Values.images.geth.repo }}:{{ if .Values.images.geth.overrideTag }}{{ .Values.images.geth.overrideTag }}{{ else }}{{ if .Values.global.dev }}{{ .Values.images.geth.devTag }}{{ else }}{{ .Values.images.geth.tag }}{{ end }}
+{{- end }}
 {{- end }}
 {{- define "conductor.image" -}}
 {{ .Values.images.conductor.repo }}:{{ if .Values.global.dev }}{{ .Values.images.conductor.devTag }}{{ else }}{{ .Values.images.conductor.tag }}{{ end }}

--- a/charts/evm-rollup/values.yaml
+++ b/charts/evm-rollup/values.yaml
@@ -11,6 +11,7 @@ images:
     repo: ghcr.io/astriaorg/astria-geth
     tag: 0.13.0
     devTag: latest
+    overrideTag: ""
   conductor:
     repo: ghcr.io/astriaorg/conductor
     tag: "0.18.0"

--- a/charts/evm-stack/Chart.lock
+++ b/charts/evm-stack/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: evm-rollup
   repository: file://../evm-rollup
-  version: 0.25.4
+  version: 0.25.5
 - name: composer
   repository: file://../composer
   version: 0.1.1
@@ -17,5 +17,5 @@ dependencies:
 - name: blockscout-stack
   repository: https://blockscout.github.io/helm-charts
   version: 1.6.2
-digest: sha256:695498fcbe82a100ca333b058196730eed9173df8528871585f40453c182d964
-generated: "2024-08-15T12:40:34.762702-07:00"
+digest: sha256:eeab7cd59d2577678f54e630b393a453a7862995f3ae0fc794b14dc640e855df
+generated: "2024-08-22T14:43:39.38871-04:00"

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -15,11 +15,11 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.3
+version: 0.3.4
 
 dependencies:
   - name: evm-rollup
-    version: 0.25.4
+    version: 0.25.5
     repository: "file://../evm-rollup"
   - name: composer
     version: 0.1.1


### PR DESCRIPTION
## Summary
Allow setting an override tag for astria-geth image.
## Background
preview environment setup with changes for both astria-geth and the monorepo can't work without setting the astria-geth image for automation to pickup 
## Changes
- added an overrideTag value which will set a specific `astria-geth` image
## Testing
Tested vs a preview enviornment

## Related Issues
#1400 