### PR TITLE
fix(ci): use commit SHA instead of PR number preview-env images

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -68,6 +68,8 @@ jobs:
             type=ref,event=pr
             type=match,pattern=refs/tags/${{ inputs.binary-name }}-v(.*),group=1,enable=${{ startsWith(env.FULL_REF, 'refs/tags/') }},value=${{ env.FULL_REF }}
             type=sha
+            # set the actual commit SHA from the PR head instead of from the PR merge commit (alternatively, we could checkout the PR head in actions/checkout)
+            type=raw,value=sha-${{ github.event.pull_request.head.sha || github.sha }},enable=${{ startsWith(env.FULL_REF, 'refs/pull/') }}
             # set latest tag for `main` branch
             type=raw,value=latest,enable=${{ env.FULL_REF == format('refs/heads/{0}', 'main') }}
       - name: Build and push

--- a/dev/argocd/pr-preview-envs/evm-appset.yaml
+++ b/dev/argocd/pr-preview-envs/evm-appset.yaml
@@ -42,6 +42,16 @@ spec:
         namespace: pr-{{.number}}
         server: https://kubernetes.default.svc
       project: default
+      info:
+        - name: 'Github Project:'
+          value: >-
+            https://github.com/astriaorg/astria
+        - name: 'Github Pull Request:'
+          value: >-
+            https://github.com/astriaorg/astria/pull/{{.number}}
+        - name: 'Github Commit:'
+          value: >-
+            https://github.com/astriaorg/astria/pull/{{.number}}/commits/{{.head_sha}}
       sources:
         - repoURL: https://github.com/astriaorg/astria.git
           targetRevision: pull/{{.number}}/head
@@ -108,10 +118,10 @@ spec:
                     token: http://celestia-service.pr-{{.number}}.svc.cluster.local:5353
                 images:
                   composer:
-                    devTag: pr-{{.number}}
+                    devTag: sha-{{.head_sha}}
                     pullPolicy: Always
                   conductor:
-                    devTag: pr-{{.number}}
+                    devTag: sha-{{.head_sha}}
                     pullPolicy: Always
                 ingress:
                   enabled: true

--- a/dev/argocd/pr-preview-envs/sequencer-appset.yaml
+++ b/dev/argocd/pr-preview-envs/sequencer-appset.yaml
@@ -51,6 +51,16 @@ spec:
         namespace: pr-{{.number}}
         server: https://kubernetes.default.svc
       project: default
+      info:
+        - name: 'Github Project:'
+          value: >-
+            https://github.com/astriaorg/astria
+        - name: 'Github Pull Request:'
+          value: >-
+            https://github.com/astriaorg/astria/pull/{{.number}}
+        - name: 'Github Commit:'
+          value: >-
+            https://github.com/astriaorg/astria/pull/{{.number}}/commits/{{.head_sha}}
       sources:
         - repoURL: https://github.com/astriaorg/astria.git
           targetRevision: pull/{{.number}}/head
@@ -84,7 +94,7 @@ spec:
 
               images:
                 sequencer:
-                  devTag: pr-{{.number}}
+                  devTag: sha-{{.head_sha}}
                   pullPolicy: Always
               ingress:
                 grpc:


### PR DESCRIPTION
## Summary
Updates preview environment manifests to use the exact commit sha when referencing artifacts to deploy (docker images). Also adds links in the GUI back to the PR and commit.

## Background
This is to ensure that any subsequent updates to a PR will always result in the preview env looking for the rebuilt image (tagged with full commit hash) rather than assuming a cached one might be valid (e.g. tagged with PR number).This change is in addition to setting the imagePullPolicy to Always to make the configuration explicit.

## Changes
- Update github action to tag docker images with the full commit hash

## Testing
- Manually tested by applying the preview environment manifests on dev cluster and creating a new PR to verify images were tagged correctly and that ArgoCD pulled the correct image.
