### PR TITLE
chore(ci): include `ibc-bridge-test` in `docker` CI target

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -213,7 +213,7 @@ jobs:
 
   docker:
     if: ${{ always() && !cancelled() }}
-    needs: [composer, conductor, sequencer, sequencer-relayer, evm-bridge-withdrawer, smoke-test, smoke-cli]
+    needs: [composer, conductor, sequencer, sequencer-relayer, evm-bridge-withdrawer, smoke-test, smoke-cli, ibc-bridge-test]
     uses: ./.github/workflows/reusable-success.yml
     with:
       success: ${{ !contains(needs.*.result, 'failure') }}


### PR DESCRIPTION
## Summary
Added missing test.

## Background
The CI target `docker` should depend upon `ibc-bridge-test`.

## Changes
- added missing test

## Testing
N/A