### PR TITLE
chore(charts): rollupName templates

### DIFF
--- a/charts/evm-rollup/Chart.yaml
+++ b/charts/evm-rollup/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.26.1
+version: 0.26.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/evm-rollup/templates/storageclasses.yaml
+++ b/charts/evm-rollup/templates/storageclasses.yaml
@@ -9,16 +9,5 @@ metadata:
 provisioner: kubernetes.io/no-provisioner
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Retain
-    {{- if $.Values.config.blockscout.enabled }}
----
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: {{ include "rollup.name" $ }}-{{ $value.persistentVolumeName }}-blockscout-local
-provisioner: kubernetes.io/no-provisioner
-volumeBindingMode: WaitForFirstConsumer
-reclaimPolicy: Retain
----
-    {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/evm-rollup/templates/storageclasses.yaml
+++ b/charts/evm-rollup/templates/storageclasses.yaml
@@ -5,7 +5,7 @@
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: {{ include "rollup.name" . }}-{{ $value.persistentVolumeName }}-geth-local
+  name: {{ include "rollup.name" $ }}-{{ $value.persistentVolumeName }}-geth-local
 provisioner: kubernetes.io/no-provisioner
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Retain
@@ -14,7 +14,7 @@ reclaimPolicy: Retain
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: {{ include "rollup.name" . }}-{{ $value.persistentVolumeName }}-blockscout-local
+  name: {{ include "rollup.name" $ }}-{{ $value.persistentVolumeName }}-blockscout-local
 provisioner: kubernetes.io/no-provisioner
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Retain

--- a/charts/evm-rollup/templates/storageclasses.yaml
+++ b/charts/evm-rollup/templates/storageclasses.yaml
@@ -5,7 +5,7 @@
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: {{ $.Values.config.rollup.name }}-{{ $value.persistentVolumeName }}-geth-local
+  name: {{ include "rollup.name" . }}-{{ $value.persistentVolumeName }}-geth-local
 provisioner: kubernetes.io/no-provisioner
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Retain
@@ -14,7 +14,7 @@ reclaimPolicy: Retain
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: {{ $.Values.config.rollup.name }}-{{ $value.persistentVolumeName }}-blockscout-local
+  name: {{ include "rollup.name" . }}-{{ $value.persistentVolumeName }}-blockscout-local
 provisioner: kubernetes.io/no-provisioner
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Retain

--- a/charts/evm-rollup/templates/volumes.yaml
+++ b/charts/evm-rollup/templates/volumes.yaml
@@ -6,7 +6,7 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: {{ $.Values.config.rollup.name }}-{{ $value.persistentVolumeName }}-geth-pv
+  name: {{ include "rollup.name" . }}-{{ $value.persistentVolumeName }}-geth-pv
 spec:
   capacity:
     storage: {{ $value.size }}
@@ -14,7 +14,7 @@ spec:
   accessModes:
     - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain
-  storageClassName: {{ $.Values.config.rollup.name }}-{{ $value.persistentVolumeName }}-geth-local
+  storageClassName: {{ include "rollup.name" . }}-{{ $value.persistentVolumeName }}-geth-local
   local:
     path: {{ $value.path }}
   nodeAffinity:
@@ -31,7 +31,7 @@ spec:
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: {{ $.Values.config.rollup.name }}-{{ $value.persistentVolumeName }}-blockscout-pv
+  name: {{ include "rollup.name" . }}-{{ $value.persistentVolumeName }}-blockscout-pv
 spec:
   capacity:
     storage: {{ $value.size }}
@@ -39,7 +39,7 @@ spec:
   accessModes:
     - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain
-  storageClassName: {{ $.Values.config.rollup.name }}-{{ $value.persistentVolumeName }}-blockscout-local
+  storageClassName: {{ include "rollup.name" . }}-{{ $value.persistentVolumeName }}-blockscout-local
   local:
     path: {{ $value.path }}
   nodeAffinity:
@@ -57,15 +57,15 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ $.Values.config.rollup.name }}-{{ $value.persistentVolumeName }}-pvc-geth
+  name: {{ include "rollup.name" . }}-{{ $value.persistentVolumeName }}-pvc-geth
   namespace: {{ include "rollup.namespace" $ }}
   labels:
-    "app.kubernetes.io/name": "{{ $.Values.config.rollup.name }}-{{ $.Chart.Name }}"
+    "app.kubernetes.io/name": "{{ include "rollup.name" . }}-{{ $.Chart.Name }}"
     "app.kubernetes.io/managed-by": {{ $.Release.Service | quote }}
     "helm.sh/chart": {{ $.Chart.Name }}-{{ $.Chart.Version | replace "+" "_" }}
 spec:
   {{- if $.Values.storage.local }}
