### PR TITLE
feat(sequencer): make mempool balance aware

### DIFF
--- a/crates/astria-sequencer/src/app/mod.rs
+++ b/crates/astria-sequencer/src/app/mod.rs
@@ -1130,7 +1130,14 @@ async fn update_mempool_after_finalization<S: accounts::StateReadExt>(
     state: &S,
 ) {
     let current_account_nonce_getter = |address: [u8; 20]| state.get_account_nonce(address);
-    mempool.run_maintenance(current_account_nonce_getter).await;
+    let current_account_balances_getter =
+        |address: [u8; 20]| state.get_account_balances_ibc(address);
+    mempool
+        .run_maintenance(
+            current_account_nonce_getter,
+            current_account_balances_getter,
+        )
+        .await;
 }
 
 /// relevant data of a block being executed.

--- a/crates/astria-sequencer/src/app/test_utils.rs
+++ b/crates/astria-sequencer/src/app/test_utils.rs
@@ -1,8 +1,14 @@
-use std::sync::Arc;
+use std::{
+    collections::HashMap,
+    sync::Arc,
+};
 
 use astria_core::{
     crypto::SigningKey,
-    primitive::v1::RollupId,
+    primitive::v1::{
+        asset::IbcPrefixed,
+        RollupId,
+    },
     protocol::transaction::v1alpha1::{
         action::{
             SequenceAction,
@@ -161,4 +167,48 @@ pub(crate) fn mock_tx(
     };
 
     Arc::new(tx.into_signed(signer))
+}
+
+pub(crate) const DENOM_0: [u8; 32] = [1u8; 32];
+pub(crate) const DENOM_1: [u8; 32] = [2u8; 32];
+const DENOM_2: [u8; 32] = [3u8; 32];
+pub(crate) const DENOM_3: [u8; 32] = [4u8; 32];
+const DENOM_4: [u8; 32] = [5u8; 32];
+const DENOM_5: [u8; 32] = [6u8; 32];
+const DENOM_6: [u8; 32] = [7u8; 32];
+
+pub(crate) fn mock_balances(
+    denom_0_balance: u128,
+    denom_1_balance: u128,
+) -> HashMap<IbcPrefixed, u128> {
+    let mut balances = HashMap::<IbcPrefixed, u128>::new();
+    if denom_0_balance != 0 {
+        balances.insert(IbcPrefixed::new(DENOM_0), denom_0_balance);
+    }
+    if denom_1_balance != 0 {
+        balances.insert(IbcPrefixed::new(DENOM_1), denom_1_balance);
+    }
+    // we don't sanitize the balance inputs
+    balances.insert(IbcPrefixed::new(DENOM_3), 100); // balance transaction costs won't have entry for
+    balances.insert(IbcPrefixed::new(DENOM_4), 0); // zero balance not in transaction
+    balances.insert(IbcPrefixed::new(DENOM_5), 0); // zero balance with corresponding zero cost 
+
+    balances
+}
+
+pub(crate) fn mock_tx_cost(
+    denom_0_cost: u128,
+    denom_1_cost: u128,
+    denom_2_cost: u128,
+) -> HashMap<IbcPrefixed, u128> {
+    let mut costs = HashMap::<IbcPrefixed, u128>::new();
+    costs.insert(IbcPrefixed::new(DENOM_0), denom_0_cost);
+    costs.insert(IbcPrefixed::new(DENOM_1), denom_1_cost);
+    costs.insert(IbcPrefixed::new(DENOM_2), denom_2_cost); // not present in balances
+
+    // we don't santize the cost inputs
+    costs.insert(IbcPrefixed::new(DENOM_5), 0); // zero in balances also 
+    costs.insert(IbcPrefixed::new(DENOM_6), 0); // not present in balances 
+
+    costs
 }

--- a/crates/astria-sequencer/src/app/tests_app.rs
+++ b/crates/astria-sequencer/src/app/tests_app.rs
@@ -452,7 +452,15 @@ async fn app_execution_results_match_proposal_vs_after_proposal() {
     // don't commit the result, now call prepare_proposal with the same data.
     // this will reset the app state.
     // this simulates executing the same block as a validator (specifically the proposer).
-    app.mempool.insert(Arc::new(signed_tx), 0).await.unwrap();
+    app.mempool
+        .insert(
+            Arc::new(signed_tx),
+            0,
+            mock_balances(0, 0),
+            mock_tx_cost(0, 0, 0),
+        )
+        .await
+        .unwrap();
 
     let proposer_address = [88u8; 20].to_vec().try_into().unwrap();
     let prepare_proposal = PrepareProposal {
@@ -473,10 +481,13 @@ async fn app_execution_results_match_proposal_vs_after_proposal() {
     assert_eq!(prepare_proposal_result.txs, finalize_block.txs);
     assert_eq!(app.executed_proposal_hash, Hash::default());
     assert_eq!(app.validator_address.unwrap(), proposer_address);
+
     // run maintence to clear out transactions
-    let current_account_nonce_getter = |address: [u8; 20]| app.state.get_account_nonce(address);
+    let current_account_nonce_getter = |address: [u8; 20]| (app.state.get_account_nonce(address));
+    let current_account_balance_getter =
+        |address: [u8; 20]| (app.state.get_account_balances_ibc(address));
     app.mempool
-        .run_maintenance(current_account_nonce_getter)
+        .run_maintenance(current_account_nonce_getter, current_account_balance_getter)
         .await;
 
     assert_eq!(app.mempool.len().await, 0);
@@ -567,8 +578,24 @@ async fn app_prepare_proposal_cometbft_max_bytes_overflow_ok() {
     }
     .into_signed(&alice);
 
-    app.mempool.insert(Arc::new(tx_pass), 0).await.unwrap();
-    app.mempool.insert(Arc::new(tx_overflow), 0).await.unwrap();
+    app.mempool
+        .insert(
+            Arc::new(tx_pass),
+            0,
+            mock_balances(0, 0),
+            mock_tx_cost(0, 0, 0),
+        )
+        .await
+        .unwrap();
+    app.mempool
+        .insert(
+            Arc::new(tx_overflow),
+            0,
+            mock_balances(0, 0),
+            mock_tx_cost(0, 0, 0),
+        )
+        .await
+        .unwrap();
 
     // send to prepare_proposal
     let prepare_args = abci::request::PrepareProposal {
@@ -589,8 +616,10 @@ async fn app_prepare_proposal_cometbft_max_bytes_overflow_ok() {
 
     // run maintence to clear out transactions
     let current_account_nonce_getter = |address: [u8; 20]| app.state.get_account_nonce(address);
+    let current_account_balance_getter =
+        |address: [u8; 20]| (app.state.get_account_balances_ibc(address));
     app.mempool
-        .run_maintenance(current_account_nonce_getter)
+        .run_maintenance(current_account_nonce_getter, current_account_balance_getter)
         .await;
 
     // see only first tx made it in
@@ -646,8 +675,24 @@ async fn app_prepare_proposal_sequencer_max_bytes_overflow_ok() {
     }
     .into_signed(&alice);
 
-    app.mempool.insert(Arc::new(tx_pass), 0).await.unwrap();
-    app.mempool.insert(Arc::new(tx_overflow), 0).await.unwrap();
+    app.mempool
+        .insert(
+            Arc::new(tx_pass),
+            0,
+            mock_balances(0, 0),
+            mock_tx_cost(0, 0, 0),
+        )
+        .await
+        .unwrap();
+    app.mempool
+        .insert(
+            Arc::new(tx_overflow),
+            0,
+            mock_balances(0, 0),
+            mock_tx_cost(0, 0, 0),
+        )
+        .await
+        .unwrap();
 
     // send to prepare_proposal
     let prepare_args = abci::request::PrepareProposal {
@@ -668,8 +713,10 @@ async fn app_prepare_proposal_sequencer_max_bytes_overflow_ok() {
 
     // run maintence to clear out transactions
     let current_account_nonce_getter = |address: [u8; 20]| app.state.get_account_nonce(address);
+    let current_account_balance_getter =
+        |address: [u8; 20]| (app.state.get_account_balances_ibc(address));
     app.mempool
-        .run_maintenance(current_account_nonce_getter)
+        .run_maintenance(current_account_nonce_getter, current_account_balance_getter)
         .await;
 
     // see only first tx made it in

--- a/crates/astria-sequencer/src/grpc/sequencer.rs
+++ b/crates/astria-sequencer/src/grpc/sequencer.rs
@@ -225,7 +225,11 @@ mod test {
     use super::*;
     use crate::{
         api_state_ext::StateWriteExt as _,
-        app::test_utils::get_alice_signing_key,
+        app::test_utils::{
+            get_alice_signing_key,
+            mock_balances,
+            mock_tx_cost,
+        },
         state_ext::StateWriteExt,
         test_utils::astria_address,
     };
@@ -267,18 +271,27 @@ mod test {
         // insert a transaction with a nonce gap
         let gapped_nonce = 99;
         let tx = crate::app::test_utils::mock_tx(gapped_nonce, &get_alice_signing_key(), "test");
-        mempool.insert(tx, 0).await.unwrap();
+        mempool
+            .insert(tx, 0, mock_balances(0, 0), mock_tx_cost(0, 0, 0))
+            .await
+            .unwrap();
 
         // insert a transaction at the current nonce
         let account_nonce = 0;
         let tx = crate::app::test_utils::mock_tx(account_nonce, &get_alice_signing_key(), "test");
-        mempool.insert(tx, 0).await.unwrap();
+        mempool
+            .insert(tx, 0, mock_balances(0, 0), mock_tx_cost(0, 0, 0))
+            .await
+            .unwrap();
 
         // insert a transactions one above account nonce (not gapped)
         let sequential_nonce = 1;
         let tx: Arc<astria_core::protocol::transaction::v1alpha1::SignedTransaction> =
             crate::app::test_utils::mock_tx(sequential_nonce, &get_alice_signing_key(), "test");
-        mempool.insert(tx, 0).await.unwrap();
+        mempool
+            .insert(tx, 0, mock_balances(0, 0), mock_tx_cost(0, 0, 0))
+            .await
+            .unwrap();
 
         let server = Arc::new(SequencerServer::new(storage.clone(), mempool));
         let request = GetPendingNonceRequest {

--- a/crates/astria-sequencer/src/mempool/mod.rs
+++ b/crates/astria-sequencer/src/mempool/mod.rs
@@ -1,9 +1,11 @@
+#[cfg(test)]
 mod benchmarks;
 mod transactions_container;
 
 use std::{
     collections::{
         HashMap,
+        HashSet,
         VecDeque,
     },
     future::Future,
@@ -11,7 +13,10 @@ use std::{
     sync::Arc,
 };
 
-use astria_core::protocol::transaction::v1alpha1::SignedTransaction;
+use astria_core::{
+    primitive::v1::asset::IbcPrefixed,
+    protocol::transaction::v1alpha1::SignedTransaction,
+};
 use tokio::{
     join,
     sync::{
@@ -37,7 +42,6 @@ pub(crate) enum RemovalReason {
     NonceStale,
     LowerNonceInvalidated,
     FailedPrepareProposal(String),
-    FailedCheckTx(String),
 }
 
 /// How long transactions are considered valid in the mempool.
@@ -159,18 +163,28 @@ impl Mempool {
         &self,
         tx: Arc<SignedTransaction>,
         current_account_nonce: u32,
+        current_account_balances: HashMap<IbcPrefixed, u128>,
+        transaction_cost: HashMap<IbcPrefixed, u128>,
     ) -> anyhow::Result<(), InsertionError> {
-        let timemarked_tx = TimemarkedTransaction::new(tx);
+        let timemarked_tx = TimemarkedTransaction::new(tx, transaction_cost);
 
         let (mut pending, mut parked) = self.acquire_both_locks().await;
 
-        // try insert into pending (will fail if nonce is gapped or already present)
-        match pending.add(timemarked_tx.clone(), current_account_nonce) {
-            Err(InsertionError::NonceGap) => {
+        // try insert into pending
+        match pending.add(
+            timemarked_tx.clone(),
+            current_account_nonce,
+            &current_account_balances,
+        ) {
+            Err(InsertionError::NonceGap | InsertionError::AccountBalanceTooLow) => {
                 // Release the lock asap.
                 drop(pending);
                 // try to add to parked queue
-                parked.add(timemarked_tx, current_account_nonce)
+                parked.add(
+                    timemarked_tx,
+                    current_account_nonce,
+                    &current_account_balances,
+                )
             }
             error @ Err(
                 InsertionError::AlreadyPresent
@@ -180,17 +194,22 @@ impl Mempool {
             ) => error,
             Ok(()) => {
                 // check parked for txs able to be promoted
-                let to_promote = parked.pop_front_account(
+                let to_promote = parked.find_promotables(
                     timemarked_tx.address(),
                     timemarked_tx
                         .nonce()
                         .checked_add(1)
                         .expect("failed to increment nonce in promotion"),
+                    &pending.remaining_account_balances(
+                        *timemarked_tx.address(),
+                        current_account_balances.clone(),
+                    ),
                 );
-                // Release the lock asap.
-                drop(parked);
+                // promote the transactions
                 for ttx in to_promote {
-                    if let Err(error) = pending.add(ttx, current_account_nonce) {
+                    if let Err(error) =
+                        pending.add(ttx, current_account_nonce, &current_account_balances)
+                    {
                         error!(
                             current_account_nonce,
                             "failed to promote transaction during insertion: {error:#}"
@@ -267,34 +286,104 @@ impl Mempool {
     }
 
     /// Updates stored transactions to reflect current blockchain state. Will remove transactions
-    /// that have stale nonces and will remove transaction that are expired.
+    /// that have stale nonces or are expired. Will also shift transation between pending and
+    /// parked to relfect changes in account balances.
     ///
     /// All removed transactions are added to the CometBFT removal cache to aid with CometBFT
     /// mempool maintenance.
     #[instrument(skip_all)]
-    pub(crate) async fn run_maintenance<F, O>(&self, current_account_nonce_getter: F)
-    where
-        F: Fn([u8; 20]) -> O,
-        O: Future<Output = anyhow::Result<u32>>,
+    pub(crate) async fn run_maintenance<F1, O1, F2, O2>(
+        &self,
+        current_account_nonce_getter: F1,
+        current_account_balances_getter: F2,
+    ) where
+        F1: Fn([u8; 20]) -> O1,
+        O1: Future<Output = anyhow::Result<u32>>,
+        F2: Fn([u8; 20]) -> O2,
+        O2: Future<Output = anyhow::Result<HashMap<IbcPrefixed, u128>>>,
     {
         let (mut pending, mut parked) = self.acquire_both_locks().await;
+        let mut removed_txs = Vec::<([u8; 32], RemovalReason)>::new();
 
-        // clean accounts of stale and expired transactions
-        let mut removed_txs = pending.clean_accounts(&current_account_nonce_getter).await;
-        removed_txs.append(&mut parked.clean_accounts(&current_account_nonce_getter).await);
+        // To clean we need to:
+        // 1.) remove stale and expired transactions from both pending and parked
+        // 2.) check if we have transactions in pending which need to be demoted due
+        //     to balance decreases
+        // 3.) if there were no demotions, check if parked has transactions we can
+        //     promote
 
-        // run promotion logic in case transactions not in this mempool advanced account state
-        let to_promote = parked.find_promotables(&current_account_nonce_getter).await;
-        // Release the lock asap.
-        drop(parked);
-        for (ttx, current_account_nonce) in to_promote {
-            if let Err(error) = pending.add(ttx, current_account_nonce) {
-                error!(
-                    current_account_nonce,
-                    "failed to promote transaction during maintenance: {error:#}"
-                );
+        // TODO reprice transactions also if FeeAssetChange or FeeChange Actions were ran :0
+
+        let addresses: HashSet<[u8; 20]> = pending
+            .addresses()
+            .into_iter()
+            .chain(parked.addresses())
+            .collect();
+
+        for address in addresses {
+            // get current account state
+            let current_nonce = match current_account_nonce_getter(address).await {
+                Ok(res) => res,
+                Err(error) => {
+                    error!(
+                        address = %telemetry::display::base64(&address),
+                        "failed to fetch account nonce when cleaning accounts: {error:#}"
+                    );
+                    continue;
+                }
+            };
+            let current_balances = match current_account_balances_getter(address).await {
+                Ok(res) => res,
+                Err(error) => {
+                    error!(
+                        address = %telemetry::display::base64(&address),
+                        "failed to fetch account balances when cleaning accounts: {error:#}"
+                    );
+                    continue;
+                }
+            };
+
+            // clean pending and parked of stale and expired
+            removed_txs.extend(pending.clean_account_stale_expired(address, current_nonce));
+            removed_txs.extend(parked.clean_account_stale_expired(address, current_nonce));
+
+            // get transactions to demote from pending
+            let demotion_txs = pending.find_demotables(address, &current_balances);
+
+            if demotion_txs.is_empty() {
+                // nothing to demote, check for transactions to promote
+                let highest_pending_nonce = pending
+                    .pending_nonce(address)
+                    .map_or(current_nonce, |nonce| nonce.saturating_add(1));
+                let remaining_balances =
+                    pending.remaining_account_balances(address, current_balances.clone());
+                let promtion_txs =
+                    parked.find_promotables(&address, highest_pending_nonce, &remaining_balances);
+
+                for tx in promtion_txs {
+                    if let Err(error) = pending.add(tx, current_nonce, &current_balances) {
+                        error!(
+                            current_nonce,
+                            "failed to promote transaction during maintenance: {error:#}"
+                        );
+                    }
+                }
+            } else {
+                // add demoted transactions to parked
+                for tx in demotion_txs {
+                    if let Err(err) = parked.add(tx, current_nonce, &current_balances) {
+                        // this shouldn't happen
+                        error!(
+                               address = %telemetry::display::base64(&address),
+                               "failed to demote transaction during maintenance: {err:#}"
+                        );
+                    }
+                }
             }
         }
+        // Release the locks asap.
+        drop(parked);
+        drop(pending);
 
         // add to removal cache for cometbft
         let mut removal_cache = self.comet_bft_removal_cache.write().await;
@@ -329,23 +418,35 @@ mod test {
     use astria_core::crypto::SigningKey;
 
     use super::*;
-    use crate::app::test_utils::mock_tx;
+    use crate::app::test_utils::{
+        mock_balances,
+        mock_tx,
+        mock_tx_cost,
+    };
 
     #[tokio::test]
     async fn insert() {
         let mempool = Mempool::new();
         let signing_key = SigningKey::from([1; 32]);
+        let account_balances = mock_balances(100, 100);
+        let tx_cost = mock_tx_cost(10, 10, 0);
 
         // sign and insert nonce 1
         let tx1 = mock_tx(1, &signing_key, "test");
         assert!(
-            mempool.insert(tx1.clone(), 0).await.is_ok(),
+            mempool
+                .insert(tx1.clone(), 0, account_balances.clone(), tx_cost.clone())
+                .await
+                .is_ok(),
             "should be able to insert nonce 1 transaction into mempool"
         );
 
         // try to insert again
         assert_eq!(
-            mempool.insert(tx1.clone(), 0).await.unwrap_err(),
+            mempool
+                .insert(tx1.clone(), 0, account_balances.clone(), tx_cost.clone())
+                .await
+                .unwrap_err(),
             InsertionError::AlreadyPresent,
             "already present"
         );
@@ -354,7 +455,12 @@ mod test {
         let tx1_replacement = mock_tx(1, &signing_key, "test_0");
         assert_eq!(
             mempool
-                .insert(tx1_replacement.clone(), 0)
+                .insert(
+                    tx1_replacement.clone(),
+                    0,
+                    account_balances.clone(),
+                    tx_cost.clone()
+                )
                 .await
                 .unwrap_err(),
             InsertionError::NonceTaken,
@@ -364,7 +470,10 @@ mod test {
         // add too low nonce
         let tx0 = mock_tx(0, &signing_key, "test");
         assert_eq!(
-            mempool.insert(tx0.clone(), 1).await.unwrap_err(),
+            mempool
+                .insert(tx0.clone(), 1, account_balances, tx_cost)
+                .await
+                .unwrap_err(),
             InsertionError::NonceTooLow,
             "nonce too low"
         );
@@ -381,33 +490,47 @@ mod test {
         let mempool = Mempool::new();
         let signing_key = SigningKey::from([1; 32]);
         let signing_address = signing_key.verification_key().address_bytes();
+        let account_balances = mock_balances(100, 100);
+        let tx_cost = mock_tx_cost(10, 10, 0);
 
         // add nonces in odd order to trigger insertion promotion logic
         // sign and insert nonce 1
         let tx1 = mock_tx(1, &signing_key, "test");
         assert!(
-            mempool.insert(tx1.clone(), 0).await.is_ok(),
+            mempool
+                .insert(tx1.clone(), 0, account_balances.clone(), tx_cost.clone())
+                .await
+                .is_ok(),
             "should be able to insert nonce 1 transaction into mempool"
         );
 
         // sign and insert nonce 2
         let tx2 = mock_tx(2, &signing_key, "test");
         assert!(
-            mempool.insert(tx2.clone(), 0).await.is_ok(),
+            mempool
+                .insert(tx2.clone(), 0, account_balances.clone(), tx_cost.clone())
+                .await
+                .is_ok(),
             "should be able to insert nonce 2 transaction into mempool"
         );
 
         // sign and insert nonce 0
         let tx0 = mock_tx(0, &signing_key, "test");
         assert!(
-            mempool.insert(tx0.clone(), 0).await.is_ok(),
+            mempool
+                .insert(tx0.clone(), 0, account_balances.clone(), tx_cost.clone())
+                .await
+                .is_ok(),
             "should be able to insert nonce 0 transaction into mempool"
         );
 
         // sign and insert nonce 4
         let tx4 = mock_tx(4, &signing_key, "test");
         assert!(
-            mempool.insert(tx4.clone(), 0).await.is_ok(),
+            mempool
+                .insert(tx4.clone(), 0, account_balances.clone(), tx_cost.clone())
+                .await
+                .is_ok(),
             "should be able to insert nonce 4 transaction into mempool"
         );
 
@@ -444,7 +567,15 @@ mod test {
             }
             Err(anyhow::anyhow!("invalid address"))
         };
-        mempool.run_maintenance(current_account_nonce_getter).await;
+        let current_account_balance_getter = |address: [u8; 20]| async move {
+            if address == signing_address {
+                return Ok(mock_balances(100, 100));
+            }
+            Err(anyhow::anyhow!("invalid address"))
+        };
+        mempool
+            .run_maintenance(current_account_nonce_getter, current_account_balance_getter)
+            .await;
 
         // assert mempool at 1
         assert_eq!(mempool.len().await, 1);
@@ -459,34 +590,240 @@ mod test {
     }
 
     #[tokio::test]
+    async fn run_maintenance_promotion() {
+        let mempool = Mempool::new();
+        let signing_key = SigningKey::from([1; 32]);
+        let signing_address = signing_key.verification_key().address_bytes();
+
+        // create transaction setup to trigger promotions
+        //
+        // initially pending has single transaction
+        let initial_balances = mock_balances(1, 0);
+        let tx_cost = mock_tx_cost(1, 0, 0);
+        let tx1 = mock_tx(1, &signing_key, "test");
+        let tx2 = mock_tx(2, &signing_key, "test");
+        let tx3 = mock_tx(3, &signing_key, "test");
+        let tx4 = mock_tx(4, &signing_key, "test");
+
+        mempool
+            .insert(tx1.clone(), 1, initial_balances.clone(), tx_cost.clone())
+            .await
+            .unwrap();
+        mempool
+            .insert(tx2.clone(), 1, initial_balances.clone(), tx_cost.clone())
+            .await
+            .unwrap();
+        mempool
+            .insert(tx3.clone(), 1, initial_balances.clone(), tx_cost.clone())
+            .await
+            .unwrap();
+        mempool
+            .insert(tx4.clone(), 1, initial_balances.clone(), tx_cost.clone())
+            .await
+            .unwrap();
+
+        // see pending only has one transaction
+        let current_account_nonce_getter = |address: [u8; 20]| async move {
+            if address == signing_address {
+                return Ok(1);
+            }
+            Err(anyhow::anyhow!("invalid address"))
+        };
+
+        let builder_queue = mempool
+            .builder_queue(current_account_nonce_getter)
+            .await
+            .expect("failed to get builder queue");
+        assert_eq!(
+            builder_queue.len(),
+            1,
+            "builder queue should only contain single transaction"
+        );
+
+        // run maintenance with account containing balance for two more transactions
+        let current_account_nonce_getter = |address: [u8; 20]| async move {
+            if address == signing_address {
+                return Ok(1);
+            }
+            Err(anyhow::anyhow!("invalid address"))
+        };
+        let current_account_balances_getter = |address: [u8; 20]| async move {
+            if address == signing_address {
+                return Ok(mock_balances(3, 0));
+            }
+            Err(anyhow::anyhow!("invalid address"))
+        };
+        mempool
+            .run_maintenance(
+                current_account_nonce_getter,
+                current_account_balances_getter,
+            )
+            .await;
+
+        // see builder queue now contains them
+        let builder_queue = mempool
+            .builder_queue(current_account_nonce_getter)
+            .await
+            .expect("failed to get builder queue");
+        assert_eq!(
+            builder_queue.len(),
+            3,
+            "builder queue should now have 3 transactions"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_maintenance_demotion() {
+        let mempool = Mempool::new();
+        let signing_key = SigningKey::from([1; 32]);
+        let signing_address = signing_key.verification_key().address_bytes();
+
+        // create transaction setup to trigger demotions
+        //
+        // initially pending has four transactions
+        let initial_balances = mock_balances(4, 0);
+        let tx_cost = mock_tx_cost(1, 0, 0);
+        let tx1 = mock_tx(1, &signing_key, "test");
+        let tx2 = mock_tx(2, &signing_key, "test");
+        let tx3 = mock_tx(3, &signing_key, "test");
+        let tx4 = mock_tx(4, &signing_key, "test");
+
+        mempool
+            .insert(tx1.clone(), 1, initial_balances.clone(), tx_cost.clone())
+            .await
+            .unwrap();
+        mempool
+            .insert(tx2.clone(), 1, initial_balances.clone(), tx_cost.clone())
+            .await
+            .unwrap();
+        mempool
+            .insert(tx3.clone(), 1, initial_balances.clone(), tx_cost.clone())
+            .await
+            .unwrap();
+        mempool
+            .insert(tx4.clone(), 1, initial_balances.clone(), tx_cost.clone())
+            .await
+            .unwrap();
+
+        // see pending only has all transactions
+        let current_account_nonce_getter = |address: [u8; 20]| async move {
+            if address == signing_address {
+                return Ok(1);
+            }
+            Err(anyhow::anyhow!("invalid address"))
+        };
+
+        let builder_queue = mempool
+            .builder_queue(current_account_nonce_getter)
+            .await
+            .expect("failed to get builder queue");
+        assert_eq!(
+            builder_queue.len(),
+            4,
+            "builder queue should only contain four transactions"
+        );
+
+        // run maintenance with account balance being lowered
+        let current_account_nonce_getter = |address: [u8; 20]| async move {
+            if address == signing_address {
+                return Ok(1);
+            }
+            Err(anyhow::anyhow!("invalid address"))
+        };
+        let current_account_balances_getter = |address: [u8; 20]| async move {
+            if address == signing_address {
+                return Ok(mock_balances(1, 0));
+            }
+            Err(anyhow::anyhow!("invalid address"))
+        };
+        mempool
+            .run_maintenance(
+                current_account_nonce_getter,
+                current_account_balances_getter,
+            )
+            .await;
+
+        // see builder queue now contains single transactions
+        let builder_queue = mempool
+            .builder_queue(current_account_nonce_getter)
+            .await
+            .expect("failed to get builder queue");
+        assert_eq!(
+            builder_queue.len(),
+            1,
+            "builder queue should contain single transaction"
+        );
+
+        // can repromote as well
+        let current_account_balances_getter = |address: [u8; 20]| async move {
+            if address == signing_address {
+                return Ok(mock_balances(3, 0));
+            }
+            Err(anyhow::anyhow!("invalid address"))
+        };
+        mempool
+            .run_maintenance(
+                current_account_nonce_getter,
+                current_account_balances_getter,
+            )
+            .await;
+        let builder_queue = mempool
+            .builder_queue(current_account_nonce_getter)
+            .await
+            .expect("failed to get builder queue");
+        assert_eq!(
+            builder_queue.len(),
+            3,
+            "builder queue should contain three transactions"
+        );
+    }
+
+    #[tokio::test]
     async fn remove_invalid() {
         let mempool = Mempool::new();
         let signing_key = SigningKey::from([1; 32]);
+        let account_balances = mock_balances(100, 100);
+        let tx_cost = mock_tx_cost(10, 10, 10);
 
         // sign and insert nonces 0,1 and 3,4,5
         let tx0 = mock_tx(0, &signing_key, "test");
         assert!(
-            mempool.insert(tx0.clone(), 0).await.is_ok(),
+            mempool
+                .insert(tx0.clone(), 0, account_balances.clone(), tx_cost.clone())
+                .await
+                .is_ok(),
             "should be able to insert nonce 0 transaction into mempool"
         );
         let tx1 = mock_tx(1, &signing_key, "test");
         assert!(
-            mempool.insert(tx1.clone(), 0).await.is_ok(),
+            mempool
+                .insert(tx1.clone(), 0, account_balances.clone(), tx_cost.clone())
+                .await
+                .is_ok(),
             "should be able to insert nonce 1 transaction into mempool"
         );
         let tx3 = mock_tx(3, &signing_key, "test");
         assert!(
-            mempool.insert(tx3.clone(), 0).await.is_ok(),
+            mempool
+                .insert(tx3.clone(), 0, account_balances.clone(), tx_cost.clone())
+                .await
+                .is_ok(),
             "should be able to insert nonce 3 transaction into mempool"
         );
         let tx4 = mock_tx(4, &signing_key, "test");
         assert!(
-            mempool.insert(tx4.clone(), 0).await.is_ok(),
+            mempool
+                .insert(tx4.clone(), 0, account_balances.clone(), tx_cost.clone())
+                .await
+                .is_ok(),
             "should be able to insert nonce 4 transaction into mempool"
         );
         let tx5 = mock_tx(5, &signing_key, "test");
         assert!(
-            mempool.insert(tx5.clone(), 0).await.is_ok(),
+            mempool
+                .insert(tx5.clone(), 0, account_balances.clone(), tx_cost.clone())
+                .await
+                .is_ok(),
             "should be able to insert nonce 5 transaction into mempool"
         );
         assert_eq!(mempool.len().await, 5);
@@ -563,28 +900,52 @@ mod test {
         let signing_address_0 = signing_key_0.verification_key().address_bytes();
         let signing_address_1 = signing_key_1.verification_key().address_bytes();
         let signing_address_2 = signing_key_2.verification_key().address_bytes();
+        let account_balances = mock_balances(100, 100);
+        let tx_cost = mock_tx_cost(10, 10, 0);
 
         // sign and insert nonces 0,1
         let tx0 = mock_tx(0, &signing_key_0, "test");
         assert!(
-            mempool.insert(tx0.clone(), 0).await.is_ok(),
+            mempool
+                .insert(tx0.clone(), 0, account_balances.clone(), tx_cost.clone())
+                .await
+                .is_ok(),
             "should be able to insert nonce 0 transaction into mempool"
         );
         let tx1 = mock_tx(1, &signing_key_0, "test");
         assert!(
-            mempool.insert(tx1.clone(), 0).await.is_ok(),
+            mempool
+                .insert(tx1.clone(), 0, account_balances.clone(), tx_cost.clone())
+                .await
+                .is_ok(),
             "should be able to insert nonce 1 transaction into mempool"
         );
 
         // sign and insert nonces 100, 101
         let tx100 = mock_tx(100, &signing_key_1, "test");
         assert!(
-            mempool.insert(tx100.clone(), 100).await.is_ok(),
+            mempool
+                .insert(
+                    tx100.clone(),
+                    100,
+                    account_balances.clone(),
+                    tx_cost.clone()
+                )
+                .await
+                .is_ok(),
             "should be able to insert nonce 100 transaction into mempool"
         );
         let tx101 = mock_tx(101, &signing_key_1, "test");
         assert!(
-            mempool.insert(tx101.clone(), 100).await.is_ok(),
+            mempool
+                .insert(
+                    tx101.clone(),
+                    100,
+                    account_balances.clone(),
+                    tx_cost.clone()
+                )
+                .await
+                .is_ok(),
             "should be able to insert nonce 101 transaction into mempool"
         );
 

--- a/crates/astria-sequencer/src/mempool/transactions_container.rs
+++ b/crates/astria-sequencer/src/mempool/transactions_container.rs
@@ -4,6 +4,7 @@ use std::{
         hash_map,
         BTreeMap,
         HashMap,
+        HashSet,
     },
     fmt,
     future::Future,
@@ -12,7 +13,10 @@ use std::{
 };
 
 use anyhow::Context;
-use astria_core::protocol::transaction::v1alpha1::SignedTransaction;
+use astria_core::{
+    primitive::v1::asset::IbcPrefixed,
+    protocol::transaction::v1alpha1::SignedTransaction,
+};
 use tokio::time::{
     Duration,
     Instant,
@@ -33,15 +37,17 @@ pub(super) struct TimemarkedTransaction {
     tx_hash: [u8; 32],
     time_first_seen: Instant,
     address: [u8; 20],
+    cost: HashMap<IbcPrefixed, u128>,
 }
 
 impl TimemarkedTransaction {
-    pub(super) fn new(signed_tx: Arc<SignedTransaction>) -> Self {
+    pub(super) fn new(signed_tx: Arc<SignedTransaction>, cost: HashMap<IbcPrefixed, u128>) -> Self {
         Self {
             tx_hash: signed_tx.sha256_of_proto_encoding(),
             address: signed_tx.verification_key().address_bytes(),
             signed_tx,
             time_first_seen: Instant::now(),
+            cost,
         }
     }
 
@@ -69,6 +75,10 @@ impl TimemarkedTransaction {
 
     pub(super) fn address(&self) -> &[u8; 20] {
         &self.address
+    }
+
+    pub(super) fn cost(&self) -> &HashMap<IbcPrefixed, u128> {
+        &self.cost
     }
 }
 
@@ -128,6 +138,7 @@ pub(crate) enum InsertionError {
     NonceTaken,
     NonceGap,
     AccountSizeLimit,
+    AccountBalanceTooLow,
 }
 
 impl fmt::Display for InsertionError {
@@ -145,11 +156,15 @@ impl fmt::Display for InsertionError {
                 f,
                 "maximum number of pending transactions has been reached for the given account"
             ),
+            InsertionError::AccountBalanceTooLow => {
+                write!(f, "account does not have enough balance to cover costs")
+            }
         }
     }
 }
 
 /// Transactions for a single account where the sequence of nonces must not have any gaps.
+/// Contains logic to restrict total cost of contained transactions to inputted balances.
 #[derive(Clone, Default, Debug)]
 pub(super) struct PendingTransactionsForAccount {
     txs: BTreeMap<u32, TimemarkedTransaction>,
@@ -158,6 +173,86 @@ pub(super) struct PendingTransactionsForAccount {
 impl PendingTransactionsForAccount {
     fn highest_nonce(&self) -> Option<u32> {
         self.txs.last_key_value().map(|(nonce, _)| *nonce)
+    }
+
+    /// Removes and returns transactions that exceed the balances in `available_balances`.
+    fn find_demotables(
+        &mut self,
+        available_balances: &HashMap<IbcPrefixed, u128>,
+    ) -> Vec<TimemarkedTransaction> {
+        let mut split_at = 0;
+        let mut break_flag = false;
+        let mut available_balances = available_balances.clone();
+
+        for (nonce, tx) in &self.txs {
+            // ensure we have enough balance to cover inclusion
+            for (denom, cost) in tx.cost() {
+                match available_balances.entry(*denom) {
+                    hash_map::Entry::Occupied(mut entry) => {
+                        if cost <= entry.get() {
+                            // subtract cost
+                            let current_cost = entry.get_mut();
+                            *current_cost = current_cost.saturating_sub(*cost);
+                        } else {
+                            // not enough balance, do not include
+                            break_flag = true;
+                            break;
+                        }
+                    }
+                    hash_map::Entry::Vacant(_) => {
+                        // not enough balance, do not include
+                        if *cost != 0 {
+                            break_flag = true;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            // break if we're out of funds for one since this is a `SequentialNonce` container
+            if break_flag {
+                break;
+            }
+            split_at = nonce.saturating_add(1);
+        }
+
+        // return all keys higher than split target
+        self.txs.split_off(&split_at).into_values().collect()
+    }
+
+    /// Returns remaining balances after accounting for costs of contained transactions.
+    ///
+    /// Note: assumes that the balances in `current_account_balance` are large enough
+    /// to cover costs for contained transactions. Will log an error if this is not true
+    /// but will not fail.
+    fn get_remaining_balances(
+        &self,
+        current_account_balances: HashMap<IbcPrefixed, u128>,
+    ) -> HashMap<IbcPrefixed, u128> {
+        let mut remaining_account_balances = current_account_balances;
+
+        // deduct costs from current account balances
+        for tx in self.txs.values() {
+            for (denom, cost) in &tx.cost {
+                match remaining_account_balances.entry(*denom) {
+                    hash_map::Entry::Occupied(mut entry) => {
+                        if entry.get() < cost {
+                            error!(
+                                "pending transaction cost greater than available account balance"
+                            );
+                        }
+                        let current_cost = entry.get_mut();
+                        *current_cost = current_cost.saturating_sub(*cost);
+                    }
+                    hash_map::Entry::Vacant(_) => {
+                        if *cost != 0 {
+                            error!("pending transactions has cost not in account balances");
+                        }
+                    }
+                }
+            }
+        }
+        remaining_account_balances
     }
 }
 
@@ -189,6 +284,35 @@ impl TransactionsForAccount for PendingTransactionsForAccount {
         // is equal to the account nonce
         self.txs().contains_key(&previous_nonce) || ttx.signed_tx.nonce() == current_account_nonce
     }
+
+    fn has_balance_to_cover(
+        &self,
+        ttx: &TimemarkedTransaction,
+        current_account_balances: &HashMap<IbcPrefixed, u128>,
+    ) -> bool {
+        let mut remaining_account_balances = current_account_balances.clone();
+
+        // deduct costs from current account balances and return false if missing funds for any
+        for tx in self.txs.values().chain(std::iter::once(ttx)) {
+            for (denom, cost) in &tx.cost {
+                match remaining_account_balances.entry(*denom) {
+                    hash_map::Entry::Occupied(mut entry) => {
+                        if entry.get() < cost {
+                            return false;
+                        }
+                        let current_cost = entry.get_mut();
+                        *current_cost = current_cost.saturating_sub(*cost);
+                    }
+                    hash_map::Entry::Vacant(_) => {
+                        if *cost != 0 {
+                            return false;
+                        }
+                    }
+                }
+            }
+        }
+        true
+    }
 }
 
 /// Transactions for a single account where gaps are allowed in the sequence of nonces, and with an
@@ -200,17 +324,45 @@ pub(super) struct ParkedTransactionsForAccount<const MAX_TX_COUNT: usize> {
 
 impl<const MAX_TX_COUNT: usize> ParkedTransactionsForAccount<MAX_TX_COUNT> {
     /// Returns contiguous transactions from front of queue starting from target nonce, removing the
-    /// transactions in the process.
+    /// transactions in the process. Will only return transactions if their cost is covered by the
+    /// `available_balances`.
     ///
     /// Note: this function only operates on the front of the queue. If the target nonce is not at
-    /// the front, an error will be logged and nothing will be returned.
-    fn pop_front_contiguous(
+    /// the front, nothing will be returned.
+    fn find_promotables(
         &mut self,
         mut target_nonce: u32,
+        mut available_balances: HashMap<IbcPrefixed, u128>,
     ) -> impl Iterator<Item = TimemarkedTransaction> {
-        let mut split_at = 0;
+        let mut split_at: u32 = 0;
+        let mut break_flag = false;
         for nonce in self.txs.keys() {
             if *nonce == target_nonce {
+                // ensure we have enough balance to cover promotions
+                for (denom, cost) in self.txs.get(nonce).unwrap().cost() {
+                    match available_balances.entry(*denom) {
+                        hash_map::Entry::Occupied(mut entry) => {
+                            if cost <= entry.get() {
+                                let remaining_balance = entry.get_mut();
+                                *remaining_balance = remaining_balance.saturating_sub(*cost);
+                            } else {
+                                // not enough balance, do not include
+                                break_flag = true;
+                                break;
+                            }
+                        }
+                        hash_map::Entry::Vacant(_) => {
+                            // not enough balance, do not return transaction
+                            if *cost != 0 {
+                                break_flag = true;
+                                break;
+                            }
+                        }
+                    }
+                }
+                if break_flag {
+                    break;
+                }
                 let Some(next_target) = target_nonce.checked_add(1) else {
                     // We've got contiguous nonces up to `u32::MAX`; return everything.
                     return mem::take(&mut self.txs).into_values();
@@ -222,11 +374,8 @@ impl<const MAX_TX_COUNT: usize> ParkedTransactionsForAccount<MAX_TX_COUNT> {
             }
         }
 
-        if split_at == 0 {
-            error!(target_nonce, "expected nonce to be present");
-        }
-
         let mut split_off = self.txs.split_off(&split_at);
+
         // The higher nonces are returned in `split_off`, but we want to keep these in `self.txs`,
         // so swap the two collections.
         mem::swap(&mut split_off, &mut self.txs);
@@ -250,6 +399,14 @@ impl<const MAX_TX_COUNT: usize> TransactionsForAccount
     }
 
     fn is_sequential_nonce_precondition_met(&self, _: &TimemarkedTransaction, _: u32) -> bool {
+        true
+    }
+
+    fn has_balance_to_cover(
+        &self,
+        _: &TimemarkedTransaction,
+        _: &HashMap<IbcPrefixed, u128>,
+    ) -> bool {
         true
     }
 }
@@ -278,10 +435,22 @@ pub(super) trait TransactionsForAccount: Default {
         current_account_nonce: u32,
     ) -> bool;
 
+    /// Returns `Ok` if adding `ttx` would not break the balance precondition, i.e. enough
+    /// balance to cover all transactions in `CostsCovered` mode.
+    fn has_balance_to_cover(
+        &self,
+        ttx: &TimemarkedTransaction,
+        current_account_balance: &HashMap<IbcPrefixed, u128>,
+    ) -> bool;
+
     /// Adds transaction to the container. Note: does NOT allow for nonce replacement.
+    ///
     /// Will fail if in `SequentialNonces` mode and adding the transaction would create a nonce gap.
+    /// Will fail if in `CostsCovered` mode if adding the transaction would cause the total
+    /// balances for the transactions to exceed an account's available balance.
     ///
     /// `current_account_nonce` should be the account's nonce in the latest chain state.
+    /// `current_account_balance` should be the account's balances in the lastest chain state.
     ///
     /// Note: if the account `current_account_nonce` ever decreases, this is a logic error
     /// and could mess up the validity of `SequentialNonces` containers.
@@ -289,6 +458,7 @@ pub(super) trait TransactionsForAccount: Default {
         &mut self,
         ttx: TimemarkedTransaction,
         current_account_nonce: u32,
+        current_account_balances: &HashMap<IbcPrefixed, u128>,
     ) -> Result<(), InsertionError> {
         if self.is_at_tx_limit() {
             return Err(InsertionError::AccountSizeLimit);
@@ -308,6 +478,10 @@ pub(super) trait TransactionsForAccount: Default {
 
         if !self.is_sequential_nonce_precondition_met(&ttx, current_account_nonce) {
             return Err(InsertionError::NonceGap);
+        }
+
+        if !self.has_balance_to_cover(&ttx, current_account_balances) {
+            return Err(InsertionError::AccountBalanceTooLow);
         }
 
         self.txs_mut().insert(ttx.signed_tx.nonce(), ttx);
@@ -334,21 +508,6 @@ pub(super) trait TransactionsForAccount: Default {
             .collect()
     }
 
-    /// Returns the transaction with the lowest nonce.
-    fn front(&self) -> Option<&TimemarkedTransaction> {
-        self.txs().first_key_value().map(|(_, ttx)| ttx)
-    }
-
-    /// Removes transactions below the given nonce. Returns the hashes of the removed transactions.
-    fn register_latest_account_nonce(
-        &mut self,
-        current_account_nonce: u32,
-    ) -> impl Iterator<Item = [u8; 32]> {
-        let mut split_off = self.txs_mut().split_off(&current_account_nonce);
-        mem::swap(&mut split_off, self.txs_mut());
-        split_off.into_values().map(|ttx| ttx.tx_hash)
-    }
-
     #[cfg(test)]
     fn contains_tx(&self, tx_hash: &[u8; 32]) -> bool {
         self.txs().values().any(|ttx| ttx.tx_hash == *tx_hash)
@@ -371,6 +530,10 @@ impl<T: TransactionsForAccount> TransactionsContainer<T> {
         }
     }
 
+    pub(super) fn addresses(&self) -> HashSet<[u8; 20]> {
+        self.txs.keys().copied().collect()
+    }
+
     /// Adds the transaction to the container.
     ///
     /// `current_account_nonce` should be the current nonce of the account associated with the
@@ -380,14 +543,17 @@ impl<T: TransactionsForAccount> TransactionsContainer<T> {
         &mut self,
         ttx: TimemarkedTransaction,
         current_account_nonce: u32,
+        current_account_balances: &HashMap<IbcPrefixed, u128>,
     ) -> Result<(), InsertionError> {
         match self.txs.entry(*ttx.address()) {
             hash_map::Entry::Occupied(entry) => {
-                entry.into_mut().add(ttx, current_account_nonce)?;
+                entry
+                    .into_mut()
+                    .add(ttx, current_account_nonce, current_account_balances)?;
             }
             hash_map::Entry::Vacant(entry) => {
                 let mut txs = T::new();
-                txs.add(ttx, current_account_nonce)?;
+                txs.add(ttx, current_account_nonce, current_account_balances)?;
                 entry.insert(txs);
             }
         }
@@ -433,65 +599,43 @@ impl<T: TransactionsForAccount> TransactionsContainer<T> {
             .unwrap_or_default()
     }
 
-    /// Cleans all of the accounts in the container. Removes any transactions with stale nonces and
-    /// evicts all transactions from accounts whose lowest transaction has expired.
-    ///
-    /// Returns all transactions that have been removed with the reason why they have been removed.
-    pub(super) async fn clean_accounts<F, O>(
+    /// Cleans the specified account of stale and expired transactions.
+    pub(super) fn clean_account_stale_expired(
         &mut self,
-        current_account_nonce_getter: &F,
-    ) -> Vec<([u8; 32], RemovalReason)>
-    where
-        F: Fn([u8; 20]) -> O,
-        O: Future<Output = anyhow::Result<u32>>,
-    {
-        // currently just removes stale nonces and will clear accounts if the
-        // transactions are older than the TTL
-        let mut accounts_to_remove = Vec::new();
-        let mut removed_txs = Vec::new();
-        let now = Instant::now();
-        for (address, account_txs) in &mut self.txs {
-            // check if first tx is older than the TTL, if so, remove all transactions
-            if let Some(first_tx) = account_txs.front() {
-                if first_tx.is_expired(now, self.tx_ttl) {
-                    // first is stale, rest popped for invalidation
-                    removed_txs.push((first_tx.tx_hash, RemovalReason::Expired));
-                    removed_txs.extend(
-                        account_txs
-                            .txs()
-                            .values()
-                            .skip(1)
-                            .map(|ttx| (ttx.tx_hash, RemovalReason::LowerNonceInvalidated)),
-                    );
-                    account_txs.txs_mut().clear();
-                } else {
-                    // clean to newest nonce
-                    let current_account_nonce = match current_account_nonce_getter(*address).await {
-                        Ok(nonce) => nonce,
-                        Err(error) => {
-                            error!(
-                                address = %telemetry::display::base64(address),
-                                "failed to fetch nonce from state when cleaning accounts: {error:#}"
-                            );
-                            continue;
-                        }
-                    };
-                    removed_txs.extend(
-                        account_txs
-                            .register_latest_account_nonce(current_account_nonce)
-                            .map(|tx_hash| (tx_hash, RemovalReason::NonceStale)),
-                    );
-                }
-            }
+        address: [u8; 20],
+        current_account_nonce: u32,
+    ) -> Vec<([u8; 32], RemovalReason)> {
+        // Take the collection for this account out of `self` temporarily if it exists.
+        let Some(mut account_txs) = self.txs.remove(&address) else {
+            return Vec::<([u8; 32], RemovalReason)>::new();
+        };
 
-            if account_txs.txs().is_empty() {
-                accounts_to_remove.push(*address);
+        // clear out stale nonces
+        let mut split_off = account_txs.txs_mut().split_off(&current_account_nonce);
+        mem::swap(&mut split_off, account_txs.txs_mut());
+        let mut removed_txs: Vec<([u8; 32], RemovalReason)> = split_off
+            .into_values()
+            .map(|ttx| (ttx.tx_hash, RemovalReason::NonceStale))
+            .collect();
+
+        // check for expired transactions
+        if let Some(first_tx) = account_txs.txs_mut().first_entry() {
+            if first_tx.get().is_expired(Instant::now(), self.tx_ttl) {
+                removed_txs.push((first_tx.get().tx_hash, RemovalReason::Expired));
+                removed_txs.extend(
+                    account_txs
+                        .txs()
+                        .values()
+                        .skip(1)
+                        .map(|ttx| (ttx.tx_hash, RemovalReason::LowerNonceInvalidated)),
+                );
+                account_txs.txs_mut().clear();
             }
         }
 
-        // remove empty accounts
-        for account in accounts_to_remove {
-            self.txs.remove(&account);
+        // Re-add the collection to `self` if it's not empty.
+        if !account_txs.txs().is_empty() {
+            let _ = self.txs.insert(address, account_txs);
         }
 
         removed_txs
@@ -514,6 +658,41 @@ impl<T: TransactionsForAccount> TransactionsContainer<T> {
 }
 
 impl TransactionsContainer<PendingTransactionsForAccount> {
+    /// Remove and return transactions that should be moved from pending to parked
+    /// based on the specified account's current balances.
+    pub(super) fn find_demotables(
+        &mut self,
+        address: [u8; 20],
+        current_balances: &HashMap<IbcPrefixed, u128>,
+    ) -> Vec<TimemarkedTransaction> {
+        // Take the collection for this account out of `self` temporarily if it exists.
+        let Some(mut account) = self.txs.remove(&address) else {
+            return Vec::<TimemarkedTransaction>::new();
+        };
+
+        let demoted = account.find_demotables(current_balances);
+
+        // Re-add the collection to `self` if it's not empty.
+        if !account.txs().is_empty() {
+            let _ = self.txs.insert(address, account);
+        }
+
+        demoted
+    }
+
+    /// Returns remaining balances for an account after accounting for contained
+    /// transactions' costs.
+    pub(super) fn remaining_account_balances(
+        &self,
+        address: [u8; 20],
+        current_balances: HashMap<IbcPrefixed, u128>,
+    ) -> HashMap<IbcPrefixed, u128> {
+        let Some(account) = self.txs.get(&address) else {
+            return current_balances;
+        };
+        account.get_remaining_balances(current_balances)
+    }
+
     /// Returns the highest nonce for an account.
     pub(super) fn pending_nonce(&self, address: [u8; 20]) -> Option<u32> {
         self.txs
@@ -576,76 +755,28 @@ impl TransactionsContainer<PendingTransactionsForAccount> {
 }
 
 impl<const MAX_TX_COUNT: usize> TransactionsContainer<ParkedTransactionsForAccount<MAX_TX_COUNT>> {
-    /// Removes and returns the transactions from the front of an account, similar to
-    /// `find_promotables`. Useful for when needing to promote transactions from a specific
-    /// account instead of all accounts.
-    pub(super) fn pop_front_account(
+    /// Removes and returns the transactions that can be promoted from parked to pending for
+    /// an account. Will only return sequential nonces from `target_nonce` whose costs are
+    /// covered by the `available_balance`.
+    pub(super) fn find_promotables(
         &mut self,
         account: &[u8; 20],
         target_nonce: u32,
+        available_balance: &HashMap<IbcPrefixed, u128>,
     ) -> Vec<TimemarkedTransaction> {
         // Take the collection for this account out of `self` temporarily.
         let Some(mut account_txs) = self.txs.remove(account) else {
             return Vec::new();
         };
 
-        let removed = account_txs.pop_front_contiguous(target_nonce);
+        let removed = account_txs.find_promotables(target_nonce, available_balance.clone());
 
         // Re-add the collection to `self` if it's not empty.
         if !account_txs.txs().is_empty() {
             let _ = self.txs.insert(*account, account_txs);
         }
+
         removed.collect()
-    }
-
-    /// Removes and returns transactions along with their account's current nonce that are lower
-    /// than or equal to that nonce. This is helpful when needing to promote transactions from
-    /// parked to pending during mempool maintenance.
-    pub(super) async fn find_promotables<F, O>(
-        &mut self,
-        current_account_nonce_getter: &F,
-    ) -> Vec<(TimemarkedTransaction, u32)>
-    where
-        F: Fn([u8; 20]) -> O,
-        O: Future<Output = anyhow::Result<u32>>,
-    {
-        let mut accounts_to_remove = Vec::new();
-        let mut promoted_txs = Vec::new();
-
-        for (address, account_txs) in &mut self.txs {
-            let current_account_nonce = match current_account_nonce_getter(*address).await {
-                Ok(nonce) => nonce,
-                Err(error) => {
-                    error!(
-                        address = %telemetry::display::base64(address),
-                        "failed to fetch nonce from state when finding promotables: {error:#}"
-                    );
-                    continue;
-                }
-            };
-
-            // find transactions that can be promoted
-            // note: can use current account nonce as target because this logic
-            // is only handling the case where transactions we didn't have in our
-            // local mempool were ran that would enable the parked transactions to
-            // be valid
-            promoted_txs.extend(
-                account_txs
-                    .pop_front_contiguous(current_account_nonce)
-                    .map(|ttx| (ttx, current_account_nonce)),
-            );
-
-            if account_txs.txs.is_empty() {
-                accounts_to_remove.push(*address);
-            }
-        }
-
-        // remove empty accounts
-        for account in accounts_to_remove {
-            self.txs.remove(&account);
-        }
-
-        promoted_txs
     }
 }
 
@@ -654,18 +785,35 @@ mod test {
     use astria_core::crypto::SigningKey;
 
     use super::*;
-    use crate::app::test_utils::mock_tx;
+    use crate::app::test_utils::{
+        mock_balances,
+        mock_tx,
+        mock_tx_cost,
+        DENOM_0,
+        DENOM_1,
+        DENOM_3,
+    };
 
     const MAX_PARKED_TXS_PER_ACCOUNT: usize = 15;
     const TX_TTL: Duration = Duration::from_secs(2);
 
-    fn mock_ttx(nonce: u32, signer: &SigningKey) -> TimemarkedTransaction {
-        TimemarkedTransaction::new(mock_tx(nonce, signer, "test"))
+    fn mock_ttx(
+        nonce: u32,
+        signer: &SigningKey,
+        denom_0_cost: u128,
+        denom_1_cost: u128,
+        denom_2_cost: u128,
+    ) -> TimemarkedTransaction {
+        TimemarkedTransaction::new(
+            mock_tx(nonce, signer, "test"),
+            mock_tx_cost(denom_0_cost, denom_1_cost, denom_2_cost),
+        )
     }
 
     #[test]
     fn transaction_priority_should_error_if_invalid() {
-        let ttx = TimemarkedTransaction::new(mock_tx(0, &[1; 32].into(), "test"));
+        let ttx =
+            TimemarkedTransaction::new(mock_tx(0, &[1; 32].into(), "test"), mock_tx_cost(0, 0, 0));
         let priority = ttx.priority(1);
 
         assert!(
@@ -781,26 +929,35 @@ mod test {
         let mut parked_txs = ParkedTransactionsForAccount::<MAX_PARKED_TXS_PER_ACCOUNT>::new();
 
         // transactions to add
-        let ttx_1 = mock_ttx(1, &[1; 32].into());
-        let ttx_3 = mock_ttx(3, &[1; 32].into());
-        let ttx_5 = mock_ttx(5, &[1; 32].into());
+        let ttx_1 = mock_ttx(1, &[1; 32].into(), 10, 0, 0);
+        let ttx_3 = mock_ttx(3, &[1; 32].into(), 0, 10, 0);
+        let ttx_5 = mock_ttx(5, &[1; 32].into(), 0, 0, 100);
+
+        // note account doesn't have balance to cover any of them
+        let account_balances = mock_balances(1, 1);
 
         let current_account_nonce = 2;
         parked_txs
-            .add(ttx_3.clone(), current_account_nonce)
+            .add(ttx_3.clone(), current_account_nonce, &account_balances)
             .unwrap();
         assert!(parked_txs.contains_tx(&ttx_3.tx_hash));
         assert_eq!(
-            parked_txs.add(ttx_3, current_account_nonce).unwrap_err(),
+            parked_txs
+                .add(ttx_3, current_account_nonce, &account_balances)
+                .unwrap_err(),
             InsertionError::AlreadyPresent
         );
 
         // add gapped transaction
-        parked_txs.add(ttx_5, current_account_nonce).unwrap();
+        parked_txs
+            .add(ttx_5, current_account_nonce, &account_balances)
+            .unwrap();
 
         // fail adding too low nonce
         assert_eq!(
-            parked_txs.add(ttx_1, current_account_nonce).unwrap_err(),
+            parked_txs
+                .add(ttx_1, current_account_nonce, &account_balances)
+                .unwrap_err(),
             InsertionError::NonceTooLow
         );
     }
@@ -810,19 +967,24 @@ mod test {
         let mut parked_txs = ParkedTransactionsForAccount::<2>::new();
 
         // transactions to add
-        let ttx_1 = mock_ttx(1, &[1; 32].into());
-        let ttx_3 = mock_ttx(3, &[1; 32].into());
-        let ttx_5 = mock_ttx(5, &[1; 32].into());
+        let ttx_1 = mock_ttx(1, &[1; 32].into(), 0, 0, 0);
+        let ttx_3 = mock_ttx(3, &[1; 32].into(), 0, 0, 0);
+        let ttx_5 = mock_ttx(5, &[1; 32].into(), 0, 0, 0);
+        let account_balances = mock_balances(1, 1);
 
         let current_account_nonce = 0;
         parked_txs
-            .add(ttx_3.clone(), current_account_nonce)
+            .add(ttx_3.clone(), current_account_nonce, &account_balances)
             .unwrap();
-        parked_txs.add(ttx_5, current_account_nonce).unwrap();
+        parked_txs
+            .add(ttx_5, current_account_nonce, &account_balances)
+            .unwrap();
 
         // fail with size limit hit
         assert_eq!(
-            parked_txs.add(ttx_1, current_account_nonce).unwrap_err(),
+            parked_txs
+                .add(ttx_1, current_account_nonce, &account_balances)
+                .unwrap_err(),
             InsertionError::AccountSizeLimit
         );
     }
@@ -831,17 +993,21 @@ mod test {
     fn pending_transactions_for_account_add() {
         let mut pending_txs = PendingTransactionsForAccount::new();
 
-        // transactions to add
-        let ttx_0 = mock_ttx(0, &[1; 32].into());
-        let ttx_1 = mock_ttx(1, &[1; 32].into());
-        let ttx_2 = mock_ttx(2, &[1; 32].into());
-        let ttx_3 = mock_ttx(3, &[1; 32].into());
+        // transactions to add, not testing balances in this unit test
+        let ttx_0 = mock_ttx(0, &[1; 32].into(), 0, 0, 0);
+        let ttx_1 = mock_ttx(1, &[1; 32].into(), 0, 0, 0);
+        let ttx_2 = mock_ttx(2, &[1; 32].into(), 0, 0, 0);
+        let ttx_3 = mock_ttx(3, &[1; 32].into(), 0, 0, 0);
+
+        let account_balances = mock_balances(1, 1);
 
         let current_account_nonce = 1;
 
         // too low nonces not added
         assert_eq!(
-            pending_txs.add(ttx_0, current_account_nonce).unwrap_err(),
+            pending_txs
+                .add(ttx_0, current_account_nonce, &account_balances)
+                .unwrap_err(),
             InsertionError::NonceTooLow
         );
         assert!(pending_txs.txs().is_empty());
@@ -849,7 +1015,7 @@ mod test {
         // too high nonces with empty container not added
         assert_eq!(
             pending_txs
-                .add(ttx_2.clone(), current_account_nonce)
+                .add(ttx_2.clone(), current_account_nonce, &account_balances)
                 .unwrap_err(),
             InsertionError::NonceGap
         );
@@ -857,21 +1023,102 @@ mod test {
 
         // add ok
         pending_txs
-            .add(ttx_1.clone(), current_account_nonce)
+            .add(ttx_1.clone(), current_account_nonce, &account_balances)
             .unwrap();
         assert_eq!(
-            pending_txs.add(ttx_1, current_account_nonce).unwrap_err(),
+            pending_txs
+                .add(ttx_1, current_account_nonce, &account_balances)
+                .unwrap_err(),
             InsertionError::AlreadyPresent
         );
 
         // gapped transaction not allowed
         assert_eq!(
-            pending_txs.add(ttx_3, current_account_nonce).unwrap_err(),
+            pending_txs
+                .add(ttx_3, current_account_nonce, &account_balances)
+                .unwrap_err(),
             InsertionError::NonceGap
         );
 
         // can add consecutive
-        pending_txs.add(ttx_2, current_account_nonce).unwrap();
+        pending_txs
+            .add(ttx_2, current_account_nonce, &account_balances)
+            .unwrap();
+    }
+
+    #[test]
+    fn pending_transactions_for_account_add_balances() {
+        let mut pending_txs = PendingTransactionsForAccount::new();
+
+        // transactions to add, testing balances
+        let ttx_0_too_expensive_0 = mock_ttx(0, &[1; 32].into(), 11, 0, 0);
+        let ttx_0_too_expensive_1 = mock_ttx(0, &[1; 32].into(), 0, 0, 1);
+        let ttx_0 = mock_ttx(0, &[1; 32].into(), 10, 0, 0);
+        let ttx_1 = mock_ttx(1, &[1; 32].into(), 0, 10, 0);
+        let ttx_2 = mock_ttx(2, &[1; 32].into(), 0, 8, 0);
+        let ttx_3 = mock_ttx(3, &[1; 32].into(), 0, 2, 0);
+        let ttx_4 = mock_ttx(4, &[1; 32].into(), 1, 0, 0);
+
+        let account_balances = mock_balances(10, 20);
+        let current_account_nonce = 0;
+
+        // transaction exceeding account balances (asset present in balances) not allowed
+        assert_eq!(
+            pending_txs
+                .add(
+                    ttx_0_too_expensive_0,
+                    current_account_nonce,
+                    &account_balances
+                )
+                .unwrap_err(),
+            InsertionError::AccountBalanceTooLow
+        );
+        assert!(pending_txs.txs().is_empty());
+
+        // transaction exceeding account balances (asset NOT present in balances) not allowed
+        assert_eq!(
+            pending_txs
+                .add(
+                    ttx_0_too_expensive_1,
+                    current_account_nonce,
+                    &account_balances
+                )
+                .unwrap_err(),
+            InsertionError::AccountBalanceTooLow
+        );
+        assert!(pending_txs.txs().is_empty());
+
+        // transactions under account cost allowed
+        pending_txs
+            .add(ttx_0, current_account_nonce, &account_balances)
+            .unwrap();
+        pending_txs
+            .add(ttx_1.clone(), current_account_nonce, &account_balances)
+            .unwrap();
+        pending_txs
+            .add(ttx_2.clone(), current_account_nonce, &account_balances)
+            .unwrap();
+        pending_txs
+            .add(ttx_3.clone(), current_account_nonce, &account_balances)
+            .unwrap();
+
+        assert_eq!(pending_txs.txs().len(), 4);
+
+        // check that remaining balances are zero
+        let remaining_balances = pending_txs.get_remaining_balances(account_balances.clone());
+        for (asset, balance) in remaining_balances {
+            if asset != IbcPrefixed::new(DENOM_3) {
+                assert_eq!(balance, 0, "balance should have been consumed");
+            }
+        }
+
+        // cost exceeding when considering already contained transactions not allowed
+        assert_eq!(
+            pending_txs
+                .add(ttx_4, current_account_nonce, &account_balances)
+                .unwrap_err(),
+            InsertionError::AccountBalanceTooLow
+        );
     }
 
     #[test]
@@ -879,15 +1126,24 @@ mod test {
         let mut account_txs = PendingTransactionsForAccount::new();
 
         // transactions to add
-        let ttx_0 = mock_ttx(0, &[1; 32].into());
-        let ttx_1 = mock_ttx(1, &[1; 32].into());
-        let ttx_2 = mock_ttx(2, &[1; 32].into());
-        let ttx_3 = mock_ttx(3, &[1; 32].into());
+        let ttx_0 = mock_ttx(0, &[1; 32].into(), 0, 0, 0);
+        let ttx_1 = mock_ttx(1, &[1; 32].into(), 0, 0, 0);
+        let ttx_2 = mock_ttx(2, &[1; 32].into(), 0, 0, 0);
+        let ttx_3 = mock_ttx(3, &[1; 32].into(), 0, 0, 0);
+        let account_balances = mock_balances(1, 1);
 
-        account_txs.add(ttx_0.clone(), 0).unwrap();
-        account_txs.add(ttx_1.clone(), 0).unwrap();
-        account_txs.add(ttx_2.clone(), 0).unwrap();
-        account_txs.add(ttx_3.clone(), 0).unwrap();
+        account_txs
+            .add(ttx_0.clone(), 0, &account_balances)
+            .unwrap();
+        account_txs
+            .add(ttx_1.clone(), 0, &account_balances)
+            .unwrap();
+        account_txs
+            .add(ttx_2.clone(), 0, &account_balances)
+            .unwrap();
+        account_txs
+            .add(ttx_3.clone(), 0, &account_balances)
+            .unwrap();
 
         // remove from end will only remove end
         assert_eq!(
@@ -915,52 +1171,6 @@ mod test {
     }
 
     #[test]
-    fn parked_transactions_for_account_pop_front_contiguous() {
-        let mut parked_txs = ParkedTransactionsForAccount::<MAX_PARKED_TXS_PER_ACCOUNT>::new();
-
-        // transactions to add
-        let ttx_0 = mock_ttx(0, &[1; 32].into());
-        let ttx_2 = mock_ttx(2, &[1; 32].into());
-        let ttx_3 = mock_ttx(3, &[1; 32].into());
-        let ttx_4 = mock_ttx(4, &[1; 32].into());
-
-        parked_txs.add(ttx_0.clone(), 0).unwrap();
-        parked_txs.add(ttx_2.clone(), 0).unwrap();
-        parked_txs.add(ttx_3.clone(), 0).unwrap();
-        parked_txs.add(ttx_4.clone(), 0).unwrap();
-
-        // lowest nonce not target nonce is noop
-        assert_eq!(
-            parked_txs.pop_front_contiguous(2).count(),
-            0,
-            "no transaction should've been removed"
-        );
-        assert_eq!(parked_txs.txs().len(), 4);
-
-        // will remove single value
-        assert_eq!(
-            parked_txs
-                .pop_front_contiguous(0)
-                .map(|ttx| ttx.tx_hash)
-                .collect::<Vec<_>>(),
-            vec![ttx_0.tx_hash],
-            "single transaction should've been returned"
-        );
-        assert_eq!(parked_txs.txs().len(), 3);
-
-        // will remove multiple values
-        assert_eq!(
-            parked_txs
-                .pop_front_contiguous(2)
-                .map(|ttx| ttx.tx_hash)
-                .collect::<Vec<_>>(),
-            vec![ttx_2.tx_hash, ttx_3.tx_hash, ttx_4.tx_hash],
-            "multiple transaction should've been returned"
-        );
-        assert!(parked_txs.txs().is_empty());
-    }
-
-    #[test]
     fn pending_transactions_for_account_highest_nonce() {
         let mut pending_txs = PendingTransactionsForAccount::new();
 
@@ -971,13 +1181,14 @@ mod test {
         );
 
         // transactions to add
-        let ttx_0 = mock_ttx(0, &[1; 32].into());
-        let ttx_1 = mock_ttx(1, &[1; 32].into());
-        let ttx_2 = mock_ttx(2, &[1; 32].into());
+        let ttx_0 = mock_ttx(0, &[1; 32].into(), 0, 0, 0);
+        let ttx_1 = mock_ttx(1, &[1; 32].into(), 0, 0, 0);
+        let ttx_2 = mock_ttx(2, &[1; 32].into(), 0, 0, 0);
+        let account_balances = mock_balances(1, 1);
 
-        pending_txs.add(ttx_0, 0).unwrap();
-        pending_txs.add(ttx_1, 0).unwrap();
-        pending_txs.add(ttx_2, 0).unwrap();
+        pending_txs.add(ttx_0, 0, &account_balances).unwrap();
+        pending_txs.add(ttx_1, 0, &account_balances).unwrap();
+        pending_txs.add(ttx_2, 0, &account_balances).unwrap();
 
         // will return last transaction
         assert_eq!(
@@ -985,85 +1196,6 @@ mod test {
             Some(2),
             "highest nonce should be returned"
         );
-    }
-
-    #[test]
-    fn transactions_for_account_front() {
-        let mut parked_txs = ParkedTransactionsForAccount::<MAX_PARKED_TXS_PER_ACCOUNT>::new();
-
-        // no transactions ok
-        assert!(
-            parked_txs.front().is_none(),
-            "no transactions will return None"
-        );
-
-        // transactions to add
-        let ttx_0 = mock_ttx(0, &[1; 32].into());
-        let ttx_2 = mock_ttx(2, &[1; 32].into());
-
-        parked_txs.add(ttx_0.clone(), 0).unwrap();
-        parked_txs.add(ttx_2, 0).unwrap();
-
-        // will return first transaction
-        assert_eq!(
-            parked_txs.front().unwrap().tx_hash,
-            ttx_0.tx_hash,
-            "lowest transaction should be returned"
-        );
-    }
-
-    #[test]
-    fn transactions_for_account_register_latest_account_nonce() {
-        let mut parked_txs = ParkedTransactionsForAccount::<MAX_PARKED_TXS_PER_ACCOUNT>::new();
-
-        // transactions to add
-        let ttx_0 = mock_ttx(0, &[1; 32].into());
-        let ttx_2 = mock_ttx(2, &[1; 32].into());
-        let ttx_3 = mock_ttx(3, &[1; 32].into());
-        let ttx_4 = mock_ttx(4, &[1; 32].into());
-
-        parked_txs.add(ttx_0.clone(), 0).unwrap();
-        parked_txs.add(ttx_2.clone(), 0).unwrap();
-        parked_txs.add(ttx_3.clone(), 0).unwrap();
-        parked_txs.add(ttx_4.clone(), 0).unwrap();
-
-        // matching nonce will not be removed
-        assert_eq!(
-            parked_txs.register_latest_account_nonce(0).count(),
-            0,
-            "no transaction should've been removed"
-        );
-        assert_eq!(parked_txs.txs().len(), 4);
-
-        // fast forwarding to non existing middle nonce ok
-        assert_eq!(
-            parked_txs
-                .register_latest_account_nonce(1)
-                .collect::<Vec<_>>(),
-            vec![ttx_0.tx_hash],
-            "ttx_0 should've been removed"
-        );
-        assert_eq!(parked_txs.txs().len(), 3);
-
-        // fast forwarding to existing nonce ok
-        assert_eq!(
-            parked_txs
-                .register_latest_account_nonce(3)
-                .collect::<Vec<_>>(),
-            vec![ttx_2.tx_hash],
-            "one transaction should've been removed"
-        );
-        assert_eq!(parked_txs.txs().len(), 2);
-
-        // fast forwarding to much higher nonce ok
-        assert_eq!(
-            parked_txs
-                .register_latest_account_nonce(10)
-                .collect::<Vec<_>>(),
-            vec![ttx_3.tx_hash, ttx_4.tx_hash],
-            "two transactions should've been removed"
-        );
-        assert!(parked_txs.txs().is_empty());
     }
 
     #[test]
@@ -1077,11 +1209,13 @@ mod test {
         let signing_address_1 = signing_key_1.address_bytes();
 
         // transactions to add to accounts
-        let ttx_s0_0_0 = mock_ttx(0, &signing_key_0);
+        let ttx_s0_0_0 = mock_ttx(0, &signing_key_0, 0, 0, 0);
         // Same nonce and signer as `ttx_s0_0_0`, but different rollup name, hence different tx.
-        let ttx_s0_0_1 = TimemarkedTransaction::new(mock_tx(0, &signing_key_0, "other"));
-        let ttx_s0_2_0 = mock_ttx(2, &signing_key_0);
-        let ttx_s1_0_0 = mock_ttx(0, &signing_key_1);
+        let ttx_s0_0_1 =
+            TimemarkedTransaction::new(mock_tx(0, &signing_key_0, "other"), mock_tx_cost(0, 0, 0));
+        let ttx_s0_2_0 = mock_ttx(2, &signing_key_0, 0, 0, 0);
+        let ttx_s1_0_0 = mock_ttx(0, &signing_key_1, 0, 0, 0);
+        let account_balances = mock_balances(1, 1);
 
         // transactions to add for account 1
 
@@ -1093,7 +1227,9 @@ mod test {
 
         // adding too low nonce shouldn't create account
         assert_eq!(
-            pending_txs.add(ttx_s0_0_0.clone(), 1).unwrap_err(),
+            pending_txs
+                .add(ttx_s0_0_0.clone(), 1, &account_balances)
+                .unwrap_err(),
             InsertionError::NonceTooLow,
             "shouldn't be able to add nonce too low transaction"
         );
@@ -1103,32 +1239,40 @@ mod test {
         );
 
         // add one transaction
-        pending_txs.add(ttx_s0_0_0.clone(), 0).unwrap();
+        pending_txs
+            .add(ttx_s0_0_0.clone(), 0, &account_balances)
+            .unwrap();
         assert_eq!(pending_txs.txs.len(), 1, "one account should exist");
 
         // re-adding transaction should fail
         assert_eq!(
-            pending_txs.add(ttx_s0_0_0, 0).unwrap_err(),
+            pending_txs
+                .add(ttx_s0_0_0, 0, &account_balances)
+                .unwrap_err(),
             InsertionError::AlreadyPresent,
             "re-adding same transaction should fail"
         );
 
         // nonce replacement fails
         assert_eq!(
-            pending_txs.add(ttx_s0_0_1, 0).unwrap_err(),
+            pending_txs
+                .add(ttx_s0_0_1, 0, &account_balances)
+                .unwrap_err(),
             InsertionError::NonceTaken,
             "nonce replacement not supported"
         );
 
         // nonce gaps not supported
         assert_eq!(
-            pending_txs.add(ttx_s0_2_0, 0).unwrap_err(),
+            pending_txs
+                .add(ttx_s0_2_0, 0, &account_balances)
+                .unwrap_err(),
             InsertionError::NonceGap,
             "gapped nonces in pending transactions not allowed"
         );
 
         // add transactions for account 2
-        pending_txs.add(ttx_s1_0_0, 0).unwrap();
+        pending_txs.add(ttx_s1_0_0, 0, &account_balances).unwrap();
 
         // check internal structures
         assert_eq!(pending_txs.txs.len(), 2, "two accounts should exist");
@@ -1156,10 +1300,11 @@ mod test {
         let signing_key_1 = SigningKey::from([2; 32]);
 
         // transactions to add to accounts
-        let ttx_s0_0 = mock_ttx(0, &signing_key_0);
-        let ttx_s0_1 = mock_ttx(1, &signing_key_0);
-        let ttx_s1_0 = mock_ttx(0, &signing_key_1);
-        let ttx_s1_1 = mock_ttx(1, &signing_key_1);
+        let ttx_s0_0 = mock_ttx(0, &signing_key_0, 0, 0, 0);
+        let ttx_s0_1 = mock_ttx(1, &signing_key_0, 0, 0, 0);
+        let ttx_s1_0 = mock_ttx(0, &signing_key_1, 0, 0, 0);
+        let ttx_s1_1 = mock_ttx(1, &signing_key_1, 0, 0, 0);
+        let account_balances = mock_balances(1, 1);
 
         // remove on empty returns the tx in Err variant.
         assert!(
@@ -1168,10 +1313,18 @@ mod test {
         );
 
         // add transactions
-        pending_txs.add(ttx_s0_0.clone(), 0).unwrap();
-        pending_txs.add(ttx_s0_1.clone(), 0).unwrap();
-        pending_txs.add(ttx_s1_0.clone(), 0).unwrap();
-        pending_txs.add(ttx_s1_1.clone(), 0).unwrap();
+        pending_txs
+            .add(ttx_s0_0.clone(), 0, &account_balances)
+            .unwrap();
+        pending_txs
+            .add(ttx_s0_1.clone(), 0, &account_balances)
+            .unwrap();
+        pending_txs
+            .add(ttx_s1_0.clone(), 0, &account_balances)
+            .unwrap();
+        pending_txs
+            .add(ttx_s1_1.clone(), 0, &account_balances)
+            .unwrap();
 
         // remove should remove tx and higher
         assert_eq!(
@@ -1204,9 +1357,10 @@ mod test {
         let signing_key_1 = SigningKey::from([2; 32]);
 
         // transactions to add to accounts
-        let ttx_s0_0 = mock_ttx(0, &signing_key_0);
-        let ttx_s0_1 = mock_ttx(1, &signing_key_0);
-        let ttx_s1_0 = mock_ttx(0, &signing_key_1);
+        let ttx_s0_0 = mock_ttx(0, &signing_key_0, 0, 0, 0);
+        let ttx_s0_1 = mock_ttx(1, &signing_key_0, 0, 0, 0);
+        let ttx_s1_0 = mock_ttx(0, &signing_key_1, 0, 0, 0);
+        let account_balances = mock_balances(1, 1);
 
         // clear all on empty returns zero
         assert!(
@@ -1215,9 +1369,15 @@ mod test {
         );
 
         // add transactions
-        pending_txs.add(ttx_s0_0.clone(), 0).unwrap();
-        pending_txs.add(ttx_s0_1.clone(), 0).unwrap();
-        pending_txs.add(ttx_s1_0.clone(), 0).unwrap();
+        pending_txs
+            .add(ttx_s0_0.clone(), 0, &account_balances)
+            .unwrap();
+        pending_txs
+            .add(ttx_s0_1.clone(), 0, &account_balances)
+            .unwrap();
+        pending_txs
+            .add(ttx_s1_0.clone(), 0, &account_balances)
+            .unwrap();
 
         // clear should return all transactions
         assert_eq!(
@@ -1239,7 +1399,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn transactions_container_clean_accounts() {
+    async fn transactions_container_clean_account_stale_expired() {
         let mut pending_txs = PendingTransactions::new(TX_TTL);
         let signing_key_0 = SigningKey::from([1; 32]);
         let signing_address_0 = signing_key_0.address_bytes();
@@ -1249,45 +1409,52 @@ mod test {
         let signing_address_2 = signing_key_2.address_bytes();
 
         // transactions to add to accounts
-        let ttx_s0_0 = mock_ttx(0, &signing_key_0);
-        let ttx_s0_1 = mock_ttx(1, &signing_key_0);
-        let ttx_s0_2 = mock_ttx(2, &signing_key_0);
-        let ttx_s1_0 = mock_ttx(0, &signing_key_1);
-        let ttx_s1_1 = mock_ttx(1, &signing_key_1);
-        let ttx_s1_2 = mock_ttx(2, &signing_key_1);
-        let ttx_s2_0 = mock_ttx(0, &signing_key_2);
-        let ttx_s2_1 = mock_ttx(1, &signing_key_2);
-        let ttx_s2_2 = mock_ttx(2, &signing_key_2);
+        let ttx_s0_0 = mock_ttx(0, &signing_key_0, 0, 0, 0);
+        let ttx_s0_1 = mock_ttx(1, &signing_key_0, 0, 0, 0);
+        let ttx_s0_2 = mock_ttx(2, &signing_key_0, 0, 0, 0);
+        let ttx_s1_0 = mock_ttx(0, &signing_key_1, 0, 0, 0);
+        let ttx_s1_1 = mock_ttx(1, &signing_key_1, 0, 0, 0);
+        let ttx_s1_2 = mock_ttx(2, &signing_key_1, 0, 0, 0);
+        let ttx_s2_0 = mock_ttx(0, &signing_key_2, 0, 0, 0);
+        let ttx_s2_1 = mock_ttx(1, &signing_key_2, 0, 0, 0);
+        let ttx_s2_2 = mock_ttx(2, &signing_key_2, 0, 0, 0);
+        let account_balances = mock_balances(1, 1);
 
         // add transactions
-        pending_txs.add(ttx_s0_0.clone(), 0).unwrap();
-        pending_txs.add(ttx_s0_1.clone(), 0).unwrap();
-        pending_txs.add(ttx_s0_2.clone(), 0).unwrap();
-        pending_txs.add(ttx_s1_0.clone(), 0).unwrap();
-        pending_txs.add(ttx_s1_1.clone(), 0).unwrap();
-        pending_txs.add(ttx_s1_2.clone(), 0).unwrap();
-        pending_txs.add(ttx_s2_0.clone(), 0).unwrap();
-        pending_txs.add(ttx_s2_1.clone(), 0).unwrap();
-        pending_txs.add(ttx_s2_2.clone(), 0).unwrap();
+        pending_txs
+            .add(ttx_s0_0.clone(), 0, &account_balances)
+            .unwrap();
+        pending_txs
+            .add(ttx_s0_1.clone(), 0, &account_balances)
+            .unwrap();
+        pending_txs
+            .add(ttx_s0_2.clone(), 0, &account_balances)
+            .unwrap();
+        pending_txs
+            .add(ttx_s1_0.clone(), 0, &account_balances)
+            .unwrap();
+        pending_txs
+            .add(ttx_s1_1.clone(), 0, &account_balances)
+            .unwrap();
+        pending_txs
+            .add(ttx_s1_2.clone(), 0, &account_balances)
+            .unwrap();
+        pending_txs
+            .add(ttx_s2_0.clone(), 0, &account_balances)
+            .unwrap();
+        pending_txs
+            .add(ttx_s2_1.clone(), 0, &account_balances)
+            .unwrap();
+        pending_txs
+            .add(ttx_s2_2.clone(), 0, &account_balances)
+            .unwrap();
 
-        // current nonce getter
+        // clean accounts
         // should pop none from signing_address_0, one from signing_address_1, and all from
         // signing_address_2
-        let current_account_nonce_getter = |address: [u8; 20]| async move {
-            if address == signing_address_0 {
-                Ok(0)
-            } else if address == signing_address_1 {
-                Ok(1)
-            } else if address == signing_address_2 {
-                Ok(4)
-            } else {
-                Err(anyhow::anyhow!("invalid address"))
-            }
-        };
-
-        let removed_txs = pending_txs
-            .clean_accounts(&current_account_nonce_getter)
-            .await;
+        let mut removed_txs = pending_txs.clean_account_stale_expired(signing_address_0, 0);
+        removed_txs.extend(pending_txs.clean_account_stale_expired(signing_address_1, 1));
+        removed_txs.extend(pending_txs.clean_account_stale_expired(signing_address_2, 4));
 
         assert_eq!(
             removed_txs.len(),
@@ -1329,33 +1496,31 @@ mod test {
         let signing_address_0 = signing_key_0.address_bytes();
         let signing_key_1 = SigningKey::from([2; 32]);
         let signing_address_1 = signing_key_1.address_bytes();
+        let account_balances = mock_balances(1, 1);
 
         // transactions to add to accounts
-        let ttx_s0_0 = mock_ttx(0, &signing_key_0);
+        let ttx_s0_0 = mock_ttx(0, &signing_key_0, 0, 0, 0);
 
         // pass time to make first transaction stale
         tokio::time::advance(TX_TTL.saturating_add(Duration::from_nanos(1))).await;
 
-        let ttx_s0_1 = mock_ttx(1, &signing_key_0);
-        let ttx_s1_0 = mock_ttx(0, &signing_key_1);
+        let ttx_s0_1 = mock_ttx(1, &signing_key_0, 0, 0, 0);
+        let ttx_s1_0 = mock_ttx(0, &signing_key_1, 0, 0, 0);
 
         // add transactions
-        pending_txs.add(ttx_s0_0.clone(), 0).unwrap();
-        pending_txs.add(ttx_s0_1.clone(), 0).unwrap();
-        pending_txs.add(ttx_s1_0.clone(), 0).unwrap();
+        pending_txs
+            .add(ttx_s0_0.clone(), 0, &account_balances)
+            .unwrap();
+        pending_txs
+            .add(ttx_s0_1.clone(), 0, &account_balances)
+            .unwrap();
+        pending_txs
+            .add(ttx_s1_0.clone(), 0, &account_balances)
+            .unwrap();
 
-        // current nonce getter
-        // all nonces should be valid
-        let current_account_nonce_getter = |address: [u8; 20]| async move {
-            if address == signing_address_0 || address == signing_address_1 {
-                return Ok(0);
-            }
-            Err(anyhow::anyhow!("invalid address"))
-        };
-
-        let removed_txs = pending_txs
-            .clean_accounts(&current_account_nonce_getter)
-            .await;
+        // clean accounts, all nonces should be valid
+        let mut removed_txs = pending_txs.clean_account_stale_expired(signing_address_0, 0);
+        removed_txs.extend(pending_txs.clean_account_stale_expired(signing_address_1, 0));
 
         assert_eq!(
             removed_txs.len(),
@@ -1394,13 +1559,14 @@ mod test {
 
         let signing_key_1 = SigningKey::from([2; 32]);
         let signing_address_1 = signing_key_1.address_bytes();
+        let account_balances = mock_balances(1, 1);
 
         // transactions to add for account 0
-        let ttx_s0_0 = mock_ttx(0, &signing_key_0);
-        let ttx_s0_1 = mock_ttx(1, &signing_key_0);
+        let ttx_s0_0 = mock_ttx(0, &signing_key_0, 0, 0, 0);
+        let ttx_s0_1 = mock_ttx(1, &signing_key_0, 0, 0, 0);
 
-        pending_txs.add(ttx_s0_0, 0).unwrap();
-        pending_txs.add(ttx_s0_1, 0).unwrap();
+        pending_txs.add(ttx_s0_0, 0, &account_balances).unwrap();
+        pending_txs.add(ttx_s0_1, 0, &account_balances).unwrap();
 
         // empty account returns zero
         assert!(
@@ -1425,16 +1591,25 @@ mod test {
         let signing_address_1 = signing_key_1.address_bytes();
 
         // transactions to add to accounts
-        let ttx_s0_1 = mock_ttx(1, &signing_key_0);
-        let ttx_s1_1 = mock_ttx(1, &signing_key_1);
-        let ttx_s1_2 = mock_ttx(2, &signing_key_1);
-        let ttx_s1_3 = mock_ttx(3, &signing_key_1);
+        let ttx_s0_1 = mock_ttx(1, &signing_key_0, 0, 0, 0);
+        let ttx_s1_1 = mock_ttx(1, &signing_key_1, 0, 0, 0);
+        let ttx_s1_2 = mock_ttx(2, &signing_key_1, 0, 0, 0);
+        let ttx_s1_3 = mock_ttx(3, &signing_key_1, 0, 0, 0);
+        let account_balances = mock_balances(1, 1);
 
         // add transactions
-        pending_txs.add(ttx_s0_1.clone(), 1).unwrap();
-        pending_txs.add(ttx_s1_1.clone(), 1).unwrap();
-        pending_txs.add(ttx_s1_2.clone(), 1).unwrap();
-        pending_txs.add(ttx_s1_3.clone(), 1).unwrap();
+        pending_txs
+            .add(ttx_s0_1.clone(), 1, &account_balances)
+            .unwrap();
+        pending_txs
+            .add(ttx_s1_1.clone(), 1, &account_balances)
+            .unwrap();
+        pending_txs
+            .add(ttx_s1_2.clone(), 1, &account_balances)
+            .unwrap();
+        pending_txs
+            .add(ttx_s1_3.clone(), 1, &account_balances)
+            .unwrap();
 
         // current nonce getter
         // should return all transactions from signing_key_0 and last two from signing_key_1
@@ -1485,100 +1660,148 @@ mod test {
     }
 
     #[tokio::test]
-    async fn parked_transactions_pop_front_account() {
+    async fn parked_transactions_find_promotables() {
         let mut parked_txs = ParkedTransactions::<MAX_PARKED_TXS_PER_ACCOUNT>::new(TX_TTL);
-        let signing_key_0 = SigningKey::from([1; 32]);
-        let signing_address_0 = signing_key_0.address_bytes();
-        let signing_key_1 = SigningKey::from([2; 32]);
-        let signing_address_1 = signing_key_1.address_bytes();
+        let signing_key = SigningKey::from([1; 32]);
+        let signing_address = signing_key.address_bytes();
 
         // transactions to add to accounts
-        let ttx_s0_1 = mock_ttx(1, &signing_key_0);
-        let ttx_s1_1 = mock_ttx(1, &signing_key_1);
-        let ttx_s1_2 = mock_ttx(2, &signing_key_1);
-        let ttx_s1_4 = mock_ttx(4, &signing_key_1);
+        let ttx_1 = mock_ttx(1, &signing_key, 10, 0, 0);
+        let ttx_2 = mock_ttx(2, &signing_key, 5, 2, 0);
+        let ttx_3 = mock_ttx(3, &signing_key, 1, 0, 0);
+        let remaining_balances = mock_balances(15, 2);
 
         // add transactions
-        parked_txs.add(ttx_s0_1.clone(), 0).unwrap();
-        parked_txs.add(ttx_s1_1.clone(), 0).unwrap();
-        parked_txs.add(ttx_s1_2.clone(), 0).unwrap();
-        parked_txs.add(ttx_s1_4.clone(), 0).unwrap();
+        parked_txs
+            .add(ttx_1.clone(), 0, &remaining_balances)
+            .unwrap();
+        parked_txs
+            .add(ttx_2.clone(), 0, &remaining_balances)
+            .unwrap();
+        parked_txs
+            .add(ttx_3.clone(), 0, &remaining_balances)
+            .unwrap();
 
-        // pop from account 1
-        assert_eq!(
-            parked_txs.pop_front_account(&signing_address_0, 1).len(),
-            1,
-            "one transactions should've been popped"
-        );
-        assert_eq!(parked_txs.txs.len(), 1, "empty accounts should be removed");
+        // none should be returned on nonce gap
+        let promotables = parked_txs.find_promotables(&signing_address, 0, &remaining_balances);
+        assert_eq!(promotables.len(), 0);
 
-        // pop from account 2
-        assert_eq!(
-            parked_txs.pop_front_account(&signing_address_1, 1).len(),
-            2,
-            "two transactions should've been popped"
-        );
-        assert_eq!(
-            parked_txs.txs.len(),
-            1,
-            "non empty accounts should not be removed"
-        );
-
+        // only first two transactions should be returned
+        let promotables = parked_txs.find_promotables(&signing_address, 1, &remaining_balances);
+        assert_eq!(promotables.len(), 2);
+        assert_eq!(promotables[0].nonce(), 1);
+        assert_eq!(promotables[1].nonce(), 2);
         assert_eq!(
             parked_txs.len(),
             1,
-            "1 transactions should be remaining from original 4"
+            "promoted transactions should've been removed from container"
         );
-        assert!(parked_txs.contains_tx(&ttx_s1_4.tx_hash));
+
+        // empty account should be removed
+        // remove last
+        parked_txs.find_promotables(&signing_address, 3, &remaining_balances);
+        assert_eq!(
+            parked_txs.addresses().len(),
+            0,
+            "empty account should've been removed from container"
+        );
     }
 
     #[tokio::test]
-    async fn parked_transactions_find_promotables() {
-        let mut parked_txs = ParkedTransactions::<MAX_PARKED_TXS_PER_ACCOUNT>::new(TX_TTL);
-        let signing_key_0 = SigningKey::from([1; 32]);
-        let signing_address_0 = signing_key_0.address_bytes();
-        let signing_key_1 = SigningKey::from([2; 32]);
-        let signing_address_1 = signing_key_1.address_bytes();
+    async fn pending_transactions_find_demotables() {
+        let mut pending_txs = PendingTransactions::new(TX_TTL);
+        let signing_key = SigningKey::from([1; 32]);
+        let signing_address = signing_key.address_bytes();
 
-        // transactions to add to accounts
-        let ttx_s0_1 = mock_ttx(1, &signing_key_0);
-        let ttx_s0_2 = mock_ttx(2, &signing_key_0);
-        let ttx_s0_3 = mock_ttx(3, &signing_key_0);
-        let ttx_s1_1 = mock_ttx(1, &signing_key_1);
-        let ttx_s1_2 = mock_ttx(2, &signing_key_1);
-        let ttx_s1_4 = mock_ttx(4, &signing_key_1);
+        // transactions to add to account
+        let ttx_1 = mock_ttx(1, &signing_key, 5, 0, 0);
+        let ttx_2 = mock_ttx(2, &signing_key, 0, 5, 0);
+        let ttx_3 = mock_ttx(3, &signing_key, 5, 0, 0);
+        let ttx_4 = mock_ttx(4, &signing_key, 0, 5, 0);
+        let account_balances_full = mock_balances(100, 100);
 
         // add transactions
-        parked_txs.add(ttx_s0_1.clone(), 0).unwrap();
-        parked_txs.add(ttx_s0_2.clone(), 0).unwrap();
-        parked_txs.add(ttx_s0_3.clone(), 0).unwrap();
-        parked_txs.add(ttx_s1_1.clone(), 0).unwrap();
-        parked_txs.add(ttx_s1_2.clone(), 0).unwrap();
-        parked_txs.add(ttx_s1_4.clone(), 0).unwrap();
+        pending_txs
+            .add(ttx_1.clone(), 1, &account_balances_full)
+            .unwrap();
+        pending_txs
+            .add(ttx_2.clone(), 1, &account_balances_full)
+            .unwrap();
+        pending_txs
+            .add(ttx_3.clone(), 1, &account_balances_full)
+            .unwrap();
+        pending_txs
+            .add(ttx_4.clone(), 1, &account_balances_full)
+            .unwrap();
 
-        // current nonce getter
-        // should pop all from signing_address_0 and two from signing_address_1
-        let current_account_nonce_getter = |address: [u8; 20]| async move {
-            if address == signing_address_0 || address == signing_address_1 {
-                return Ok(1);
-            }
-            Err(anyhow::anyhow!("invalid address"))
-        };
+        // demote none
+        let demotables: Vec<TimemarkedTransaction> =
+            pending_txs.find_demotables(signing_address, &account_balances_full);
+        assert_eq!(demotables.len(), 0);
 
+        // demote last
+        let account_balances_demotion = mock_balances(100, 9);
+        let demotables = pending_txs.find_demotables(signing_address, &account_balances_demotion);
+        assert_eq!(demotables.len(), 1);
+        assert_eq!(demotables[0].nonce(), 4);
+
+        // demote multiple
+        let account_balances_demotion = mock_balances(100, 4);
+        let demotables = pending_txs.find_demotables(signing_address, &account_balances_demotion);
+        assert_eq!(demotables.len(), 2);
+        assert_eq!(demotables[0].nonce(), 2);
+
+        // demote rest
+        let account_balances_demotion = mock_balances(0, 5);
+        let demotables = pending_txs.find_demotables(signing_address, &account_balances_demotion);
+        assert_eq!(demotables.len(), 1);
+        assert_eq!(demotables[0].nonce(), 1);
+
+        // empty account removed
         assert_eq!(
-            parked_txs
-                .find_promotables(&current_account_nonce_getter)
-                .await
-                .len(),
-            5,
-            "five transactions should've been popped"
+            pending_txs.addresses().len(),
+            0,
+            "empty account should've been removed from container"
         );
-        assert_eq!(parked_txs.txs.len(), 1, "empty accounts should be removed");
+    }
+
+    #[tokio::test]
+    async fn pending_transactions_remaining_account_balances() {
+        let mut pending_txs = PendingTransactions::new(TX_TTL);
+        let signing_key = SigningKey::from([1; 32]);
+        let signing_address = signing_key.address_bytes();
+
+        // transactions to add to account
+        let ttx_1 = mock_ttx(1, &signing_key, 6, 0, 0);
+        let ttx_2 = mock_ttx(2, &signing_key, 0, 5, 0);
+        let ttx_3 = mock_ttx(3, &signing_key, 6, 0, 0);
+        let ttx_4 = mock_ttx(4, &signing_key, 0, 5, 0);
+        let account_balances_full = mock_balances(100, 100);
+
+        // add transactions
+        pending_txs
+            .add(ttx_1.clone(), 1, &account_balances_full)
+            .unwrap();
+        pending_txs
+            .add(ttx_2.clone(), 1, &account_balances_full)
+            .unwrap();
+        pending_txs
+            .add(ttx_3.clone(), 1, &account_balances_full)
+            .unwrap();
+        pending_txs
+            .add(ttx_4.clone(), 1, &account_balances_full)
+            .unwrap();
+
+        // get balances
+        let remaining_balances =
+            pending_txs.remaining_account_balances(signing_address, account_balances_full);
         assert_eq!(
-            parked_txs.len(),
-            1,
-            "1 transactions should be remaining from original 6"
+            remaining_balances.get(&IbcPrefixed::new(DENOM_0)).unwrap(),
+            &88
         );
-        assert!(parked_txs.contains_tx(&ttx_s1_4.tx_hash));
+        assert_eq!(
+            remaining_balances.get(&IbcPrefixed::new(DENOM_1)).unwrap(),
+            &90
+        );
     }
 }

--- a/crates/astria-sequencer/src/service/consensus.rs
+++ b/crates/astria-sequencer/src/service/consensus.rs
@@ -233,7 +233,11 @@ mod test {
 
     use super::*;
     use crate::{
-        app::test_utils::default_fees,
+        app::test_utils::{
+            default_fees,
+            mock_balances,
+            mock_tx_cost,
+        },
         mempool::Mempool,
         metrics::Metrics,
         proposal::commitment::generate_rollup_datas_commitment,
@@ -291,7 +295,15 @@ mod test {
         let signed_tx = Arc::new(tx.into_signed(&signing_key));
         let tx_bytes = signed_tx.to_raw().encode_to_vec();
         let txs = vec![tx_bytes.into()];
-        mempool.insert(signed_tx.clone(), 0).await.unwrap();
+        mempool
+            .insert(
+                signed_tx.clone(),
+                0,
+                mock_balances(0, 0),
+                mock_tx_cost(0, 0, 0),
+            )
+            .await
+            .unwrap();
 
         let res = generate_rollup_datas_commitment(&vec![(*signed_tx).clone()], HashMap::new());
 
@@ -510,7 +522,10 @@ mod test {
             .await
             .unwrap();
 
-        mempool.insert(signed_tx, 0).await.unwrap();
+        mempool
+            .insert(signed_tx, 0, mock_balances(0, 0), mock_tx_cost(0, 0, 0))
+            .await
+            .unwrap();
         let finalize_block = request::FinalizeBlock {
             hash: Hash::try_from([0u8; 32].to_vec()).unwrap(),
             height: 1u32.into(),

--- a/crates/astria-sequencer/src/service/mempool.rs
+++ b/crates/astria-sequencer/src/service/mempool.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashMap,
     pin::Pin,
     sync::Arc,
     task::{
@@ -11,6 +12,7 @@ use std::{
 use anyhow::Context as _;
 use astria_core::{
     generated::protocol::transaction::v1alpha1 as raw,
+    primitive::v1::asset::IbcPrefixed,
     protocol::{
         abci::AbciErrorCode,
         transaction::v1alpha1::SignedTransaction,
@@ -20,7 +22,6 @@ use cnidarium::Storage;
 use futures::{
     Future,
     FutureExt,
-    TryFutureExt as _,
 };
 use prost::Message as _;
 use tendermint::{
@@ -214,27 +215,6 @@ async fn handle_check_tx<S: accounts::StateReadExt + address::StateReadExt + 'st
         finished_check_chain_id.saturating_duration_since(finished_check_nonce),
     );
 
-    if let Err(e) = transaction::check_balance_mempool(&signed_tx, &state).await {
-        mempool
-            .remove_tx_invalid(
-                Arc::new(signed_tx),
-                RemovalReason::FailedCheckTx(e.to_string()),
-            )
-            .await;
-        metrics.increment_check_tx_removed_account_balance();
-        return response::CheckTx {
-            code: Code::Err(AbciErrorCode::INSUFFICIENT_FUNDS.value()),
-            info: "failed verifying account balance".into(),
-            log: e.to_string(),
-            ..response::CheckTx::default()
-        };
-    };
-
-    let finished_check_balance = Instant::now();
-    metrics.record_check_tx_duration_seconds_check_balance(
-        finished_check_balance.saturating_duration_since(finished_check_chain_id),
-    );
-
     if let Some(removal_reason) = mempool.check_removed_comet_bft(tx_hash).await {
         match removal_reason {
             RemovalReason::Expired => {
@@ -275,26 +255,34 @@ async fn handle_check_tx<S: accounts::StateReadExt + address::StateReadExt + 'st
                     ..response::CheckTx::default()
                 };
             }
-            RemovalReason::FailedCheckTx(err) => {
-                return response::CheckTx {
-                    code: Code::Err(AbciErrorCode::TRANSACTION_FAILED.value()),
-                    info: "transaction failed check tx".into(),
-                    log: format!("transaction failed check tx because: {err}"),
-                    ..response::CheckTx::default()
-                };
-            }
         }
     };
 
     let finished_check_removed = Instant::now();
     metrics.record_check_tx_duration_seconds_check_removed(
-        finished_check_removed.saturating_duration_since(finished_check_balance),
+        finished_check_removed.saturating_duration_since(finished_check_chain_id),
     );
 
-    // tx is valid, push to mempool
-    let current_account_nonce = match state
+    // tx is valid, push to mempool with current state
+    let address = match state
         .try_base_prefixed(&signed_tx.verification_key().address_bytes())
-        .and_then(|address| state.get_account_nonce(address))
+        .await
+        .context("failed to generate address for signed transaction")
+    {
+        Err(err) => {
+            return response::CheckTx {
+                code: Code::Err(AbciErrorCode::INTERNAL_ERROR.value()),
+                info: AbciErrorCode::INTERNAL_ERROR.info(),
+                log: format!("failed to generate address because: {err:#?}"),
+                ..response::CheckTx::default()
+            };
+        }
+        Ok(nonce) => nonce,
+    };
+
+    // fetch current account
+    let current_account_nonce = match state
+        .get_account_nonce(address)
         .await
         .context("failed fetching nonce for account")
     {
@@ -302,17 +290,70 @@ async fn handle_check_tx<S: accounts::StateReadExt + address::StateReadExt + 'st
             return response::CheckTx {
                 code: Code::Err(AbciErrorCode::INTERNAL_ERROR.value()),
                 info: AbciErrorCode::INTERNAL_ERROR.info(),
-                log: format!("transaction failed execution because: {err:#?}"),
+                log: format!("failed to fetch account nonce because: {err:#?}"),
                 ..response::CheckTx::default()
             };
         }
         Ok(nonce) => nonce,
     };
 
+    let finished_convert_address = Instant::now();
+    metrics.record_check_tx_duration_seconds_convert_address(
+        finished_convert_address.saturating_duration_since(finished_check_removed),
+    );
+
+    // grab cost of transaction
+    let transaction_cost = match transaction::get_total_transaction_cost(&signed_tx, &state)
+        .await
+        .context("failed fetching cost of the transaction")
+    {
+        Err(err) => {
+            return response::CheckTx {
+                code: Code::Err(AbciErrorCode::INTERNAL_ERROR.value()),
+                info: AbciErrorCode::INTERNAL_ERROR.info(),
+                log: format!("failed to fetch cost of the transaction because: {err:#?}"),
+                ..response::CheckTx::default()
+            };
+        }
+        Ok(transaction_cost) => transaction_cost,
+    };
+
+    let finished_fetch_tx_cost = Instant::now();
+    metrics.record_check_tx_duration_seconds_fetch_tx_cost(
+        finished_fetch_tx_cost.saturating_duration_since(finished_convert_address),
+    );
+
+    // grab current account's balances
+    let current_account_balance: HashMap<IbcPrefixed, u128> = match state
+        .get_account_balances_ibc(address)
+        .await
+        .context("failed fetching balances for account")
+    {
+        Err(err) => {
+            return response::CheckTx {
+                code: Code::Err(AbciErrorCode::INTERNAL_ERROR.value()),
+                info: AbciErrorCode::INTERNAL_ERROR.info(),
+                log: format!("failed to fetch account balances because: {err:#?}"),
+                ..response::CheckTx::default()
+            };
+        }
+        Ok(account_balance) => account_balance,
+    };
+
+    let finished_fetch_balances = Instant::now();
+    metrics.record_check_tx_duration_seconds_fetch_balances(
+        finished_fetch_balances.saturating_duration_since(finished_fetch_tx_cost),
+    );
+
     let actions_count = signed_tx.actions().len();
 
     if let Err(err) = mempool
-        .insert(Arc::new(signed_tx), current_account_nonce)
+        .insert(
+            Arc::new(signed_tx),
+            current_account_nonce,
+            current_account_balance,
+            transaction_cost,
+        )
         .await
     {
         return response::CheckTx {
@@ -326,7 +367,7 @@ async fn handle_check_tx<S: accounts::StateReadExt + address::StateReadExt + 'st
     let mempool_len = mempool.len().await;
 
     metrics
-        .record_check_tx_duration_seconds_insert_to_app_mempool(finished_check_removed.elapsed());
+        .record_check_tx_duration_seconds_insert_to_app_mempool(finished_fetch_tx_cost.elapsed());
     metrics.record_actions_per_transaction_in_mempool(actions_count);
     metrics.record_transaction_in_mempool_size_bytes(tx_len);
     metrics.set_transactions_in_mempool_total(mempool_len);

--- a/crates/astria-sequencer/src/transaction/checks.rs
+++ b/crates/astria-sequencer/src/transaction/checks.rs
@@ -63,17 +63,6 @@ pub(crate) async fn check_chain_id_mempool<S: StateRead>(
 }
 
 #[instrument(skip_all)]
-pub(crate) async fn check_balance_mempool<S: StateRead>(
-    tx: &SignedTransaction,
-    state: &S,
-) -> anyhow::Result<()> {
-    check_balance_for_total_fees_and_transfers(tx, state)
-        .await
-        .context("failed to check balance for total fees and transfers")?;
-    Ok(())
-}
-
-#[instrument(skip_all)]
 pub(crate) async fn get_fees_for_transaction<S: StateRead>(
     tx: &UnsignedTransaction,
     state: &S,
@@ -154,9 +143,36 @@ pub(crate) async fn check_balance_for_total_fees_and_transfers<S: StateRead>(
     tx: &SignedTransaction,
     state: &S,
 ) -> anyhow::Result<()> {
-    let mut cost_by_asset = get_fees_for_transaction(tx.unsigned_transaction(), state)
+    let cost_by_asset = get_total_transaction_cost(tx, state)
         .await
-        .context("failed to get fees for transaction")?;
+        .context("failed to get transaction costs")?;
+
+    for (asset, total_fee) in cost_by_asset {
+        let balance = state
+            .get_account_balance(tx, asset)
+            .await
+            .context("failed to get account balance")?;
+        ensure!(
+            balance >= total_fee,
+            "insufficient funds for asset {}",
+            asset
+        );
+    }
+
+    Ok(())
+}
+
+// Returns the total cost of the transaction (fees and transferred values for all actions in the
+// transaction).
+#[instrument(skip_all)]
+pub(crate) async fn get_total_transaction_cost<S: StateRead>(
+    tx: &SignedTransaction,
+    state: &S,
+) -> anyhow::Result<HashMap<asset::IbcPrefixed, u128>> {
+    let mut cost_by_asset: HashMap<asset::IbcPrefixed, u128> =
+        get_fees_for_transaction(tx.unsigned_transaction(), state)
+            .await
+            .context("failed to get fees for transaction")?;
 
     // add values transferred within the tx to the cost
     for action in tx.actions() {
@@ -203,19 +219,7 @@ pub(crate) async fn check_balance_for_total_fees_and_transfers<S: StateRead>(
         }
     }
 
-    for (asset, total_fee) in cost_by_asset {
-        let balance = state
-            .get_account_balance(tx, asset)
-            .await
-            .context("failed to get account balance")?;
-        ensure!(
-            balance >= total_fee,
-            "insufficient funds for asset {}",
-            asset
-        );
-    }
-
-    Ok(())
+    Ok(cost_by_asset)
 }
 
 fn transfer_update_fees(
@@ -327,7 +331,7 @@ mod tests {
     };
 
     #[tokio::test]
-    async fn check_balance_mempool_ok() {
+    async fn check_balance_total_fees_transfers_ok() {
         let storage = cnidarium::TempStorage::new().await.unwrap();
         let snapshot = storage.latest_snapshot();
         let mut state_tx = StateDelta::new(snapshot);
@@ -398,13 +402,13 @@ mod tests {
         };
 
         let signed_tx = tx.into_signed(&alice);
-        check_balance_mempool(&signed_tx, &state_tx)
+        check_balance_for_total_fees_and_transfers(&signed_tx, &state_tx)
             .await
             .expect("sufficient balance for all actions");
     }
 
     #[tokio::test]
-    async fn check_balance_mempool_insufficient_other_asset_balance() {
+    async fn check_balance_total_fees_and_transfers_insufficient_other_asset_balance() {
         let storage = cnidarium::TempStorage::new().await.unwrap();
         let snapshot = storage.latest_snapshot();
         let mut state_tx = StateDelta::new(snapshot);
@@ -464,7 +468,7 @@ mod tests {
         };
 
         let signed_tx = tx.into_signed(&alice);
-        let err = check_balance_mempool(&signed_tx, &state_tx)
+        let err = check_balance_for_total_fees_and_transfers(&signed_tx, &state_tx)
             .await
             .err()
             .unwrap();

--- a/crates/astria-sequencer/src/transaction/mod.rs
+++ b/crates/astria-sequencer/src/transaction/mod.rs
@@ -14,9 +14,9 @@ use astria_core::protocol::transaction::v1alpha1::{
 };
 pub(crate) use checks::{
     check_balance_for_total_fees_and_transfers,
-    check_balance_mempool,
     check_chain_id_mempool,
     check_nonce_mempool,
+    get_total_transaction_cost,
 };
 use cnidarium::StateWrite;
 // Conditional to quiet warnings. This object is used throughout the codebase,


### PR DESCRIPTION
## Summary
Added logic to the mempool to make it's pending vs parked logic balance aware. Transactions will only be added to the pending queue if the signing account has enough balance to cover the cost of all of the transactions in the pending plus the new transaction. Transactions that exceed the account's available balance are put into parked. 

Note: this is a draft because it is missing the logic to re-cost all of the transactions after a `FeeAssetChange` or `FeeChange` action occur.

## Background
Previously the mempool did not have sufficient logic to deal with transaction costs. `CheckTx` would kick out any transaction that the account did not have enough balance to cover. This didn't account for the edge cases of:
1. A different in-flight transaction from another account funding the deficient account.
2. Sequential transactions that together exceed an account's balance but independently are fine. This causes unnecessary transaction failures in `prepare_proposal()`'s block construction. 

## Changes
TODO

## Testing
TODO

## Metrics
TODO

## Breaking Changelist
TODO

## Related Issues
TODO

closes <!-- list any issues closed here -->
