### PR TITLE
chore(chart): update geth tag

### DIFF
--- a/charts/evm-rollup/Chart.yaml
+++ b/charts/evm-rollup/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.27.0
+version: 0.27.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/evm-rollup/values.yaml
+++ b/charts/evm-rollup/values.yaml
@@ -10,7 +10,7 @@ images:
   geth:
     repo: ghcr.io/astriaorg/astria-geth
     tag: 0.14.0
-    devTag: pr-42  # update to latest once geth changes(https://github.com/astriaorg/astria-geth/pull/42) merged
+    devTag: latest
     overrideTag: ""
   conductor:
     repo: ghcr.io/astriaorg/conductor

--- a/charts/evm-stack/Chart.lock
+++ b/charts/evm-stack/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.3.6
 - name: evm-rollup
   repository: file://../evm-rollup
-  version: 0.27.0
+  version: 0.27.1
 - name: composer
   repository: file://../composer
   version: 0.1.2
@@ -20,5 +20,5 @@ dependencies:
 - name: blockscout-stack
   repository: https://blockscout.github.io/helm-charts
   version: 1.6.2
-digest: sha256:e2209c2b6aa17c3163bcbd32eea4bdbb0df9b108ff353a0020ff951186bb1350
-generated: "2024-09-04T11:23:10.710044-05:00"
+digest: sha256:a10877e17ed14e2a28db0dd6a968e8eafdd7529c6aab84ca8e0b1a9f5302b189
+generated: "2024-09-11T11:05:50.356152-05:00"

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.5.1
 
 dependencies:
   - name: celestia-node
@@ -23,7 +23,7 @@ dependencies:
     repository: "file://../celestia-node"
     condition: celestia-node.enabled
   - name: evm-rollup
-    version: 0.27.0
+    version: 0.27.1
     repository: "file://../evm-rollup"
   - name: composer
     version: 0.1.2


### PR DESCRIPTION
## Summary
Update geth tag to `latest` for https://github.com/astriaorg/astria-geth/pull/42

## Background
#1410 required changes to `astria-geth`, which necessitated changing the geth dev tag to be the specific PR number. Now that the geth PR is merged, we can bump the tag.

## Changes
- Changed `evm-rollup` geth dev tag to `latest` and bumped chart versions.