### PR TITLE
rework oracle types

### DIFF
--- a/crates/astria-core/src/display.rs
+++ b/crates/astria-core/src/display.rs
@@ -1,0 +1,50 @@
+use std::fmt::{
+    Display,
+    Formatter,
+    Result,
+};
+
+/// Format `bytes` using standard base64 formatting.
+///
+/// See the [`base64::engine::general_purpose::STANDARD`] for the formatting definition.
+pub fn base64<T: AsRef<[u8]> + ?Sized>(bytes: &T) -> Base64<'_> {
+    Base64(bytes.as_ref())
+}
+
+pub struct Base64<'a>(&'a [u8]);
+
+impl<'a> Display for Base64<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        use base64::{
+            display::Base64Display,
+            engine::general_purpose::STANDARD,
+        };
+        Base64Display::new(self.0, &STANDARD).fmt(f)
+    }
+}
+
+/// A newtype wrapper of a byte slice that implements [`std::fmt::Display`].
+///
+/// To be used in tracing contexts. See the [`self::hex`] utility.
+pub struct Hex<'a>(&'a [u8]);
+
+/// Format `bytes` as lower-cased hex.
+///
+/// # Example
+/// ```
+/// use astria_telemetry::display;
+/// let signature = vec![1u8, 2, 3, 4, 5, 6, 7, 8];
+/// tracing::info!(signature = %display::hex(&signature), "received signature");
+/// ```
+pub fn hex<T: AsRef<[u8]> + ?Sized>(bytes: &T) -> Hex<'_> {
+    Hex(bytes.as_ref())
+}
+
+impl<'a> Display for Hex<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        for byte in self.0 {
+            f.write_fmt(format_args!("{byte:02x}"))?;
+        }
+        Ok(())
+    }
+}

--- a/crates/astria-core/src/lib.rs
+++ b/crates/astria-core/src/lib.rs
@@ -10,6 +10,7 @@ compile_error!(
 pub mod generated;
 
 pub mod crypto;
+pub mod display;
 pub mod execution;
 pub mod primitive;
 pub mod protocol;

--- a/crates/astria-core/src/primitive/mod.rs
+++ b/crates/astria-core/src/primitive/mod.rs
@@ -1,1 +1,2 @@
+pub use pbjson_types::Timestamp;
 pub mod v1;

--- a/crates/astria-core/src/protocol/genesis/v1alpha1.rs
+++ b/crates/astria-core/src/protocol/genesis/v1alpha1.rs
@@ -17,14 +17,8 @@ use crate::{
         Bech32m,
     },
     slinky::{
-        market_map::v1::{
-            GenesisState as MarketMapGenesisState,
-            GenesisStateError as MarketMapGenesisStateError,
-        },
-        oracle::v1::{
-            GenesisState as OracleGenesisState,
-            GenesisStateError as OracleGenesisStateError,
-        },
+        market_map,
+        oracle,
     },
     Protobuf,
 };
