### PR TITLE
fix: ignore `RUSTSEC-2024-0370`

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,4 +1,9 @@
 [advisories]
-# RUSTSEC-2021-0139: `ansi_term` is Unmaintained. It is a transient dependency of penumbra crates
-# and dylint, so cannot easily be replaced.
-ignore = ["RUSTSEC-2021-0139"]
+ignore = [
+  # `ansi_term` is Unmaintained. It is a transient dependency of penumbra crates and dylint, so
+  # cannot easily be replaced.
+  "RUSTSEC-2021-0139",
+  # `proc-macro-error` is Unmaintained. It is a transient dependency of borsh crates, so cannot
+  # easily be replaced.
+  "RUSTSEC-2024-0370",
+]

--- a/crates/astria-telemetry/src/metrics/builders.rs
+++ b/crates/astria-telemetry/src/metrics/builders.rs
@@ -16,7 +16,7 @@ use metrics_exporter_prometheus::{
     PrometheusRecorder,
 };
 
-#[cfg(docs)]
+#[cfg(doc)]
 use super::{
     Counter,
     Gauge,


### PR DESCRIPTION
## Summary
Ignore RustSec warning.

## Background
We get a non-critical warning when running `cargo audit`: [RUSTSEC-2024-0370](https://rustsec.org/advisories/RUSTSEC-2024-0370).

When running `cargo tree -i -p=proc-macro-error` we can see that `proc-macro-error` is a dependency of `borsh` which is already at the latest version.

Given that the RustSec report doesn't suggest any concrete problems with `proc-macro-error` and how difficult it will be to move away from this dependency, I have just ignored this warning in CI.

## Changes
- Ignore RustSec warning in `.cargo/audit.toml`.
- Also fixed a typo causing a compiler warning.

## Testing
Ran `cargo audit` locally.
