### PR TITLE
chore(charts): increase rpc.gascap

### DIFF
--- a/charts/evm-rollup/Chart.yaml
+++ b/charts/evm-rollup/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.26.1
+version: 0.26.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/evm-rollup/values.yaml
+++ b/charts/evm-rollup/values.yaml
@@ -36,8 +36,8 @@ genesis:
 
   ## These are general configuration values with some recommended defaults
 
-  # Configure the gas Limit
-  gasLimit: "50000000"
+  # Configure the gas Limit for rpc read only ops (eth_estimateGas and eth_call)
+  gasLimit: "550000000"
   # If set to true the genesis block will contain extra data
   overrideGenesisExtraData: true
   # The hrp for bech32m addresses, unlikely to be changed

--- a/charts/evm-stack/Chart.lock
+++ b/charts/evm-stack/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.3.6
 - name: evm-rollup
   repository: file://../evm-rollup
-  version: 0.26.1
+  version: 0.26.2
 - name: composer
   repository: file://../composer
   version: 0.1.2
@@ -20,5 +20,5 @@ dependencies:
 - name: blockscout-stack
   repository: https://blockscout.github.io/helm-charts
   version: 1.6.2
-digest: sha256:b964035934951500ea972b9f38aaeaac37180523acee810ad1b17ae8641d81f4
-generated: "2024-08-29T20:24:02.892112-04:00"
+digest: sha256:d9eba8331d5b2adadb63118a62342f469a30387a7edb290047ff1bcd35d5d4f8
+generated: "2024-09-04T09:25:43.918735-04:00"

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -23,7 +23,7 @@ dependencies:
     repository: "file://../celestia-node"
     condition: celestia-node.enabled
   - name: evm-rollup
-    version: 0.26.1
+    version: 0.26.2
     repository: "file://../evm-rollup"
   - name: composer
     version: 0.1.2

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.2
+version: 0.4.3
 
 dependencies:
   - name: celestia-node

--- a/dev/values/rollup/dev.yaml
+++ b/dev/values/rollup/dev.yaml
@@ -24,8 +24,8 @@ evm-rollup:
 
     ## These are general configuration values with some recommended defaults
 
-    # Configure the gas Limit
-    gasLimit: "50000000"
+    # Configure the gas Limit for rpc read only ops (eth_estimateGas and eth_call)
+    gasLimit: "550000000"
     # If set to true the genesis block will contain extra data
     overrideGenesisExtraData: true
     # The hrp for bech32m addresses, unlikely to be changed


### PR DESCRIPTION
## Summary
Increase `rpc.gascap` to 550M

## Background
The default rpc gas cap for read only rpc ops (`eth_estimateGas` and `eth_call`) is quite low (50M). Many infra providers set this much higher (Infura @ 300M and Alchemy @ 550M). Some protocols and contract views require a higher setting to function correctly, e.g, Uniswap V3 requires at least 150M for its off chain router.

## Changes
- Increased `rpc.gascap` to from 50M 550M

## Testing
N/A changing standard geth flag