### PR TITLE
fix, refactor(sequencer): refactor ics20 logic

### DIFF
--- a/crates/astria-core/src/primitive/v1/asset/denom.rs
+++ b/crates/astria-core/src/primitive/v1/asset/denom.rs
@@ -207,82 +207,42 @@ impl TracePrefixed {
         self.trace.is_empty()
     }
 
-    /// Checks if the trace prefixed denom starts with `s`.
+    /// Checks if the trace prefixed denom has `port` in left-most position.
     ///
     /// # Examples
     ///
     /// ```
     /// use astria_core::primitive::v1::asset::denom::TracePrefixed;
     /// let denom = "four/segments/of/a/denom".parse::<TracePrefixed>().unwrap();
-    ///
-    /// // Empty string is always true:
-    /// assert!(denom.starts_with_str(""));
-    /// // Single slash is always false:
-    /// assert!(!denom.starts_with_str("/"));
-    /// // Emptry strings are false:
-    /// assert!(!denom.starts_with_str(" "));
-    ///
-    /// // In general, whitespace is not trimmed and leads to false
-    /// assert!(!denom.starts_with_str("four/segments /"));
-    ///
-    /// // Trailing slashes don't change the result if they are part of the trace prefix:
-    /// assert!(denom.starts_with_str("four/segments"));
-    /// assert!(denom.starts_with_str("four/segments/"));
-    ///
-    /// // Trailing slashes on the full trace prefix denom however return false:
-    /// assert!(!denom.starts_with_str("four/segments/of/a/denom/"));
-    ///
-    /// // Providing only a port is true
-    /// assert!(denom.starts_with_str("four"));
-    /// // Providing a full port/channel pair followed by just a port is also true
-    /// assert!(denom.starts_with_str("four/segments/of"));
-    ///
-    /// // Half of a port or channel is false
-    /// assert!(!denom.starts_with_str("four/segm"));
-    ///
-    /// // The full trace prefixed denom is true:
-    /// assert!(denom.starts_with_str("four/segments/of/a/denom"));
+    /// assert!(denom.has_leading_port("four"));
+    /// assert!(!denom.has_leading_port("segments"));
+    /// assert!(!denom.has_leading_port("of"));
+    /// assert!(!denom.has_leading_port("a"));
+    /// assert!(!denom.has_leading_port("denom"));
+    /// assert!(!denom.has_leading_port(""));
     /// ```
     #[must_use]
