### PR TITLE
fix(core): restructure modules to match proto

### DIFF
--- a/crates/astria-core/src/generated/astria.protocol.genesis.v1alpha1.rs
+++ b/crates/astria-core/src/generated/astria.protocol.genesis.v1alpha1.rs
@@ -131,11 +131,11 @@ impl ::prost::Name for Fees {
 pub struct SlinkyGenesis {
     #[prost(message, optional, tag = "1")]
     pub market_map: ::core::option::Option<
-        super::super::super::astria_vendored::slinky::marketmap::v1::GenesisState,
+        super::super::super::super::astria_vendored::slinky::marketmap::v1::GenesisState,
     >,
     #[prost(message, optional, tag = "2")]
     pub oracle: ::core::option::Option<
-        super::super::super::astria_vendored::slinky::oracle::v1::GenesisState,
+        super::super::super::super::astria_vendored::slinky::oracle::v1::GenesisState,
     >,
 }
 impl ::prost::Name for SlinkyGenesis {

--- a/crates/astria-core/src/generated/astria.protocol.transactions.v1alpha1.rs
+++ b/crates/astria-core/src/generated/astria.protocol.transactions.v1alpha1.rs
@@ -92,7 +92,7 @@ pub mod action {
         SudoAddressChangeAction(super::SudoAddressChangeAction),
         #[prost(message, tag = "51")]
         ValidatorUpdateAction(
-            crate::generated::astria_vendored::tendermint::abci::ValidatorUpdate,
+            super::super::super::super::super::astria_vendored::tendermint::abci::ValidatorUpdate,
         ),
         #[prost(message, tag = "52")]
         IbcRelayerChangeAction(super::IbcRelayerChangeAction),

--- a/crates/astria-core/src/generated/mod.rs
+++ b/crates/astria-core/src/generated/mod.rs
@@ -11,6 +11,8 @@
 //! [`buf`]: https://buf.build
 //! [`tools/protobuf-compiler`]: ../../../../tools/protobuf-compiler
 
+pub use astria::*;
+
 #[path = ""]
 pub mod astria_vendored {
     #[path = ""]
@@ -101,106 +103,109 @@ pub mod astria_vendored {
 }
 
 #[path = ""]
-pub mod execution {
-    #[path = "astria.execution.v1alpha1.rs"]
-    pub mod v1alpha1;
-
-    pub mod v1alpha2 {
-        include!("astria.execution.v1alpha2.rs");
-
-        #[cfg(feature = "serde")]
-        mod _serde_impl {
-            use super::*;
-            include!("astria.execution.v1alpha2.serde.rs");
-        }
-    }
-}
-
-#[path = ""]
-pub mod primitive {
-    pub mod v1 {
-        include!("astria.primitive.v1.rs");
-
-        #[cfg(feature = "serde")]
-        mod _serde_impl {
-            use super::*;
-            include!("astria.primitive.v1.serde.rs");
-        }
-    }
-}
-
-#[path = ""]
-pub mod protocol {
+pub mod astria {
     #[path = ""]
-    pub mod accounts {
-        #[path = "astria.protocol.accounts.v1alpha1.rs"]
+    pub mod execution {
+        #[path = "astria.execution.v1alpha1.rs"]
         pub mod v1alpha1;
-    }
-    #[path = ""]
-    pub mod asset {
-        #[path = "astria.protocol.asset.v1alpha1.rs"]
-        pub mod v1alpha1;
-    }
-    #[path = ""]
-    pub mod bridge {
-        #[path = "astria.protocol.bridge.v1alpha1.rs"]
-        pub mod v1alpha1;
-    }
-    #[path = ""]
-    pub mod genesis {
-        pub mod v1alpha1 {
-            include!("astria.protocol.genesis.v1alpha1.rs");
 
-            #[cfg(feature = "serde")]
-            mod _serde_impls {
-                use super::*;
-                include!("astria.protocol.genesis.v1alpha1.serde.rs");
-            }
-        }
-    }
-    #[path = ""]
-    pub mod memos {
-        pub mod v1alpha1 {
-            include!("astria.protocol.memos.v1alpha1.rs");
-
-            #[cfg(feature = "serde")]
-            mod _serde_impls {
-                use super::*;
-                include!("astria.protocol.memos.v1alpha1.serde.rs");
-            }
-        }
-    }
-    #[path = ""]
-    pub mod transactions {
-        pub mod v1alpha1 {
-            include!("astria.protocol.transactions.v1alpha1.rs");
+        pub mod v1alpha2 {
+            include!("astria.execution.v1alpha2.rs");
 
             #[cfg(feature = "serde")]
             mod _serde_impl {
                 use super::*;
-                include!("astria.protocol.transactions.v1alpha1.serde.rs");
+                include!("astria.execution.v1alpha2.serde.rs");
             }
         }
     }
-}
 
-#[path = ""]
-pub mod sequencerblock {
-    pub mod v1alpha1 {
-        include!("astria.sequencerblock.v1alpha1.rs");
+    #[path = ""]
+    pub mod primitive {
+        pub mod v1 {
+            include!("astria.primitive.v1.rs");
 
-        #[cfg(feature = "serde")]
-        mod _serde_impl {
-            use super::*;
-            include!("astria.sequencerblock.v1alpha1.serde.rs");
+            #[cfg(feature = "serde")]
+            mod _serde_impl {
+                use super::*;
+                include!("astria.primitive.v1.serde.rs");
+            }
         }
     }
-}
 
-#[path = ""]
-pub mod composer {
-    #[path = "astria.composer.v1alpha1.rs"]
-    pub mod v1alpha1;
+    #[path = ""]
+    pub mod protocol {
+        #[path = ""]
+        pub mod accounts {
+            #[path = "astria.protocol.accounts.v1alpha1.rs"]
+            pub mod v1alpha1;
+        }
+        #[path = ""]
+        pub mod asset {
+            #[path = "astria.protocol.asset.v1alpha1.rs"]
+            pub mod v1alpha1;
+        }
+        #[path = ""]
+        pub mod bridge {
+            #[path = "astria.protocol.bridge.v1alpha1.rs"]
+            pub mod v1alpha1;
+        }
+        #[path = ""]
+        pub mod genesis {
+            pub mod v1alpha1 {
+                include!("astria.protocol.genesis.v1alpha1.rs");
+
+                #[cfg(feature = "serde")]
+                mod _serde_impls {
+                    use super::*;
+                    include!("astria.protocol.genesis.v1alpha1.serde.rs");
+                }
+            }
+        }
+        #[path = ""]
+        pub mod memos {
+            pub mod v1alpha1 {
+                include!("astria.protocol.memos.v1alpha1.rs");
+
+                #[cfg(feature = "serde")]
+                mod _serde_impls {
+                    use super::*;
+                    include!("astria.protocol.memos.v1alpha1.serde.rs");
+                }
+            }
+        }
+        #[path = ""]
+        pub mod transactions {
+            pub mod v1alpha1 {
+                include!("astria.protocol.transactions.v1alpha1.rs");
+
+                #[cfg(feature = "serde")]
+                mod _serde_impl {
+                    use super::*;
+                    include!("astria.protocol.transactions.v1alpha1.serde.rs");
+                }
+            }
+        }
+    }
+
+    #[path = ""]
+    pub mod sequencerblock {
+        pub mod v1alpha1 {
+            include!("astria.sequencerblock.v1alpha1.rs");
+
+            #[cfg(feature = "serde")]
+            mod _serde_impl {
+                use super::*;
+                include!("astria.sequencerblock.v1alpha1.serde.rs");
+            }
+        }
+    }
+
+    #[path = ""]
+    pub mod composer {
+        #[path = "astria.composer.v1alpha1.rs"]
+        pub mod v1alpha1;
+    }
 }
 
 #[path = ""]

--- a/tools/protobuf-compiler/src/main.rs
+++ b/tools/protobuf-compiler/src/main.rs
@@ -74,18 +74,6 @@ fn main() {
         .client_mod_attribute(".", "#[cfg(feature=\"client\")]")
         .server_mod_attribute(".", "#[cfg(feature=\"server\")]")
         .extern_path(".astria_vendored.penumbra", "::penumbra-proto")
-        // .extern_path(
-        //     ".astria_vendored.slinky.marketmap.v1.GenesisState",
-        //     "crate::generated::astria_vendored::slinky::marketmap::v1::GenesisState",
-        // )
-        // .extern_path(
-        //     ".astria_vendored.slinky.oracle.v1.GenesisState",
-        //     "crate::generated::astria_vendored::slinky::oracle::v1::GenesisState",
-        // )
-        .extern_path(
-            ".astria_vendored.tendermint.abci.ValidatorUpdate",
-            "crate::generated::astria_vendored::tendermint::abci::ValidatorUpdate",
-        )
         .type_attribute(".astria.primitive.v1.Uint128", "#[derive(Copy)]")
         .type_attribute(
             ".astria.protocol.genesis.v1alpha1.IbcParameters",


### PR DESCRIPTION
The module structure for the generated rust code was messed up and didn't match the protobuf package definitions. That messed up type references created by prost.