### PR TITLE
chore: memoize `address_bytes` of verification key

### DIFF
--- a/crates/astria-sequencer/src/app/tests_app.rs
+++ b/crates/astria-sequencer/src/app/tests_app.rs
@@ -179,7 +179,7 @@ async fn app_begin_block_remove_byzantine_validators() {
     // assert that validator with pubkey_a is removed
     let validator_set = app.state.get_validator_set().await.unwrap();
     assert_eq!(validator_set.len(), 1);
-    assert_eq!(validator_set.get(verification_key(2)).unwrap().power, 1,);
+    assert_eq!(validator_set.get(&verification_key(2)).unwrap().power, 1,);
 }
 
 #[tokio::test]

--- a/crates/astria-sequencer/src/authority/mod.rs
+++ b/crates/astria-sequencer/src/authority/mod.rs
@@ -28,8 +28,8 @@ impl From<[u8; ADDRESS_LEN]> for ValidatorSetKey {
     }
 }
 
-impl From<VerificationKey> for ValidatorSetKey {
-    fn from(value: VerificationKey) -> Self {
+impl From<&VerificationKey> for ValidatorSetKey {
+    fn from(value: &VerificationKey) -> Self {
         Self(value.address_bytes())
     }
 }
@@ -45,7 +45,7 @@ impl ValidatorSet {
         Self(
             updates
                 .into_iter()
-                .map(|update| (update.verification_key.into(), update))
+                .map(|update| ((&update.verification_key).into(), update))
                 .collect::<BTreeMap<_, _>>(),
         )
     }
@@ -59,7 +59,7 @@ impl ValidatorSet {
     }
 
     pub(super) fn push_update(&mut self, update: ValidatorUpdate) {
-        self.0.insert(update.verification_key.into(), update);
+        self.0.insert((&update.verification_key).into(), update);
     }
 
     pub(super) fn remove<T: Into<ValidatorSetKey>>(&mut self, address: T) {

--- a/crates/astria-sequencer/src/benchmark_utils.rs
+++ b/crates/astria-sequencer/src/benchmark_utils.rs
@@ -74,6 +74,8 @@ pub(crate) fn transactions(tx_types: TxTypes) -> &'static Vec<Arc<SignedTransact
     .unwrap()
 }
 
+// allow: false-positive as described in "Known problems" of lint.
+#[allow(clippy::mutable_key_type)]
 fn sequence_actions() -> Vec<Arc<SignedTransaction>> {
     let mut nonces_and_chain_ids = HashMap::new();
     signing_keys()


### PR DESCRIPTION
## Summary
Added a lazily-initialized field `address_bytes` to `VerificationKey`.

## Background
Testing showed that `address_bytes` was called multiple times on a given `VerificationKey` (up to 11 times in some cases).  Each time the key's bytes were being hashed, so this change ensures that hashing only happens once for a given verification key instance.

Note that this was implemented previously in #1111 and was then reverted in #1124.  However, when reverted, the manual impls of `PartialEq`, `Eq`, `PartialOrd`, `Ord` and `Hash` were left as-is, as were the unit tests for these.  Hence this PR doesn't need to make any changes to these trait impls or tests.

## Changes
- Added `address_bytes: OnceLock<[u8; ADDRESS_LEN]>` to `VerificiationKey`.

## Testing
No new tests required.  

## Related Issues
Closes #1351.