### PR TITLE
fix(ci): typo for required field in sequencer preview-env

### DIFF
--- a/dev/argocd/pr-preview-envs/sequencer-appset.yaml
+++ b/dev/argocd/pr-preview-envs/sequencer-appset.yaml
@@ -31,7 +31,7 @@ spec:
           labels:
             # ALL of the following labels are required to be set on the PR for the app to be created
             - preview
-            - evm
+            - sequencer
             - docker-build
         requeueAfterSeconds: 60
   template:


### PR DESCRIPTION
## Summary
Updates a required pull-request label in order to create a preview env for the sequencer component

## Background
There was a typo in the manifest configuration.

## Changes
- Changed `evm` to `sequencer` as a required PR label for creating preview environments.

## Testing
These were manually applied to the existing argocd dev instance