-  storageClassName: {{ $.Values.config.rollup.name }}-{{ $value.persistentVolumeName }}-geth-local
+  storageClassName: {{ include "rollup.name" . }}-{{ $value.persistentVolumeName }}-geth-local
   {{- end }}
   {{- if $value.storageClassName }}
   storageClassName: {{ $value.storageClassName }}
@@ -80,15 +80,15 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ $.Values.config.rollup.name }}-{{ $value.persistentVolumeName }}-pvc-blockscout
+  name: {{ include "rollup.name" . }}-{{ $value.persistentVolumeName }}-pvc-blockscout
   namespace: {{ include "rollup.namespace" $ }}
   labels:
-    "app.kubernetes.io/name": {{ $.Values.config.rollup.name }}-{{ $.Chart.Name }}
+    "app.kubernetes.io/name": {{ include "rollup.name" . }}-{{ $.Chart.Name }}
     "app.kubernetes.io/managed-by": {{ $.Release.Service | quote }}
     "helm.sh/chart": {{ $.Chart.Name }}-{{ $.Chart.Version | replace "+" "_" }}
 spec:
     {{- if $.Values.storage.local }}
-  storageClassName: {{ $.Values.config.rollup.name }}-{{ $value.persistentVolumeName }}-blockscout-local
+  storageClassName: {{ include "rollup.name" . }}-{{ $value.persistentVolumeName }}-blockscout-local
     {{- end }}
     {{- if $value.storageClassName }}
   storageClassName: {{ $value.storageClassName }}

--- a/charts/evm-rollup/templates/volumes.yaml
+++ b/charts/evm-rollup/templates/volumes.yaml
@@ -6,7 +6,7 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: {{ include "rollup.name" . }}-{{ $value.persistentVolumeName }}-geth-pv
+  name: {{ include "rollup.name" $ }}-{{ $value.persistentVolumeName }}-geth-pv
 spec:
   capacity:
     storage: {{ $value.size }}
@@ -14,7 +14,7 @@ spec:
   accessModes:
     - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain
-  storageClassName: {{ include "rollup.name" . }}-{{ $value.persistentVolumeName }}-geth-local
+  storageClassName: {{ include "rollup.name" $ }}-{{ $value.persistentVolumeName }}-geth-local
   local:
     path: {{ $value.path }}
   nodeAffinity:
@@ -31,7 +31,7 @@ spec:
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: {{ include "rollup.name" . }}-{{ $value.persistentVolumeName }}-blockscout-pv
+  name: {{ include "rollup.name" $ }}-{{ $value.persistentVolumeName }}-blockscout-pv
 spec:
   capacity:
     storage: {{ $value.size }}
@@ -39,7 +39,7 @@ spec:
   accessModes:
     - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain
-  storageClassName: {{ include "rollup.name" . }}-{{ $value.persistentVolumeName }}-blockscout-local
+  storageClassName: {{ include "rollup.name" $ }}-{{ $value.persistentVolumeName }}-blockscout-local
   local:
     path: {{ $value.path }}
   nodeAffinity:
@@ -60,7 +60,7 @@ metadata:
   name: {{ include "rollup.name" $ }}-{{ $value.persistentVolumeName }}-pvc-geth
   namespace: {{ include "rollup.namespace" $ }}
   labels:
-    "app.kubernetes.io/name": "{{ include "rollup.name" . }}-{{ $.Chart.Name }}"
+    "app.kubernetes.io/name": "{{ include "rollup.name" $ }}-{{ $.Chart.Name }}"
     "app.kubernetes.io/managed-by": {{ $.Release.Service | quote }}
     "helm.sh/chart": {{ $.Chart.Name }}-{{ $.Chart.Version | replace "+" "_" }}
 spec:
@@ -80,15 +80,15 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ include "rollup.name" . }}-{{ $value.persistentVolumeName }}-pvc-blockscout
+  name: {{ include "rollup.name" $ }}-{{ $value.persistentVolumeName }}-pvc-blockscout
   namespace: {{ include "rollup.namespace" $ }}
   labels:
-    "app.kubernetes.io/name": {{ include "rollup.name" . }}-{{ $.Chart.Name }}
+    "app.kubernetes.io/name": {{ include "rollup.name" $ }}-{{ $.Chart.Name }}
     "app.kubernetes.io/managed-by": {{ $.Release.Service | quote }}
     "helm.sh/chart": {{ $.Chart.Name }}-{{ $.Chart.Version | replace "+" "_" }}
 spec:
     {{- if $.Values.storage.local }}
-  storageClassName: {{ include "rollup.name" . }}-{{ $value.persistentVolumeName }}-blockscout-local
+  storageClassName: {{ include "rollup.name" $ }}-{{ $value.persistentVolumeName }}-blockscout-local
     {{- end }}
     {{- if $value.storageClassName }}
   storageClassName: {{ $value.storageClassName }}

