### PR TITLE
fix: build docker when workflow explicitly includes component

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -51,6 +51,7 @@ jobs:
       package-name: composer
       binary-name: composer
       tag: ${{ inputs.tag }}
+      force: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'composer' }}
     secrets: inherit
 
   conductor:
@@ -66,6 +67,7 @@ jobs:
       package-name: conductor
       binary-name: conductor
       tag: ${{ inputs.tag }}
+      force: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'conductor' }}
     secrets: inherit
 
   sequencer:
@@ -81,6 +83,7 @@ jobs:
       package-name: sequencer
       binary-name: sequencer
       tag: ${{ inputs.tag }}
+      force: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'sequencer' }}
     secrets: inherit
 
   sequencer-relayer:
@@ -96,6 +99,7 @@ jobs:
       package-name: sequencer-relayer
       binary-name: sequencer-relayer
       tag: ${{ inputs.tag }}
+      force: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'sequencer-relayer' }}
     secrets: inherit
 
   evm-bridge-withdrawer:
@@ -111,6 +115,7 @@ jobs:
       package-name: evm-bridge-withdrawer
       binary-name: bridge-withdrawer
       tag: ${{ inputs.tag }}
+      force: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'evm-bridge-withdrawer' }}
     secrets: inherit
 
   smoke-test:

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -18,6 +18,10 @@ on:
       tag:
         required: false
         type: string
+      force:
+        required: false
+        type: boolean
+        default: false
     secrets:
       DOCKER_TOKEN:
         required: false
@@ -34,7 +38,7 @@ jobs:
       contents: read
       id-token: write
       packages: write
-    if: startsWith(inputs.tag, inputs.binary-name) || !inputs.tag && (startsWith(github.ref, format('refs/tags/{0}-v', inputs.binary-name)) || github.ref == 'refs/heads/main' || github.event_name == 'pull_request' || github.event_name == 'merge_group')
+    if: inputs.force || startsWith(inputs.tag, inputs.binary-name) || !inputs.tag && (startsWith(github.ref, format('refs/tags/{0}-v', inputs.binary-name)) || github.ref == 'refs/heads/main' || github.event_name == 'pull_request' || github.event_name == 'merge_group')
     steps:
       # Checking out the repo
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
We have a workflow docker build which specifies a component but that was only building that component if the tag passed in was also a target tag. 