@@ -36,18 +30,18 @@ use crate::{
     serde(try_from = "raw::SlinkyGenesis", into = "raw::SlinkyGenesis")
 )]
 pub struct SlinkyGenesis {
-    market_map: MarketMapGenesisState,
-    oracle: OracleGenesisState,
+    market_map: market_map::v1::GenesisState,
+    oracle: oracle::v1::GenesisState,
 }
 
 impl SlinkyGenesis {
     #[must_use]
-    pub fn market_map(&self) -> &MarketMapGenesisState {
+    pub fn market_map(&self) -> &market_map::v1::GenesisState {
         &self.market_map
     }
 
     #[must_use]
-    pub fn oracle(&self) -> &OracleGenesisState {
+    pub fn oracle(&self) -> &oracle::v1::GenesisState {
         &self.oracle
     }
 }
@@ -65,13 +59,14 @@ impl Protobuf for SlinkyGenesis {
             .as_ref()
             .ok_or_else(|| Self::Error::field_not_set("market_map"))
             .and_then(|market_map| {
-                MarketMapGenesisState::try_from_raw_ref(market_map).map_err(Self::Error::market_map)
+                market_map::v1::GenesisState::try_from_raw_ref(market_map)
+                    .map_err(Self::Error::market_map)
             })?;
         let oracle = oracle
             .as_ref()
             .ok_or_else(|| Self::Error::field_not_set("oracle"))
             .and_then(|oracle| {
-                OracleGenesisState::try_from_raw_ref(oracle).map_err(Self::Error::oracle)
+                oracle::v1::GenesisState::try_from_raw_ref(oracle).map_err(Self::Error::oracle)
             })?;
         Ok(Self {
             market_map,
@@ -116,13 +111,13 @@ impl SlinkyGenesisError {
         })
     }
 
-    fn market_map(source: MarketMapGenesisStateError) -> Self {
+    fn market_map(source: market_map::v1::GenesisStateError) -> Self {
         Self(SlinkyGenesisErrorKind::MarketMap {
             source,
         })
     }
 
-    fn oracle(source: OracleGenesisStateError) -> Self {
+    fn oracle(source: oracle::v1::GenesisStateError) -> Self {
         Self(SlinkyGenesisErrorKind::Oracle {
             source,
         })
@@ -135,9 +130,13 @@ enum SlinkyGenesisErrorKind {
     #[error("field was not set: `{name}`")]
     FieldNotSet { name: &'static str },
     #[error("`market_map` field was invalid")]
-    MarketMap { source: MarketMapGenesisStateError },
+    MarketMap {
+        source: market_map::v1::GenesisStateError,
+    },
     #[error("`oracle` field was invalid")]
-    Oracle { source: OracleGenesisStateError },
+    Oracle {
+        source: oracle::v1::GenesisStateError,
+    },
 }
 
 /// The genesis state of Astria's Sequencer.
@@ -351,7 +350,7 @@ impl Protobuf for GenesisAppState {
             .as_ref()
             .ok_or_else(|| Self::Error::field_not_set("market_map"))
             .and_then(|market_map| {
-                MarketMapGenesisState::try_from_raw(market_map.clone())
+                market_map::v1::GenesisState::try_from_raw(market_map.clone())
                     .map_err(Self::Error::market_map)
             })?;
 
@@ -360,7 +359,7 @@ impl Protobuf for GenesisAppState {
             .as_ref()
             .ok_or_else(|| Self::Error::field_not_set("oracle"))
             .and_then(|oracle| {
-                OracleGenesisState::try_from_raw(oracle.clone()).map_err(Self::Error::oracle)
+                oracle::v1::GenesisState::try_from_raw(oracle.clone()).map_err(Self::Error::oracle)
             })?;
 
         let this = Self {
@@ -493,13 +492,13 @@ impl GenesisAppStateError {
         })
     }
 
-    fn market_map(source: MarketMapGenesisStateError) -> Self {
+    fn market_map(source: market_map::v1::GenesisStateError) -> Self {
         Self(GenesisAppStateErrorKind::MarketMap {
             source,
         })
     }
 
-    fn oracle(source: OracleGenesisStateError) -> Self {
+    fn oracle(source: oracle::v1::GenesisStateError) -> Self {
         Self(GenesisAppStateErrorKind::Oracle {
             source,
         })
@@ -532,9 +531,13 @@ enum GenesisAppStateErrorKind {
     #[error("`native_asset_base_denomination` field was invalid")]
     NativeAssetBaseDenomination { source: ParseTracePrefixedError },
     #[error("`market_map` field was invalid")]
-    MarketMap { source: MarketMapGenesisStateError },
+    MarketMap {
+        source: market_map::v1::GenesisStateError,
+    },
     #[error("`oracle` field was invalid")]
-    Oracle { source: OracleGenesisStateError },
+    Oracle {
+        source: oracle::v1::GenesisStateError,
+    },
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/astria-core/src/slinky/abci.rs
+++ b/crates/astria-core/src/slinky/abci.rs
@@ -1,32 +1,69 @@
 pub mod v1 {
+    use bytes::Bytes;
     use indexmap::IndexMap;
 
-    use crate::generated::astria_vendored::slinky::abci::v1 as raw;
+    use crate::{
+        generated::astria_vendored::slinky::abci::v1 as raw,
+        slinky::types::v1::{
+            CurrencyPairId,
+            Price,
+        },
+    };
+
+    #[derive(Debug, thiserror::Error)]
+    #[error(transparent)]
+    pub struct OracleVoteExtensionError(#[from] OracleVoteExtensionErrorKind);
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("failed to validate astria_vendored.slinky.abci.v1.OracleVoteExtension")]
+    enum OracleVoteExtensionErrorKind {
+        #[error("failed decoding price value in .prices field for key `{id}`")]
+        DecodePrice {
+            id: u64,
+            source: crate::slinky::types::v1::DecodePriceError,
+        },
+    }
 
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct OracleVoteExtension {
-        pub prices: IndexMap<u64, bytes::Bytes>,
+        pub prices: IndexMap<CurrencyPairId, Price>,
     }
 
     impl OracleVoteExtension {
-        #[must_use]
-        pub fn from_raw(raw: raw::OracleVoteExtension) -> Self {
-            Self {
-                prices: raw.prices.into_iter().collect(),
-            }
+        pub fn try_from_raw(
+            raw: raw::OracleVoteExtension,
+        ) -> Result<Self, OracleVoteExtensionError> {
+            let prices = raw
+                .prices
+                .into_iter()
+                .map(|(id, price)| {
+                    let price = Price::try_from(price).map_err(|source| {
+                        OracleVoteExtensionErrorKind::DecodePrice {
+                            id,
+                            source,
+                        }
+                    })?;
+                    Ok::<_, OracleVoteExtensionErrorKind>((CurrencyPairId::new(id), price))
+                })
+                .collect::<Result<_, _>>()?;
+            Ok(Self {
+                prices,
+            })
         }
 
         #[must_use]
         pub fn into_raw(self) -> raw::OracleVoteExtension {
-            raw::OracleVoteExtension {
-                prices: self.prices.into_iter().collect(),
+            fn encode_price(input: Price) -> Bytes {
+                Bytes::copy_from_slice(&input.get().to_be_bytes())
             }
-        }
-    }
 
-    impl From<raw::OracleVoteExtension> for OracleVoteExtension {
-        fn from(raw: raw::OracleVoteExtension) -> Self {
-            Self::from_raw(raw)
+            raw::OracleVoteExtension {
+                prices: self
+                    .prices
+                    .into_iter()
+                    .map(|(id, price)| (id.get(), encode_price(price)))
+                    .collect(),
+            }
         }
     }
 }

--- a/crates/astria-core/src/slinky/market_map.rs
+++ b/crates/astria-core/src/slinky/market_map.rs
@@ -9,7 +9,10 @@ pub mod v1 {
             Address,
             AddressError,
         },
-        slinky::types::v1::CurrencyPair,
+        slinky::types::v1::{
+            CurrencyPair,
+            CurrencyPairError,
+        },
         Protobuf,
     };
 
@@ -350,9 +353,11 @@ pub mod v1 {
         /// - if the `currency_pair` field is missing
         /// - if the `currency_pair` field is invalid
         pub fn try_from_raw(raw: raw::Ticker) -> Result<Self, TickerError> {
-            let Some(currency_pair) = raw.currency_pair.map(CurrencyPair::from_raw) else {
-                return Err(TickerError::missing_currency_pair());
-            };
+            let currency_pair = raw
+                .currency_pair
+                .ok_or_else(|| TickerError::field_not_set("currency_pair"))?
+                .try_into()
+                .map_err(|source| TickerError::invalid_currency_pair(source))?;
 
             Ok(Self {
                 currency_pair,
@@ -377,19 +382,32 @@ pub mod v1 {
 
     #[derive(Debug, thiserror::Error)]
     #[error(transparent)]
-    pub struct TickerError(TickerErrorKind);
+    pub struct TickerError(#[from] TickerErrorKind);
 
     impl TickerError {
         #[must_use]
-        pub fn missing_currency_pair() -> Self {
-            Self(TickerErrorKind::MissingCurrencyPair)
+        pub fn field_not_set(name: &'static str) -> Self {
+            TickerErrorKind::FieldNotSet {
+                name,
+            }
+            .into()
+        }
+
+        pub fn invalid_currency_pair(source: CurrencyPairError) -> Self {
+            TickerErrorKind::InvalidCurrencyPair {
+                source,
+            }
+            .into()
         }
     }
 
     #[derive(Debug, thiserror::Error)]
+    #[error("failed validating wire type `{}`", raw::Ticker::full_name())]
     enum TickerErrorKind {
-        #[error("missing currency pair")]
-        MissingCurrencyPair,
+        #[error("required field not set: .{name}")]
+        FieldNotSet { name: &'static str },
+        #[error("field `.currency_pair` was invalid")]
+        InvalidCurrencyPair { source: CurrencyPairError },
     }
 
     #[cfg_attr(
@@ -427,9 +445,11 @@ pub mod v1 {
         ///
         /// - if the `normalize_by_pair` field is missing
         pub fn try_from_raw(raw: raw::ProviderConfig) -> Result<Self, ProviderConfigError> {
-            let Some(normalize_by_pair) = raw.normalize_by_pair.map(CurrencyPair::from_raw) else {
-                return Err(ProviderConfigError::missing_normalize_by_pair());
-            };
+            let normalize_by_pair = raw
+                .normalize_by_pair
+                .ok_or_else(|| ProviderConfigError::field_not_set("normalize_by_pair"))?
+                .try_into()
+                .map_err(ProviderConfigError::invalid_normalize_by_pair)?;
             Ok(Self {
                 name: raw.name,
                 off_chain_ticker: raw.off_chain_ticker,
@@ -453,19 +473,32 @@ pub mod v1 {
 
     #[derive(Debug, thiserror::Error)]
     #[error(transparent)]
-    pub struct ProviderConfigError(ProviderConfigErrorKind);
+    pub struct ProviderConfigError(#[from] ProviderConfigErrorKind);
 
     impl ProviderConfigError {
         #[must_use]
-        pub fn missing_normalize_by_pair() -> Self {
-            Self(ProviderConfigErrorKind::MissingNormalizeByPair)
+        fn field_not_set(name: &'static str) -> Self {
+            ProviderConfigErrorKind::FieldNotSet {
+                name,
+            }
+            .into()
+        }
+
+        fn invalid_normalize_by_pair(source: CurrencyPairError) -> Self {
+            ProviderConfigErrorKind::InvalidNormalizeByPair {
+                source,
+            }
+            .into()
         }
     }
 
     #[derive(Debug, thiserror::Error)]
+    #[error("failed validating wire type `{}`", raw::ProviderConfig::full_name())]
     enum ProviderConfigErrorKind {
-        #[error("missing normalize by pair")]
-        MissingNormalizeByPair,
+        #[error("required field not set: .{name}")]
+        FieldNotSet { name: &'static str },
+        #[error("field `.normalize_by_pair` was invalid")]
+        InvalidNormalizeByPair { source: CurrencyPairError },
     }
 
     #[cfg_attr(

--- a/crates/astria-core/src/slinky/mod.rs
+++ b/crates/astria-core/src/slinky/mod.rs
@@ -1,4 +1,5 @@
 pub mod abci;
 pub mod market_map;
 pub mod oracle;
+pub mod service;
 pub mod types;

--- a/crates/astria-core/src/slinky/service.rs
+++ b/crates/astria-core/src/slinky/service.rs
@@ -1,0 +1,78 @@
+pub mod v1 {
+    use indexmap::IndexMap;
+
+    use crate::{
+        generated::astria_vendored::slinky::service::v1 as raw,
+        slinky::types::v1::{
+            CurrencyPair,
+            CurrencyPairParseError,
+            ParsePriceError,
+            Price,
+        },
+    };
+
+    #[derive(Debug, thiserror::Error)]
+    #[error(transparent)]
+    pub struct QueryPriceResponseError(#[from] QueryPriceResponseErrorKind);
+
+    #[derive(Debug, thiserror::Error)]
+    #[error(
+        "failed validating wire type {}",
+        raw::QueryPriceResponseError::full_name()
+    )]
+    enum QueryPriceResponseErrorKind {
+        #[error("failed to parse key `{input}` in `.prices` field as currency pair")]
+        ParseCurrencyPair {
+            input: String,
+            source: CurrencyPairParseError,
+        },
+        #[error("failed to parse value `{input}` in `.prices` field at key `{key}` as price")]
+        ParsePrice {
+            input: String,
+            key: String,
+            source: ParsePriceError,
+        },
+    }
+
+    pub struct QueryPricesResponse {
+        pub prices: IndexMap<CurrencyPair, Price>,
+        pub timestamp: ::core::option::Option<::pbjson_types::Timestamp>,
+    }
+
+    impl QueryPricesResponse {
+        pub fn try_from_raw(
+            wire: raw::QueryPricesResponse,
+        ) -> Result<QueryPricesResponse, QueryPriceResponseError> {
+            let raw::QueryPricesResponse {
+                prices,
+                timestamp,
+            } = wire;
+            let prices = prices
+                .into_iter()
+                .map(|(key, value)| {
+                    let currency_pair = match key.parse() {
+                        Err(source) => {
+                            return Err(QueryPriceResponseErrorKind::ParseCurrencyPair {
+                                input: key,
+                                source,
+                            });
+                        }
+                        Ok(parsed) => parsed,
+                    };
+                    let price = value.parse().map_err(move |source| {
+                        QueryPriceResponseErrorKind::ParsePrice {
+                            input: value,
+                            key,
+                            source,
+                        }
+                    })?;
+                    Ok((currency_pair, price))
+                })
+                .collect::<Result<_, _>>()?;
+            Ok(Self {
+                prices,
+                timestamp,
+            })
+        }
+    }
+}

--- a/crates/astria-core/src/slinky/types.rs
+++ b/crates/astria-core/src/slinky/types.rs
@@ -1,48 +1,233 @@
 pub mod v1 {
+    use std::{
+        fmt::Display,
+        num::ParseIntError,
+        str::FromStr,
+    };
+
+    use bytes::Bytes;
+
     use crate::generated::astria_vendored::slinky::types::v1 as raw;
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+    pub struct Price(u128);
+
+    impl Price {
+        pub fn new(value: u128) -> Self {
+            Self(value)
+        }
+
+        pub fn get(self) -> u128 {
+            self.0
+        }
+    }
+
+    impl Price {
+        pub fn checked_add(self, rhs: Self) -> Option<Self> {
+            self.get().checked_add(rhs.get()).map(Self)
+        }
+
+        pub fn checked_div(self, rhs: u128) -> Option<Self> {
+            self.get().checked_div(rhs).map(Self)
+        }
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    #[error(transparent)]
+    pub struct ParsePriceError(#[from] ParseIntError);
+
+    impl FromStr for Price {
+        type Err = ParsePriceError;
+
+        fn from_str(s: &str) -> Result<Self, Self::Err> {
+            s.parse().map(Self::new).map_err(Into::into)
+        }
+    }
+
+    impl Display for Price {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            self.0.fmt(f)
+        }
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("failed decoding `{}` as u128 integer", crate::display::base64(.input))]
+    pub struct DecodePriceError {
+        input: Bytes,
+    }
+
+    impl TryFrom<Bytes> for Price {
+        type Error = DecodePriceError;
+
+        fn try_from(input: Bytes) -> Result<Self, Self::Error> {
+            // throw away the error because it does not contain extra information.
+            let be_bytes = <[u8; 16]>::try_from(&*input).map_err(|_| Self::Error {
+                input,
+            })?;
+            Ok(Price::new(u128::from_be_bytes(be_bytes)))
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    pub struct Base(String);
+
+    impl Display for Base {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            self.0.fmt(f)
+        }
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    #[error(
+        "failed to parse input `{input}` as base part of currency pair; only ascii alpha \
+         characters are permitted"
+    )]
+    pub struct ParseBaseError {
+        input: String,
+    }
+
+    impl FromStr for Base {
+        type Err = ParseBaseError;
+
+        fn from_str(s: &str) -> Result<Self, Self::Err> {
+            static REGEX: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
+            fn get_regex() -> &'static regex::Regex {
+                REGEX.get_or_init(|| regex::Regex::new(r"^[a-zA-Z]+$").expect("valid regex"))
+            }
+            // allocating here because the string will always be allocated on both branches.
+            // TODO: check if this string can be represented by a stack-optimized alternative
+            //       like ecow, compact_str, or similar.
+            let input = s.to_string();
+            if get_regex().find(s).is_none() {
+                return Err(Self::Err {
+                    input,
+                });
+            }
+            Ok(Self(input))
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    pub struct Quote(String);
+
+    impl Display for Quote {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            self.0.fmt(f)
+        }
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    #[error(
+        "failed to parse input `{input}` as quote part of currency pair; only ascii alpha \
+         characters are permitted"
+    )]
+    pub struct ParseQuoteError {
+        input: String,
+    }
+
+    impl FromStr for Quote {
+        type Err = ParseQuoteError;
+
+        fn from_str(s: &str) -> Result<Self, Self::Err> {
+            static REGEX: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
+            fn get_regex() -> &'static regex::Regex {
+                REGEX.get_or_init(|| regex::Regex::new(r"^[a-zA-Z]+$").expect("valid regex"))
+            }
+            // allocating here because the string will always be allocated on both branches.
+            // TODO: check if this string can be represented by a stack-optimized alternative
+            //       like ecow, compact_str, or similar.
+            let input = s.to_string();
+            if get_regex().find(s).is_none() {
+                return Err(Self::Err {
+                    input,
+                });
+            }
+            Ok(Self(input))
+        }
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    #[error(transparent)]
+    pub struct CurrencyPairError(#[from] CurrencyPairErrorKind);
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("failed validating wire type `{}`", CurrencyPair::full_name())]
+    enum CurrencyPairErrorKind {
+        #[error("invalid field `.base`")]
+        ParseBase { source: ParseBaseError },
+        #[error("invalid field `.quote`")]
+        ParseQuote { source: ParseQuoteError },
+    }
 
     #[cfg_attr(
         feature = "serde",
         derive(serde::Deserialize, serde::Serialize),
-        serde(from = "raw::CurrencyPair", into = "raw::CurrencyPair")
+        serde(try_from = "raw::CurrencyPair", into = "raw::CurrencyPair")
     )]
     #[derive(Debug, Clone, PartialEq, Eq, Hash)]
     pub struct CurrencyPair {
-        base: String,
-        quote: String,
+        base: Base,
+        quote: Quote,
     }
 
     impl CurrencyPair {
         #[must_use]
+        pub fn from_parts(base: Base, quote: Quote) -> Self {
+            Self {
+                base,
+                quote,
+            }
+        }
+
+        /// Returns the `(base, quote)` pair that makes up this [`CurrencyPair`].
+        #[must_use]
+        pub fn into_parts(self) -> (String, String) {
+            (self.base.0, self.quote.0)
+        }
+
+        #[must_use]
         pub fn base(&self) -> &str {
-            &self.base
+            &self.base.0
         }
 
         #[must_use]
         pub fn quote(&self) -> &str {
-            &self.quote
+            &self.quote.0
         }
 
-        #[must_use]
-        pub fn from_raw(raw: raw::CurrencyPair) -> Self {
-            Self {
-                base: raw.base,
-                quote: raw.quote,
-            }
+        pub fn try_from_raw(raw: raw::CurrencyPair) -> Result<Self, CurrencyPairError> {
+            let base = raw
+                .base
+                .parse()
+                .map_err(|source| CurrencyPairErrorKind::ParseBase {
+                    source,
+                })?;
+            let quote = raw
+                .quote
+                .parse()
+                .map_err(|source| CurrencyPairErrorKind::ParseQuote {
+                    source,
+                })?;
+            Ok(Self {
+                base,
+                quote,
+            })
         }
 
         #[must_use]
         pub fn into_raw(self) -> raw::CurrencyPair {
             raw::CurrencyPair {
-                base: self.base,
-                quote: self.quote,
+                base: self.base.0,
+                quote: self.quote.0,
             }
         }
     }
 
-    impl From<raw::CurrencyPair> for CurrencyPair {
-        fn from(raw: raw::CurrencyPair) -> Self {
-            Self::from_raw(raw)
+    impl TryFrom<raw::CurrencyPair> for CurrencyPair {
+        type Error = CurrencyPairError;
+
+        fn try_from(raw: raw::CurrencyPair) -> Result<Self, Self::Error> {
+            Self::try_from_raw(raw)
         }
     }
 
@@ -76,8 +261,8 @@ pub mod v1 {
                 .as_str();
 
             Ok(Self {
-                base: base.to_string(),
-                quote: quote.to_string(),
+                base: Base(base.to_string()),
+                quote: Quote(quote.to_string()),
             })
         }
     }
@@ -94,10 +279,53 @@ pub mod v1 {
 
     impl CurrencyPairParseError {
         #[must_use]
-        pub fn invalid_currency_pair_string(s: &str) -> Self {
+        fn invalid_currency_pair_string(s: &str) -> Self {
             Self(CurrencyPairParseErrorKind::InvalidCurrencyPairString(
                 s.to_string(),
             ))
+        }
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub struct CurrencyPairId(u64);
+
+    impl std::fmt::Display for CurrencyPairId {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            self.0.fmt(f)
+        }
+    }
+
+    impl CurrencyPairId {
+        pub fn new(value: u64) -> Self {
+            Self(value)
+        }
+
+        pub fn get(self) -> u64 {
+            self.0
+        }
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub struct CurrencyPairNonce(u64);
+
+    impl std::fmt::Display for CurrencyPairNonce {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            self.0.fmt(f)
+        }
+    }
+
+    impl CurrencyPairNonce {
+        pub fn new(value: u64) -> Self {
+            Self(value)
+        }
+
+        pub fn get(self) -> u64 {
+            self.0
+        }
+
+        pub fn increment(self) -> Option<Self> {
+            let new_nonce = self.get().checked_add(1)?;
+            Some(Self::new(new_nonce))
         }
     }
 }

--- a/crates/astria-sequencer/src/app/test_utils.rs
+++ b/crates/astria-sequencer/src/app/test_utils.rs
@@ -111,13 +111,9 @@ pub(crate) fn proto_genesis_state()
             IbcParameters,
             SlinkyGenesis,
         },
-        slinky::{
-            market_map::v1::{
-                GenesisState as MarketMapGenesisState,
-                MarketMap,
-                Params,
-            },
-            oracle::v1::GenesisState as OracleGenesisState,
+        slinky::market_map::v1::{
+            MarketMap,
+            Params,
         },
     };
 
@@ -141,7 +137,7 @@ pub(crate) fn proto_genesis_state()
         fees: Some(default_fees().to_raw()),
         slinky: Some(SlinkyGenesis {
             market_map: Some(
-                MarketMapGenesisState {
+                astria_core::slinky::market_map::v1::GenesisState {
                     market_map: MarketMap {
                         markets: IndexMap::new(),
                     },
@@ -154,11 +150,10 @@ pub(crate) fn proto_genesis_state()
                 .into_raw(),
             ),
             oracle: Some(
-                OracleGenesisState {
+                astria_core::generated::astria_vendored::slinky::oracle::v1::GenesisState {
                     currency_pair_genesis: vec![],
                     next_id: 0,
-                }
-                .into_raw(),
+                },
             ),
         }),
     }

--- a/crates/astria-sequencer/src/grpc/slinky.rs
+++ b/crates/astria-sequencer/src/grpc/slinky.rs
@@ -174,12 +174,20 @@ impl OracleService for SequencerServer {
         let Some(currency_pair) = request.currency_pair else {
             return Err(Status::invalid_argument("currency pair is required"));
         };
-        let currency_pair = CurrencyPair::from_raw(currency_pair);
+        let currency_pair = CurrencyPair::try_from_raw(currency_pair).map_err(|e| {
+            Status::invalid_argument(format!(
+                "failed to validate currency pair provided in request: {e:#}"
+            ))
+        })?;
         let snapshot = self.storage.latest_snapshot();
         let Some(state) = snapshot
             .get_currency_pair_state(&currency_pair)
             .await
-            .map_err(|e| Status::internal(format!("failed to get state from storage: {e:#}")))?
+            .map_err(|e| {
+                Status::internal(format!(
+                    "failed to get currency pair state from storage: {e:#}"
+                ))
+            })?
         else {
             return Err(Status::not_found("currency pair state not found"));
         };
@@ -201,8 +209,8 @@ impl OracleService for SequencerServer {
 
         Ok(Response::new(GetPriceResponse {
             price: Some(state.price.into_raw()),
-            nonce: state.nonce,
-            id: state.id,
+            nonce: state.nonce.get(),
+            id: state.id.get(),
             decimals: market.ticker.decimals,
         }))
     }
@@ -259,8 +267,8 @@ impl OracleService for SequencerServer {
 
             prices.push(GetPriceResponse {
                 price: Some(state.price.into_raw()),
-                nonce: state.nonce,
-                id: state.id,
+                nonce: state.nonce.get(),
+                id: state.id.get(),
                 decimals: market.ticker.decimals,
             });
         }

--- a/crates/astria-sequencer/src/slinky/oracle/component.rs
+++ b/crates/astria-sequencer/src/slinky/oracle/component.rs
@@ -33,8 +33,8 @@ impl Component for OracleComponent {
                 price: currency_pair.currency_pair_price().clone(),
             };
             state
-                .put_currency_pair_state(currency_pair.currency_pair(), currency_pair_state)
-                .context("failed to put currency pair")?;
+                .put_currency_pair_state(currency_pair.currency_pair().clone(), currency_pair_state)
+                .context("failed to write currency pair to state")?;
         }
 
         state

--- a/crates/astria-sequencer/src/slinky/oracle/currency_pair_strategy.rs
+++ b/crates/astria-sequencer/src/slinky/oracle/currency_pair_strategy.rs
@@ -1,8 +1,8 @@
-use anyhow::{
-    ensure,
-    Context as _,
+use anyhow::Context as _;
+use astria_core::slinky::types::v1::{
+    CurrencyPair,
+    CurrencyPairId,
 };
-use astria_core::slinky::types::v1::CurrencyPair;
 
 use crate::slinky::oracle::state_ext::StateReadExt;
 
@@ -13,29 +13,15 @@ impl DefaultCurrencyPairStrategy {
     pub(crate) async fn id<S: StateReadExt>(
         state: &S,
         currency_pair: &CurrencyPair,
-    ) -> anyhow::Result<u64> {
+    ) -> anyhow::Result<Option<CurrencyPairId>> {
         state.get_currency_pair_id(currency_pair).await
     }
 
     pub(crate) async fn from_id<S: StateReadExt>(
         state: &S,
-        id: u64,
+        id: CurrencyPairId,
     ) -> anyhow::Result<Option<CurrencyPair>> {
         state.get_currency_pair(id).await
-    }
-
-    pub(crate) fn get_encoded_price<S: StateReadExt>(_state: &S, price: u128) -> Vec<u8> {
-        price.to_be_bytes().to_vec()
-    }
-
-    pub(crate) fn get_decoded_price<S: StateReadExt>(
-        _state: &S,
-        encoded_price: &[u8],
-    ) -> anyhow::Result<u128> {
-        ensure!(encoded_price.len() == 16, "invalid encoded price length");
-        let mut bytes = [0; 16];
-        bytes.copy_from_slice(encoded_price);
-        Ok(u128::from_be_bytes(bytes))
     }
 
     pub(crate) async fn get_max_num_currency_pairs<S: StateReadExt>(


### PR DESCRIPTION
This patch enforces more type strictes on slinky oracle domain types:

1. Nonces, Ids, and Prices are new-type wrappers around their respective primtives; This is to avoid using `u128` in place of a `Price`, for example.
2. All oracle types written to state get their own types that themselves derive the borsh serialization traits.
3. All json is removed from the oracle state read and write extension trait.
4. A lot of validation code is moved from sequencer to core so that validation happens closer to the boundary.
5. Functions in the public interface for constructing various validation errors were removed.
6. Constructors that would allow violating invariants (specifically invariants around the contents of currency pairs) were removed.

  A bug was fixed in the `oracle::StateReadExt::put_price_for_currency_pair`
  trait method, which was not updating the nonce.