--- a/charts/evm-rollup/templates/volumes.yaml
+++ b/charts/evm-rollup/templates/volumes.yaml
@@ -27,32 +27,6 @@ spec:
                 - astria-dev-cluster-control-plane
                 - astria-dev-cluster-worker
 ---
-        {{- if $.Values.config.blockscout.enabled }}
-apiVersion: v1
-kind: PersistentVolume
-metadata:
-  name: {{ include "rollup.name" $ }}-{{ $value.persistentVolumeName }}-blockscout-pv
-spec:
-  capacity:
-    storage: {{ $value.size }}
-  volumeMode: Filesystem
-  accessModes:
-    - ReadWriteOnce
-  persistentVolumeReclaimPolicy: Retain
-  storageClassName: {{ include "rollup.name" $ }}-{{ $value.persistentVolumeName }}-blockscout-local
-  local:
-    path: {{ $value.path }}
-  nodeAffinity:
-    required:
-      nodeSelectorTerms:
-        - matchExpressions:
-            - key: kubernetes.io/hostname
-              operator: In
-              values:
-                - astria-dev-cluster-control-plane
-                - astria-dev-cluster-worker
----
-      {{- end }}
     {{- end }}
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -76,29 +50,5 @@ spec:
     requests:
       storage: {{ $value.size }}
 ---
-  {{- if $.Values.config.blockscout.enabled }}
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: {{ include "rollup.name" $ }}-{{ $value.persistentVolumeName }}-pvc-blockscout
-  namespace: {{ include "rollup.namespace" $ }}
-  labels:
-    "app.kubernetes.io/name": {{ include "rollup.name" $ }}-{{ $.Chart.Name }}
-    "app.kubernetes.io/managed-by": {{ $.Release.Service | quote }}
-    "helm.sh/chart": {{ $.Chart.Name }}-{{ $.Chart.Version | replace "+" "_" }}
-spec:
-    {{- if $.Values.storage.local }}
-  storageClassName: {{ include "rollup.name" $ }}-{{ $value.persistentVolumeName }}-blockscout-local
-    {{- end }}
-    {{- if $value.storageClassName }}
-  storageClassName: {{ $value.storageClassName }}
-    {{- end }}
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: {{ $value.size }}
----
-    {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/evm-rollup/templates/volumes.yaml
+++ b/charts/evm-rollup/templates/volumes.yaml
@@ -57,7 +57,7 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ include "rollup.name" . }}-{{ $value.persistentVolumeName }}-pvc-geth
+  name: {{ include "rollup.name" $ }}-{{ $value.persistentVolumeName }}-pvc-geth
   namespace: {{ include "rollup.namespace" $ }}
   labels:
     "app.kubernetes.io/name": "{{ include "rollup.name" . }}-{{ $.Chart.Name }}"
@@ -65,7 +65,7 @@ metadata:
     "helm.sh/chart": {{ $.Chart.Name }}-{{ $.Chart.Version | replace "+" "_" }}
 spec:
   {{- if $.Values.storage.local }}
-  storageClassName: {{ include "rollup.name" . }}-{{ $value.persistentVolumeName }}-geth-local
+  storageClassName: {{ include "rollup.name" $ }}-{{ $value.persistentVolumeName }}-geth-local
   {{- end }}
   {{- if $value.storageClassName }}
   storageClassName: {{ $value.storageClassName }}

--- a/charts/evm-stack/Chart.lock
+++ b/charts/evm-stack/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.3.6
 - name: evm-rollup
   repository: file://../evm-rollup
-  version: 0.26.1
+  version: 0.26.2
 - name: composer
   repository: file://../composer
   version: 0.1.2
@@ -20,5 +20,5 @@ dependencies:
 - name: blockscout-stack
   repository: https://blockscout.github.io/helm-charts
   version: 1.6.2
-digest: sha256:b964035934951500ea972b9f38aaeaac37180523acee810ad1b17ae8641d81f4
-generated: "2024-08-29T20:24:02.892112-04:00"
+digest: sha256:d9eba8331d5b2adadb63118a62342f469a30387a7edb290047ff1bcd35d5d4f8
+generated: "2024-09-05T15:18:03.739771-04:00"

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.2
+version: 0.4.3
 
 dependencies:
   - name: celestia-node
@@ -23,7 +23,7 @@ dependencies:
     repository: "file://../celestia-node"
     condition: celestia-node.enabled
   - name: evm-rollup
-    version: 0.26.1
+    version: 0.26.2
     repository: "file://../evm-rollup"
   - name: composer
     version: 0.1.2


### PR DESCRIPTION
## Summary
Changes to the value used for naming in volumes and storage

## Background
The volume and storage class has a bug for production deployment where rollup name is not being set properly

## Changes
- use templated global rollup name value instead of old one
- removes unused blockscout storage and volume

## Testing
run locally, against devdev

This unblocks an issue with preview environments
