### PR TITLE
chore(charts): bump celestia versions

### DIFF
--- a/charts/celestia-local/Chart.yaml
+++ b/charts/celestia-local/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.1
+version: 0.6.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/celestia-local/files/scripts/init-celestia-appd.sh
+++ b/charts/celestia-local/files/scripts/init-celestia-appd.sh
@@ -27,6 +27,7 @@ celestia-appd gentx \
   "$validator_stake" \
   --keyring-backend="$keyring_backend" \
   --chain-id "$chainid" \
+  --fees "$fees" \
   --home "$home_dir"
 
 # add ibc account

--- a/charts/celestia-local/files/scripts/start-bridge.sh
+++ b/charts/celestia-local/files/scripts/start-bridge.sh
@@ -42,6 +42,6 @@ exec celestia bridge start \
   --gateway.port "$bridge_host_port" \
   --rpc.addr 0.0.0.0 \
   --rpc.port "$bridge_rpc_port" \
-  --keyring.accname "$validator_key_name" \
+  --keyring.keyname "$validator_key_name" \
   --log.level "debug" \
   --log.level.module "share/discovery:error"

--- a/charts/celestia-local/templates/configmap.yaml
+++ b/charts/celestia-local/templates/configmap.yaml
@@ -6,6 +6,7 @@ metadata:
 data:
   home_dir: "/home/celestia"
   coins: "{{ .Values.coins }}"
+  fees: "{{ .Values.fees }}"
   validator_stake: "{{ .Values.validatorStake }}"
   validator_mnemonic: "{{ .Values.validatorMnemonic }}"
   chainid: "{{ .Values.chainId }}"

--- a/charts/celestia-local/values.yaml
+++ b/charts/celestia-local/values.yaml
@@ -16,7 +16,7 @@ storage:
       path: "/data/celestia-data"
 
 celestiaAppImage: "ghcr.io/celestiaorg/celestia-app:v2.0.0"
-celestiaNodeImage: "ghcr.io/celestiaorg/celestia-node:v0.15.0"
+celestiaNodeImage: "ghcr.io/celestiaorg/celestia-node:v0.16.0-rc0"
 
 podSecurityContext:
   runAsUser: 10001

--- a/charts/celestia-local/values.yaml
+++ b/charts/celestia-local/values.yaml
@@ -15,8 +15,8 @@ storage:
       persistentVolumeName: "celestia-shared-storage"
       path: "/data/celestia-data"
 
-celestiaAppImage: "ghcr.io/celestiaorg/celestia-app:v1.9.0"
-celestiaNodeImage: "ghcr.io/celestiaorg/celestia-node:v0.14.1"
+celestiaAppImage: "ghcr.io/celestiaorg/celestia-app:v2.0.0"
+celestiaNodeImage: "ghcr.io/celestiaorg/celestia-node:v0.15.0"
 
 podSecurityContext:
   runAsUser: 10001
@@ -35,6 +35,8 @@ validatorKeyName: "validator"
 validatorMnemonic: connect soon random stable toddler tired glove drastic comfort donor struggle island cactus pole shell alpha taste able story business cross dismiss book brass
 # Genesis amount
 coins: "10000000000000000000000000utia"
+# Default fee for genTx
+fees: "1utia"
 # Staking amount
 validatorStake: "5000000000utia"
 # ibc account

--- a/charts/celestia-node/Chart.yaml
+++ b/charts/celestia-node/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.5
+version: 0.3.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/celestia-node/values.yaml
+++ b/charts/celestia-node/values.yaml
@@ -19,7 +19,7 @@ config:
 
 images:
   pullPolicy: IfNotPresent
-  node: ghcr.io/celestiaorg/celestia-node:v0.14.1
+  node: ghcr.io/celestiaorg/celestia-node:v0.16.0-rc0
 
 ports:
   celestia:

--- a/charts/evm-stack/Chart.lock
+++ b/charts/evm-stack/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: celestia-node
   repository: file://../celestia-node
-  version: 0.3.5
+  version: 0.3.6
 - name: evm-rollup
   repository: file://../evm-rollup
   version: 0.26.1
@@ -20,5 +20,5 @@ dependencies:
 - name: blockscout-stack
   repository: https://blockscout.github.io/helm-charts
   version: 1.6.2
-digest: sha256:6406abf0864a14a8268dc0c78512ca5d18779e9f20dac8ad540399ddcfbe062c
-generated: "2024-08-28T09:44:42.794673-04:00"
+digest: sha256:b964035934951500ea972b9f38aaeaac37180523acee810ad1b17ae8641d81f4
+generated: "2024-08-29T20:24:02.892112-04:00"

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -15,11 +15,11 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.1
+version: 0.4.2
 
 dependencies:
   - name: celestia-node
-    version: "0.3.5"
+    version: 0.3.6
     repository: "file://../celestia-node"
     condition: celestia-node.enabled
   - name: evm-rollup


### PR DESCRIPTION
## Summary
`celestia-app` and `celestia-node` version bump to support lateset `mocha-4` upgrade
## Background
celestia mocha-4 testnet went through an upgrade, devnets rollups are not getting firm blocks duo to it. 
## Changes
- changes flag `keyring.accname` -> `keyring.keyname`
- adds fee field for genTx
- bumps celestia images

## Testing
- locally vs latest components, confirmed getting firms
- will run on devdev before merging