-    pub fn starts_with_str(&self, s: &str) -> bool {
-        if s.is_empty() {
-            return true;
-        }
-        let mut had_trailing_slash = false;
-        let s = s
-            .strip_suffix('/')
-            .inspect(|_| had_trailing_slash = true)
-            .unwrap_or(s);
-        if s.is_empty() {
-            return false;
-        }
-        let mut parts = s.split('/');
-        for segment in self.trace.iter() {
-            // first iteration: we know that s is not empty after stripping the /
-            // so that this is not wrongly returning true.
-            let Some(port) = parts.next() else {
-                return true;
-            };
-            if segment.port() != port {
-                return false;
-            }
-            let Some(channel) = parts.next() else {
-                return true;
-            };
-            if segment.channel() != channel {
-                return false;
-            }
-        }
-        let Some(base_denom) = parts.next() else {
-            return true;
-        };
-        if base_denom != self.base_denom {
-            return false;
-        }
-        if had_trailing_slash {
-            return false;
-        }
-        parts.next().is_none()
+    pub fn has_leading_port<T: AsRef<str>>(&self, port: T) -> bool {
+        self.trace.leading_port() == Some(port.as_ref())
+    }
+
+    /// Checks if the trace prefixed denom has `channel` in left-most position.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use astria_core::primitive::v1::asset::denom::TracePrefixed;
+    /// let denom = "four/segments/of/a/denom".parse::<TracePrefixed>().unwrap();
+    /// assert!(!denom.has_leading_channel("four"));
+    /// assert!(denom.has_leading_channel("segments"));
+    /// assert!(!denom.has_leading_channel("of"));
+    /// assert!(!denom.has_leading_channel("a"));
+    /// assert!(!denom.has_leading_channel("denom"));
+    /// assert!(!denom.has_leading_channel(""));
+    /// ```
+    #[must_use]
+    pub fn has_leading_channel<T: AsRef<str>>(&self, channel: T) -> bool {
+        self.trace.leading_channel() == Some(channel.as_ref())
     }
 
     #[must_use]
@@ -290,7 +250,7 @@ impl TracePrefixed {
         self.trace.last_channel()
     }
 
-    pub fn pop_trace_segment(&mut self) -> Option<PortAndChannel> {
+    pub fn pop_leading_port_and_channel(&mut self) -> Option<PortAndChannel> {
         self.trace.pop()
     }
 
@@ -311,6 +271,14 @@ impl TraceSegments {
         }
     }
 
+    fn leading_port(&self) -> Option<&str> {
+        self.inner.front().map(|segment| &*segment.port)
+    }
+
+    fn leading_channel(&self) -> Option<&str> {
+        self.inner.front().map(|segment| &*segment.channel)
+    }
+
     fn push(&mut self, seg: PortAndChannel) {
         self.inner.push_back(seg);
     }
@@ -325,10 +293,6 @@ impl TraceSegments {
 
     fn is_empty(&self) -> bool {
         self.inner.is_empty()
-    }
-
-    fn iter(&self) -> impl Iterator<Item = &PortAndChannel> {
-        self.inner.iter()
     }
 }
 
@@ -717,37 +681,14 @@ mod tests {
     #[test]
     fn pop_path() {
         let mut denom = "a/long/path/to/denom".parse::<TracePrefixed>().unwrap();
-        let port_and_channel = denom.pop_trace_segment().unwrap();
+        let port_and_channel = denom.pop_leading_port_and_channel().unwrap();
         assert_eq!("a", port_and_channel.port());
         assert_eq!("long", port_and_channel.channel());
 
-        let port_and_channel = denom.pop_trace_segment().unwrap();
+        let port_and_channel = denom.pop_leading_port_and_channel().unwrap();
         assert_eq!("path", port_and_channel.port());
         assert_eq!("to", port_and_channel.channel());
 
-        assert_eq!(None, denom.pop_trace_segment());
-    }
-
-    #[test]
-    fn start_prefixes() {
-        let denom = "four/segments/of/a/denom".parse::<TracePrefixed>().unwrap();
-
-        assert!(denom.starts_with_str(""));
-        assert!(!denom.starts_with_str("/"));
-        assert!(!denom.starts_with_str(" "));
-
-        assert!(!denom.starts_with_str("four/segments /"));
-
-        assert!(denom.starts_with_str("four/segments"));
-        assert!(denom.starts_with_str("four/segments/"));
-
-        assert!(!denom.starts_with_str("four/segments/of/a/denom/"));
-
-        assert!(denom.starts_with_str("four"));
-        assert!(denom.starts_with_str("four/segments/of"));
-
-        assert!(!denom.starts_with_str("four/segm"));
-
-        assert!(denom.starts_with_str("four/segments/of/a/denom"));
+        assert_eq!(None, denom.pop_leading_port_and_channel());
     }
 }

--- a/crates/astria-core/src/protocol/test_utils.rs
+++ b/crates/astria-core/src/protocol/test_utils.rs
@@ -116,10 +116,10 @@ impl ConfigureSequencerBlock {
 
         let mut deposits_map: HashMap<RollupId, Vec<Deposit>> = HashMap::new();
         for deposit in deposits {
-            if let Some(entry) = deposits_map.get_mut(deposit.rollup_id()) {
+            if let Some(entry) = deposits_map.get_mut(&deposit.rollup_id) {
                 entry.push(deposit);
             } else {
-                deposits_map.insert(*deposit.rollup_id(), vec![deposit]);
+                deposits_map.insert(deposit.rollup_id, vec![deposit]);
             }
         }
 

--- a/crates/astria-core/src/sequencerblock/v1alpha1/block.rs
+++ b/crates/astria-core/src/sequencerblock/v1alpha1/block.rs
@@ -1291,85 +1291,23 @@ impl FilteredSequencerBlockError {
 )]
 pub struct Deposit {
     // the address on the sequencer to which the funds were sent to.
-    bridge_address: Address,
+    pub bridge_address: Address,
     // the rollup ID registered to the `bridge_address`
-    rollup_id: RollupId,
+    pub rollup_id: RollupId,
     // the amount that was transferred to `bridge_address`
-    amount: u128,
+    pub amount: u128,
     // the IBC ICS20 denom of the asset that was transferred
-    asset: asset::Denom,
+    pub asset: asset::Denom,
     // the address on the destination chain (rollup) which to send the bridged funds to
-    destination_chain_address: String,
+    pub destination_chain_address: String,
     // the transaction ID of the source action for the deposit, consisting
     // of the transaction hash.
-    source_transaction_id: TransactionId,
+    pub source_transaction_id: TransactionId,
     // index of the deposit's source action within its transaction
-    source_action_index: u64,
-}
-
-impl From<Deposit> for crate::generated::sequencerblock::v1alpha1::Deposit {
-    fn from(deposit: Deposit) -> Self {
-        deposit.into_raw()
-    }
+    pub source_action_index: u64,
 }
 
 impl Deposit {
-    #[must_use]
-    pub fn new(
-        bridge_address: Address,
-        rollup_id: RollupId,
-        amount: u128,
-        asset: asset::Denom,
-        destination_chain_address: String,
-        source_transaction_id: TransactionId,
-        source_action_index: u64,
-    ) -> Self {
-        Self {
-            bridge_address,
-            rollup_id,
-            amount,
-            asset,
-            destination_chain_address,
-            source_transaction_id,
-            source_action_index,
-        }
-    }
-
-    #[must_use]
-    pub fn bridge_address(&self) -> &Address {
-        &self.bridge_address
-    }
-
-    #[must_use]
-    pub fn rollup_id(&self) -> &RollupId {
-        &self.rollup_id
-    }
-
-    #[must_use]
-    pub fn amount(&self) -> u128 {
-        self.amount
-    }
-
-    #[must_use]
-    pub fn asset(&self) -> &asset::Denom {
-        &self.asset
-    }
-
-    #[must_use]
-    pub fn destination_chain_address(&self) -> &str {
-        &self.destination_chain_address
-    }
-
-    #[must_use]
-    pub fn source_transaction_id(&self) -> &TransactionId {
-        &self.source_transaction_id
-    }
-
-    #[must_use]
-    pub fn source_action_index(&self) -> u64 {
-        self.source_action_index
-    }
-
     #[must_use]
     pub fn into_raw(self) -> raw::Deposit {
         let Self {
@@ -1436,6 +1374,12 @@ impl Deposit {
             source_transaction_id,
             source_action_index,
         })
+    }
+}
+
+impl From<Deposit> for crate::generated::sequencerblock::v1alpha1::Deposit {
+    fn from(deposit: Deposit) -> Self {
+        deposit.into_raw()
     }
 }
 

--- a/crates/astria-sequencer-utils/src/blob_parser.rs
+++ b/crates/astria-sequencer-utils/src/blob_parser.rs
@@ -537,11 +537,11 @@ impl TryFrom<&RawDeposit> for PrintableDeposit {
     fn try_from(raw_deposit: &RawDeposit) -> Result<Self, Self::Error> {
         let deposit = Deposit::try_from_raw(raw_deposit.clone())?;
         Ok(PrintableDeposit {
-            bridge_address: deposit.bridge_address().to_string(),
-            rollup_id: deposit.rollup_id().to_string(),
-            amount: deposit.amount(),
-            asset: deposit.asset().to_string(),
-            destination_chain_address: deposit.destination_chain_address().to_string(),
+            bridge_address: deposit.bridge_address.to_string(),
+            rollup_id: deposit.rollup_id.to_string(),
+            amount: deposit.amount,
+            asset: deposit.asset.to_string(),
+            destination_chain_address: deposit.destination_chain_address.to_string(),
         })
     }
 }

--- a/crates/astria-sequencer/src/accounts/mod.rs
+++ b/crates/astria-sequencer/src/accounts/mod.rs
@@ -22,11 +22,19 @@ pub(crate) use state_ext::{
 
 pub(crate) trait AddressBytes: Send + Sync {
     fn address_bytes(&self) -> [u8; ADDRESS_LEN];
+
+    fn display_address(&self) -> impl std::fmt::Display {
+        telemetry::display::base64(self.address_bytes())
+    }
 }
 
 impl AddressBytes for Address {
     fn address_bytes(&self) -> [u8; ADDRESS_LEN] {
         self.bytes()
+    }
+
+    fn display_address(&self) -> impl std::fmt::Display {
+        self
     }
 }
 

--- a/crates/astria-sequencer/src/accounts/state_ext.rs
+++ b/crates/astria-sequencer/src/accounts/state_ext.rs
@@ -186,7 +186,7 @@ pub(crate) trait StateReadExt: StateRead + crate::assets::StateReadExt {
         }
     }
 
-    #[instrument(skip_all)]
+    #[instrument(skip_all, fields(address = %address.display_address(), %asset), err)]
     async fn get_account_balance<'a, TAddress, TAsset>(
         &self,
         address: TAddress,
@@ -244,7 +244,7 @@ impl<T: StateRead + ?Sized> StateReadExt for T {}
 
 #[async_trait]
 pub(crate) trait StateWriteExt: StateWrite {
-    #[instrument(skip_all)]
+    #[instrument(skip_all, fields(address = %address.display_address(), %asset, balance), err)]
     fn put_account_balance<TAddress, TAsset>(
         &mut self,
         address: TAddress,
@@ -267,7 +267,7 @@ pub(crate) trait StateWriteExt: StateWrite {
         Ok(())
     }
 
-    #[instrument(skip_all)]
+    #[instrument(skip_all, fields(address = %address.display_address(), %asset, amount), err)]
     async fn increase_balance<TAddress, TAsset>(
         &mut self,
         address: TAddress,
@@ -294,7 +294,7 @@ pub(crate) trait StateWriteExt: StateWrite {
         Ok(())
     }
 
-    #[instrument(skip_all)]
+    #[instrument(skip_all, fields(address = %address.display_address(), %asset, amount))]
     async fn decrease_balance<TAddress, TAsset>(
         &mut self,
         address: TAddress,

--- a/crates/astria-sequencer/src/accounts/state_ext.rs
+++ b/crates/astria-sequencer/src/accounts/state_ext.rs
@@ -186,6 +186,8 @@ pub(crate) trait StateReadExt: StateRead + crate::assets::StateReadExt {
         }
     }
 
+    // allow: false positive due to proc macro; fixed with rust/clippy 1.81
+    #[allow(clippy::blocks_in_conditions)]
     #[instrument(skip_all, fields(address = %address.display_address(), %asset), err)]
     async fn get_account_balance<'a, TAddress, TAsset>(
         &self,
@@ -267,6 +269,8 @@ pub(crate) trait StateWriteExt: StateWrite {
         Ok(())
     }
 
+    // allow: false positive due to proc macro; fixed with rust/clippy 1.81
+    #[allow(clippy::blocks_in_conditions)]
     #[instrument(skip_all, fields(address = %address.display_address(), %asset, amount), err)]
     async fn increase_balance<TAddress, TAsset>(
         &mut self,

--- a/crates/astria-sequencer/src/address/state_ext.rs
+++ b/crates/astria-sequencer/src/address/state_ext.rs
@@ -53,7 +53,7 @@ pub(crate) trait StateReadExt: StateRead {
             .wrap_err("failed to construct address from byte slice and state-provided base prefix")
     }
 
-    #[instrument(skip_all)]
+    #[instrument(skip_all, err)]
     async fn get_base_prefix(&self) -> Result<String> {
         let Some(bytes) = self
             .get_raw(base_prefix_key())
@@ -66,7 +66,7 @@ pub(crate) trait StateReadExt: StateRead {
         String::from_utf8(bytes).context("prefix retrieved from storage is not valid utf8")
     }
 
-    #[instrument(skip_all)]
+    #[instrument(skip_all, err)]
     async fn get_ibc_compat_prefix(&self) -> Result<String> {
         let Some(bytes) = self
             .get_raw(ibc_compat_prefix_key())

--- a/crates/astria-sequencer/src/address/state_ext.rs
+++ b/crates/astria-sequencer/src/address/state_ext.rs
@@ -53,6 +53,8 @@ pub(crate) trait StateReadExt: StateRead {
             .wrap_err("failed to construct address from byte slice and state-provided base prefix")
     }
 
+    // allow: false positive due to proc macro; fixed with rust/clippy 1.81
+    #[allow(clippy::blocks_in_conditions)]
     #[instrument(skip_all, err)]
     async fn get_base_prefix(&self) -> Result<String> {
         let Some(bytes) = self
@@ -66,6 +68,8 @@ pub(crate) trait StateReadExt: StateRead {
         String::from_utf8(bytes).context("prefix retrieved from storage is not valid utf8")
     }
 
+    // allow: false positive due to proc macro; fixed with rust/clippy 1.81
+    #[allow(clippy::blocks_in_conditions)]
     #[instrument(skip_all, err)]
     async fn get_ibc_compat_prefix(&self) -> Result<String> {
         let Some(bytes) = self

--- a/crates/astria-sequencer/src/api_state_ext.rs
+++ b/crates/astria-sequencer/src/api_state_ext.rs
@@ -419,15 +419,15 @@ mod test {
             let amount = rng.gen::<u128>();
             let asset = "testasset".parse().unwrap();
             let destination_chain_address = rng.gen::<u8>().to_string();
-            let deposit = Deposit::new(
+            let deposit = Deposit {
                 bridge_address,
                 rollup_id,
                 amount,
                 asset,
                 destination_chain_address,
-                TransactionId::new([0; 32]),
-                0,
-            );
+                source_transaction_id: TransactionId::new([0; 32]),
+                source_action_index: 9,
+            };
             deposits.push(deposit);
         }
 

--- a/crates/astria-sequencer/src/app/tests_app/mod.rs
+++ b/crates/astria-sequencer/src/app/tests_app/mod.rs
@@ -331,15 +331,15 @@ async fn app_create_sequencer_block_with_sequenced_data_and_deposits() {
 
     let signed_tx = tx.into_signed(&alice);
 
-    let expected_deposit = Deposit::new(
+    let expected_deposit = Deposit {
         bridge_address,
         rollup_id,
         amount,
-        nria().into(),
-        "nootwashere".to_string(),
-        signed_tx.id(),
-        starting_index_of_action,
-    );
+        asset: nria().into(),
+        destination_chain_address: "nootwashere".to_string(),
+        source_transaction_id: signed_tx.id(),
+        source_action_index: starting_index_of_action,
+    };
     let deposits = HashMap::from_iter(vec![(rollup_id, vec![expected_deposit.clone()])]);
     let commitments = generate_rollup_datas_commitment(&[signed_tx.clone()], deposits.clone());
 
@@ -424,15 +424,15 @@ async fn app_execution_results_match_proposal_vs_after_proposal() {
 
     let signed_tx = tx.into_signed(&alice);
 
-    let expected_deposit = Deposit::new(
+    let expected_deposit = Deposit {
         bridge_address,
         rollup_id,
         amount,
-        nria().into(),
-        "nootwashere".to_string(),
-        signed_tx.id(),
-        starting_index_of_action,
-    );
+        asset: nria().into(),
+        destination_chain_address: "nootwashere".to_string(),
+        source_transaction_id: signed_tx.id(),
+        source_action_index: starting_index_of_action,
+    };
     let deposits = HashMap::from_iter(vec![(rollup_id, vec![expected_deposit.clone()])]);
     let commitments = generate_rollup_datas_commitment(&[signed_tx.clone()], deposits.clone());
 

--- a/crates/astria-sequencer/src/app/tests_block_fees.rs
+++ b/crates/astria-sequencer/src/app/tests_block_fees.rs
@@ -262,15 +262,15 @@ async fn ensure_correct_block_fees_bridge_lock() {
     let signed_tx = Arc::new(tx.into_signed(&alice));
     app.execute_transaction(signed_tx.clone()).await.unwrap();
 
-    let test_deposit = Deposit::new(
+    let test_deposit = Deposit {
         bridge_address,
         rollup_id,
-        1,
-        nria().into(),
-        rollup_id.to_string(),
-        signed_tx.id(),
-        starting_index_of_action,
-    );
+        amount: 1,
+        asset: nria().into(),
+        destination_chain_address: rollup_id.to_string(),
+        source_transaction_id: signed_tx.id(),
+        source_action_index: starting_index_of_action,
+    };
 
     let total_block_fees: u128 = app
         .state

--- a/crates/astria-sequencer/src/app/tests_breaking_changes.rs
+++ b/crates/astria-sequencer/src/app/tests_breaking_changes.rs
@@ -121,15 +121,15 @@ async fn app_finalize_block_snapshot() {
 
     let signed_tx = tx.into_signed(&alice);
 
-    let expected_deposit = Deposit::new(
+    let expected_deposit = Deposit {
         bridge_address,
         rollup_id,
         amount,
-        nria().into(),
-        "nootwashere".to_string(),
-        signed_tx.id(),
-        starting_index_of_action,
-    );
+        asset: nria().into(),
+        destination_chain_address: "nootwashere".to_string(),
+        source_transaction_id: signed_tx.id(),
+        source_action_index: starting_index_of_action,
+    };
     let deposits = HashMap::from_iter(vec![(rollup_id, vec![expected_deposit.clone()])]);
     let commitments = generate_rollup_datas_commitment(&[signed_tx.clone()], deposits.clone());
 

--- a/crates/astria-sequencer/src/app/tests_execute_transaction.rs
+++ b/crates/astria-sequencer/src/app/tests_execute_transaction.rs
@@ -740,15 +740,15 @@ async fn app_execute_transaction_bridge_lock_action_ok() {
     app.execute_transaction(signed_tx.clone()).await.unwrap();
     assert_eq!(app.state.get_account_nonce(alice_address).await.unwrap(), 1);
     let transfer_fee = app.state.get_transfer_base_fee().await.unwrap();
-    let expected_deposit = Deposit::new(
+    let expected_deposit = Deposit {
         bridge_address,
         rollup_id,
         amount,
-        nria().into(),
-        "nootwashere".to_string(),
-        signed_tx.id(),
-        starting_index_of_action,
-    );
+        asset: nria().into(),
+        destination_chain_address: "nootwashere".to_string(),
+        source_transaction_id: signed_tx.id(),
+        source_action_index: starting_index_of_action,
+    };
 
     let fee = transfer_fee
         + app
@@ -1117,9 +1117,9 @@ async fn app_execute_transaction_action_index_correctly_increments() {
 
     let deposits = app.state.get_deposit_events(&rollup_id).await.unwrap();
     assert_eq!(deposits.len(), 2);
-    assert_eq!(deposits[0].source_action_index(), starting_index_of_action);
+    assert_eq!(deposits[0].source_action_index, starting_index_of_action);
     assert_eq!(
-        deposits[1].source_action_index(),
+        deposits[1].source_action_index,
         starting_index_of_action + 1
     );
 }
@@ -1158,15 +1158,15 @@ async fn transaction_execution_records_deposit_event() {
 
     let signed_tx = Arc::new(tx.into_signed(&alice));
 
-    let expected_deposit = Deposit::new(
-        bob_address,
-        [0; 32].into(),
-        1,
-        nria().into(),
-        "test_chain_address".to_string(),
-        signed_tx.id(),
-        0,
-    );
+    let expected_deposit = Deposit {
+        bridge_address: bob_address,
+        rollup_id: [0; 32].into(),
+        amount: 1,
+        asset: nria().into(),
+        destination_chain_address: "test_chain_address".to_string(),
+        source_transaction_id: signed_tx.id(),
+        source_action_index: 0,
+    };
     let expected_deposit_event = create_deposit_event(&expected_deposit);
 
     signed_tx.check_and_execute(&mut state_tx).await.unwrap();

--- a/crates/astria-sequencer/src/assets/state_ext.rs
+++ b/crates/astria-sequencer/src/assets/state_ext.rs
@@ -99,7 +99,7 @@ pub(crate) trait StateReadExt: StateRead {
             .is_some())
     }
 
-    #[instrument(skip_all)]
+    #[instrument(skip_all, fields(%asset), err)]
     async fn map_ibc_to_trace_prefixed_asset(
         &self,
         asset: asset::IbcPrefixed,

--- a/crates/astria-sequencer/src/assets/state_ext.rs
+++ b/crates/astria-sequencer/src/assets/state_ext.rs
@@ -99,6 +99,8 @@ pub(crate) trait StateReadExt: StateRead {
             .is_some())
     }
 
+    // allow: false positive due to proc macro; fixed with rust/clippy 1.81
+    #[allow(clippy::blocks_in_conditions)]
     #[instrument(skip_all, fields(%asset), err)]
     async fn map_ibc_to_trace_prefixed_asset(
         &self,

--- a/crates/astria-sequencer/src/bridge/bridge_lock_action.rs
+++ b/crates/astria-sequencer/src/bridge/bridge_lock_action.rs
@@ -74,7 +74,7 @@ impl ActionHandler for BridgeLockAction {
             .await
             .context("failed to get transfer base fee")?;
 
-        let transaction_id = state
+        let source_transaction_id = state
             .get_transaction_context()
             .expect("current source should be set before executing action")
             .transaction_id;
@@ -83,15 +83,15 @@ impl ActionHandler for BridgeLockAction {
             .expect("current source should be set before executing action")
             .source_action_index;
 
-        let deposit = Deposit::new(
-            self.to,
+        let deposit = Deposit {
+            bridge_address: self.to,
             rollup_id,
-            self.amount,
-            self.asset.clone(),
-            self.destination_chain_address.clone(),
-            transaction_id,
+            amount: self.amount,
+            asset: self.asset.clone(),
+            destination_chain_address: self.destination_chain_address.clone(),
+            source_transaction_id,
             source_action_index,
-        );
+        };
         let deposit_abci_event = create_deposit_event(&deposit);
 
         let byte_cost_multiplier = state
@@ -226,15 +226,15 @@ mod tests {
 
         // enough balance; should pass
         let expected_deposit_fee = transfer_fee
-            + get_deposit_byte_len(&Deposit::new(
+            + get_deposit_byte_len(&Deposit {
                 bridge_address,
                 rollup_id,
-                100,
-                asset.clone(),
-                "someaddress".to_string(),
-                transaction_id,
-                0,
-            )) * 2;
+                amount: 100,
+                asset: asset.clone(),
+                destination_chain_address: "someaddress".to_string(),
+                source_transaction_id: transaction_id,
+                source_action_index: 0,
+            }) * 2;
         state
             .put_account_balance(from_address, &asset, 100 + expected_deposit_fee)
             .unwrap();

--- a/crates/astria-sequencer/src/bridge/state_ext.rs
+++ b/crates/astria-sequencer/src/bridge/state_ext.rs
@@ -492,13 +492,13 @@ pub(crate) trait StateWriteExt: StateWrite {
 
     #[instrument(skip_all)]
     async fn put_deposit_event(&mut self, deposit: Deposit) -> Result<()> {
-        let nonce = self.get_deposit_nonce(deposit.rollup_id()).await?;
+        let nonce = self.get_deposit_nonce(&deposit.rollup_id).await?;
         self.put_deposit_nonce(
-            deposit.rollup_id(),
+            &deposit.rollup_id,
             nonce.checked_add(1).ok_or_eyre("nonce overflowed")?,
         );
 
-        let key = deposit_storage_key(deposit.rollup_id(), nonce);
+        let key = deposit_storage_key(&deposit.rollup_id, nonce);
         self.nonverifiable_put_raw(key, deposit.into_raw().encode_to_vec());
         Ok(())
     }
@@ -853,24 +853,25 @@ mod test {
 
         let rollup_id = RollupId::new([1u8; 32]);
         let bridge_address = astria_address(&[42u8; 20]);
-        let mut amount = 10u128;
+        let amount = 10u128;
         let asset = asset_0();
         let destination_chain_address = "0xdeadbeef";
-        let mut deposit = Deposit::new(
+
+        let mut deposit = Deposit {
             bridge_address,
             rollup_id,
             amount,
-            asset.clone(),
-            destination_chain_address.to_string(),
-            TransactionId::new([0; 32]),
-            0,
-        );
+            asset: asset.clone(),
+            destination_chain_address: destination_chain_address.to_string(),
+            source_transaction_id: TransactionId::new([0; 32]),
+            source_action_index: 0,
+        };
 
         let mut deposits = vec![deposit.clone()];
 
         // can write
         state
-            .put_deposit_event(deposit)
+            .put_deposit_event(deposit.clone())
             .await
             .expect("writing deposit events should be ok");
         assert_eq!(
@@ -892,27 +893,22 @@ mod test {
         );
 
         // can write additional
-        amount = 20u128;
-        deposit = Deposit::new(
-            bridge_address,
-            rollup_id,
+        deposit = Deposit {
             amount,
-            asset.clone(),
-            destination_chain_address.to_string(),
-            TransactionId::new([0; 32]),
-            1,
-        );
+            source_action_index: 1,
+            ..deposit
+        };
         deposits.append(&mut vec![deposit.clone()]);
         state
-            .put_deposit_event(deposit)
+            .put_deposit_event(deposit.clone())
             .await
             .expect("writing deposit events should be ok");
         let mut returned_deposits = state
             .get_deposit_events(&rollup_id)
             .await
             .expect("deposit info was written to the database and must exist");
-        returned_deposits.sort_by_key(Deposit::amount);
-        deposits.sort_by_key(Deposit::amount);
+        returned_deposits.sort_by_key(|d| d.amount);
+        deposits.sort_by_key(|d| d.amount);
         assert_eq!(
             returned_deposits, deposits,
             "stored deposits do not match what was expected"
@@ -929,15 +925,11 @@ mod test {
 
         // can write different rollup id and both ok
         let rollup_id_1 = RollupId::new([2u8; 32]);
-        deposit = Deposit::new(
-            bridge_address,
-            rollup_id_1,
-            amount,
-            asset,
-            destination_chain_address.to_string(),
-            TransactionId::new([0; 32]),
-            2,
-        );
+        deposit = Deposit {
+            rollup_id: rollup_id_1,
+            source_action_index: 2,
+            ..deposit
+        };
         let deposits_1 = vec![deposit.clone()];
         state
             .put_deposit_event(deposit)
@@ -956,7 +948,7 @@ mod test {
             .get_deposit_events(&rollup_id)
             .await
             .expect("deposit info was written to the database and must exist");
-        returned_deposits.sort_by_key(Deposit::amount);
+        returned_deposits.sort_by_key(|d| d.amount);
         assert_eq!(
             returned_deposits, deposits,
             "stored deposits do not match what was expected"
@@ -974,15 +966,16 @@ mod test {
         let amount = 10u128;
         let asset = asset_0();
         let destination_chain_address = "0xdeadbeef";
-        let mut deposit = Deposit::new(
+
+        let mut deposit = Deposit {
             bridge_address,
-            rollup_id_0,
+            rollup_id: rollup_id_0,
             amount,
-            asset.clone(),
-            destination_chain_address.to_string(),
-            TransactionId::new([0; 32]),
-            0,
-        );
+            asset: asset.clone(),
+            destination_chain_address: destination_chain_address.to_string(),
+            source_transaction_id: TransactionId::new([0; 32]),
+            source_action_index: 0,
+        };
 
         // write same rollup id twice
         state
@@ -998,15 +991,11 @@ mod test {
 
         // writing additional different rollup id
         let rollup_id_1 = RollupId::new([2u8; 32]);
-        deposit = Deposit::new(
-            bridge_address,
-            rollup_id_1,
-            amount,
-            asset.clone(),
-            destination_chain_address.to_string(),
-            TransactionId::new([0; 32]),
-            1,
-        );
+        deposit = Deposit {
+            rollup_id: rollup_id_1,
+            source_action_index: 1,
+            ..deposit
+        };
         state
             .put_deposit_event(deposit)
             .await
@@ -1049,15 +1038,16 @@ mod test {
         let amount = 10u128;
         let asset = asset_0();
         let destination_chain_address = "0xdeadbeef";
-        let deposit = Deposit::new(
+
+        let deposit = Deposit {
             bridge_address,
             rollup_id,
             amount,
-            asset,
-            destination_chain_address.to_string(),
-            TransactionId::new([0; 32]),
-            0,
-        );
+            asset: asset.clone(),
+            destination_chain_address: destination_chain_address.to_string(),
+            source_transaction_id: TransactionId::new([0; 32]),
+            source_action_index: 0,
+        };
 
         let deposits = vec![deposit.clone()];
 
@@ -1106,15 +1096,15 @@ mod test {
         let amount = 10u128;
         let asset = asset_0();
         let destination_chain_address = "0xdeadbeef";
-        let mut deposit = Deposit::new(
+        let mut deposit = Deposit {
             bridge_address,
             rollup_id,
             amount,
-            asset.clone(),
-            destination_chain_address.to_string(),
-            TransactionId::new([0; 32]),
-            0,
-        );
+            asset: asset.clone(),
+            destination_chain_address: destination_chain_address.to_string(),
+            source_transaction_id: TransactionId::new([0; 32]),
+            source_action_index: 0,
+        };
 
         // write to first
         state
@@ -1124,15 +1114,15 @@ mod test {
 
         // write to second
         let rollup_id_1 = RollupId::new([2u8; 32]);
-        deposit = Deposit::new(
+        deposit = Deposit {
             bridge_address,
-            rollup_id_1,
+            rollup_id: rollup_id_1,
             amount,
-            asset.clone(),
-            destination_chain_address.to_string(),
-            TransactionId::new([0; 32]),
-            1,
-        );
+            asset: asset.clone(),
+            destination_chain_address: destination_chain_address.to_string(),
+            source_transaction_id: TransactionId::new([0; 32]),
+            source_action_index: 1,
+        };
         let deposits_1 = vec![deposit.clone()];
 
         state
@@ -1202,35 +1192,31 @@ mod test {
         let amount = 10u128;
         let asset = asset_0();
         let destination_chain_address = "0xdeadbeef";
-        let mut deposit = Deposit::new(
+        let mut deposit = Deposit {
             bridge_address,
             rollup_id,
             amount,
-            asset.clone(),
-            destination_chain_address.to_string(),
-            TransactionId::new([0; 32]),
-            0,
-        );
+            asset: asset.clone(),
+            destination_chain_address: destination_chain_address.to_string(),
+            source_transaction_id: TransactionId::new([0; 32]),
+            source_action_index: 0,
+        };
 
         // write to first
         state
-            .put_deposit_event(deposit)
+            .put_deposit_event(deposit.clone())
             .await
             .expect("writing deposit events should be ok");
 
         // write to second
         let rollup_id_1 = RollupId::new([2u8; 32]);
-        deposit = Deposit::new(
-            bridge_address,
-            rollup_id_1,
-            amount,
-            asset.clone(),
-            destination_chain_address.to_string(),
-            TransactionId::new([0; 32]),
-            1,
-        );
+        deposit = Deposit {
+            rollup_id: rollup_id_1,
+            source_action_index: 1,
+            ..deposit
+        };
         state
-            .put_deposit_event(deposit)
+            .put_deposit_event(deposit.clone())
             .await
             .expect("writing deposit events for rollup 2 should be ok");
 

--- a/crates/astria-sequencer/src/bridge/state_ext.rs
+++ b/crates/astria-sequencer/src/bridge/state_ext.rs
@@ -175,6 +175,8 @@ pub(crate) trait StateReadExt: StateRead + address::StateReadExt {
         Ok(maybe_id.is_some())
     }
 
+    // allow: false positive due to proc macro; fixed with rust/clippy 1.81
+    #[allow(clippy::blocks_in_conditions)]
     #[instrument(skip_all, fields(address = %address.display_address()), err)]
     async fn get_bridge_account_rollup_id<T: AddressBytes>(
         &self,
@@ -195,6 +197,8 @@ pub(crate) trait StateReadExt: StateRead + address::StateReadExt {
         Ok(Some(rollup_id))
     }
 
+    // allow: false positive due to proc macro; fixed with rust/clippy 1.81
+    #[allow(clippy::blocks_in_conditions)]
     #[instrument(skip_all, fields(address = %address.display_address()), err)]
     async fn get_bridge_account_ibc_asset<T: AddressBytes>(
         &self,
@@ -490,6 +494,8 @@ pub(crate) trait StateWriteExt: StateWrite {
         );
     }
 
+    // allow: false positive due to proc macro; fixed with rust/clippy 1.81
+    #[allow(clippy::blocks_in_conditions)]
     #[instrument(skip_all, err)]
     async fn put_deposit_event(&mut self, deposit: Deposit) -> Result<()> {
         let nonce = self.get_deposit_nonce(&deposit.rollup_id).await?;

--- a/crates/astria-sequencer/src/bridge/state_ext.rs
+++ b/crates/astria-sequencer/src/bridge/state_ext.rs
@@ -175,7 +175,7 @@ pub(crate) trait StateReadExt: StateRead + address::StateReadExt {
         Ok(maybe_id.is_some())
     }
 
-    #[instrument(skip_all)]
+    #[instrument(skip_all, fields(address = %address.display_address()), err)]
     async fn get_bridge_account_rollup_id<T: AddressBytes>(
         &self,
         address: T,
@@ -195,7 +195,7 @@ pub(crate) trait StateReadExt: StateRead + address::StateReadExt {
         Ok(Some(rollup_id))
     }
 
-    #[instrument(skip_all)]
+    #[instrument(skip_all, fields(address = %address.display_address()), err)]
     async fn get_bridge_account_ibc_asset<T: AddressBytes>(
         &self,
         address: T,
@@ -490,7 +490,7 @@ pub(crate) trait StateWriteExt: StateWrite {
         );
     }
 
-    #[instrument(skip_all)]
+    #[instrument(skip_all, err)]
     async fn put_deposit_event(&mut self, deposit: Deposit) -> Result<()> {
         let nonce = self.get_deposit_nonce(&deposit.rollup_id).await?;
         self.put_deposit_nonce(

--- a/crates/astria-sequencer/src/ibc/ics20_transfer.rs
+++ b/crates/astria-sequencer/src/ibc/ics20_transfer.rs
@@ -579,28 +579,12 @@ async fn refund_tokens_to_sequencer<S: StateWrite>(
         state
             .decrease_ibc_channel_balance(source_channel, &asset, amount)
             .await
-            .context("failed to withdraw refund amount from ibc20 channel")?;
+            .context("failed to withdraw refund amount from escrow account")?;
         state
             .increase_balance(recipient, &asset, amount)
             .await
-            .context("failed to update user account balance in execute_ics20_transfer")?;
+            .context("failed to increase user account balance")?;
     } else {
-        // register denomination in global ID -> denom map if it's not already there
-        // XXX(janis): is this correct? Shouldn't an asset that is being refunded always
-        // be present in the state if one attempted to transfer it out?
-        //
-        // TODO(janis): check if writing the asset to state if already present actually changes it.
-        // We could just always write it to state to avoid this extra check.
-        if !state
-            .has_ibc_asset(&asset)
-            .await
-            .context("failed to check if ibc asset exists in state")?
-        {
-            state
-                .put_ibc_asset(&asset)
-                .context("failed to put IBC asset in storage")?;
-        }
-
         state
             .increase_balance(recipient, asset, amount)
             .await

--- a/crates/astria-sequencer/src/ibc/ics20_transfer.rs
+++ b/crates/astria-sequencer/src/ibc/ics20_transfer.rs
@@ -478,17 +478,11 @@ async fn receive_tokens<S: StateWrite>(mut state: S, packet: &Packet) -> Result<
 
     if is_source {
         // the asset being transferred in is an asset that originated on Astria;
-        // subtract balance from escrow account and transfer to `recipient`.
-
+        // subtract balance from escrow account.
         state
             .decrease_ibc_channel_balance(&packet.chan_on_b, &asset, amount)
             .await
             .context("failed to deduct funds from IBC escrow account")?;
-
-        state
-            .increase_balance(recipient, &asset, amount)
-            .await
-            .wrap_err("failed to update user account balance")?;
     } else {
         // register denomination in global ID -> denom map if it's not already there
         if !state
@@ -500,12 +494,12 @@ async fn receive_tokens<S: StateWrite>(mut state: S, packet: &Packet) -> Result<
                 .put_ibc_asset(&asset)
                 .wrap_err("failed to write IBC asset to state")?;
         }
-
-        state
-            .increase_balance(recipient, &asset, amount)
-            .await
-            .context("failed to update user account balance")?;
     }
+
+    state
+        .increase_balance(recipient, &asset, amount)
+        .await
+        .context("failed to update user account balance")?;
 
     Ok(())
 }
@@ -595,13 +589,12 @@ async fn refund_tokens_to_sequencer_address<S: StateWrite>(
             .decrease_ibc_channel_balance(source_channel, &asset, amount)
             .await
             .context("failed to withdraw refund amount from escrow account")?;
-    } 
-    
-   state
-          .increase_balance(recipient, asset, amount)
-          .await
-          .wrap_err("failed to update user account balance when refunding")?;
- 
+    }
+    state
+        .increase_balance(recipient, asset, amount)
+        .await
+        .wrap_err("failed to update user account balance when refunding")?;
+
     Ok(())
 }
 

--- a/crates/astria-sequencer/src/ibc/ics20_transfer.rs
+++ b/crates/astria-sequencer/src/ibc/ics20_transfer.rs
@@ -345,9 +345,9 @@ impl AppHandlerExecute for Ics20Transfer {
 
     async fn chan_close_init_execute<S: StateWrite>(_: S, _: &MsgChannelCloseInit) {}
 
-    #[instrument(skip_all, err)]
     // allow: false positive due to proc macro; fixed with rust/clippy 1.81
     #[allow(clippy::blocks_in_conditions)]
+    #[instrument(skip_all, err)]
     async fn recv_packet_execute<S: StateWrite>(
         mut state: S,
         msg: &MsgRecvPacket,
@@ -373,9 +373,9 @@ impl AppHandlerExecute for Ics20Transfer {
             .context("failed to write acknowledgement")
     }
 
-    #[instrument(skip_all, err)]
     // allow: false positive due to proc macro; fixed with rust/clippy 1.81
     #[allow(clippy::blocks_in_conditions)]
+    #[instrument(skip_all, err)]
     async fn timeout_packet_execute<S: StateWrite>(
         mut state: S,
         msg: &MsgTimeout,
@@ -385,9 +385,9 @@ impl AppHandlerExecute for Ics20Transfer {
         })
     }
 
-    #[instrument(skip_all, err)]
     // allow: false positive due to proc macro; fixed with rust/clippy 1.81
     #[allow(clippy::blocks_in_conditions)]
+    #[instrument(skip_all, err)]
     async fn acknowledge_packet_execute<S: StateWrite>(
         mut state: S,
         msg: &MsgAcknowledgement,

--- a/crates/astria-sequencer/src/ibc/ics20_transfer.rs
+++ b/crates/astria-sequencer/src/ibc/ics20_transfer.rs
@@ -9,7 +9,6 @@
 //! [`AppHandler`] consists of two traits: [`AppHandlerCheck`] and [`AppHandlerExecute`].
 //! [`AppHandlerCheck`] is used for stateless and stateful checks, while
 //! [`AppHandlerExecute`] is used for execution.
-use std::borrow::Cow;
 
 use astria_core::{
     primitive::v1::{
@@ -21,7 +20,10 @@ use astria_core::{
         Bech32,
         Bech32m,
     },
-    protocol::memos,
+    protocol::memos::v1alpha1::{
+        Ics20TransferDeposit,
+        Ics20WithdrawalFromRollup,
+    },
     sequencerblock::v1alpha1::block::Deposit,
 };
 use astria_eyre::{
@@ -57,6 +59,7 @@ use ibc_types::{
             MsgTimeout,
         },
         ChannelId,
+        Packet,
         PortId,
     },
     transfer::acknowledgement::TokenTransferAcknowledgement,
@@ -67,8 +70,12 @@ use penumbra_ibc::component::app_handler::{
     AppHandlerExecute,
 };
 use penumbra_proto::penumbra::core::component::ibc::v1::FungibleTokenPacketData;
+use prost::Name as _;
 use tokio::try_join;
-use tracing::instrument;
+use tracing::{
+    info,
+    instrument,
+};
 
 use crate::{
     accounts::StateWriteExt as _,
@@ -82,8 +89,8 @@ use crate::{
         StateWriteExt as _,
     },
     ibc::{
-        self,
         StateReadExt as _,
+        StateWriteExt as _,
     },
     transaction::StateReadExt as _,
     utils::create_deposit_event,
@@ -94,6 +101,78 @@ const MAX_PACKET_DATA_BYTE_LENGTH: usize = 2048;
 
 /// The maximum length of the rollup address in bytes.
 const MAX_ROLLUP_ADDRESS_BYTE_LENGTH: usize = 256;
+
+/// Returns if Sequencer originated `asset`, or if `asset` was bridged.
+///
+/// To use cosmos nomenclature: if Sequencer is a source zone or a sink zone.
+///
+/// # Idea behind this test
+///
+/// Assume Sequencer and the counterparty chain established an IBC channel with
+/// `(Sp, Sc)` the (port, channel) pair on the sequencer side, and `(Cp, Cc)` the
+/// (port, channel) pair on the counterparty side.
+///
+/// ## Sequencer sends a token that originates on Sequencer
+///
+/// 1. Sequencer sends `Original` from `(Sp, Sc)` to `(Cp, Cc)`.
+/// 2. Counterparty receives `Original`, prefixes it `Cp/Cc/Original`, and stores the prefixed
+///    version.
+///
+/// ## Counterparty sends a token that originates on Sequencer
+///
+/// 1. Counterparty sends `Cp/Cc/Original` from `(Cp, Cc)` to `(Sp, Sc)`.
+/// 2. Sequencer tests if it was the origin of `Cp/Cc/Original` source by checking if it is prefixed
+///    by the source (port, channel) pair of this transfer (answer: yes, `source_port` is `Cp`,
+///    `source_channel` is `Cc`).
+/// 3. Sequencer strips `Cp/Cc/` and credits `Original` to the relevant recipient address.
+///
+/// ## Counterparty sends a different asset
+///
+/// If the counterparty sends back `DifferentAsset` that does not carry the
+/// prefix `Cp/Cc/`, then the test in the previous section will be negative
+/// and Sequencer will add the prefix `Sp/Sc/DifferentAsset` before crediting a
+/// receiving Astria address.
+///
+/// Note that `DifferentAsset` could have any number of prefixes, including `Cp/Cc`,
+/// as long as `Cp/Cc` are not the leading prefixes for this test! So Sequencer would
+/// consider `DifferentAsset` as not originating on Sequencer in the same way as
+/// `Dp/Dc/Ep/Ec/Fp/Fc/Cp/Cc/Asset` did not originate on Sequencer either.
+///
+/// # Refunds
+///
+/// Refund logic negates the above result.
+///
+/// If a Sequencer initiated ICS20 transfer fails, then the original packet it sent is
+/// returned unchanged:
+///
+/// As before, Sequencer sends `Asset` from `(Sp, Sc)` to `(Cp, Cc)`, but the packet is
+/// returned as-is. Where for a packet coming on from another chain `source_port = Cp`
+/// and `source_channel = Cc`, for a refund `source_port = Sp` and `source_channel = Sc`.
+///
+/// ## Refunding a token for which Sequencer is the source zone
+///
+/// If Sequencer is the source zone of a an `<asset>`, then `<asset>` will *not* be prefixed
+/// `Sp/Sc/<asset>`. The reason is that any non-originating asset will be prefixed
+/// `Sp/Sc/<asset>`, and so when sending `Sp/Sc/<asset>`, Sequencer will set
+/// `source_port = Sp` and `source_channel = Sc` always.
+///
+/// ## Refunding an asset that was sent to Sequencer / that is bridged in
+///
+/// If `<asset>` was sent to Sequencer and did not originate on Sequencer, then Sequencer will
+/// have prefixed it `Sp/Sc/<asset>` upon receipt. And so when sending, the payload asset
+/// *will* be prefixed `Sp/Sc/<asset>` with `source_port = Sp` and `source_channel = Sc` set.
+fn is_transfer_source_zone(
+    asset: &denom::TracePrefixed,
+    port: &PortId,
+    channel: &ChannelId,
+) -> bool {
+    asset.has_leading_port(port) && asset.has_leading_channel(channel)
+}
+
+/// See [`is_transfer_source_zone`] for what this does.
+fn is_refund_source_zone(asset: &denom::TracePrefixed, port: &PortId, channel: &ChannelId) -> bool {
+    !is_transfer_source_zone(asset, port, channel)
+}
 
 /// The ICS20 transfer handler.
 ///
@@ -219,7 +298,7 @@ impl AppHandlerCheck for Ics20Transfer {
 }
 
 async fn refund_tokens_check<S: StateRead>(
-    mut state: S,
+    state: S,
     data: &[u8],
     source_port: &PortId,
     source_channel: &ChannelId,
@@ -227,23 +306,19 @@ async fn refund_tokens_check<S: StateRead>(
     let packet_data: FungibleTokenPacketData = serde_json::from_slice(data)
         .wrap_err("failed to decode fungible token packet data json")?;
 
-    let denom = {
-        let denom = packet_data
-            .denom
-            .parse::<Denom>()
-            .wrap_err("failed parsing denom packet data")?;
-        convert_denomination_if_ibc_prefixed(&mut state, denom)
-            .await
-            .wrap_err("failed to convert denomination if ibc/ prefixed")?
-    };
+    let asset = parse_asset(&state, &packet_data.denom)
+        .await
+        .wrap_err_with(|| {
+            format!(
+                "failed to read packet.denom `{}` as trace prefixed asset",
+                packet_data.denom
+            )
+        })?;
 
-    let is_source = !denom.starts_with_str(&format!("{source_port}/{source_channel}"));
-    if is_source {
-        // recipient of packet (us) was the source chain
-        //
+    if is_refund_source_zone(&asset, source_port, source_channel) {
         // check if escrow account has enough balance to refund user
         let balance = state
-            .get_ibc_channel_balance(source_channel, denom)
+            .get_ibc_channel_balance(source_channel, asset)
             .await
             .wrap_err("failed to get channel balance in refund_tokens_check")?;
 
@@ -251,9 +326,10 @@ async fn refund_tokens_check<S: StateRead>(
             .amount
             .parse()
             .wrap_err("failed to parse packet amount as u128")?;
-        if balance < packet_amount {
-            bail!("insufficient balance to refund tokens to sender");
-        }
+        ensure!(
+            balance >= packet_amount,
+            "insufficient balance to refund tokens to sender",
+        );
     }
 
     Ok(())
@@ -279,24 +355,14 @@ impl AppHandlerExecute for Ics20Transfer {
     ) -> anyhow::Result<()> {
         use penumbra_ibc::component::packet::WriteAcknowledgement as _;
 
-        let ack = match execute_ics20_transfer(
-            &mut state,
-            &msg.packet.data,
-            &msg.packet.port_on_a,
-            &msg.packet.chan_on_a,
-            &msg.packet.port_on_b,
-            &msg.packet.chan_on_b,
-            false,
-        )
-        .await
-        {
+        let ack = match receive_tokens(&mut state, &msg.packet).await {
             Ok(()) => TokenTransferAcknowledgement::success(),
             Err(e) => {
                 tracing::debug!(
                     error = AsRef::<dyn std::error::Error>::as_ref(&e),
                     "failed to execute ics20 transfer"
                 );
-                TokenTransferAcknowledgement::Error(e.to_string())
+                TokenTransferAcknowledgement::Error(format!("{e:#}"))
             }
         };
 
@@ -312,226 +378,236 @@ impl AppHandlerExecute for Ics20Transfer {
         mut state: S,
         msg: &MsgTimeout,
     ) -> anyhow::Result<()> {
-        // we put source and dest as chain_a (the source) as we're refunding tokens,
-        // and the destination chain of the refund is the source.
-        execute_ics20_transfer(
-            &mut state,
-            &msg.packet.data,
-            &msg.packet.port_on_a,
-            &msg.packet.chan_on_a,
-            &msg.packet.port_on_a,
-            &msg.packet.chan_on_a,
-            true,
-        )
-        .await
-        .map_err(|err| {
+        refund_tokens(&mut state, &msg.packet).await.map_err(|err| {
             eyre_to_anyhow(err).context("failed to refund tokens during timeout_packet_execute")
         })
     }
 
+    #[instrument(skip_all)]
     async fn acknowledge_packet_execute<S: StateWrite>(
         mut state: S,
         msg: &MsgAcknowledgement,
     ) -> anyhow::Result<()> {
-        let ack: TokenTransferAcknowledgement = serde_json::from_slice(
-            msg.acknowledgement.as_slice(),
-        )
-        .expect("valid acknowledgement, should have been checked in acknowledge_packet_check");
-        if ack.is_successful() {
-            return Ok(());
+        let ack: TokenTransferAcknowledgement = astria_eyre::anyhow::Context::context(
+            serde_json::from_slice(msg.acknowledgement.as_slice()),
+            "failed to deserialize token transfer acknowledgement",
+        )?;
+        if !ack.is_successful() {
+            return refund_tokens(&mut state, &msg.packet)
+                .await
+                .map_err(|err| eyre_to_anyhow(err).context("failed to refund tokens"));
         }
-
-        // we put source and dest as chain_a (the source) as we're refunding tokens,
-        // and the destination chain of the refund is the source.
-        execute_ics20_transfer(
-            &mut state,
-            &msg.packet.data,
-            &msg.packet.port_on_a,
-            &msg.packet.chan_on_a,
-            &msg.packet.port_on_a,
-            &msg.packet.chan_on_a,
-            true,
-        )
-        .await
-        .map_err(|err| {
-            eyre_to_anyhow(err).context("failed to refund tokens during timeout_packet_execute")
-        })
+        Ok(())
     }
 }
 
 #[async_trait::async_trait]
 impl AppHandler for Ics20Transfer {}
 
-async fn convert_denomination_if_ibc_prefixed<S: ibc::StateReadExt>(
-    state: &mut S,
-    packet_denom: Denom,
-) -> Result<denom::TracePrefixed> {
-    // if the asset is prefixed with `ibc`, the rest of the denomination string is the asset ID,
-    // so we need to look up the full trace from storage.
-    // see https://github.com/cosmos/ibc-go/blob/main/docs/architecture/adr-001-coin-source-tracing.md#decision
-    let denom = match packet_denom {
-        Denom::TracePrefixed(trace) => trace,
-        Denom::IbcPrefixed(ibc) => state
-            .map_ibc_to_trace_prefixed_asset(ibc)
-            .await
-            .wrap_err("failed to get denom trace from asset id")?
-            .ok_or_eyre("denom for given asset id not found in state")?,
-    };
-    Ok(denom)
-}
-
-fn prepend_denom_if_not_refund<'a>(
-    packet_denom: &'a denom::TracePrefixed,
-    dest_port: &PortId,
-    dest_channel: &ChannelId,
-    is_refund: bool,
-) -> Cow<'a, denom::TracePrefixed> {
-    if is_refund {
-        Cow::Borrowed(packet_denom)
-    } else {
-        // FIXME: we should provide a method on `denom::TracePrefixed` to prepend segments to its
-        // prefix
-        let denom = format!("{dest_port}/{dest_channel}/{packet_denom}")
-            .parse()
-            .expect(
-                "dest port and channel are valid prefix segments, so this concatenation must be a \
-                 valid denom",
-            );
-        Cow::Owned(denom)
-    }
-}
-
-// FIXME: temporarily allowed, but this must be fixed
-#[allow(clippy::too_many_lines)]
-async fn execute_ics20_transfer<S: ibc::StateWriteExt>(
-    state: &mut S,
-    data: &[u8],
-    source_port: &PortId,
-    source_channel: &ChannelId,
-    dest_port: &PortId,
-    dest_channel: &ChannelId,
-    is_refund: bool,
-) -> Result<()> {
-    let packet_data: FungibleTokenPacketData =
-        serde_json::from_slice(data).wrap_err("failed to decode FungibleTokenPacketData")?;
-
-    // if the memo deserializes into an `Ics20WithdrawalFromRollupMemo`,
-    // we can assume this is a refund from an attempted withdrawal from
-    // a rollup directly to another IBC chain via the sequencer.
-    //
-    // in this case, we lock the tokens back in the bridge account and
-    // emit a `Deposit` event to send the tokens back to the rollup.
-    if is_refund
-        && serde_json::from_str::<memos::v1alpha1::Ics20WithdrawalFromRollup>(&packet_data.memo)
-            .is_ok()
+async fn parse_asset<S: StateRead>(state: S, input: &str) -> Result<denom::TracePrefixed> {
+    let asset = match input
+        .parse::<Denom>()
+        .wrap_err("failed parsing input as IBC denomination")?
     {
-        execute_withdrawal_refund_to_rollup(state, packet_data)
+        Denom::TracePrefixed(trace_prefixed) => trace_prefixed,
+        Denom::IbcPrefixed(ibc_prefixed) => state
+            .map_ibc_to_trace_prefixed_asset(ibc_prefixed)
             .await
-            .wrap_err("failed to execute rollup withdrawal refund")?;
-        return Ok(());
-    }
+            .wrap_err("failed reading state to map ibc prefixed asset to trace prefixed asset")?
+            .ok_or_eyre(
+                "could not find trace prefixed counterpart to ibc prefixed asset in state",
+            )?,
+    };
+    Ok(asset)
+}
 
-    let packet_amount: u128 = packet_data
+async fn receive_tokens<S: StateWrite>(mut state: S, packet: &Packet) -> Result<()> {
+    let packet_data: FungibleTokenPacketData = serde_json::from_slice(&packet.data)
+        .wrap_err("failed to deserialize fungible token packet data")?;
+
+    let amount: u128 = packet_data
         .amount
         .parse()
         .wrap_err("failed to parse packet data amount to u128")?;
-    let mut denom_trace = {
-        let denom = packet_data
-            .denom
-            .parse::<Denom>()
-            .wrap_err("failed parsing denom in packet data as Denom")?;
-        // convert denomination if it's prefixed with `ibc/`
-        // note: this denomination might have a prefix, but it wasn't prefixed by us right now.
-        convert_denomination_if_ibc_prefixed(state, denom)
+
+    let recipient = packet_data
+        .receiver
+        .parse()
+        .wrap_err("invalid recipient address")?;
+
+    let mut asset = parse_asset(&state, &packet_data.denom)
+        .await
+        .with_context(|| {
+            format!(
+                "failed reading asset `{}` from packet data",
+                packet_data.denom
+            )
+        })?;
+
+    let is_source = is_transfer_source_zone(&asset, &packet.port_on_a, &packet.chan_on_a);
+    if is_source {
+        asset.pop_leading_port_and_channel();
+    } else {
+        // TODO(janis): we should provide a method on `denom::TracePrefixed` to directly
+        // prefix it with a (port, channel) pair.
+        asset = format!(
+            "{destination_port}/{destination_channel}/{asset}",
+            destination_port = &packet.port_on_b,
+            destination_channel = &packet.chan_on_b,
+        )
+        .parse()
+        .expect(
+            "dest port and channel are valid prefix segments, so this concatenation must be a \
+             valid denom",
+        );
+    }
+
+    // If `recipient` is a bridge account then create a deposit event to signal to
+    // its associated rollup that funds were received.
+    //
+    // `recipient` is a bridge account if it has an associated rollup identified by its ID.
+    if state
+        .get_bridge_account_rollup_id(recipient)
+        .await
+        .context("failed to get bridge account rollup ID from state")?
+        .is_some()
+    {
+        emit_bridge_lock_deposit(&mut state, recipient, &asset, amount, &packet_data.memo)
             .await
-            .wrap_err("failed to convert denomination if ibc/ prefixed")?
-    };
-
-    // the IBC packet should have the address as a bech32 string
-    let recipient = if is_refund {
-        packet_data.sender.clone()
-    } else {
-        packet_data.receiver
-    };
-    let recipient = recipient.parse().wrap_err("invalid recipient address")?;
-
-    let is_prefixed = denom_trace.starts_with_str(&format!("{source_port}/{source_channel}"));
-    let is_source = if is_refund {
-        // we are the source if the denom is not prefixed by source_port/source_channel
-        !is_prefixed
-    } else {
-        // we are the source if the denom is prefixed by source_port/source_channel
-        is_prefixed
-    };
-
-    // prefix the denomination with the destination port and channel if not a refund
-    let trace_with_dest =
-        prepend_denom_if_not_refund(&denom_trace, dest_port, dest_channel, is_refund);
-
-    // check if this is a transfer to a bridge account and
-    // execute relevant state changes if it is
-    execute_ics20_transfer_bridge_lock(
-        state,
-        recipient,
-        &trace_with_dest,
-        packet_amount,
-        packet_data.memo.clone(),
-        is_refund,
-    )
-    .await
-    .wrap_err("failed to execute ics20 transfer to bridge account")?;
+            .context("failed to execute ics20 transfer to bridge account")?;
+    }
 
     if is_source {
-        // the asset being transferred in is an asset that originated from astria
-        // subtract balance from escrow account and transfer to user
-
-        // strip the prefix from the denom, as we're back on the source chain
-        // note: if this is a refund, this is a no-op.
-        if !is_refund {
-            denom_trace.pop_trace_segment().ok_or_eyre(
-                "there must be a source segment because above it was checked if the denom trace \
-                 contains a segment",
-            )?;
-        }
-        let escrow_channel = if is_refund {
-            source_channel
-        } else {
-            dest_channel
-        };
-
-        let escrow_balance = state
-            .get_ibc_channel_balance(escrow_channel, &denom_trace)
-            .await
-            .wrap_err("failed to get IBC channel balance in execute_ics20_transfer")?;
+        // the asset being transferred in is an asset that originated on Astria;
+        // subtract balance from escrow account and transfer to `recipient`.
 
         state
-            .put_ibc_channel_balance(
-                escrow_channel,
-                &denom_trace,
-                escrow_balance
-                    .checked_sub(packet_amount)
-                    .ok_or_eyre("insufficient balance in escrow account to transfer tokens")?,
-            )
-            .wrap_err("failed to update escrow account balance in execute_ics20_transfer")?;
+            .decrease_ibc_channel_balance(&packet.chan_on_b, &asset, amount)
+            .await
+            .context("failed to deduct funds from IBC escrow account")?;
 
         state
-            .increase_balance(recipient, &denom_trace, packet_amount)
+            .increase_balance(recipient, &asset, amount)
             .await
-            .wrap_err("failed to update user account balance in execute_ics20_transfer")?;
+            .wrap_err("failed to update user account balance")?;
     } else {
         // register denomination in global ID -> denom map if it's not already there
         if !state
-            .has_ibc_asset(&*trace_with_dest)
+            .has_ibc_asset(&asset)
             .await
-            .wrap_err("failed to check if ibc asset exists in state")?
+            .wrap_err("failed to check if IBC asset exists in state")?
         {
             state
-                .put_ibc_asset(&trace_with_dest)
-                .wrap_err("failed to put IBC asset in storage")?;
+                .put_ibc_asset(&asset)
+                .wrap_err("failed to write IBC asset to state")?;
         }
 
         state
-            .increase_balance(recipient, &*trace_with_dest, packet_amount)
+            .increase_balance(recipient, &asset, amount)
+            .await
+            .context("failed to update user account balance")?;
+    }
+
+    Ok(())
+}
+
+#[instrument(skip_all)]
+async fn refund_tokens<S: StateWrite>(mut state: S, packet: &Packet) -> Result<()> {
+    let packet_data: FungibleTokenPacketData = serde_json::from_slice(&packet.data)
+        .wrap_err("failed to deserialize fungible token packet data")?;
+
+    let amount: u128 = packet_data
+        .amount
+        .parse()
+        .wrap_err("failed to parse packet data amount to u128")?;
+
+    // Since we are refunding tokens, packet_data.sender is an address on Astria:
+    // the packet was not commited on the counter party chain but returned as-is.
+    let receiver = parse_sender(&state, &packet_data.sender)
+        .await
+        .with_context(|| {
+            format!(
+                "failed parsing packet.sender `{}` as the return address",
+                packet_data.sender
+            )
+        })?;
+
+    let asset = parse_asset(&state, &packet_data.denom)
+        .await
+        .with_context(|| format!("failed parsing packet.asset `{}`", packet_data.denom))?;
+
+    if let Ok(memo) = serde_json::from_str::<Ics20WithdrawalFromRollup>(&packet_data.memo) {
+        info!(
+                memo.rollup_return_address,
+                memo_name = astria_core::generated::protocol::memos::v1alpha1::Ics20WithdrawalFromRollup::full_name(),
+                "was able to parse memo; refunding to rollup",
+            );
+        refund_tokens_to_rollup(&mut state, receiver, asset, amount, memo)
+            .await
+            .context("failed to refund the rollup")?;
+    } else {
+        info!(
+            recipient = packet_data.sender,
+            "memo in fungible token packet was unknown; taking packet sender as recipient address \
+             on sequencer",
+        );
+        let recipient = packet_data.sender.parse().wrap_err_with(|| {
+            format!(
+                "failed to parse recipient `{}` as Astria address",
+                packet_data.sender
+            )
+        })?;
+        refund_tokens_to_sequencer(
+            &mut state,
+            recipient,
+            asset,
+            amount,
+            &packet.port_on_a,
+            &packet.chan_on_a,
+        )
+        .await
+        .context("failed to refund a sequencer address")?;
+    }
+
+    Ok(())
+}
+#[instrument(skip_all)]
+async fn refund_tokens_to_sequencer<S: StateWrite>(
+    mut state: S,
+    recipient: Address,
+    asset: denom::TracePrefixed,
+    amount: u128,
+    source_port: &PortId,
+    source_channel: &ChannelId,
+) -> Result<()> {
+    if is_refund_source_zone(&asset, source_port, source_channel) {
+        state
+            .decrease_ibc_channel_balance(source_channel, &asset, amount)
+            .await
+            .context("failed to withdraw refund amount from ibc20 channel")?;
+        state
+            .increase_balance(recipient, &asset, amount)
+            .await
+            .context("failed to update user account balance in execute_ics20_transfer")?;
+    } else {
+        // register denomination in global ID -> denom map if it's not already there
+        // XXX(janis): is this correct? Shouldn't an asset that is being refunded always
+        // be present in the state if one attempted to transfer it out?
+        //
+        // TODO(janis): check if writing the asset to state if already present actually changes it.
+        // We could just always write it to state to avoid this extra check.
+        if !state
+            .has_ibc_asset(&asset)
+            .await
+            .context("failed to check if ibc asset exists in state")?
+        {
+            state
+                .put_ibc_asset(&asset)
+                .context("failed to put IBC asset in storage")?;
+        }
+
+        state
+            .increase_balance(recipient, asset, amount)
             .await
             .wrap_err("failed to update user account balance in execute_ics20_transfer")?;
     }
@@ -539,67 +615,34 @@ async fn execute_ics20_transfer<S: ibc::StateWriteExt>(
     Ok(())
 }
 
-/// Execute a refund for a failed ics20 transfer from a rollup to a remote IBC chain.
-///
-/// A withdrawal of tokens from a rollup to a remote IBC chain is started with a
-/// `Ics20Withdrawal` action via a (rollup's) bridge account on the sequencer.
-///
-/// This function then sends the tokens back to the rollup via a `Deposit` event,
-/// and again locks the tokens in the specified bridge account.
-///
-/// This function must only be called if the following conditions hold:
-/// 1. The ics20 tranfer is a refund;
-/// 2. The memo contained in the ics20 transfer packet can be parsed as a Ics20WithdrawalFromRollup.
-///
-/// The function then assumes that the `packet_data.sender` is the bridge account, and
-/// attempts to parse it as either a base-prefixed bech32m address, or as an ibc-compat-prefixed
-/// bech32 address. If the sender is an ibc-compat address, then it will be converted to its
-/// base-prefixed version.
-///
-/// The emitted deposit as seen by the rollup will *never* be the ibc-compat prefixed version.
 // TODO: Add `err` with https://github.com/astriaorg/astria/issues/1386 being done
 #[instrument(skip_all)]
-async fn execute_withdrawal_refund_to_rollup<S: StateWrite>(
-    state: &mut S,
-    packet_data: FungibleTokenPacketData,
+async fn refund_tokens_to_rollup<S: StateWrite>(
+    mut state: S,
+    bridge_address: Address,
+    asset: denom::TracePrefixed,
+    amount: u128,
+    memo: Ics20WithdrawalFromRollup,
 ) -> Result<()> {
-    let amount: u128 = packet_data
-        .amount
-        .parse()
-        .wrap_err("failed to parse packet data amount to u128")?;
-    let denom = {
-        let denom = packet_data
-            .denom
-            .parse::<Denom>()
-            .wrap_err("failed parsing denom in packet data as Denom")?;
-        // convert denomination if it's prefixed with `ibc/`
-        // note: this denomination might have a prefix, but it wasn't prefixed by us right now.
-        convert_denomination_if_ibc_prefixed(state, denom)
-            .await
-            .context("failed to convert denomination if ibc/ prefixed")?
-    };
-    let bridge_address = parse_refund_sender(&*state, &packet_data.sender)
-        .await
-        .context("failed to parse ibc packet sender as the refund target address")?;
-    execute_deposit(
-        state,
+    emit_deposit(
+        &mut state,
         bridge_address,
-        &denom,
+        memo.rollup_return_address,
+        &asset,
         amount,
-        bridge_address.to_string(),
     )
     .await
     .context("failed to emit deposit")?;
 
     state
-        .increase_balance(bridge_address, denom, amount)
+        .increase_balance(bridge_address, asset, amount)
         .await
         .wrap_err("failed to update bridge account account balance")?;
 
     Ok(())
 }
 
-async fn parse_refund_sender<S: StateRead>(state: &S, sender: &str) -> Result<Address> {
+async fn parse_sender<S: StateRead>(state: &S, sender: &str) -> Result<Address> {
     use futures::TryFutureExt as _;
     let (base_prefix, compat_prefix) = match try_join!(
         state
@@ -642,45 +685,17 @@ async fn parse_refund_sender<S: StateRead>(state: &S, sender: &str) -> Result<Ad
     // "sender address was neither base nor ibc-compat prefixed; returning last error",
 }
 
-/// execute an ics20 transfer where the recipient is a bridge account.
-///
-/// if the recipient is not a bridge account, or the incoming packet is a refund,
-/// this function is a no-op.
-async fn execute_ics20_transfer_bridge_lock<S: ibc::StateWriteExt>(
-    state: &mut S,
-    recipient: Address,
+/// Emits a deposit event signaling to the rollup that funds
+/// were added to `bridge_address`.
+async fn emit_bridge_lock_deposit<S: StateWrite>(
+    mut state: S,
+    bridge_address: Address,
     denom: &denom::TracePrefixed,
     amount: u128,
-    memo: String,
-    is_refund: bool,
+    memo: &str,
 ) -> Result<()> {
-    // check if the recipient is a bridge account; if so,
-    // ensure that the packet memo field (`destination_address`) is set.
-    let is_bridge_lock = state
-        .get_bridge_account_rollup_id(recipient)
-        .await
-        .wrap_err("failed to get bridge account rollup ID from state")?
-        .is_some();
-
-    // if account being transferred to is not a bridge account, or
-    // the incoming packet is a refund, return
-    //
-    // note on refunds: bridge accounts *are* allowed to do ICS20 withdrawals,
-    // so this could be a refund to a bridge account if that withdrawal times out.
-    //
-    // so, if this is a refund transaction, we don't need to emit a `Deposit`,
-    // as the tokens are being refunded to the bridge's account.
-    //
-    // then, we don't need to check the memo field (as no `Deposit` is created),
-    // or check the asset IDs (as the asset IDs that can be sent out are the same
-    // as those that can be received).
-    if !is_bridge_lock || is_refund {
-        return Ok(());
-    }
-
-    // assert memo is valid
-    let deposit_memo: memos::v1alpha1::Ics20TransferDeposit =
-        serde_json::from_str(&memo).wrap_err("failed to parse memo as Ics20TransferDepositMemo")?;
+    let deposit_memo: Ics20TransferDeposit =
+        serde_json::from_str(memo).wrap_err("failed to parse memo as Ics20TransferDepositMemo")?;
 
     ensure!(
         !deposit_memo.rollup_deposit_address.is_empty(),
@@ -692,22 +707,22 @@ async fn execute_ics20_transfer_bridge_lock<S: ibc::StateWriteExt>(
         "rollup address is too long: exceeds MAX_ROLLUP_ADDRESS_BYTE_LENGTH",
     );
 
-    execute_deposit(
-        state,
-        recipient,
+    emit_deposit(
+        &mut state,
+        bridge_address,
+        deposit_memo.rollup_deposit_address,
         denom,
         amount,
-        deposit_memo.rollup_deposit_address,
     )
     .await
 }
 
-async fn execute_deposit<S: ibc::StateWriteExt>(
-    state: &mut S,
+async fn emit_deposit<S: StateWrite>(
+    mut state: S,
     bridge_address: Address,
-    denom: &denom::TracePrefixed,
+    destination_chain_address: String,
+    asset: &denom::TracePrefixed,
     amount: u128,
-    destination_address: String,
 ) -> Result<()> {
     // check if the recipient is a bridge account and
     // ensure that the asset ID being transferred
@@ -725,53 +740,82 @@ async fn execute_deposit<S: ibc::StateWriteExt>(
         .await
         .wrap_err("failed to get bridge account asset ID")?;
     ensure!(
-        allowed_asset == denom.to_ibc_prefixed(),
-        "asset ID is not authorized for transfer to bridge account",
+        allowed_asset == asset.to_ibc_prefixed(),
+        "asset `{asset}` with ID `{}` is not authorized for transfer to bridge account",
+        asset.to_ibc_prefixed(),
     );
 
     let transaction_context = state
         .get_transaction_context()
         .ok_or_eyre("transaction source should be present in state when executing an action")?;
-    let transaction_id = transaction_context.transaction_id;
-    let index_of_action = transaction_context.source_action_index;
+    let source_transaction_id = transaction_context.transaction_id;
+    let source_action_index = transaction_context.source_action_index;
 
-    let deposit = Deposit::new(
+    let deposit = Deposit {
         bridge_address,
         rollup_id,
         amount,
-        denom.into(),
-        destination_address,
-        transaction_id,
-        index_of_action,
-    );
+        asset: asset.into(),
+        destination_chain_address,
+        source_transaction_id,
+        source_action_index,
+    };
     let deposit_abci_event = create_deposit_event(&deposit);
     state.record(deposit_abci_event);
     state
         .put_deposit_event(deposit)
         .await
         .wrap_err("failed to put deposit event into state")?;
-
     Ok(())
 }
 
 #[cfg(test)]
-mod test {
-    use astria_core::primitive::v1::{
-        RollupId,
-        TransactionId,
+mod tests {
+    use astria_core::{
+        primitive::v1::{
+            asset::Denom,
+            RollupId,
+            TransactionId,
+        },
+        protocol::memos::v1alpha1::{
+            Ics20TransferDeposit,
+            Ics20WithdrawalFromRollup,
+        },
+        sequencerblock::v1alpha1::block::Deposit,
     };
     use cnidarium::StateDelta;
-    use denom::TracePrefixed;
+    use ibc_types::{
+        core::channel::{
+            packet::Sequence,
+            ChannelId,
+            Packet,
+            PortId,
+            TimeoutHeight,
+        },
+        timestamp::Timestamp,
+    };
+    use penumbra_proto::core::component::ibc::v1::FungibleTokenPacketData;
 
-    use super::*;
+    use super::{
+        receive_tokens,
+        refund_tokens,
+    };
     use crate::{
         accounts::StateReadExt as _,
-        address::StateWriteExt,
-        ibc::StateWriteExt as _,
+        address::StateWriteExt as _,
+        bridge::{
+            StateReadExt as _,
+            StateWriteExt as _,
+        },
+        ibc::{
+            StateReadExt as _,
+            StateWriteExt,
+        },
         test_utils::{
             astria_address,
             astria_address_from_hex_string,
             astria_compat_address,
+            nria,
             ASTRIA_COMPAT_PREFIX,
             ASTRIA_PREFIX,
         },
@@ -781,111 +825,78 @@ mod test {
         },
     };
 
-    #[tokio::test]
-    async fn prefix_denomination_not_refund() {
-        let packet_denom = "asset".parse().unwrap();
-        let dest_port = "transfer".to_string().parse().unwrap();
-        let dest_channel = "channel-99".to_string().parse().unwrap();
-        let is_refund = false;
+    fn packet() -> Packet {
+        Packet {
+            sequence: Sequence(0),
+            port_on_a: PortId("transfer".into()),
+            chan_on_a: ChannelId("achan".into()),
+            port_on_b: PortId("transfer".into()),
+            chan_on_b: ChannelId("bchan".into()),
+            data: Vec::new(),
+            timeout_height_on_b: TimeoutHeight::Never,
+            timeout_timestamp_on_b: Timestamp {
+                time: None,
+            },
+        }
+    }
 
-        let denom =
-            prepend_denom_if_not_refund(&packet_denom, &dest_port, &dest_channel, is_refund);
-        let expected = "transfer/channel-99/asset"
-            .parse::<TracePrefixed>()
-            .unwrap();
+    fn source_asset() -> Denom {
+        format!("{}/{}/{}", packet().port_on_a, packet().chan_on_a, nria())
+            .parse::<Denom>()
+            .unwrap()
+    }
 
-        assert_eq!(denom.as_ref(), &expected);
+    fn sink_asset() -> Denom {
+        format!("{}/{}/{}", packet().port_on_b, packet().chan_on_b, nria())
+            .parse::<Denom>()
+            .unwrap()
     }
 
     #[tokio::test]
-    async fn prefix_denomination_refund() {
-        let packet_denom = "asset".parse::<TracePrefixed>().unwrap();
-        let dest_port = "transfer".to_string().parse().unwrap();
-        let dest_channel = "channel-99".to_string().parse().unwrap();
-        let is_refund = true;
-
-        let expected = packet_denom.clone();
-        let denom =
-            prepend_denom_if_not_refund(&packet_denom, &dest_port, &dest_channel, is_refund);
-        assert_eq!(denom.as_ref(), &expected);
-    }
-
-    #[tokio::test]
-    async fn convert_denomination_if_ibc_prefixed_with_prefix() {
+    async fn receive_on_user_account() {
         let storage = cnidarium::TempStorage::new().await.unwrap();
         let snapshot = storage.latest_snapshot();
         let mut state_tx = StateDelta::new(snapshot.clone());
 
-        let denom_trace = "asset".parse().unwrap();
-        state_tx.put_ibc_asset(&denom_trace).unwrap();
-
-        let expected = denom_trace.clone();
-        let packet_denom = denom_trace.to_ibc_prefixed().into();
-        let denom = convert_denomination_if_ibc_prefixed(&mut state_tx, packet_denom)
-            .await
-            .unwrap();
-        assert_eq!(denom, expected);
-    }
-
-    #[tokio::test]
-    async fn convert_denomination_if_ibc_prefixed_without_prefix() {
-        let storage = cnidarium::TempStorage::new().await.unwrap();
-        let snapshot = storage.latest_snapshot();
-        let mut state_tx = StateDelta::new(snapshot.clone());
-
-        let packet_denom = "asset".parse::<Denom>().unwrap();
-        let expected = packet_denom.clone().unwrap_trace_prefixed();
-        let denom = convert_denomination_if_ibc_prefixed(&mut state_tx, packet_denom)
-            .await
-            .unwrap();
-        assert_eq!(denom, expected);
-    }
-
-    #[tokio::test]
-    async fn execute_ics20_transfer_to_user_account() {
-        let storage = cnidarium::TempStorage::new().await.unwrap();
-        let snapshot = storage.latest_snapshot();
-        let mut state_tx = StateDelta::new(snapshot.clone());
+        let amount = 100;
 
         let recipient = astria_address_from_hex_string("1c0c490f1b5528d8173c5de46d131160e4b2c0c3");
-        let packet = FungibleTokenPacketData {
-            denom: "nootasset".to_string(),
+        let packet_data = FungibleTokenPacketData {
+            denom: nria().to_string(),
             sender: String::new(),
-            amount: "100".to_string(),
+            amount: amount.to_string(),
             receiver: recipient.to_string(),
             memo: String::new(),
         };
-        let packet_bytes = serde_json::to_vec(&packet).unwrap();
 
-        execute_ics20_transfer(
+        receive_tokens(
             &mut state_tx,
-            &packet_bytes,
-            &"source_port".to_string().parse().unwrap(),
-            &"source_channel".to_string().parse().unwrap(),
-            &"dest_port".to_string().parse().unwrap(),
-            &"dest_channel".to_string().parse().unwrap(),
-            false,
+            &Packet {
+                data: serde_json::to_vec(&packet_data).unwrap(),
+                ..packet()
+            },
         )
         .await
         .expect("valid ics20 transfer to user account; recipient, memo, and asset ID are valid");
 
-        let denom = "dest_port/dest_channel/nootasset".parse::<Denom>().unwrap();
-        let balance = state_tx.get_account_balance(recipient, denom).await.expect(
-            "ics20 transfer to user account should succeed and balance should be minted to this \
-             account",
-        );
-        assert_eq!(balance, 100);
+        let balance = state_tx
+            .get_account_balance(recipient, sink_asset())
+            .await
+            .expect(
+                "ics20 transfer to user account should succeed and balance should be minted to \
+                 this account",
+            );
+        assert_eq!(balance, amount);
     }
 
     #[tokio::test]
-    async fn execute_ics20_transfer_to_bridge_account_ok() {
+    async fn receive_source_asset_on_bridge_account_and_emit_to_rollup() {
         let storage = cnidarium::TempStorage::new().await.unwrap();
         let snapshot = storage.latest_snapshot();
         let mut state_tx = StateDelta::new(snapshot.clone());
 
         let bridge_address = astria_address(&[99; 20]);
         let rollup_id = RollupId::from_unhashed_bytes(b"testchainid");
-        let denom = "dest_port/dest_channel/nootasset".parse::<Denom>().unwrap();
 
         state_tx.put_transaction_context(TransactionContext {
             address_bytes: bridge_address.bytes(),
@@ -893,39 +904,39 @@ mod test {
             source_action_index: 0,
         });
 
+        let rollup_deposit_address = "rollupaddress";
+        let amount = 100;
+
         state_tx.put_bridge_account_rollup_id(bridge_address, &rollup_id);
         state_tx
-            .put_bridge_account_ibc_asset(bridge_address, &denom)
+            .put_bridge_account_ibc_asset(bridge_address, nria())
+            .unwrap();
+        state_tx
+            .put_ibc_channel_balance(&packet().chan_on_b, nria(), amount)
             .unwrap();
 
-        let memo = memos::v1alpha1::Ics20TransferDeposit {
-            rollup_deposit_address: "rollupaddress".to_string(),
-        };
-
-        let packet = FungibleTokenPacketData {
-            denom: "nootasset".to_string(),
+        let packet_data = FungibleTokenPacketData {
+            denom: source_asset().to_string(),
             sender: String::new(),
-            amount: "100".to_string(),
+            amount: amount.to_string(),
             receiver: bridge_address.to_string(),
-            memo: serde_json::to_string(&memo).unwrap(),
+            memo: serde_json::to_string(&Ics20TransferDeposit {
+                rollup_deposit_address: rollup_deposit_address.to_string(),
+            })
+            .unwrap(),
         };
-        let packet_bytes = serde_json::to_vec(&packet).unwrap();
-
-        execute_ics20_transfer(
+        receive_tokens(
             &mut state_tx,
-            &packet_bytes,
-            &"source_port".to_string().parse().unwrap(),
-            &"source_channel".to_string().parse().unwrap(),
-            &"dest_port".to_string().parse().unwrap(),
-            &"dest_channel".to_string().parse().unwrap(),
-            false,
+            &Packet {
+                data: serde_json::to_vec(&packet_data).unwrap(),
+                ..packet()
+            },
         )
         .await
-        .expect("valid ics20 transfer to bridge account; recipient, memo, and asset ID are valid");
+        .unwrap();
 
-        let denom = "dest_port/dest_channel/nootasset".parse::<Denom>().unwrap();
         let balance = state_tx
-            .get_account_balance(bridge_address, denom)
+            .get_account_balance(bridge_address, nria())
             .await
             .expect(
                 "ics20 transfer from sender to bridge account should have updated funds in the \
@@ -933,191 +944,269 @@ mod test {
             );
         assert_eq!(balance, 100);
 
-        let deposit = state_tx
+        let deposits = state_tx
             .get_block_deposits()
             .await
             .expect("a deposit should exist as a result of the transfer to a bridge account");
-        assert_eq!(deposit.len(), 1);
+        assert_eq!(deposits.len(), 1);
+
+        let expected_deposit = Deposit {
+            bridge_address,
+            rollup_id,
+            amount,
+            asset: nria().into(),
+            destination_chain_address: rollup_deposit_address.to_string(),
+            source_transaction_id: TransactionId::new([0; 32]),
+            source_action_index: 0,
+        };
+
+        let actual_deposit = deposits
+            .get(&rollup_id)
+            .expect("a depsit fo the given rollup ID should exist as result of the refund")
+            .first()
+            .unwrap();
+        assert_eq!(&expected_deposit, actual_deposit);
     }
 
     #[tokio::test]
-    async fn execute_ics20_transfer_to_bridge_account_invalid_memo() {
+    async fn receive_sink_asset_on_bridge_account_and_emit_to_rollup() {
         let storage = cnidarium::TempStorage::new().await.unwrap();
         let snapshot = storage.latest_snapshot();
         let mut state_tx = StateDelta::new(snapshot.clone());
 
         let bridge_address = astria_address(&[99; 20]);
         let rollup_id = RollupId::from_unhashed_bytes(b"testchainid");
-        let denom = "dest_port/dest_channel/nootasset".parse::<Denom>().unwrap();
+
+        state_tx.put_transaction_context(TransactionContext {
+            address_bytes: bridge_address.bytes(),
+            transaction_id: TransactionId::new([0; 32]),
+            source_action_index: 0,
+        });
+
+        let rollup_deposit_address = "rollupaddress";
+        let amount = 100;
+
+        let remote_asset = "foreignasset".parse::<Denom>().unwrap();
+        let remote_asset_on_sequencer = format!(
+            "{}/{}/{remote_asset}",
+            packet().port_on_b,
+            packet().chan_on_b
+        )
+        .parse::<Denom>()
+        .unwrap();
+        state_tx.put_bridge_account_rollup_id(bridge_address, &rollup_id);
+        state_tx
+            .put_bridge_account_ibc_asset(bridge_address, &remote_asset_on_sequencer)
+            .unwrap();
+        state_tx
+            .put_ibc_channel_balance(&packet().chan_on_b, &remote_asset_on_sequencer, amount)
+            .unwrap();
+
+        let packet_data = FungibleTokenPacketData {
+            denom: remote_asset.to_string(),
+            sender: String::new(),
+            amount: amount.to_string(),
+            receiver: bridge_address.to_string(),
+            memo: serde_json::to_string(&Ics20TransferDeposit {
+                rollup_deposit_address: rollup_deposit_address.to_string(),
+            })
+            .unwrap(),
+        };
+        receive_tokens(
+            &mut state_tx,
+            &Packet {
+                data: serde_json::to_vec(&packet_data).unwrap(),
+                ..packet()
+            },
+        )
+        .await
+        .unwrap();
+
+        let balance = state_tx
+            .get_account_balance(bridge_address, &remote_asset_on_sequencer)
+            .await
+            .expect("receipt of funds to a rollup should have updated funds in the bridge account");
+        assert_eq!(balance, amount);
+
+        let deposits = state_tx
+            .get_block_deposits()
+            .await
+            .expect("a deposit should exist as a result of the transfer to a bridge account");
+        assert_eq!(deposits.len(), 1);
+
+        let expected_deposit = Deposit {
+            bridge_address,
+            rollup_id,
+            amount,
+            asset: remote_asset_on_sequencer,
+            destination_chain_address: rollup_deposit_address.to_string(),
+            source_transaction_id: TransactionId::new([0; 32]),
+            source_action_index: 0,
+        };
+
+        assert_eq!(&expected_deposit, &deposits[&rollup_id][0]);
+    }
+
+    #[tokio::test]
+    async fn transfer_to_bridge_is_rejected_due_to_invalid_memo() {
+        let storage = cnidarium::TempStorage::new().await.unwrap();
+        let snapshot = storage.latest_snapshot();
+        let mut state_tx = StateDelta::new(snapshot.clone());
+
+        let bridge_address = astria_address(&[99; 20]);
+        let rollup_id = RollupId::from_unhashed_bytes(b"testchainid");
 
         state_tx.put_bridge_account_rollup_id(bridge_address, &rollup_id);
         state_tx
-            .put_bridge_account_ibc_asset(bridge_address, &denom)
+            .put_bridge_account_ibc_asset(bridge_address, &sink_asset())
             .unwrap();
 
-        // use invalid memo, which should fail
-        let packet = FungibleTokenPacketData {
-            denom: "nootasset".to_string(),
+        let packet_data = FungibleTokenPacketData {
+            denom: nria().to_string(),
             sender: String::new(),
             amount: "100".to_string(),
             receiver: bridge_address.to_string(),
             memo: "invalid".to_string(),
         };
-        let packet_bytes = serde_json::to_vec(&packet).unwrap();
-
-        let _ = execute_ics20_transfer(
+        // FIXME(janis): assert that the failure is actually due to the malformed memo
+        // and not becase of some other input.
+        let _ = receive_tokens(
             &mut state_tx,
-            &packet_bytes,
-            &"source_port".to_string().parse().unwrap(),
-            &"source_channel".to_string().parse().unwrap(),
-            &"dest_port".to_string().parse().unwrap(),
-            &"dest_channel".to_string().parse().unwrap(),
-            false,
+            &Packet {
+                data: serde_json::to_vec(&packet_data).unwrap(),
+                ..packet()
+            },
         )
         .await
-        .expect_err("empty packet memo field during transfer to bridge account should fail");
+        .expect_err("malformed packet memo field during transfer to bridge account should fail");
     }
 
     #[tokio::test]
-    async fn execute_ics20_transfer_to_bridge_account_invalid_asset() {
+    async fn transfer_to_bridge_account_is_rejected_due_to_not_permitted_token() {
         let storage = cnidarium::TempStorage::new().await.unwrap();
         let snapshot = storage.latest_snapshot();
         let mut state_tx = StateDelta::new(snapshot.clone());
 
         let bridge_address = astria_address(&[99; 20]);
         let rollup_id = RollupId::from_unhashed_bytes(b"testchainid");
-        let denom = "dest_port/dest_channel/nootasset".parse::<Denom>().unwrap();
 
         state_tx.put_bridge_account_rollup_id(bridge_address, &rollup_id);
         state_tx
-            .put_bridge_account_ibc_asset(bridge_address, &denom)
+            .put_bridge_account_ibc_asset(bridge_address, &sink_asset())
             .unwrap();
 
-        // use invalid asset, which should fail
-        let packet = FungibleTokenPacketData {
-            denom: "fake".to_string(),
+        let packet_data = FungibleTokenPacketData {
+            denom: "unknown".to_string(),
             sender: String::new(),
             amount: "100".to_string(),
             receiver: bridge_address.to_string(),
-            memo: "destinationaddress".to_string(),
+            memo: serde_json::to_string(&Ics20TransferDeposit {
+                rollup_deposit_address: "rollupaddress".to_string(),
+            })
+            .unwrap(),
         };
-        let packet_bytes = serde_json::to_vec(&packet).unwrap();
-
-        let _ = execute_ics20_transfer(
+        // FIXME(janis): assert that the failure is actually due to the not permitted asset
+        // and not because of some other input.
+        let _ = receive_tokens(
             &mut state_tx,
-            &packet_bytes,
-            &"source_port".to_string().parse().unwrap(),
-            &"source_channel".to_string().parse().unwrap(),
-            &"dest_port".to_string().parse().unwrap(),
-            &"dest_channel".to_string().parse().unwrap(),
-            false,
+            &Packet {
+                data: serde_json::to_vec(&packet_data).unwrap(),
+                ..packet()
+            },
         )
         .await
-        .expect_err("invalid asset during transfer to bridge account should fail");
+        .expect_err("unknown asset during transfer to bridge account should fail");
     }
 
     #[tokio::test]
-    async fn execute_ics20_transfer_to_user_account_is_source_not_refund() {
+    async fn receive_funds_on_user_account_of_source_asset() {
         let storage = cnidarium::TempStorage::new().await.unwrap();
         let snapshot = storage.latest_snapshot();
         let mut state_tx = StateDelta::new(snapshot.clone());
 
         let recipient_address = astria_address(&[1; 20]);
         let amount = 100;
-        let base_denom = "nootasset".parse::<Denom>().unwrap();
         state_tx
-            .put_ibc_channel_balance(
-                &"dest_channel".to_string().parse().unwrap(),
-                &base_denom,
-                amount,
-            )
+            .put_ibc_channel_balance(&packet().chan_on_b, nria(), amount)
             .unwrap();
 
-        let packet = FungibleTokenPacketData {
-            denom: format!("source_port/source_channel/{base_denom}"),
+        let packet_data = FungibleTokenPacketData {
+            denom: source_asset().to_string(),
             sender: String::new(),
             amount: amount.to_string(),
             receiver: recipient_address.to_string(),
             memo: String::new(),
         };
-        let packet_bytes = serde_json::to_vec(&packet).unwrap();
 
-        execute_ics20_transfer(
+        receive_tokens(
             &mut state_tx,
-            &packet_bytes,
-            &"source_port".to_string().parse().unwrap(),
-            &"source_channel".to_string().parse().unwrap(),
-            &"dest_port".to_string().parse().unwrap(),
-            &"dest_channel".to_string().parse().unwrap(),
-            false,
+            &Packet {
+                data: serde_json::to_vec(&packet_data).unwrap(),
+                ..packet()
+            },
         )
         .await
-        .expect("valid ics20 transfer to user account; recipient, memo, and asset ID are valid");
+        .unwrap();
 
-        let balance = state_tx
-            .get_account_balance(recipient_address, &base_denom)
+        let user_balance = state_tx
+            .get_account_balance(recipient_address, &nria())
             .await
             .expect("ics20 transfer to user account should succeed");
-        assert_eq!(balance, amount);
-        let balance = state_tx
-            .get_ibc_channel_balance(&"dest_channel".to_string().parse().unwrap(), &base_denom)
+        assert_eq!(user_balance, amount);
+        let escrow_balance = state_tx
+            .get_ibc_channel_balance(&packet().chan_on_b, &nria())
             .await
             .expect("ics20 transfer to user account from escrow account should succeed");
-        assert_eq!(balance, 0);
+        assert_eq!(escrow_balance, 0);
     }
 
     #[tokio::test]
-    async fn execute_ics20_transfer_to_user_account_is_source_refund() {
+    async fn refund_user_account_with_source_zone_asset() {
         let storage = cnidarium::TempStorage::new().await.unwrap();
         let snapshot = storage.latest_snapshot();
         let mut state_tx = StateDelta::new(snapshot.clone());
 
+        state_tx.put_base_prefix(ASTRIA_PREFIX);
+        state_tx.put_ibc_compat_prefix(ASTRIA_COMPAT_PREFIX);
+
         let recipient_address = astria_address(&[1; 20]);
         let amount = 100;
-        let base_denom = "nootasset".parse::<Denom>().unwrap();
         state_tx
-            .put_ibc_channel_balance(
-                &"source_channel".to_string().parse().unwrap(),
-                &base_denom,
-                amount,
-            )
+            .put_ibc_channel_balance(&packet().chan_on_a, &nria(), amount)
             .unwrap();
 
-        let packet = FungibleTokenPacketData {
-            denom: base_denom.to_string(),
+        let packet_data = FungibleTokenPacketData {
+            denom: nria().to_string(),
             sender: recipient_address.to_string(),
             amount: amount.to_string(),
             receiver: recipient_address.to_string(),
             memo: String::new(),
         };
-        let packet_bytes = serde_json::to_vec(&packet).unwrap();
 
-        execute_ics20_transfer(
+        refund_tokens(
             &mut state_tx,
-            &packet_bytes,
-            &"source_port".to_string().parse().unwrap(),
-            &"source_channel".to_string().parse().unwrap(),
-            &"source_port".to_string().parse().unwrap(),
-            &"source_channel".to_string().parse().unwrap(),
-            true,
+            &Packet {
+                data: serde_json::to_vec(&packet_data).unwrap(),
+                ..packet()
+            },
         )
         .await
         .expect("valid ics20 refund to user account; recipient, memo, and asset ID are valid");
 
         let balance = state_tx
-            .get_account_balance(recipient_address, &base_denom)
+            .get_account_balance(recipient_address, &nria())
             .await
             .expect("ics20 refund to user account should succeed");
         assert_eq!(balance, amount);
         let balance = state_tx
-            .get_ibc_channel_balance(&"source_channel".to_string().parse().unwrap(), &base_denom)
+            .get_ibc_channel_balance(&packet().chan_on_a, &nria())
             .await
             .expect("ics20 refund to user account from escrow account should succeed");
         assert_eq!(balance, 0);
     }
 
     #[tokio::test]
-    async fn execute_rollup_withdrawal_refund_ok() {
+    async fn refund_rollup_with_sink_asset() {
         let storage = cnidarium::TempStorage::new().await.unwrap();
         let snapshot = storage.latest_snapshot();
         let mut state_tx = StateDelta::new(snapshot.clone());
@@ -1128,9 +1217,6 @@ mod test {
         let bridge_address = astria_address(&[99u8; 20]);
 
         let rollup_id = RollupId::from_unhashed_bytes(b"testchainid");
-        let denom = "dest_port/dest_channel/nootasset"
-            .parse::<TracePrefixed>()
-            .unwrap();
 
         state_tx.put_transaction_context(TransactionContext {
             address_bytes: bridge_address.bytes(),
@@ -1140,38 +1226,61 @@ mod test {
 
         state_tx.put_bridge_account_rollup_id(bridge_address, &rollup_id);
         state_tx
-            .put_bridge_account_ibc_asset(bridge_address, &denom)
+            .put_bridge_account_ibc_asset(bridge_address, &sink_asset())
             .unwrap();
 
         let amount = 100;
         let address_on_rollup = "address_on_rollup".to_string();
 
-        let packet = FungibleTokenPacketData {
-            denom: denom.to_string(),
+        let rollup_return_address = "rollup-defined-return-address";
+        let packet_data = FungibleTokenPacketData {
+            denom: sink_asset().to_string(),
             sender: bridge_address.to_string(),
             amount: amount.to_string(),
             receiver: address_on_rollup.to_string(),
-            memo: String::new(),
+            memo: serde_json::to_string(&Ics20WithdrawalFromRollup {
+                rollup_block_number: 42,
+                rollup_withdrawal_event_id: "rollup-defined-id".to_string(),
+                rollup_return_address: rollup_return_address.to_string(),
+                memo: String::new(),
+            })
+            .unwrap(),
         };
-        execute_withdrawal_refund_to_rollup(&mut state_tx, packet)
-            .await
-            .expect("valid rollup withdrawal refund");
+        refund_tokens(
+            &mut state_tx,
+            &Packet {
+                data: serde_json::to_vec(&packet_data).unwrap(),
+                ..packet()
+            },
+        )
+        .await
+        .expect("valid rollup withdrawal refund");
 
         let balance = state_tx
-            .get_account_balance(bridge_address, denom)
+            .get_account_balance(bridge_address, sink_asset())
             .await
             .expect("rollup withdrawal refund should have updated funds in the bridge address");
-        assert_eq!(balance, 100);
+        assert_eq!(balance, amount);
 
         let deposit = state_tx
             .get_block_deposits()
             .await
             .expect("a deposit should exist as a result of the rollup withdrawal refund");
-        assert_eq!(deposit.len(), 1);
+
+        let expected_deposit = Deposit {
+            bridge_address,
+            rollup_id,
+            amount,
+            asset: sink_asset(),
+            destination_chain_address: rollup_return_address.to_string(),
+            source_transaction_id: TransactionId::new([0; 32]),
+            source_action_index: 0,
+        };
+        assert_eq!(expected_deposit, deposit[&rollup_id][0],);
     }
 
     #[tokio::test]
-    async fn rollup_withdrawal_refund_succeeds() {
+    async fn refund_rollup_with_source_asset() {
         let storage = cnidarium::TempStorage::new().await.unwrap();
         let snapshot = storage.latest_snapshot();
         let mut state_tx = StateDelta::new(snapshot.clone());
@@ -1179,9 +1288,9 @@ mod test {
         state_tx.put_base_prefix(ASTRIA_PREFIX);
         state_tx.put_ibc_compat_prefix(ASTRIA_COMPAT_PREFIX);
 
+        let amount = 100;
         let bridge_address = astria_address(&[99u8; 20]);
-        let destination_chain_address = bridge_address.to_string();
-        let denom = "nootasset".parse::<Denom>().unwrap();
+        let destination_chain_address = "rollup-defined";
         let rollup_id = RollupId::from_unhashed_bytes(b"testchainid");
 
         state_tx.put_transaction_context(TransactionContext {
@@ -1192,66 +1301,63 @@ mod test {
 
         state_tx.put_bridge_account_rollup_id(bridge_address, &rollup_id);
         state_tx
-            .put_bridge_account_ibc_asset(bridge_address, &denom)
+            .put_bridge_account_ibc_asset(bridge_address, &nria())
             .unwrap();
 
-        let packet = FungibleTokenPacketData {
-            denom: denom.to_string(),
+        let packet_denom = FungibleTokenPacketData {
+            denom: nria().to_string(),
             sender: bridge_address.to_string(),
-            amount: "100".to_string(),
+            amount: amount.to_string(),
             receiver: "other-chain-address".to_string(),
-            memo: serde_json::to_string(&memos::v1alpha1::Ics20WithdrawalFromRollup {
+            memo: serde_json::to_string(&Ics20WithdrawalFromRollup {
                 memo: String::new(),
                 rollup_block_number: 1,
-                rollup_return_address: "rollup-defined".to_string(),
+                rollup_return_address: destination_chain_address.to_string(),
                 rollup_withdrawal_event_id: "a-rollup-defined-id".into(),
             })
             .unwrap(),
         };
-        let packet_bytes = serde_json::to_vec(&packet).unwrap();
 
-        execute_ics20_transfer(
+        refund_tokens(
             &mut state_tx,
-            &packet_bytes,
-            &"source_port".to_string().parse().unwrap(),
-            &"source_channel".to_string().parse().unwrap(),
-            &"source_port".to_string().parse().unwrap(),
-            &"source_channel".to_string().parse().unwrap(),
-            true,
+            &Packet {
+                data: serde_json::to_vec(&packet_denom).unwrap(),
+                ..packet()
+            },
         )
         .await
-        .expect("valid ics20 transfer refund; recipient, memo, and asset ID are valid");
+        .unwrap();
 
         let balance = state_tx
-            .get_account_balance(bridge_address, &denom)
+            .get_account_balance(bridge_address, &nria())
             .await
-            .expect(
-                "ics20 transfer refunding to rollup should succeed and balance should be added to \
-                 the bridge account",
-            );
-        assert_eq!(balance, 100);
+            .expect("refunds of rollup withdrawals should be credited to the bridge account");
+        assert_eq!(balance, amount);
 
         let deposits = state_tx
             .get_block_deposits()
             .await
             .expect("a deposit should exist as a result of the rollup withdrawal refund");
-        assert_eq!(deposits.len(), 1);
 
-        let deposit = deposits.get(&rollup_id).unwrap().first().unwrap();
-        let expected_deposit = Deposit::new(
+        let deposit = deposits
+            .get(&rollup_id)
+            .expect("a depsit fo the given rollup ID should exist as result of the refund")
+            .first()
+            .unwrap();
+        let expected_deposit = Deposit {
             bridge_address,
             rollup_id,
-            100,
-            denom,
-            destination_chain_address,
-            TransactionId::new([0; 32]),
-            0,
-        );
+            amount,
+            asset: nria().into(),
+            destination_chain_address: destination_chain_address.to_string(),
+            source_transaction_id: TransactionId::new([0; 32]),
+            source_action_index: 0,
+        };
         assert_eq!(deposit, &expected_deposit);
     }
 
     #[tokio::test]
-    async fn rollup_withdrawal_refund_with_compat_address_succeeds() {
+    async fn refund_rollup_with_compat_prefix() {
         let storage = cnidarium::TempStorage::new().await.unwrap();
         let snapshot = storage.latest_snapshot();
         let mut state_tx = StateDelta::new(snapshot.clone());
@@ -1261,28 +1367,33 @@ mod test {
 
         let bridge_address = astria_address(&[99u8; 20]);
         let bridge_address_compat = astria_compat_address(&[99u8; 20]);
-        let denom = "nootasset".parse::<Denom>().unwrap();
+        let destination_chain_address = "rollup-defined-address".to_string();
+
+        let asset: Denom = format!("{}/{}/usdc", packet().port_on_a, packet().chan_on_b)
+            .parse()
+            .unwrap();
+        let amount = 100;
+
         let rollup_id = RollupId::from_unhashed_bytes(b"testchainid");
 
         state_tx.put_bridge_account_rollup_id(bridge_address, &rollup_id);
         state_tx
-            .put_bridge_account_ibc_asset(bridge_address, &denom)
+            .put_bridge_account_ibc_asset(bridge_address, &asset)
             .unwrap();
 
-        let packet = FungibleTokenPacketData {
-            denom: denom.to_string(),
+        let packet_data = FungibleTokenPacketData {
+            denom: asset.to_string(),
             sender: bridge_address_compat.to_string(),
-            amount: "100".to_string(),
+            amount: amount.to_string(),
             receiver: "other-chain-address".to_string(),
-            memo: serde_json::to_string(&memos::v1alpha1::Ics20WithdrawalFromRollup {
+            memo: serde_json::to_string(&Ics20WithdrawalFromRollup {
                 memo: String::new(),
                 rollup_block_number: 1,
-                rollup_return_address: "rollup-defined".to_string(),
-                rollup_withdrawal_event_id: hex::encode([1u8; 32]),
+                rollup_return_address: destination_chain_address.clone(),
+                rollup_withdrawal_event_id: "rollup-defined-id".to_string(),
             })
             .unwrap(),
         };
-        let packet_bytes = serde_json::to_vec(&packet).unwrap();
 
         let transaction_context = TransactionContext {
             address_bytes: bridge_address.bytes(),
@@ -1291,25 +1402,20 @@ mod test {
         };
         state_tx.put_transaction_context(transaction_context);
 
-        execute_ics20_transfer(
+        refund_tokens(
             &mut state_tx,
-            &packet_bytes,
-            &"source_port".to_string().parse().unwrap(),
-            &"source_channel".to_string().parse().unwrap(),
-            &"source_port".to_string().parse().unwrap(),
-            &"source_channel".to_string().parse().unwrap(),
-            true,
+            &Packet {
+                data: serde_json::to_vec(&packet_data).unwrap(),
+                ..packet()
+            },
         )
         .await
         .expect("valid ics20 transfer refund; recipient, memo, and asset ID are valid");
 
         let balance = state_tx
-            .get_account_balance(bridge_address, &denom)
+            .get_account_balance(bridge_address, &asset)
             .await
-            .expect(
-                "ics20 transfer refunding to rollup should succeed and balance should be added to \
-                 the bridge account",
-            );
+            .expect("refunding a rollup should add the tokens to its bridge address");
         assert_eq!(balance, 100);
 
         let deposits = state_tx
@@ -1319,18 +1425,15 @@ mod test {
         assert_eq!(deposits.len(), 1);
 
         let deposit = deposits.get(&rollup_id).unwrap().first().unwrap();
-        let expected_deposit = Deposit::new(
+        let expected_deposit = Deposit {
             bridge_address,
             rollup_id,
-            100,
-            denom,
-            bridge_address.to_string(), /* NOTE: this is the non-compat address because it will
-                                         * be converted from the compat bech32 to the
-                                         * standard/non-compat bech32m version before emitting
-                                         * the deposit event */
-            TransactionId::new([0; 32]),
-            0,
-        );
+            amount,
+            asset,
+            destination_chain_address: destination_chain_address.clone(),
+            source_transaction_id: TransactionId::new([0; 32]),
+            source_action_index: 0,
+        };
         assert_eq!(deposit, &expected_deposit);
     }
 }

--- a/crates/astria-sequencer/src/ibc/ics20_transfer.rs
+++ b/crates/astria-sequencer/src/ibc/ics20_transfer.rs
@@ -791,7 +791,6 @@ mod tests {
         },
         test_utils::{
             astria_address,
-            astria_address_from_hex_string,
             astria_compat_address,
             nria,
             ASTRIA_COMPAT_PREFIX,

--- a/crates/astria-sequencer/src/ibc/ics20_transfer.rs
+++ b/crates/astria-sequencer/src/ibc/ics20_transfer.rs
@@ -595,16 +595,13 @@ async fn refund_tokens_to_sequencer_address<S: StateWrite>(
             .decrease_ibc_channel_balance(source_channel, &asset, amount)
             .await
             .context("failed to withdraw refund amount from escrow account")?;
-        state
-            .increase_balance(recipient, &asset, amount)
-            .await
-            .context("failed to increase user account balance")?;
-    } else {
-        state
-            .increase_balance(recipient, asset, amount)
-            .await
-            .wrap_err("failed to update user account balance in execute_ics20_transfer")?;
-    }
+    } 
+    
+   state
+          .increase_balance(recipient, asset, amount)
+          .await
+          .wrap_err("failed to update user account balance when refunding")?;
+ 
     Ok(())
 }
 

--- a/crates/astria-sequencer/src/ibc/ics20_withdrawal.rs
+++ b/crates/astria-sequencer/src/ibc/ics20_withdrawal.rs
@@ -272,7 +272,7 @@ impl ActionHandler for action::Ics20Withdrawal {
 
 fn is_source(source_port: &PortId, source_channel: &ChannelId, asset: &Denom) -> bool {
     if let Denom::TracePrefixed(trace) = asset {
-        !trace.starts_with_str(&format!("{source_port}/{source_channel}"))
+        !trace.has_leading_port(source_port) || !trace.has_leading_channel(source_channel)
     } else {
         false
     }

--- a/crates/astria-sequencer/src/ibc/state_ext.rs
+++ b/crates/astria-sequencer/src/ibc/state_ext.rs
@@ -72,6 +72,8 @@ fn ibc_relayer_key<T: AddressBytes>(address: &T) -> String {
 
 #[async_trait]
 pub(crate) trait StateReadExt: StateRead {
+    // allow: false positive due to proc macro; fixed with rust/clippy 1.81
+    #[allow(clippy::blocks_in_conditions)]
     #[instrument(skip_all, fields(%channel, %asset), err)]
     async fn get_ibc_channel_balance<TAsset>(
         &self,

--- a/crates/astria-sequencer/src/transaction/checks.rs
+++ b/crates/astria-sequencer/src/transaction/checks.rs
@@ -275,16 +275,16 @@ fn bridge_lock_update_fees(
     use astria_core::sequencerblock::v1alpha1::block::Deposit;
 
     let expected_deposit_fee = transfer_fee.saturating_add(
-        crate::bridge::get_deposit_byte_len(&Deposit::new(
-            act.to,
+        crate::bridge::get_deposit_byte_len(&Deposit {
+            bridge_address: act.to,
             // rollup ID doesn't matter here, as this is only used as a size-check
-            RollupId::from_unhashed_bytes([0; 32]),
-            act.amount,
-            act.asset.clone(),
-            act.destination_chain_address.clone(),
-            TransactionId::new([0; 32]),
-            tx_index_of_action,
-        ))
+            rollup_id: RollupId::from_unhashed_bytes([0; 32]),
+            amount: act.amount,
+            asset: act.asset.clone(),
+            destination_chain_address: act.destination_chain_address.clone(),
+            source_transaction_id: TransactionId::new([0; 32]),
+            source_action_index: tx_index_of_action,
+        })
         .saturating_mul(bridge_lock_byte_cost_multiplier),
     );
 

--- a/crates/astria-sequencer/src/utils.rs
+++ b/crates/astria-sequencer/src/utils.rs
@@ -42,25 +42,21 @@ pub(crate) fn create_deposit_event(deposit: &Deposit) -> abci::Event {
     abci::Event::new(
         "tx.deposit",
         [
-            ("bridgeAddress", deposit.bridge_address().to_string()).index(),
-            ("rollupId", deposit.rollup_id().to_string()).index(),
-            ("amount", deposit.amount().to_string()).index(),
-            ("asset", deposit.asset().to_string()).index(),
+            ("bridgeAddress", deposit.bridge_address.to_string()).index(),
+            ("rollupId", deposit.rollup_id.to_string()).index(),
+            ("amount", deposit.amount.to_string()).index(),
+            ("asset", deposit.asset.to_string()).index(),
             (
                 "destinationChainAddress",
-                deposit.destination_chain_address().to_string(),
+                deposit.destination_chain_address.to_string(),
             )
                 .index(),
             (
                 "sourceTransactionId",
-                deposit.source_transaction_id().to_string(),
+                deposit.source_transaction_id.to_string(),
             )
                 .index(),
-            (
-                "sourceActionIndex",
-                deposit.source_action_index().to_string(),
-            )
-                .index(),
+            ("sourceActionIndex", deposit.source_action_index.to_string()).index(),
         ],
     )
 }


### PR DESCRIPTION
## Summary
Fixes incorrect addresses in ics20 refunds, and fixes/adds source vs sink zone detection of received/refunded asets.

## Background
This PR started with the goal of using `Ics20WithdrawalFromRollup.rollup_return_address` when emitting ics20 deposit events instead of the rollup's bridge address (which for the rollup was quite meaningless).

However, because the original logic was overly convoluted, this patch evolved into a refactor which subsequently revealed 2 more bugs.

## Changes
- Refactor ics20 logic: split up `execute_ics20_transfer` into two functions `receive_tokens` and `refund_tokens`
- Fix deposit events being emitted with the packet sender/bridge address as the receiving address on the rollup: instead use `Ics20WithdrawalFromRollup.rollup_return_address` which is the address originally supplied and understood by the rollup.
- Fix bridge lock events of source tokens being emitted with an extra (port, channel) pair added (this resulting token is likely completely meaningless and not understood by the rollup): instead strip the leading (port, channel) pair to get the original token on sequencer.
- Fix refunds to a rollup of failed ics20 transfers not checking if sequencer is their source or sink zone: instead perform the check and decrease the ibc escrow account is necessary.

## Testing

Renamed and expanded tests to also check for sink vs source zone assets being received, the correct asset being emitted in bridge lock events, and the correct rollup return address being emitted in refunds. Specifically these tests were added or renamed:


- `receive_source_zone_asset_on_sequencer_account`
- `receive_sink_zone_asset_on_sequencer_account`
- `receive_source_zone_asset_on_bridge_account_and_emit_to_rollup`
- `receive_sink_zone_asset_on_bridge_account_and_emit_to_rollup`
- `transfer_to_bridge_is_rejected_due_to_invalid_memo`
- `transfer_to_bridge_account_is_rejected_due_to_not_permitted_token`
- `refund_sequencer_account_with_source_zone_asset`
- `refund_sequencer_account_with_sink_zone_asset`
- `refund_rollup_with_sink_zone_asset`
- `refund_rollup_with_source_zone_asset`
- `refund_rollup_with_source_zone_asset_compat_prefix`

## Related Issues
Closes https://github.com/astriaorg/astria/issues/1439
Closes https://github.com/astriaorg/astria/issues/1496
Closes https://github.com/astriaorg/astria/issues/1514
