### PR TITLE
smallest fix

### DIFF
--- a/crates/astria-bridge-contracts/src/lib.rs
+++ b/crates/astria-bridge-contracts/src/lib.rs
@@ -332,7 +332,7 @@ where
     pub async fn get_for_block_hash(
         &self,
         block_hash: H256,
-    ) -> Result<Vec<Action>, GetWithdrawalActionsError> {
+    ) -> Result<Vec<Result<Action, GetWithdrawalActionsError>>, GetWithdrawalActionsError> {
         use futures::FutureExt as _;
         let get_ics20_logs = if self.configured_for_ics20_withdrawals() {
             get_logs::<Ics20WithdrawalFilter, _>(&self.provider, self.contract_address, block_hash)
@@ -358,7 +358,7 @@ where
         // XXX: The calls to `log_to_*_action` rely on only be called if `GetWithdrawalActions`
         // is configured for either ics20 or sequencer withdrawals (or both). They would panic
         // otherwise.
-        ics20_logs
+        Ok(ics20_logs
             .into_iter()
             .map(|log| self.log_to_ics20_withdrawal_action(log))
             .chain(
@@ -366,7 +366,7 @@ where
                     .into_iter()
                     .map(|log| self.log_to_sequencer_withdrawal_action(log)),
             )
-            .collect()
+            .collect())
     }
 
     fn log_to_ics20_withdrawal_action(

--- a/crates/astria-bridge-withdrawer/src/bridge_withdrawer/ethereum/watcher.rs
+++ b/crates/astria-bridge-withdrawer/src/bridge_withdrawer/ethereum/watcher.rs
@@ -7,9 +7,12 @@ use astria_bridge_contracts::{
     GetWithdrawalActions,
     GetWithdrawalActionsBuilder,
 };
-use astria_core::primitive::v1::{
-    asset,
-    Address,
+use astria_core::{
+    primitive::v1::{
+        asset,
+        Address,
+    },
+    protocol::transaction::v1alpha1::Action,
 };
 use astria_eyre::{
     eyre::{
@@ -348,10 +351,21 @@ async fn get_and_forward_block_events(
         .number
         .ok_or_eyre("block did not contain a rollup height")?
         .as_u64();
-    let actions = actions_fetcher
+    let actions: Vec<Action> = actions_fetcher
         .get_for_block_hash(block_hash)
         .await
-        .wrap_err("failed getting actions for block")?;
+        .wrap_err("failed getting actions for block")?
+        .into_iter()
+        .filter_map(|r| {
+            r.map_err(|e| {
+                warn!(
+                    error = &e as &dyn std::error::Error,
+                    "failed to convert withdrawal event to sequecner action"
+                );
+            })
+            .ok()
+        })
+        .collect();
 
     if actions.is_empty() {
         info!(

--- a/crates/astria-cli/src/commands/bridge/collect.rs
+++ b/crates/astria-cli/src/commands/bridge/collect.rs
@@ -202,7 +202,10 @@ async fn block_to_actions(
                 "failed getting actions for block; block hash: `{block_hash}`, block height: \
                  `{rollup_height}`"
             )
-        })?;
+        })?
+        .into_iter()
+        .collect::<Result<_, _>>()?;
+
     actions_by_rollup_height.insert(rollup_height, actions)
 }
 


### PR DESCRIPTION
## Summary
Brief summary of the changes made, ie "what?"

## Background
Brief background on why these changes were made, ie "why?"

## Changes
- Separate the errors for getting logs from the conversion errors
- Conversion returns a `Result<Vec<Result<Action, WithdrawalConversionError>>, GetWithdrawalLogsError> ` instead of `Result<Vec<Action>, GetWithdrawalActionsError>`
- Handle failed conversions in the cli and withdrawer crates

## Testing
- Unit tests for the conversions will be added in a subsequent PR: 

## Breaking Changelist
- This fixes the bug described in #1251, where a single withdrawal which fails to be converted to an action will cause the entire rollup block's batch of withdrawals to fail, causing the withdrawer to be stuck.

## Related Issues

closes #1251 
