### PR TITLE
fix(sequencer): grpc height hack to fix ibc invalid proof error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8852,3 +8852,28 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "cnidarium"
+version = "0.80.4"
+source = "git+https://github.com/noot/penumbra.git?rev=636b9f12d6c5e7324e798236e4a514983f6a8c6d#636b9f12d6c5e7324e798236e4a514983f6a8c6d"
+
+[[patch.unused]]
+name = "cnidarium-component"
+version = "0.80.4"
+source = "git+https://github.com/noot/penumbra.git?rev=636b9f12d6c5e7324e798236e4a514983f6a8c6d#636b9f12d6c5e7324e798236e4a514983f6a8c6d"
+
+[[patch.unused]]
+name = "penumbra-ibc"
+version = "0.80.4"
+source = "git+https://github.com/noot/penumbra.git?rev=636b9f12d6c5e7324e798236e4a514983f6a8c6d#636b9f12d6c5e7324e798236e4a514983f6a8c6d"
+
+[[patch.unused]]
+name = "penumbra-proto"
+version = "0.80.4"
+source = "git+https://github.com/noot/penumbra.git?rev=636b9f12d6c5e7324e798236e4a514983f6a8c6d#636b9f12d6c5e7324e798236e4a514983f6a8c6d"
+
+[[patch.unused]]
+name = "penumbra-tower-trace"
+version = "0.80.4"
+source = "git+https://github.com/noot/penumbra.git?rev=636b9f12d6c5e7324e798236e4a514983f6a8c6d#636b9f12d6c5e7324e798236e4a514983f6a8c6d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,3 +107,10 @@ tracing = "0.1"
 tryhard = "0.5.1"
 which = "4.4.0"
 wiremock = "0.5"
+
+[patch.'https://github.com/penumbra-zone/penumbra.git']
+penumbra-ibc = { git = "https://github.com/noot/penumbra.git", rev = "636b9f12d6c5e7324e798236e4a514983f6a8c6d" }
+penumbra-proto = { git = "https://github.com/noot/penumbra.git", rev = "636b9f12d6c5e7324e798236e4a514983f6a8c6d" }
+penumbra-tower-trace = { git = "https://github.com/noot/penumbra.git", rev = "636b9f12d6c5e7324e798236e4a514983f6a8c6d" }
+cnidarium = { git = "https://github.com/noot/penumbra.git", rev = "636b9f12d6c5e7324e798236e4a514983f6a8c6d" }
+cnidarium-component = { git = "https://github.com/noot/penumbra.git", rev = "636b9f12d6c5e7324e798236e4a514983f6a8c6d" }

--- a/charts/hermes/Chart.yaml
+++ b/charts/hermes/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hermes/values.yaml
+++ b/charts/hermes/values.yaml
@@ -3,7 +3,7 @@ global:
   replicaCount: 1
   logLevel: debug
 
-image: ghcr.io/penumbra-zone/hermes:main
+image: ghcr.io/astriaorg/hermes:sha-903bac5
 
 fullnameOverride: ""
 nameOverride: ""


### PR DESCRIPTION
## Summary
patch penumbra and our hermes fork temporarily so that height is passed from hermes's requests to the ibc grpc server.

## Background
there was an IBC proof validation failure error on dusk-10. the computed app hash was one height *after* the expected app hash, which could be caused by the grpc queries always using the latest state snapshot, instead of at the height intended by hermes. however the grpc requests don't contain the height (:/) so the hack is to put the height in the grpc request metadata, which is then used by the grpc query server to use the correct snapshot.

the actual fix is to get https://github.com/cosmos/ibc-go/pull/5685 merged and put the heights in the actual grpc requests.

## Changes
- patch penumbra dep to https://github.com/noot/penumbra/pull/3 temporarily
- hermes commit in chart is https://github.com/astriaorg/hermes/pull/12

## Testing
ibc smoke test
