### PR TITLE
release: end of iteration release cuts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "astria-sequencer-relayer"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "assert-json-diff",
  "astria-build-info",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -514,7 +514,7 @@ dependencies = [
 
 [[package]]
 name = "astria-bridge-withdrawer"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "astria-bridge-contracts",
  "astria-build-info",
@@ -561,7 +561,7 @@ dependencies = [
 
 [[package]]
 name = "astria-cli"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "astria-bridge-contracts",
  "astria-core",
@@ -588,7 +588,7 @@ dependencies = [
 
 [[package]]
 name = "astria-composer"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "astria-build-info",
  "astria-config",
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "astria-conductor"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "astria-build-info",
  "astria-config",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "astria-sequencer"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "astria-build-info",

--- a/crates/astria-bridge-withdrawer/Cargo.toml
+++ b/crates/astria-bridge-withdrawer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astria-bridge-withdrawer"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.76"
 license = "MIT OR Apache-2.0"

--- a/crates/astria-cli/Cargo.toml
+++ b/crates/astria-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astria-cli"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 rust-version = "1.74.1"
 license = "MIT OR Apache-2.0"

--- a/crates/astria-composer/Cargo.toml
+++ b/crates/astria-composer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astria-composer"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2021"
 rust-version = "1.76"
 license = "MIT OR Apache-2.0"

--- a/crates/astria-conductor/Cargo.toml
+++ b/crates/astria-conductor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astria-conductor"
-version = "0.20.0"
+version = "0.20.1"
 edition = "2021"
 rust-version = "1.76"
 license = "MIT OR Apache-2.0"

--- a/crates/astria-sequencer-relayer/Cargo.toml
+++ b/crates/astria-sequencer-relayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astria-sequencer-relayer"
-version = "0.16.1"
+version = "0.16.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 rust-version = "1.76"

--- a/crates/astria-sequencer/Cargo.toml
+++ b/crates/astria-sequencer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astria-sequencer"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 rust-version = "1.76"


### PR DESCRIPTION
Regular 2 week release cuts, includes breaking changes to sequencer, bridge-withdrawer, patch updates for composer, conductor and cli.