### PR TITLE
fix(charts)!: sequencer-relayer chart correct startup env var

### DIFF
--- a/charts/sequencer-relayer/Chart.yaml
+++ b/charts/sequencer-relayer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.11.2
+version: 0.12.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sequencer-relayer/files/scripts/start-relayer.sh
+++ b/charts/sequencer-relayer/files/scripts/start-relayer.sh
@@ -4,16 +4,6 @@ set -o errexit -o nounset -o pipefail
 
 echo "Starting the Astria Sequencer Relayer..."
 
-if ! [ -z ${ASTRIA_SEQUENCER_RELAYER_PRE_SUBMIT_PATH+x} ] && ! [ -f "$ASTRIA_SEQUENCER_RELAYER_PRE_SUBMIT_PATH" ]; then
-    echo "Pre-submit storage file not found, instantiating with ignore state. Post submit storage file will be created on first submit."
-    echo "{\"state\": \"ignore\"}" > $ASTRIA_SEQUENCER_RELAYER_PRE_SUBMIT_PATH
-fi
-
-if ! [ -z ${ASTRIA_SEQUENCER_RELAYER_POST_SUBMIT_PATH+x} ] && ! [ -f "$ASTRIA_SEQUENCER_RELAYER_POST_SUBMIT_PATH" ]; then
-    echo "Post-submit storage file does not exist, instantiating with fresh state. Will start relaying from first sequencer block."
-    echo "{\"state\": \"fresh\"}" > $ASTRIA_SEQUENCER_RELAYER_POST_SUBMIT_PATH
-fi
-
 if ! [ -z ${ASTRIA_SEQUENCER_RELAYER_SUBMISSION_STATE_PATH+x} ] && ! [ -f "$ASTRIA_SEQUENCER_RELAYER_SUBMISSION_STATE_PATH" ]; then
     echo "Submission state file does not exist, instantiating with fresh state. Will start relaying from first sequencer block."
     echo "{\"state\": \"fresh\"}" > $ASTRIA_SEQUENCER_RELAYER_SUBMISSION_STATE_PATH

--- a/charts/sequencer-relayer/templates/configmaps.yaml
+++ b/charts/sequencer-relayer/templates/configmaps.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ include "sequencer-relayer.namespace" . }}
 data:
   ASTRIA_SEQUENCER_RELAYER_LOG: "astria_sequencer_relayer=debug"
+  ASTRIA_SEQUENCER_RELAYER_SUBMISSION_STATE_PATH: "{{ include "sequencer-relayer.storage.submissionStatePath" . }}"
   ASTRIA_SEQUENCER_RELAYER_BLOCK_TIME: "1000"
   ASTRIA_SEQUENCER_RELAYER_COMETBFT_ENDPOINT: "{{ .Values.config.relayer.cometbftRpc }}"
   ASTRIA_SEQUENCER_RELAYER_SEQUENCER_GRPC_ENDPOINT: "{{ .Values.config.relayer.sequencerGrpc }}"
@@ -28,10 +29,7 @@ data:
   ASTRIA_SEQUENCER_RELAYER_SEQUENCER_CHAIN_ID: "{{ .Values.config.relayer.sequencerChainId }}"
   ASTRIA_SEQUENCER_RELAYER_CELESTIA_CHAIN_ID: "{{ .Values.config.relayer.celestiaChainId }}"
   {{- if not .Values.global.dev }}
-  ASTRIA_SEQUENCER_RELAYER_PRE_SUBMIT_PATH: "{{ include "sequencer-relayer.storage.preSubmitPath" . }}"
-  ASTRIA_SEQUENCER_RELAYER_POST_SUBMIT_PATH: "{{ include "sequencer-relayer.storage.postSubmitPath" . }}"
   {{- else }}
-  ASTRIA_SEQUENCER_RELAYER_SUBMISSION_STATE_PATH: "{{ include "sequencer-relayer.storage.submissionStatePath" . }}"
   {{- end }}
 ---
 apiVersion: v1

--- a/charts/sequencer/Chart.lock
+++ b/charts/sequencer/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: sequencer-relayer
   repository: file://../sequencer-relayer
-  version: 0.11.2
-digest: sha256:76454e176c237a3099be9d76ffd20a1a640cfc3d48c7598c9de8a9332ac802ad
-generated: "2024-08-22T13:56:23.979747-07:00"
+  version: 0.12.0
+digest: sha256:e7eaa26032e2e92f8df8eaea11580ad9e464866360d4e5d4c14bae4eec8a090b
+generated: "2024-08-30T12:12:47.838866-07:00"

--- a/charts/sequencer/Chart.yaml
+++ b/charts/sequencer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.21.0
+version: 0.22.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -24,7 +24,7 @@ appVersion: "0.16.0"
 
 dependencies:
   - name: sequencer-relayer
-    version: "0.11.2"
+    version: "0.12.0"
     repository: "file://../sequencer-relayer"
     condition: sequencer-relayer.enabled
 


### PR DESCRIPTION
## Summary
After sequencer relayer version update there was missed config update in chart this corrects.
