### PR TITLE
refactor(sequencer): use streams for fetching slinky data from state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,6 +814,7 @@ dependencies = [
  "penumbra-ibc",
  "penumbra-proto",
  "penumbra-tower-trace",
+ "pin-project-lite",
  "prost",
  "rand 0.8.5",
  "rand_chacha 0.3.1",

--- a/crates/astria-sequencer/Cargo.toml
+++ b/crates/astria-sequencer/Cargo.toml
@@ -51,6 +51,7 @@ indexmap = { workspace = true }
 penumbra-ibc = { workspace = true, features = ["component", "rpc"] }
 penumbra-proto = { workspace = true }
 penumbra-tower-trace = { workspace = true }
+pin-project-lite = { workspace = true }
 prost = { workspace = true }
 rand = { workspace = true }
 regex = { workspace = true }


### PR DESCRIPTION
Extensions on `cnidarium::StateRead` should implement a stream rather than allocate and collect into datastructures.