### PR TITLE
feat(sequencer)!: introduce transaction categories (type version)

### DIFF
--- a/crates/astria-bridge-withdrawer/src/bridge_withdrawer/batch.rs
+++ b/crates/astria-bridge-withdrawer/src/bridge_withdrawer/batch.rs
@@ -1,9 +1,9 @@
-use astria_core::protocol::transaction::v1alpha1::Action;
+use astria_core::protocol::transaction::v1alpha1::action_groups::BundlableGeneralAction;
 
 #[derive(Debug)]
 pub(crate) struct Batch {
     /// The withdrawal payloads
-    pub(crate) actions: Vec<Action>,
+    pub(crate) actions: Vec<BundlableGeneralAction>,
     /// The corresponding rollup block height
     pub(crate) rollup_height: u64,
 }

--- a/crates/astria-bridge-withdrawer/src/bridge_withdrawer/ethereum/watcher.rs
+++ b/crates/astria-bridge-withdrawer/src/bridge_withdrawer/ethereum/watcher.rs
@@ -12,7 +12,7 @@ use astria_core::{
         asset,
         Address,
     },
-    protocol::transaction::v1alpha1::Action,
+    protocol::transaction::v1alpha1::action_groups::BundlableGeneralAction,
 };
 use astria_eyre::{
     eyre::{
@@ -354,7 +354,7 @@ async fn get_and_forward_block_events(
         .number
         .ok_or_eyre("block did not contain a rollup height")?
         .as_u64();
-    let actions: Vec<Action> = actions_fetcher
+    let actions: Vec<BundlableGeneralAction> = actions_fetcher
         .get_for_block_hash(block_hash)
         .await
         .wrap_err("failed getting actions for block")?

--- a/crates/astria-bridge-withdrawer/src/bridge_withdrawer/submitter/mod.rs
+++ b/crates/astria-bridge-withdrawer/src/bridge_withdrawer/submitter/mod.rs
@@ -12,7 +12,10 @@ use astria_core::{
         GetPendingNonceRequest,
     },
     protocol::transaction::v1alpha1::{
-        Action,
+        action_groups::{
+            BundlableGeneral,
+            BundlableGeneralAction,
+        },
         TransactionParams,
         UnsignedTransaction,
     },
@@ -137,7 +140,7 @@ impl Submitter {
         &self,
         sequencer_grpc_client: SequencerServiceClient<Channel>,
         sequencer_chain_id: &String,
-        actions: Vec<Action>,
+        actions: Vec<BundlableGeneralAction>,
         rollup_height: u64,
     ) -> eyre::Result<()> {
         let Self {
@@ -159,7 +162,10 @@ impl Submitter {
         debug!(nonce, "fetched latest nonce");
 
         let unsigned = UnsignedTransaction {
-            actions,
+            actions: BundlableGeneral {
+                actions,
+            }
+            .into(),
             params: TransactionParams::builder()
                 .nonce(nonce)
                 .chain_id(sequencer_chain_id)

--- a/crates/astria-bridge-withdrawer/tests/blackbox/helpers/test_bridge_withdrawer.rs
+++ b/crates/astria-bridge-withdrawer/tests/blackbox/helpers/test_bridge_withdrawer.rs
@@ -24,7 +24,7 @@ use astria_core::{
                 BridgeUnlockAction,
                 Ics20Withdrawal,
             },
-            Action,
+            action_groups::BundlableGeneralAction,
         },
     },
 };
@@ -363,12 +363,18 @@ impl Default for TestBridgeWithdrawerConfig {
 }
 
 #[track_caller]
-pub fn assert_actions_eq(expected: &Action, actual: &Action) {
+pub fn assert_actions_eq(expected: &BundlableGeneralAction, actual: &BundlableGeneralAction) {
     match (expected.clone(), actual.clone()) {
-        (Action::BridgeUnlock(expected), Action::BridgeUnlock(actual)) => {
+        (
+            BundlableGeneralAction::BridgeUnlock(expected),
+            BundlableGeneralAction::BridgeUnlock(actual),
+        ) => {
             assert_eq!(expected, actual, "BridgeUnlock actions do not match");
         }
-        (Action::Ics20Withdrawal(expected), Action::Ics20Withdrawal(actual)) => {
+        (
+            BundlableGeneralAction::Ics20Withdrawal(expected),
+            BundlableGeneralAction::Ics20Withdrawal(actual),
+        ) => {
             assert_eq!(
                 SubsetOfIcs20Withdrawal::from(expected),
                 SubsetOfIcs20Withdrawal::from(actual),
@@ -427,7 +433,7 @@ impl From<Ics20Withdrawal> for SubsetOfIcs20Withdrawal {
 }
 
 #[must_use]
-pub fn make_bridge_unlock_action(receipt: &TransactionReceipt) -> Action {
+pub fn make_bridge_unlock_action(receipt: &TransactionReceipt) -> BundlableGeneralAction {
     let denom = default_native_asset();
     let inner = BridgeUnlockAction {
         to: default_sequencer_address(),
@@ -438,11 +444,11 @@ pub fn make_bridge_unlock_action(receipt: &TransactionReceipt) -> Action {
         fee_asset: denom,
         bridge_address: default_bridge_address(),
     };
-    Action::BridgeUnlock(inner)
+    BundlableGeneralAction::BridgeUnlock(inner)
 }
 
 #[must_use]
-pub fn make_ics20_withdrawal_action(receipt: &TransactionReceipt) -> Action {
+pub fn make_ics20_withdrawal_action(receipt: &TransactionReceipt) -> BundlableGeneralAction {
     let timeout_height = IbcHeight::new(u64::MAX, u64::MAX).unwrap();
     let timeout_time = make_ibc_timeout_time();
     let denom = default_ibc_asset();
@@ -466,7 +472,7 @@ pub fn make_ics20_withdrawal_action(receipt: &TransactionReceipt) -> Action {
         use_compat_address: false,
     };
 
-    Action::Ics20Withdrawal(inner)
+    BundlableGeneralAction::Ics20Withdrawal(inner)
 }
 
 #[must_use]

--- a/crates/astria-cli/src/commands/bridge/collect.rs
+++ b/crates/astria-cli/src/commands/bridge/collect.rs
@@ -19,7 +19,7 @@ use astria_core::{
         },
         Address,
     },
-    protocol::transaction::v1alpha1::Action,
+    protocol::transaction::v1alpha1::action_groups::BundlableGeneralAction,
 };
 use clap::Args;
 use color_eyre::eyre::{
@@ -211,19 +211,23 @@ async fn block_to_actions(
 
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 #[serde(transparent)]
-pub(crate) struct ActionsByRollupHeight(BTreeMap<u64, Vec<Action>>);
+pub(crate) struct ActionsByRollupHeight(BTreeMap<u64, Vec<BundlableGeneralAction>>);
 
 impl ActionsByRollupHeight {
     fn new() -> Self {
         Self(BTreeMap::new())
     }
 
-    pub(crate) fn into_inner(self) -> BTreeMap<u64, Vec<Action>> {
+    pub(crate) fn into_inner(self) -> BTreeMap<u64, Vec<BundlableGeneralAction>> {
         self.0
     }
 
     #[instrument(skip_all, err)]
-    fn insert(&mut self, rollup_height: u64, actions: Vec<Action>) -> eyre::Result<()> {
+    fn insert(
+        &mut self,
+        rollup_height: u64,
+        actions: Vec<BundlableGeneralAction>,
+    ) -> eyre::Result<()> {
         ensure!(
             self.0.insert(rollup_height, actions).is_none(),
             "already collected actions for block at rollup height `{rollup_height}`; no 2 blocks \

--- a/crates/astria-cli/src/commands/bridge/submit.rs
+++ b/crates/astria-cli/src/commands/bridge/submit.rs
@@ -6,7 +6,11 @@ use std::path::{
 use astria_core::{
     crypto::SigningKey,
     protocol::transaction::v1alpha1::{
-        Action,
+        action_groups::{
+            ActionGroup,
+            BundlableGeneral,
+            BundlableGeneralAction,
+        },
         TransactionParams,
         UnsignedTransaction,
     },
@@ -116,7 +120,7 @@ async fn submit_transaction(
     chain_id: &str,
     prefix: &str,
     signing_key: &SigningKey,
-    actions: Vec<Action>,
+    actions: Vec<BundlableGeneralAction>,
 ) -> eyre::Result<Response> {
     let from_address = Address::builder()
         .array(signing_key.verification_key().address_bytes())
@@ -134,7 +138,9 @@ async fn submit_transaction(
             .nonce(nonce_res.nonce)
             .chain_id(chain_id)
             .build(),
-        actions,
+        actions: ActionGroup::BundlableGeneral(BundlableGeneral {
+            actions,
+        }),
     }
     .into_signed(signing_key);
     let res = client

--- a/crates/astria-composer/src/executor/bundle_factory/mod.rs
+++ b/crates/astria-composer/src/executor/bundle_factory/mod.rs
@@ -10,10 +10,7 @@ use std::{
 
 use astria_core::{
     primitive::v1::RollupId,
-    protocol::transaction::v1alpha1::{
-        action::SequenceAction,
-        Action,
-    },
+    protocol::transaction::v1alpha1::action::SequenceAction,
     Protobuf as _,
 };
 use serde::ser::{
@@ -53,7 +50,7 @@ impl<'a> Serialize for SizedBundleReport<'a> {
 #[derive(Clone)]
 pub(super) struct SizedBundle {
     /// The buffer of actions
-    buffer: Vec<Action>,
+    buffer: Vec<SequenceAction>,
     /// The current size of the bundle in bytes. This is equal to the sum of the size of the
     /// `seq_action`s + `ROLLUP_ID_LEN` for each.
     curr_size: usize,
@@ -95,7 +92,7 @@ impl SizedBundle {
             .entry(seq_action.rollup_id)
             .and_modify(|count| *count = count.saturating_add(1))
             .or_insert(1);
-        self.buffer.push(Action::Sequence(seq_action));
+        self.buffer.push(seq_action);
         self.curr_size = new_size;
 
         Ok(())
@@ -112,7 +109,7 @@ impl SizedBundle {
     }
 
     /// Consume self and return the underlying buffer of actions.
-    pub(super) fn into_actions(self) -> Vec<Action> {
+    pub(super) fn into_actions(self) -> Vec<SequenceAction> {
         self.buffer
     }
 

--- a/crates/astria-composer/src/executor/bundle_factory/tests.rs
+++ b/crates/astria-composer/src/executor/bundle_factory/tests.rs
@@ -75,7 +75,7 @@ mod sized_bundle {
         // assert that the flushed bundle has just the sequence action pushed earlier
         let actions = flushed_bundle.into_actions();
         assert_eq!(actions.len(), 1);
-        let actual_seq_action = actions[0].as_sequence().unwrap();
+        let actual_seq_action = &actions[0];
         assert_eq!(actual_seq_action.rollup_id, seq_action.rollup_id);
         assert_eq!(actual_seq_action.data, seq_action.data);
     }
@@ -138,7 +138,7 @@ mod bundle_factory {
         // assert `pop_finished()` will return `seq_action0`
         let next_actions = bundle_factory.next_finished();
         let actions = next_actions.unwrap().pop().into_actions();
-        let actual_seq_action = actions[0].as_sequence().unwrap();
+        let actual_seq_action = &actions[0];
         assert_eq!(actual_seq_action.rollup_id, seq_action0.rollup_id);
         assert_eq!(actual_seq_action.data, seq_action0.data);
     }
@@ -237,7 +237,7 @@ mod bundle_factory {
         assert_eq!(bundle_factory.finished.len(), 0);
         // assert `pop_now()` returns `seq_action`
         let actions = bundle_factory.pop_now().into_actions();
-        let actual_seq_action = actions[0].as_sequence().unwrap();
+        let actual_seq_action = &actions[0];
         assert_eq!(actual_seq_action.rollup_id, seq_action.rollup_id);
         assert_eq!(actual_seq_action.data, seq_action.data);
     }
@@ -262,7 +262,7 @@ mod bundle_factory {
         assert_eq!(bundle_factory.finished.len(), 1);
         // assert `pop_now()` will return `seq_action0`
         let actions = bundle_factory.pop_now().into_actions();
-        let actual_seq_action = actions[0].as_sequence().unwrap();
+        let actual_seq_action = &actions[0];
         assert_eq!(actual_seq_action.rollup_id, seq_action0.rollup_id);
         assert_eq!(actual_seq_action.data, seq_action0.data);
     }
@@ -298,7 +298,7 @@ mod bundle_factory {
         // assert `pop_now()` will return `seq_action0` on the first call
         let actions_finished = bundle_factory.pop_now().into_actions();
         assert_eq!(actions_finished.len(), 1);
-        let actual_seq_action = actions_finished[0].as_sequence().unwrap();
+        let actual_seq_action = &actions_finished[0];
         assert_eq!(actual_seq_action.rollup_id, seq_action0.rollup_id);
         assert_eq!(actual_seq_action.data, seq_action0.data);
 
@@ -308,7 +308,7 @@ mod bundle_factory {
         // assert `pop_now()` will return `seq_action1` on the second call (i.e. from curr)
         let actions_curr = bundle_factory.pop_now().into_actions();
         assert_eq!(actions_curr.len(), 1);
-        let actual_seq_action = actions_curr[0].as_sequence().unwrap();
+        let actual_seq_action = &actions_curr[0];
         assert_eq!(actual_seq_action.rollup_id, seq_action1.rollup_id);
         assert_eq!(actual_seq_action.data, seq_action1.data);
 

--- a/crates/astria-composer/src/executor/mod.rs
+++ b/crates/astria-composer/src/executor/mod.rs
@@ -16,6 +16,7 @@ use astria_core::{
         abci::AbciErrorCode,
         transaction::v1alpha1::{
             action::SequenceAction,
+            action_groups::BundlableGeneral,
             SignedTransaction,
             TransactionParams,
             UnsignedTransaction,
@@ -682,7 +683,16 @@ impl Future for SubmitFut {
                         .chain_id(&*this.chain_id)
                         .build();
                     let tx = UnsignedTransaction {
-                        actions: this.bundle.clone().into_actions(),
+                        actions: BundlableGeneral {
+                            actions: this
+                                .bundle
+                                .clone()
+                                .into_actions()
+                                .into_iter()
+                                .map(std::convert::Into::into)
+                                .collect(),
+                        }
+                        .into(),
                         params,
                     }
                     .into_signed(this.signing_key);
@@ -760,7 +770,16 @@ impl Future for SubmitFut {
                             .chain_id(&*this.chain_id)
                             .build();
                         let tx = UnsignedTransaction {
-                            actions: this.bundle.clone().into_actions(),
+                            actions: BundlableGeneral {
+                                actions: this
+                                    .bundle
+                                    .clone()
+                                    .into_actions()
+                                    .into_iter()
+                                    .map(std::convert::Into::into)
+                                    .collect(),
+                            }
+                            .into(),
                             params,
                         }
                         .into_signed(this.signing_key);

--- a/crates/astria-core/src/protocol/test_utils.rs
+++ b/crates/astria-core/src/protocol/test_utils.rs
@@ -19,6 +19,10 @@ use crate::{
         derive_merkle_tree_from_rollup_txs,
         RollupId,
     },
+    protocol::transaction::v1alpha1::action_groups::{
+        BundlableGeneral,
+        BundlableGeneralAction,
+    },
     sequencerblock::v1alpha1::{
         block::Deposit,
         SequencerBlock,
@@ -63,10 +67,7 @@ impl ConfigureSequencerBlock {
     pub fn make(self) -> SequencerBlock {
         use tendermint::Time;
 
-        use crate::{
-            protocol::transaction::v1alpha1::Action,
-            sequencerblock::v1alpha1::block::RollupData,
-        };
+        use crate::sequencerblock::v1alpha1::block::RollupData;
 
         let Self {
             block_hash,
@@ -90,7 +91,7 @@ impl ConfigureSequencerBlock {
             tendermint::account::Id::from(public_key)
         });
 
-        let actions: Vec<Action> = sequence_data
+        let actions: Vec<BundlableGeneralAction> = sequence_data
             .into_iter()
             .map(|(rollup_id, data)| {
                 SequenceAction {
@@ -105,7 +106,10 @@ impl ConfigureSequencerBlock {
             vec![]
         } else {
             let unsigned_transaction = UnsignedTransaction {
-                actions,
+                actions: BundlableGeneral {
+                    actions,
+                }
+                .into(),
                 params: TransactionParams::builder()
                     .nonce(1)
                     .chain_id(chain_id.clone())

--- a/crates/astria-core/src/protocol/transaction/v1alpha1/action.rs
+++ b/crates/astria-core/src/protocol/transaction/v1alpha1/action.rs
@@ -8,7 +8,17 @@ use ibc_types::{
 };
 use penumbra_ibc::IbcRelay;
 
-use super::raw;
+use super::{
+    action_groups::{
+        ActionGroupType,
+        ActionGroupTypeConverter,
+        BundlableGeneralAction,
+        BundlableSudoAction,
+        GeneralAction,
+        SudoAction,
+    },
+    raw,
+};
 use crate::{
     primitive::v1::{
         asset::{
@@ -23,294 +33,65 @@ use crate::{
     Protobuf,
 };
 
-#[derive(Clone, Debug)]
-#[cfg_attr(
-    feature = "serde",
-    derive(::serde::Deserialize, ::serde::Serialize),
-    serde(into = "raw::Action", try_from = "raw::Action")
-)]
-pub enum Action {
-    Sequence(SequenceAction),
-    Transfer(TransferAction),
-    ValidatorUpdate(ValidatorUpdate),
-    SudoAddressChange(SudoAddressChangeAction),
-    Ibc(IbcRelay),
-    Ics20Withdrawal(Ics20Withdrawal),
-    IbcRelayerChange(IbcRelayerChangeAction),
-    FeeAssetChange(FeeAssetChangeAction),
-    InitBridgeAccount(InitBridgeAccountAction),
-    BridgeLock(BridgeLockAction),
-    BridgeUnlock(BridgeUnlockAction),
-    BridgeSudoChange(BridgeSudoChangeAction),
-    FeeChange(FeeChangeAction),
-}
-
-impl Protobuf for Action {
-    type Error = ActionError;
-    type Raw = raw::Action;
-
-    #[must_use]
-    fn to_raw(&self) -> Self::Raw {
-        use raw::action::Value;
-        let kind = match self {
-            Action::Sequence(act) => Value::SequenceAction(act.to_raw()),
-            Action::Transfer(act) => Value::TransferAction(act.to_raw()),
-            Action::ValidatorUpdate(act) => Value::ValidatorUpdateAction(act.to_raw()),
-            Action::SudoAddressChange(act) => {
-                Value::SudoAddressChangeAction(act.clone().into_raw())
-            }
-            Action::Ibc(act) => Value::IbcAction(act.clone().into()),
-            Action::Ics20Withdrawal(act) => Value::Ics20Withdrawal(act.to_raw()),
-            Action::IbcRelayerChange(act) => Value::IbcRelayerChangeAction(act.to_raw()),
-            Action::FeeAssetChange(act) => Value::FeeAssetChangeAction(act.to_raw()),
-            Action::InitBridgeAccount(act) => Value::InitBridgeAccountAction(act.to_raw()),
-            Action::BridgeLock(act) => Value::BridgeLockAction(act.to_raw()),
-            Action::BridgeUnlock(act) => Value::BridgeUnlockAction(act.to_raw()),
-            Action::BridgeSudoChange(act) => Value::BridgeSudoChangeAction(act.to_raw()),
-            Action::FeeChange(act) => Value::FeeChangeAction(act.to_raw()),
-        };
-        raw::Action {
-            value: Some(kind),
-        }
-    }
-
-    /// Attempt to convert from a reference to raw, unchecked protobuf [`raw::Action`].
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if conversion of one of the inner raw action variants
-    /// to a native action ([`SequenceAction`] or [`TransferAction`]) fails.
-    fn try_from_raw_ref(raw: &Self::Raw) -> Result<Self, ActionError> {
-        Self::try_from_raw(raw.clone())
-    }
-
-    /// Attempt to convert from a raw, unchecked protobuf [`raw::Action`].
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if conversion of one of the inner raw action variants
-    /// to a native action ([`SequenceAction`] or [`TransferAction`]) fails.
-    fn try_from_raw(proto: raw::Action) -> Result<Self, ActionError> {
-        use raw::action::Value;
-        let raw::Action {
-            value,
-        } = proto;
-        let Some(action) = value else {
-            return Err(ActionError::unset());
-        };
-        let action = match action {
-            Value::SequenceAction(act) => {
-                Self::Sequence(SequenceAction::try_from_raw(act).map_err(ActionError::sequence)?)
-            }
-            Value::TransferAction(act) => {
-                Self::Transfer(TransferAction::try_from_raw(act).map_err(ActionError::transfer)?)
-            }
-            Value::ValidatorUpdateAction(act) => Self::ValidatorUpdate(
-                ValidatorUpdate::try_from_raw(act).map_err(ActionError::validator_update)?,
-            ),
-            Value::SudoAddressChangeAction(act) => Self::SudoAddressChange(
-                SudoAddressChangeAction::try_from_raw(act)
-                    .map_err(ActionError::sudo_address_change)?,
-            ),
-            Value::IbcAction(act) => {
-                Self::Ibc(IbcRelay::try_from(act).map_err(|e| ActionError::ibc(e.into()))?)
-            }
-            Value::Ics20Withdrawal(act) => Self::Ics20Withdrawal(
-                Ics20Withdrawal::try_from_raw(act).map_err(ActionError::ics20_withdrawal)?,
-            ),
-            Value::IbcRelayerChangeAction(act) => Self::IbcRelayerChange(
-                IbcRelayerChangeAction::try_from_raw_ref(&act)
-                    .map_err(ActionError::ibc_relayer_change)?,
-            ),
-            Value::FeeAssetChangeAction(act) => Self::FeeAssetChange(
-                FeeAssetChangeAction::try_from_raw_ref(&act)
-                    .map_err(ActionError::fee_asset_change)?,
-            ),
-            Value::InitBridgeAccountAction(act) => Self::InitBridgeAccount(
-                InitBridgeAccountAction::try_from_raw(act)
-                    .map_err(ActionError::init_bridge_account)?,
-            ),
-            Value::BridgeLockAction(act) => Self::BridgeLock(
-                BridgeLockAction::try_from_raw(act).map_err(ActionError::bridge_lock)?,
-            ),
-            Value::BridgeUnlockAction(act) => Self::BridgeUnlock(
-                BridgeUnlockAction::try_from_raw(act).map_err(ActionError::bridge_unlock)?,
-            ),
-            Value::BridgeSudoChangeAction(act) => Self::BridgeSudoChange(
-                BridgeSudoChangeAction::try_from_raw(act)
-                    .map_err(ActionError::bridge_sudo_change)?,
-            ),
-            Value::FeeChangeAction(act) => Self::FeeChange(
-                FeeChangeAction::try_from_raw_ref(&act).map_err(ActionError::fee_change)?,
-            ),
-        };
-        Ok(action)
-    }
-}
-
-impl Action {
-    #[must_use]
-    pub fn as_sequence(&self) -> Option<&SequenceAction> {
-        let Self::Sequence(sequence_action) = self else {
-            return None;
-        };
-        Some(sequence_action)
-    }
-
-    #[must_use]
-    pub fn as_transfer(&self) -> Option<&TransferAction> {
-        let Self::Transfer(transfer_action) = self else {
-            return None;
-        };
-        Some(transfer_action)
-    }
-}
-
-impl From<SequenceAction> for Action {
-    fn from(value: SequenceAction) -> Self {
-        Self::Sequence(value)
-    }
-}
-
-impl From<TransferAction> for Action {
-    fn from(value: TransferAction) -> Self {
-        Self::Transfer(value)
-    }
-}
-
-impl From<SudoAddressChangeAction> for Action {
-    fn from(value: SudoAddressChangeAction) -> Self {
-        Self::SudoAddressChange(value)
-    }
-}
-
-impl From<IbcRelay> for Action {
-    fn from(value: IbcRelay) -> Self {
-        Self::Ibc(value)
-    }
-}
-
-impl From<Ics20Withdrawal> for Action {
-    fn from(value: Ics20Withdrawal) -> Self {
-        Self::Ics20Withdrawal(value)
-    }
-}
-
-impl From<IbcRelayerChangeAction> for Action {
-    fn from(value: IbcRelayerChangeAction) -> Self {
-        Self::IbcRelayerChange(value)
-    }
-}
-
-impl From<FeeAssetChangeAction> for Action {
-    fn from(value: FeeAssetChangeAction) -> Self {
-        Self::FeeAssetChange(value)
-    }
-}
-
-impl From<InitBridgeAccountAction> for Action {
-    fn from(value: InitBridgeAccountAction) -> Self {
-        Self::InitBridgeAccount(value)
-    }
-}
-
-impl From<BridgeLockAction> for Action {
-    fn from(value: BridgeLockAction) -> Self {
-        Self::BridgeLock(value)
-    }
-}
-
-impl From<BridgeUnlockAction> for Action {
-    fn from(value: BridgeUnlockAction) -> Self {
-        Self::BridgeUnlock(value)
-    }
-}
-
-impl From<BridgeSudoChangeAction> for Action {
-    fn from(value: BridgeSudoChangeAction) -> Self {
-        Self::BridgeSudoChange(value)
-    }
-}
-
-impl From<FeeChangeAction> for Action {
-    fn from(value: FeeChangeAction) -> Self {
-        Self::FeeChange(value)
-    }
-}
-
-impl From<Action> for raw::Action {
-    fn from(value: Action) -> Self {
-        value.into_raw()
-    }
-}
-
-impl TryFrom<raw::Action> for Action {
-    type Error = ActionError;
-
-    fn try_from(value: raw::Action) -> Result<Self, Self::Error> {
-        Self::try_from_raw(value)
-    }
-}
-
 #[allow(clippy::module_name_repetitions)]
 #[derive(Debug, thiserror::Error)]
 #[error(transparent)]
 pub struct ActionError(ActionErrorKind);
 
 impl ActionError {
-    fn unset() -> Self {
+    pub(crate) fn unset() -> Self {
         Self(ActionErrorKind::Unset)
     }
 
-    fn sequence(inner: SequenceActionError) -> Self {
+    pub(crate) fn sequence(inner: SequenceActionError) -> Self {
         Self(ActionErrorKind::Sequence(inner))
     }
 
-    fn transfer(inner: TransferActionError) -> Self {
+    pub(crate) fn transfer(inner: TransferActionError) -> Self {
         Self(ActionErrorKind::Transfer(inner))
     }
 
-    fn validator_update(inner: ValidatorUpdateError) -> Self {
+    pub(crate) fn validator_update(inner: ValidatorUpdateError) -> Self {
         Self(ActionErrorKind::ValidatorUpdate(inner))
     }
 
-    fn sudo_address_change(inner: SudoAddressChangeActionError) -> Self {
+    pub(crate) fn sudo_address_change(inner: SudoAddressChangeActionError) -> Self {
         Self(ActionErrorKind::SudoAddressChange(inner))
     }
 
-    fn ibc(inner: Box<dyn std::error::Error + Send + Sync>) -> Self {
+    pub(crate) fn ibc(inner: Box<dyn std::error::Error + Send + Sync>) -> Self {
         Self(ActionErrorKind::Ibc(inner))
     }
 
-    fn ics20_withdrawal(inner: Ics20WithdrawalError) -> Self {
+    pub(crate) fn ics20_withdrawal(inner: Ics20WithdrawalError) -> Self {
         Self(ActionErrorKind::Ics20Withdrawal(inner))
     }
 
-    fn ibc_relayer_change(inner: IbcRelayerChangeActionError) -> Self {
+    pub(crate) fn ibc_relayer_change(inner: IbcRelayerChangeActionError) -> Self {
         Self(ActionErrorKind::IbcRelayerChange(inner))
     }
 
-    fn fee_asset_change(inner: FeeAssetChangeActionError) -> Self {
+    pub(crate) fn fee_asset_change(inner: FeeAssetChangeActionError) -> Self {
         Self(ActionErrorKind::FeeAssetChange(inner))
     }
 
-    fn init_bridge_account(inner: InitBridgeAccountActionError) -> Self {
+    pub(crate) fn init_bridge_account(inner: InitBridgeAccountActionError) -> Self {
         Self(ActionErrorKind::InitBridgeAccount(inner))
     }
 
-    fn bridge_lock(inner: BridgeLockActionError) -> Self {
+    pub(crate) fn bridge_lock(inner: BridgeLockActionError) -> Self {
         Self(ActionErrorKind::BridgeLock(inner))
     }
 
-    fn bridge_unlock(inner: BridgeUnlockActionError) -> Self {
+    pub(crate) fn bridge_unlock(inner: BridgeUnlockActionError) -> Self {
         Self(ActionErrorKind::BridgeUnlock(inner))
     }
 
-    fn bridge_sudo_change(inner: BridgeSudoChangeActionError) -> Self {
+    pub(crate) fn bridge_sudo_change(inner: BridgeSudoChangeActionError) -> Self {
         Self(ActionErrorKind::BridgeSudoChange(inner))
     }
 
-    fn fee_change(inner: FeeChangeActionError) -> Self {
+    pub(crate) fn fee_change(inner: FeeChangeActionError) -> Self {
         Self(ActionErrorKind::FeeChange(inner))
     }
 }
@@ -427,6 +208,36 @@ impl Protobuf for SequenceAction {
     }
 }
 
+impl ActionGroupTypeConverter for SequenceAction {
+    fn to_action_group(&self) -> ActionGroupType {
+        ActionGroupType::BundlableGeneral
+    }
+}
+
+impl From<SequenceAction> for BundlableGeneralAction {
+    fn from(action: SequenceAction) -> Self {
+        BundlableGeneralAction::Sequence(action)
+    }
+}
+
+impl BundlableGeneralAction {
+    #[must_use]
+    pub fn as_sequence(&self) -> Option<&SequenceAction> {
+        let Self::Sequence(sequence_action) = self else {
+            return None;
+        };
+        Some(sequence_action)
+    }
+
+    #[must_use]
+    pub fn as_transfer(&self) -> Option<&TransferAction> {
+        let Self::Transfer(transfer_action) = self else {
+            return None;
+        };
+        Some(transfer_action)
+    }
+}
+
 #[derive(Clone, Debug)]
 #[allow(clippy::module_name_repetitions)]
 pub struct TransferAction {
@@ -519,6 +330,18 @@ enum TransferActionErrorKind {
     Asset(#[source] asset::ParseDenomError),
     #[error("`fee_asset` field did not contain a valid asset ID")]
     FeeAsset(#[source] asset::ParseDenomError),
+}
+
+impl ActionGroupTypeConverter for TransferAction {
+    fn to_action_group(&self) -> ActionGroupType {
+        ActionGroupType::BundlableGeneral
+    }
+}
+
+impl From<TransferAction> for BundlableGeneralAction {
+    fn from(action: TransferAction) -> Self {
+        BundlableGeneralAction::Transfer(action)
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -673,6 +496,18 @@ impl TryFrom<crate::generated::astria_vendored::tendermint::abci::ValidatorUpdat
     }
 }
 
+impl ActionGroupTypeConverter for ValidatorUpdate {
+    fn to_action_group(&self) -> ActionGroupType {
+        ActionGroupType::BundlableGeneral
+    }
+}
+
+impl From<ValidatorUpdate> for BundlableGeneralAction {
+    fn from(action: ValidatorUpdate) -> Self {
+        BundlableGeneralAction::ValidatorUpdate(action)
+    }
+}
+
 #[derive(Clone, Debug)]
 #[allow(clippy::module_name_repetitions)]
 pub struct SudoAddressChangeAction {
@@ -745,6 +580,18 @@ enum SudoAddressChangeActionErrorKind {
     FieldNotSet(&'static str),
     #[error("`new_address` field did not contain a valid address")]
     Address { source: AddressError },
+}
+
+impl ActionGroupTypeConverter for SudoAddressChangeAction {
+    fn to_action_group(&self) -> ActionGroupType {
+        ActionGroupType::Sudo
+    }
+}
+
+impl From<SudoAddressChangeAction> for SudoAction {
+    fn from(action: SudoAddressChangeAction) -> Self {
+        SudoAction::SudoAddressChange(action)
+    }
 }
 
 /// Represents an IBC withdrawal of an asset from a source chain to a destination chain.
@@ -1065,6 +912,30 @@ impl Ics20WithdrawalError {
     }
 }
 
+impl ActionGroupTypeConverter for Ics20Withdrawal {
+    fn to_action_group(&self) -> ActionGroupType {
+        ActionGroupType::BundlableGeneral
+    }
+}
+
+impl From<Ics20Withdrawal> for BundlableGeneralAction {
+    fn from(action: Ics20Withdrawal) -> Self {
+        BundlableGeneralAction::Ics20Withdrawal(action)
+    }
+}
+
+impl ActionGroupTypeConverter for IbcRelay {
+    fn to_action_group(&self) -> ActionGroupType {
+        ActionGroupType::BundlableGeneral
+    }
+}
+
+impl From<IbcRelay> for BundlableGeneralAction {
+    fn from(action: IbcRelay) -> Self {
+        BundlableGeneralAction::Ibc(action)
+    }
+}
+
 #[derive(Debug, thiserror::Error)]
 enum Ics20WithdrawalErrorKind {
     #[error("expected field `{field}` was not set`")]
@@ -1162,6 +1033,18 @@ enum IbcRelayerChangeActionErrorKind {
     MissingAddress,
 }
 
+impl ActionGroupTypeConverter for IbcRelayerChangeAction {
+    fn to_action_group(&self) -> ActionGroupType {
+        ActionGroupType::BundlableSudo
+    }
+}
+
+impl From<IbcRelayerChangeAction> for BundlableSudoAction {
+    fn from(action: IbcRelayerChangeAction) -> Self {
+        BundlableSudoAction::IbcRelayerChange(action)
+    }
+}
+
 #[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Clone)]
 pub enum FeeAssetChangeAction {
@@ -1243,6 +1126,19 @@ enum FeeAssetChangeActionErrorKind {
     MissingAsset,
 }
 
+impl ActionGroupTypeConverter for FeeAssetChangeAction {
+    fn to_action_group(&self) -> ActionGroupType {
+        ActionGroupType::BundlableSudo
+    }
+}
+
+impl From<FeeAssetChangeAction> for BundlableSudoAction {
+    fn from(action: FeeAssetChangeAction) -> Self {
+        BundlableSudoAction::FeeAssetChange(action)
+    }
+}
+
+#[allow(clippy::module_name_repetitions)]
 #[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Clone)]
 pub struct InitBridgeAccountAction {
@@ -1381,6 +1277,18 @@ impl InitBridgeAccountActionError {
         Self(InitBridgeAccountActionErrorKind::InvalidWithdrawerAddress(
             err,
         ))
+    }
+}
+
+impl ActionGroupTypeConverter for InitBridgeAccountAction {
+    fn to_action_group(&self) -> ActionGroupType {
+        ActionGroupType::General
+    }
+}
+
+impl From<InitBridgeAccountAction> for GeneralAction {
+    fn from(action: InitBridgeAccountAction) -> Self {
+        GeneralAction::InitBridgeAccount(action)
     }
 }
 
@@ -1536,6 +1444,18 @@ enum BridgeLockActionErrorKind {
     InvalidFeeAsset(#[source] asset::ParseDenomError),
 }
 
+impl ActionGroupTypeConverter for BridgeLockAction {
+    fn to_action_group(&self) -> ActionGroupType {
+        ActionGroupType::BundlableGeneral
+    }
+}
+
+impl From<BridgeLockAction> for BundlableGeneralAction {
+    fn from(action: BridgeLockAction) -> Self {
+        BundlableGeneralAction::BridgeLock(action)
+    }
+}
+
 #[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BridgeUnlockAction {
@@ -1684,6 +1604,18 @@ enum BridgeUnlockActionErrorKind {
     BridgeAddress { source: AddressError },
 }
 
+impl ActionGroupTypeConverter for BridgeUnlockAction {
+    fn to_action_group(&self) -> ActionGroupType {
+        ActionGroupType::BundlableGeneral
+    }
+}
+
+impl From<BridgeUnlockAction> for BundlableGeneralAction {
+    fn from(action: BridgeUnlockAction) -> Self {
+        BundlableGeneralAction::BridgeUnlock(action)
+    }
+}
+
 #[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Clone)]
 pub struct BridgeSudoChangeAction {
@@ -1820,6 +1752,18 @@ enum BridgeSudoChangeActionErrorKind {
     InvalidFeeAsset(#[source] asset::ParseDenomError),
 }
 
+impl ActionGroupTypeConverter for BridgeSudoChangeAction {
+    fn to_action_group(&self) -> ActionGroupType {
+        ActionGroupType::General
+    }
+}
+
+impl From<BridgeSudoChangeAction> for GeneralAction {
+    fn from(action: BridgeSudoChangeAction) -> Self {
+        GeneralAction::BridgeSudoChange(action)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum FeeChange {
     TransferBaseFee,
@@ -1926,4 +1870,16 @@ impl FeeChangeActionError {
 enum FeeChangeActionErrorKind {
     #[error("the value which to change was missing")]
     MissingValueToChange,
+}
+
+impl ActionGroupTypeConverter for FeeChangeAction {
+    fn to_action_group(&self) -> ActionGroupType {
+        ActionGroupType::BundlableSudo
+    }
+}
+
+impl From<FeeChangeAction> for BundlableSudoAction {
+    fn from(action: FeeChangeAction) -> Self {
+        BundlableSudoAction::FeeChange(action)
+    }
 }

--- a/crates/astria-core/src/protocol/transaction/v1alpha1/action_groups.rs
+++ b/crates/astria-core/src/protocol/transaction/v1alpha1/action_groups.rs
@@ -1,0 +1,569 @@
+use penumbra_ibc::IbcRelay;
+
+use super::{
+    action::{
+        ActionError,
+        BridgeLockAction,
+        BridgeSudoChangeAction,
+        BridgeUnlockAction,
+        FeeAssetChangeAction,
+        FeeChangeAction,
+        IbcRelayerChangeAction,
+        Ics20Withdrawal,
+        InitBridgeAccountAction,
+        SequenceAction,
+        SudoAddressChangeAction,
+        TransferAction,
+        ValidatorUpdate,
+    },
+    raw,
+};
+use crate::Protobuf;
+// Used to determine the type of action group to create
+pub enum ActionGroupType {
+    BundlableGeneral,
+    General,
+    BundlableSudo,
+    Sudo,
+}
+
+pub trait ActionGroupTypeConverter {
+    fn to_action_group(&self) -> ActionGroupType;
+}
+
+use raw::action::Value;
+
+impl ActionGroupTypeConverter for Value {
+    fn to_action_group(&self) -> ActionGroupType {
+        use raw::action::Value;
+        match self {
+            Value::SequenceAction(_)
+            | Value::TransferAction(_)
+            | Value::ValidatorUpdateAction(_)
+            | Value::IbcAction(_)
+            | Value::Ics20Withdrawal(_)
+            | Value::BridgeLockAction(_)
+            | Value::BridgeUnlockAction(_) => ActionGroupType::BundlableGeneral,
+            Value::SudoAddressChangeAction(_) => ActionGroupType::Sudo,
+            Value::InitBridgeAccountAction(_) | Value::BridgeSudoChangeAction(_) => {
+                ActionGroupType::General
+            }
+            Value::IbcRelayerChangeAction(_)
+            | Value::FeeAssetChangeAction(_)
+            | Value::FeeChangeAction(_) => ActionGroupType::BundlableSudo,
+        }
+    }
+}
+
+impl ActionGroup {
+    #[allow(clippy::too_many_lines)] // TODO: refactor if reviewers request
+    pub(super) fn try_from_raw(mut actions: Vec<raw::Action>) -> Result<Self, ActionGroupError> {
+        let first_action = actions.first().ok_or_else(ActionGroupError::empty)?;
+        let raw::Action {
+            value,
+        } = first_action;
+        let Some(value_ref) = value else {
+            return Err(ActionGroupError::action(ActionError::unset()));
+        };
+
+        let group_type = value_ref.to_action_group();
+
+        match group_type {
+            ActionGroupType::General => {
+                if actions.len() > 1 {
+                    return Err(ActionGroupError::not_bundlable());
+                }
+                let action = actions.pop().ok_or_else(ActionGroupError::empty)?;
+                let Some(value) = action.value else {
+                    return Err(ActionGroupError::action(ActionError::unset()));
+                };
+                match value {
+                    Value::InitBridgeAccountAction(act) => Ok(ActionGroup::General(General {
+                        actions: GeneralAction::InitBridgeAccount(
+                            InitBridgeAccountAction::try_from_raw(act)
+                                .map_err(ActionError::init_bridge_account)
+                                .map_err(ActionGroupError::action)?,
+                        ),
+                    })),
+                    Value::BridgeSudoChangeAction(act) => Ok(ActionGroup::General(General {
+                        actions: GeneralAction::BridgeSudoChange(
+                            BridgeSudoChangeAction::try_from_raw(act)
+                                .map_err(ActionError::bridge_sudo_change)
+                                .map_err(ActionGroupError::action)?,
+                        ),
+                    })),
+                    _ => Err(ActionGroupError::mixed()),
+                }
+            }
+            ActionGroupType::Sudo => {
+                if actions.len() > 1 {
+                    return Err(ActionGroupError::not_bundlable());
+                }
+                let action = actions.pop().ok_or_else(ActionGroupError::empty)?;
+                let Some(value) = action.value else {
+                    return Err(ActionGroupError::action(ActionError::unset()));
+                };
+                match value {
+                    Value::SudoAddressChangeAction(act) => Ok(ActionGroup::Sudo(Sudo {
+                        actions: SudoAction::SudoAddressChange(
+                            SudoAddressChangeAction::try_from_raw(act)
+                                .map_err(ActionError::sudo_address_change)
+                                .map_err(ActionGroupError::action)?,
+                        ),
+                    })),
+                    _ => Err(ActionGroupError::mixed()),
+                }
+            }
+            ActionGroupType::BundlableSudo => {
+                let mut sudo_bundle_actions = Vec::<BundlableSudoAction>::new();
+                for action in actions {
+                    let Some(value) = action.value else {
+                        return Err(ActionGroupError::action(ActionError::unset()));
+                    };
+                    match value {
+                        Value::IbcRelayerChangeAction(act) => {
+                            sudo_bundle_actions.push(BundlableSudoAction::IbcRelayerChange(
+                                IbcRelayerChangeAction::try_from_raw(act)
+                                    .map_err(ActionError::ibc_relayer_change)
+                                    .map_err(ActionGroupError::action)?,
+                            ));
+                        }
+                        Value::FeeAssetChangeAction(act) => {
+                            sudo_bundle_actions.push(BundlableSudoAction::FeeAssetChange(
+                                FeeAssetChangeAction::try_from_raw(act)
+                                    .map_err(ActionError::fee_asset_change)
+                                    .map_err(ActionGroupError::action)?,
+                            ));
+                        }
+                        Value::FeeChangeAction(act) => {
+                            sudo_bundle_actions.push(BundlableSudoAction::FeeChange(
+                                FeeChangeAction::try_from_raw(act)
+                                    .map_err(ActionError::fee_change)
+                                    .map_err(ActionGroupError::action)?,
+                            ));
+                        }
+                        _ => return Err(ActionGroupError::mixed()),
+                    }
+                }
+                Ok(ActionGroup::BundlableSudo(BundlableSudo {
+                    actions: sudo_bundle_actions,
+                }))
+            }
+            ActionGroupType::BundlableGeneral => {
+                let mut bundlable_general_actions = Vec::<BundlableGeneralAction>::new();
+                for action in actions {
+                    let Some(value) = action.value else {
+                        return Err(ActionGroupError::action(ActionError::unset()));
+                    };
+                    match value {
+                        Value::SequenceAction(act) => {
+                            bundlable_general_actions.push(BundlableGeneralAction::Sequence(
+                                SequenceAction::try_from_raw(act)
+                                    .map_err(ActionError::sequence)
+                                    .map_err(ActionGroupError::action)?,
+                            ));
+                        }
+                        Value::TransferAction(act) => {
+                            bundlable_general_actions.push(BundlableGeneralAction::Transfer(
+                                TransferAction::try_from_raw(act)
+                                    .map_err(ActionError::transfer)
+                                    .map_err(ActionGroupError::action)?,
+                            ));
+                        }
+                        Value::IbcAction(act) => {
+                            bundlable_general_actions.push(BundlableGeneralAction::Ibc(
+                                IbcRelay::try_from(act)
+                                    .map_err(|e| ActionError::ibc(e.into()))
+                                    .map_err(ActionGroupError::action)?,
+                            ));
+                        }
+                        Value::Ics20Withdrawal(act) => {
+                            bundlable_general_actions.push(
+                                BundlableGeneralAction::Ics20Withdrawal(
+                                    Ics20Withdrawal::try_from_raw(act)
+                                        .map_err(ActionError::ics20_withdrawal)
+                                        .map_err(ActionGroupError::action)?,
+                                ),
+                            );
+                        }
+                        Value::BridgeLockAction(act) => {
+                            bundlable_general_actions.push(BundlableGeneralAction::BridgeLock(
+                                BridgeLockAction::try_from_raw(act)
+                                    .map_err(ActionError::bridge_lock)
+                                    .map_err(ActionGroupError::action)?,
+                            ));
+                        }
+                        Value::BridgeUnlockAction(act) => {
+                            bundlable_general_actions.push(BundlableGeneralAction::BridgeUnlock(
+                                BridgeUnlockAction::try_from_raw(act)
+                                    .map_err(ActionError::bridge_unlock)
+                                    .map_err(ActionGroupError::action)?,
+                            ));
+                        }
+                        Value::ValidatorUpdateAction(act) => {
+                            bundlable_general_actions.push(
+                                BundlableGeneralAction::ValidatorUpdate(
+                                    ValidatorUpdate::try_from_raw(act)
+                                        .map_err(ActionError::validator_update)
+                                        .map_err(ActionGroupError::action)?,
+                                ),
+                            );
+                        }
+                        _ => return Err(ActionGroupError::mixed()),
+                    }
+                }
+                Ok(ActionGroup::BundlableGeneral(BundlableGeneral {
+                    actions: bundlable_general_actions,
+                }))
+            }
+        }
+    }
+
+    pub(super) fn to_raw_protobuf_mut(&mut self) -> Vec<raw::Action> {
+        match self {
+            ActionGroup::Sudo(sudo) => {
+                let action = &sudo.actions;
+                match action {
+                    SudoAction::SudoAddressChange(act) => {
+                        vec![raw::Action {
+                            value: Some(Value::SudoAddressChangeAction(act.to_raw())),
+                        }]
+                    }
+                }
+            }
+            ActionGroup::General(general) => {
+                let action = &general.actions;
+                match action {
+                    GeneralAction::InitBridgeAccount(act) => {
+                        vec![raw::Action {
+                            value: Some(Value::InitBridgeAccountAction(act.to_raw())),
+                        }]
+                    }
+                    GeneralAction::BridgeSudoChange(act) => {
+                        vec![raw::Action {
+                            value: Some(Value::BridgeSudoChangeAction(act.to_raw())),
+                        }]
+                    }
+                }
+            }
+            ActionGroup::BundlableGeneral(bundlable_general) => {
+                let mut actions = Vec::<raw::Action>::new();
+                for action in &mut bundlable_general.actions {
+                    match action {
+                        BundlableGeneralAction::Sequence(act) => {
+                            actions.push(raw::Action {
+                                value: Some(Value::SequenceAction(act.to_raw())),
+                            });
+                        }
+                        BundlableGeneralAction::Transfer(act) => {
+                            actions.push(raw::Action {
+                                value: Some(Value::TransferAction(act.to_raw())),
+                            });
+                        }
+                        BundlableGeneralAction::Ibc(act) => {
+                            actions.push(raw::Action {
+                                value: Some(Value::IbcAction(act.clone().into())),
+                            });
+                        }
+                        BundlableGeneralAction::Ics20Withdrawal(act) => {
+                            actions.push(raw::Action {
+                                value: Some(Value::Ics20Withdrawal(act.to_raw())),
+                            });
+                        }
+                        BundlableGeneralAction::BridgeLock(act) => {
+                            actions.push(raw::Action {
+                                value: Some(Value::BridgeLockAction(act.to_raw())),
+                            });
+                        }
+                        BundlableGeneralAction::BridgeUnlock(act) => {
+                            actions.push(raw::Action {
+                                value: Some(Value::BridgeUnlockAction(act.to_raw())),
+                            });
+                        }
+                        BundlableGeneralAction::ValidatorUpdate(act) => {
+                            actions.push(raw::Action {
+                                value: Some(Value::ValidatorUpdateAction(act.to_raw())),
+                            });
+                        }
+                    }
+                }
+                actions
+            }
+            ActionGroup::BundlableSudo(bundleable_sudo) => {
+                let mut actions = Vec::<raw::Action>::new();
+                for action in &mut bundleable_sudo.actions {
+                    match action {
+                        BundlableSudoAction::IbcRelayerChange(act) => {
+                            actions.push(raw::Action {
+                                value: Some(Value::IbcRelayerChangeAction(act.to_raw())),
+                            });
+                        }
+                        BundlableSudoAction::FeeAssetChange(act) => {
+                            actions.push(raw::Action {
+                                value: Some(Value::FeeAssetChangeAction(act.to_raw())),
+                            });
+                        }
+                        BundlableSudoAction::FeeChange(act) => {
+                            actions.push(raw::Action {
+                                value: Some(Value::FeeChangeAction(act.to_raw())),
+                            });
+                        }
+                    }
+                }
+                actions
+            }
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum ActionGroupErrorKind {
+    #[error("`actions` field is invalid")]
+    Action(#[source] ActionError),
+    #[error("no actions provided")]
+    Empty,
+    #[error("input contains mixed action types")]
+    Mixed,
+    #[error("input attempted to bundle non bundleable action type")]
+    NotBundleable,
+    #[error("tried to convert from wrong ActionGroup type for inner action")]
+    WrongActionGroupType,
+}
+
+#[allow(clippy::module_name_repetitions)]
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub struct ActionGroupError(ActionGroupErrorKind);
+impl ActionGroupError {
+    fn action(inner: ActionError) -> Self {
+        Self(ActionGroupErrorKind::Action(inner))
+    }
+
+    fn empty() -> Self {
+        Self(ActionGroupErrorKind::Empty)
+    }
+
+    fn mixed() -> Self {
+        Self(ActionGroupErrorKind::Mixed)
+    }
+
+    fn not_bundlable() -> Self {
+        Self(ActionGroupErrorKind::NotBundleable)
+    }
+
+    fn wrong_action_group_type() -> Self {
+        Self(ActionGroupErrorKind::WrongActionGroupType)
+    }
+}
+
+#[allow(clippy::large_enum_variant)] // TODO: figure out if this is a problem
+#[derive(Clone, Debug)]
+pub enum ActionGroup {
+    BundlableGeneral(BundlableGeneral),
+    General(General),
+    BundlableSudo(BundlableSudo),
+    Sudo(Sudo),
+}
+
+#[derive(Clone, Debug)]
+pub struct BundlableGeneral {
+    pub actions: Vec<BundlableGeneralAction>,
+}
+
+#[derive(Clone, Debug)]
+#[cfg_attr(
+    feature = "serde",
+    derive(::serde::Deserialize, ::serde::Serialize),
+    serde(into = "raw::Action", try_from = "raw::Action")
+)]
+pub enum BundlableGeneralAction {
+    Sequence(SequenceAction),
+    Transfer(TransferAction),
+    Ibc(IbcRelay),
+    Ics20Withdrawal(Ics20Withdrawal),
+    BridgeLock(BridgeLockAction),
+    BridgeUnlock(BridgeUnlockAction),
+    ValidatorUpdate(ValidatorUpdate),
+}
+
+impl From<BundlableGeneralAction> for raw::Action {
+    fn from(value: BundlableGeneralAction) -> Self {
+        use raw::action::Value;
+        match value {
+            BundlableGeneralAction::Sequence(act) => Self {
+                value: Some(Value::SequenceAction(act.into_raw())),
+            },
+            BundlableGeneralAction::Transfer(act) => Self {
+                value: Some(Value::TransferAction(act.to_raw())),
+            },
+            BundlableGeneralAction::Ibc(act) => Self {
+                value: Some(Value::IbcAction(act.into())),
+            },
+            BundlableGeneralAction::Ics20Withdrawal(act) => Self {
+                value: Some(Value::Ics20Withdrawal(act.to_raw())),
+            },
+            BundlableGeneralAction::BridgeLock(act) => Self {
+                value: Some(Value::BridgeLockAction(act.to_raw())),
+            },
+            BundlableGeneralAction::BridgeUnlock(act) => Self {
+                value: Some(Value::BridgeUnlockAction(act.to_raw())),
+            },
+            BundlableGeneralAction::ValidatorUpdate(act) => Self {
+                value: Some(Value::ValidatorUpdateAction(act.to_raw())),
+            },
+        }
+    }
+}
+
+impl TryFrom<raw::Action> for BundlableGeneralAction {
+    type Error = ActionGroupError;
+
+    fn try_from(value: raw::Action) -> Result<Self, Self::Error> {
+        match value.value {
+            Some(raw::action::Value::SequenceAction(act)) => Ok(BundlableGeneralAction::Sequence(
+                SequenceAction::try_from_raw(act)
+                    .map_err(ActionError::sequence)
+                    .map_err(ActionGroupError::action)?,
+            )),
+            Some(raw::action::Value::TransferAction(act)) => Ok(BundlableGeneralAction::Transfer(
+                TransferAction::try_from_raw(act)
+                    .map_err(ActionError::transfer)
+                    .map_err(ActionGroupError::action)?,
+            )),
+            Some(raw::action::Value::IbcAction(act)) => Ok(BundlableGeneralAction::Ibc(
+                IbcRelay::try_from(act)
+                    .map_err(|e| ActionError::ibc(e.into()))
+                    .map_err(ActionGroupError::action)?,
+            )),
+            Some(raw::action::Value::Ics20Withdrawal(act)) => {
+                Ok(BundlableGeneralAction::Ics20Withdrawal(
+                    Ics20Withdrawal::try_from_raw(act)
+                        .map_err(ActionError::ics20_withdrawal)
+                        .map_err(ActionGroupError::action)?,
+                ))
+            }
+            Some(raw::action::Value::BridgeLockAction(act)) => {
+                Ok(BundlableGeneralAction::BridgeLock(
+                    BridgeLockAction::try_from_raw(act)
+                        .map_err(ActionError::bridge_lock)
+                        .map_err(ActionGroupError::action)?,
+                ))
+            }
+            Some(raw::action::Value::BridgeUnlockAction(act)) => {
+                Ok(BundlableGeneralAction::BridgeUnlock(
+                    BridgeUnlockAction::try_from_raw(act)
+                        .map_err(ActionError::bridge_unlock)
+                        .map_err(ActionGroupError::action)?,
+                ))
+            }
+            Some(raw::action::Value::ValidatorUpdateAction(act)) => {
+                Ok(BundlableGeneralAction::ValidatorUpdate(
+                    ValidatorUpdate::try_from_raw(act)
+                        .map_err(ActionError::validator_update)
+                        .map_err(ActionGroupError::action)?,
+                ))
+            }
+            _ => Err(ActionGroupError::wrong_action_group_type()),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct General {
+    pub actions: GeneralAction,
+}
+
+#[derive(Clone, Debug)]
+#[cfg_attr(
+    feature = "serde",
+    derive(::serde::Deserialize, ::serde::Serialize),
+    serde(into = "raw::Action", try_from = "raw::Action")
+)]
+pub enum GeneralAction {
+    InitBridgeAccount(InitBridgeAccountAction),
+    BridgeSudoChange(BridgeSudoChangeAction),
+}
+
+impl From<GeneralAction> for raw::Action {
+    fn from(value: GeneralAction) -> Self {
+        use raw::action::Value;
+        match value {
+            GeneralAction::InitBridgeAccount(act) => Self {
+                value: Some(Value::InitBridgeAccountAction(act.to_raw())),
+            },
+            GeneralAction::BridgeSudoChange(act) => Self {
+                value: Some(Value::BridgeSudoChangeAction(act.to_raw())),
+            },
+        }
+    }
+}
+
+impl TryFrom<raw::Action> for GeneralAction {
+    type Error = ActionGroupError;
+
+    fn try_from(value: raw::Action) -> Result<Self, Self::Error> {
+        match value.value {
+            Some(raw::action::Value::InitBridgeAccountAction(act)) => {
+                Ok(GeneralAction::InitBridgeAccount(
+                    InitBridgeAccountAction::try_from_raw(act)
+                        .map_err(ActionError::init_bridge_account)
+                        .map_err(ActionGroupError::action)?,
+                ))
+            }
+            Some(raw::action::Value::BridgeSudoChangeAction(act)) => {
+                Ok(GeneralAction::BridgeSudoChange(
+                    BridgeSudoChangeAction::try_from_raw(act)
+                        .map_err(ActionError::bridge_sudo_change)
+                        .map_err(ActionGroupError::action)?,
+                ))
+            }
+            _ => Err(ActionGroupError::wrong_action_group_type()),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct BundlableSudo {
+    pub actions: Vec<BundlableSudoAction>,
+}
+
+#[derive(Clone, Debug)]
+pub enum BundlableSudoAction {
+    IbcRelayerChange(IbcRelayerChangeAction),
+    FeeAssetChange(FeeAssetChangeAction),
+    FeeChange(FeeChangeAction),
+}
+
+#[derive(Clone, Debug)]
+pub struct Sudo {
+    pub actions: SudoAction,
+}
+
+#[derive(Clone, Debug)]
+pub enum SudoAction {
+    SudoAddressChange(SudoAddressChangeAction),
+}
+
+impl From<BundlableGeneral> for ActionGroup {
+    fn from(bundlable_general: BundlableGeneral) -> Self {
+        ActionGroup::BundlableGeneral(bundlable_general)
+    }
+}
+
+impl From<BundlableSudo> for ActionGroup {
+    fn from(bundlable_sudo: BundlableSudo) -> Self {
+        ActionGroup::BundlableSudo(bundlable_sudo)
+    }
+}
+
+impl From<General> for ActionGroup {
+    fn from(general: General) -> Self {
+        ActionGroup::General(general)
+    }
+}
+
+impl From<Sudo> for ActionGroup {
+    fn from(sudo: Sudo) -> Self {
+        ActionGroup::Sudo(sudo)
+    }
+}

--- a/crates/astria-sequencer-client/src/tests/http.rs
+++ b/crates/astria-sequencer-client/src/tests/http.rs
@@ -6,6 +6,7 @@ use astria_core::{
     primitive::v1::Address,
     protocol::transaction::v1alpha1::{
         action::TransferAction,
+        action_groups::BundlableGeneral,
         SignedTransaction,
         TransactionParams,
         UnsignedTransaction,
@@ -162,7 +163,10 @@ fn create_signed_transaction() -> SignedTransaction {
             .nonce(1)
             .chain_id("test")
             .build(),
-        actions,
+        actions: BundlableGeneral {
+            actions,
+        }
+        .into(),
     }
     .into_signed(&alice_key)
 }

--- a/crates/astria-sequencer/src/app/test_utils.rs
+++ b/crates/astria-sequencer/src/app/test_utils.rs
@@ -23,6 +23,7 @@ use astria_core::{
                 SequenceAction,
                 ValidatorUpdate,
             },
+            action_groups::BundlableGeneral,
             SignedTransaction,
             TransactionParams,
             UnsignedTransaction,
@@ -228,14 +229,17 @@ pub(crate) fn mock_tx(
             .nonce(nonce)
             .chain_id("test")
             .build(),
-        actions: vec![
-            SequenceAction {
-                rollup_id: RollupId::from_unhashed_bytes(rollup_name.as_bytes()),
-                data: Bytes::from_static(&[0x99]),
-                fee_asset: denom_0(),
-            }
-            .into(),
-        ],
+        actions: BundlableGeneral {
+            actions: vec![
+                SequenceAction {
+                    rollup_id: RollupId::from_unhashed_bytes(rollup_name.as_bytes()),
+                    data: Bytes::from_static(&[0x99]),
+                    fee_asset: denom_0(),
+                }
+                .into(),
+            ],
+        }
+        .into(),
     };
 
     Arc::new(tx.into_signed(signer))

--- a/crates/astria-sequencer/src/app/tests_app/mempool.rs
+++ b/crates/astria-sequencer/src/app/tests_app/mempool.rs
@@ -9,6 +9,7 @@ use astria_core::{
                 FeeChangeAction,
                 TransferAction,
             },
+            action_groups::BundlableSudo,
             TransactionParams,
             UnsignedTransaction,
         },
@@ -56,13 +57,16 @@ async fn trigger_cleaning() {
             .nonce(0)
             .chain_id("test")
             .build(),
-        actions: vec![
-            FeeChangeAction {
-                fee_change: FeeChange::TransferBaseFee,
-                new_value: 10,
-            }
-            .into(),
-        ],
+        actions: BundlableSudo {
+            actions: vec![
+                FeeChangeAction {
+                    fee_change: FeeChange::TransferBaseFee,
+                    new_value: 10,
+                }
+                .into(),
+            ],
+        }
+        .into(),
     }
     .into_signed(&sudo);
 
@@ -156,13 +160,16 @@ async fn do_not_trigger_cleaning() {
             .nonce(0)
             .chain_id("test")
             .build(),
-        actions: vec![
-            FeeChangeAction {
-                fee_change: FeeChange::TransferBaseFee,
-                new_value: 10,
-            }
-            .into(),
-        ],
+        actions: BundlableSudo {
+            actions: vec![
+                FeeChangeAction {
+                    fee_change: FeeChange::TransferBaseFee,
+                    new_value: 10,
+                }
+                .into(),
+            ],
+        }
+        .into(),
     }
     .into_signed(&alice);
 
@@ -229,15 +236,18 @@ async fn maintenance_recosting_promotes() {
             .nonce(0)
             .chain_id("test")
             .build(),
-        actions: vec![
-            TransferAction {
-                to: astria_address_from_hex_string(CAROL_ADDRESS),
-                amount: 1u128,
-                asset: nria().into(),
-                fee_asset: nria().into(),
-            }
-            .into(),
-        ],
+        actions: BundlableGeneral {
+            actions: vec![
+                TransferAction {
+                    to: astria_address_from_hex_string(CAROL_ADDRESS),
+                    amount: 1u128,
+                    asset: nria().into(),
+                    fee_asset: nria().into(),
+                }
+                .into(),
+            ],
+        }
+        .into(),
     }
     .into_signed(&get_bob_signing_key());
 
@@ -261,13 +271,16 @@ async fn maintenance_recosting_promotes() {
             .nonce(0)
             .chain_id("test")
             .build(),
-        actions: vec![
-            FeeChangeAction {
-                fee_change: FeeChange::TransferBaseFee,
-                new_value: 10, // originally 12
-            }
-            .into(),
-        ],
+        actions: BundlableSudo {
+            actions: vec![
+                FeeChangeAction {
+                    fee_change: FeeChange::TransferBaseFee,
+                    new_value: 10, // originally 12
+                }
+                .into(),
+            ],
+        }
+        .into(),
     }
     .into_signed(&get_judy_signing_key());
 
@@ -402,15 +415,18 @@ async fn maintenance_funds_added_promotes() {
             .nonce(0)
             .chain_id("test")
             .build(),
-        actions: vec![
-            TransferAction {
-                to: astria_address_from_hex_string(BOB_ADDRESS),
-                amount: 10u128,
-                asset: nria().into(),
-                fee_asset: nria().into(),
-            }
-            .into(),
-        ],
+        actions: BundlableGeneral {
+            actions: vec![
+                TransferAction {
+                    to: astria_address_from_hex_string(BOB_ADDRESS),
+                    amount: 10u128,
+                    asset: nria().into(),
+                    fee_asset: nria().into(),
+                }
+                .into(),
+            ],
+        }
+        .into(),
     }
     .into_signed(&get_carol_signing_key());
 
@@ -434,15 +450,18 @@ async fn maintenance_funds_added_promotes() {
             .nonce(0)
             .chain_id("test")
             .build(),
-        actions: vec![
-            TransferAction {
-                to: astria_address_from_hex_string(CAROL_ADDRESS),
-                amount: 22u128,
-                asset: nria().into(),
-                fee_asset: nria().into(),
-            }
-            .into(),
-        ],
+        actions: BundlableGeneral {
+            actions: vec![
+                TransferAction {
+                    to: astria_address_from_hex_string(CAROL_ADDRESS),
+                    amount: 22u128,
+                    asset: nria().into(),
+                    fee_asset: nria().into(),
+                }
+                .into(),
+            ],
+        }
+        .into(),
     }
     .into_signed(&get_alice_signing_key());
 

--- a/crates/astria-sequencer/src/app/tests_app/mod.rs
+++ b/crates/astria-sequencer/src/app/tests_app/mod.rs
@@ -15,6 +15,11 @@ use astria_core::{
                 SequenceAction,
                 TransferAction,
             },
+            action_groups::{
+                ActionGroup,
+                BundlableGeneral,
+                BundlableGeneralAction,
+            },
             TransactionParams,
             UnsignedTransaction,
         },
@@ -236,15 +241,14 @@ async fn app_transfer_block_fees_to_sudo() {
             .nonce(0)
             .chain_id("test")
             .build(),
-        actions: vec![
-            TransferAction {
+        actions: ActionGroup::BundlableGeneral(BundlableGeneral {
+            actions: vec![BundlableGeneralAction::Transfer(TransferAction {
                 to: bob_address,
                 amount,
                 asset: nria().into(),
                 fee_asset: nria().into(),
-            }
-            .into(),
-        ],
+            })],
+        }),
     };
 
     let signed_tx = tx.into_signed(&alice);
@@ -326,7 +330,10 @@ async fn app_create_sequencer_block_with_sequenced_data_and_deposits() {
             .nonce(0)
             .chain_id("test")
             .build(),
-        actions: vec![lock_action.into(), sequence_action.into()],
+        actions: BundlableGeneral {
+            actions: vec![lock_action.into(), sequence_action.into()],
+        }
+        .into(),
     };
 
     let signed_tx = tx.into_signed(&alice);
@@ -419,7 +426,10 @@ async fn app_execution_results_match_proposal_vs_after_proposal() {
             .nonce(0)
             .chain_id("test")
             .build(),
-        actions: vec![lock_action.into(), sequence_action.into()],
+        actions: BundlableGeneral {
+            actions: vec![lock_action.into(), sequence_action.into()],
+        }
+        .into(),
     };
 
     let signed_tx = tx.into_signed(&alice);
@@ -556,14 +566,17 @@ async fn app_prepare_proposal_cometbft_max_bytes_overflow_ok() {
             .nonce(0)
             .chain_id("test")
             .build(),
-        actions: vec![
-            SequenceAction {
-                rollup_id: RollupId::from([1u8; 32]),
-                data: Bytes::copy_from_slice(&[1u8; 100_000]),
-                fee_asset: nria().into(),
-            }
-            .into(),
-        ],
+        actions: BundlableGeneral {
+            actions: vec![
+                SequenceAction {
+                    rollup_id: RollupId::from([1u8; 32]),
+                    data: Bytes::copy_from_slice(&[1u8; 100_000]),
+                    fee_asset: nria().into(),
+                }
+                .into(),
+            ],
+        }
+        .into(),
     }
     .into_signed(&alice);
     let tx_overflow = UnsignedTransaction {
@@ -571,14 +584,17 @@ async fn app_prepare_proposal_cometbft_max_bytes_overflow_ok() {
             .nonce(1)
             .chain_id("test")
             .build(),
-        actions: vec![
-            SequenceAction {
-                rollup_id: RollupId::from([1u8; 32]),
-                data: Bytes::copy_from_slice(&[1u8; 100_000]),
-                fee_asset: nria().into(),
-            }
-            .into(),
-        ],
+        actions: BundlableGeneral {
+            actions: vec![
+                SequenceAction {
+                    rollup_id: RollupId::from([1u8; 32]),
+                    data: Bytes::copy_from_slice(&[1u8; 100_000]),
+                    fee_asset: nria().into(),
+                }
+                .into(),
+            ],
+        }
+        .into(),
     }
     .into_signed(&alice);
 
@@ -648,14 +664,17 @@ async fn app_prepare_proposal_sequencer_max_bytes_overflow_ok() {
             .nonce(0)
             .chain_id("test")
             .build(),
-        actions: vec![
-            SequenceAction {
-                rollup_id: RollupId::from([1u8; 32]),
-                data: Bytes::copy_from_slice(&[1u8; 200_000]),
-                fee_asset: nria().into(),
-            }
-            .into(),
-        ],
+        actions: BundlableGeneral {
+            actions: vec![
+                SequenceAction {
+                    rollup_id: RollupId::from([1u8; 32]),
+                    data: Bytes::copy_from_slice(&[1u8; 200_000]),
+                    fee_asset: nria().into(),
+                }
+                .into(),
+            ],
+        }
+        .into(),
     }
     .into_signed(&alice);
     let tx_overflow = UnsignedTransaction {
@@ -663,14 +682,17 @@ async fn app_prepare_proposal_sequencer_max_bytes_overflow_ok() {
             .nonce(1)
             .chain_id("test")
             .build(),
-        actions: vec![
-            SequenceAction {
-                rollup_id: RollupId::from([1u8; 32]),
-                data: Bytes::copy_from_slice(&[1u8; 100_000]),
-                fee_asset: nria().into(),
-            }
-            .into(),
-        ],
+        actions: BundlableGeneral {
+            actions: vec![
+                SequenceAction {
+                    rollup_id: RollupId::from([1u8; 32]),
+                    data: Bytes::copy_from_slice(&[1u8; 100_000]),
+                    fee_asset: nria().into(),
+                }
+                .into(),
+            ],
+        }
+        .into(),
     }
     .into_signed(&alice);
 

--- a/crates/astria-sequencer/src/app/tests_block_fees.rs
+++ b/crates/astria-sequencer/src/app/tests_block_fees.rs
@@ -10,6 +10,11 @@ use astria_core::{
             SequenceAction,
             TransferAction,
         },
+        action_groups::{
+            BundlableGeneral,
+            General,
+            GeneralAction,
+        },
         TransactionParams,
         UnsignedTransaction,
     },
@@ -58,15 +63,18 @@ async fn transaction_execution_records_fee_event() {
             .nonce(0)
             .chain_id("test")
             .build(),
-        actions: vec![
-            TransferAction {
-                to: bob_address,
-                amount: value,
-                asset: nria().into(),
-                fee_asset: nria().into(),
-            }
-            .into(),
-        ],
+        actions: BundlableGeneral {
+            actions: vec![
+                TransferAction {
+                    to: bob_address,
+                    amount: value,
+                    asset: nria().into(),
+                    fee_asset: nria().into(),
+                }
+                .into(),
+            ],
+        }
+        .into(),
     };
 
     let signed_tx = Arc::new(tx.into_signed(&alice));
@@ -119,7 +127,10 @@ async fn ensure_correct_block_fees_transfer() {
             .nonce(0)
             .chain_id("test")
             .build(),
-        actions,
+        actions: BundlableGeneral {
+            actions,
+        }
+        .into(),
     };
     let signed_tx = Arc::new(tx.into_signed(&alice));
     app.execute_transaction(signed_tx).await.unwrap();
@@ -160,7 +171,10 @@ async fn ensure_correct_block_fees_sequence() {
             .nonce(0)
             .chain_id("test")
             .build(),
-        actions,
+        actions: BundlableGeneral {
+            actions,
+        }
+        .into(),
     };
     let signed_tx = Arc::new(tx.into_signed(&alice));
     app.execute_transaction(signed_tx).await.unwrap();
@@ -187,23 +201,24 @@ async fn ensure_correct_block_fees_init_bridge_acct() {
 
     let alice = get_alice_signing_key();
 
-    let actions = vec![
-        InitBridgeAccountAction {
-            rollup_id: RollupId::from_unhashed_bytes(b"testchainid"),
-            asset: nria().into(),
-            fee_asset: nria().into(),
-            sudo_address: None,
-            withdrawer_address: None,
-        }
-        .into(),
-    ];
+    let actions: GeneralAction = InitBridgeAccountAction {
+        rollup_id: RollupId::from_unhashed_bytes(b"testchainid"),
+        asset: nria().into(),
+        fee_asset: nria().into(),
+        sudo_address: None,
+        withdrawer_address: None,
+    }
+    .into();
 
     let tx = UnsignedTransaction {
         params: TransactionParams::builder()
             .nonce(0)
             .chain_id("test")
             .build(),
-        actions,
+        actions: General {
+            actions,
+        }
+        .into(),
     };
     let signed_tx = Arc::new(tx.into_signed(&alice));
     app.execute_transaction(signed_tx).await.unwrap();
@@ -257,7 +272,10 @@ async fn ensure_correct_block_fees_bridge_lock() {
             .nonce(0)
             .chain_id("test")
             .build(),
-        actions,
+        actions: BundlableGeneral {
+            actions,
+        }
+        .into(),
     };
     let signed_tx = Arc::new(tx.into_signed(&alice));
     app.execute_transaction(signed_tx.clone()).await.unwrap();
@@ -304,22 +322,23 @@ async fn ensure_correct_block_fees_bridge_sudo_change() {
         .unwrap();
     app.apply(state_tx);
 
-    let actions = vec![
-        BridgeSudoChangeAction {
-            bridge_address,
-            new_sudo_address: None,
-            new_withdrawer_address: None,
-            fee_asset: nria().into(),
-        }
-        .into(),
-    ];
+    let actions = BridgeSudoChangeAction {
+        bridge_address,
+        new_sudo_address: None,
+        new_withdrawer_address: None,
+        fee_asset: nria().into(),
+    }
+    .into();
 
     let tx = UnsignedTransaction {
         params: TransactionParams::builder()
             .nonce(0)
             .chain_id("test")
             .build(),
-        actions,
+        actions: General {
+            actions,
+        }
+        .into(),
     };
     let signed_tx = Arc::new(tx.into_signed(&alice));
     app.execute_transaction(signed_tx).await.unwrap();

--- a/crates/astria-sequencer/src/app/tests_execute_transaction.rs
+++ b/crates/astria-sequencer/src/app/tests_execute_transaction.rs
@@ -18,7 +18,12 @@ use astria_core::{
                 TransferAction,
                 ValidatorUpdate,
             },
-            Action,
+            action_groups::{
+                BundlableGeneral,
+                BundlableSudo,
+                General,
+                Sudo,
+            },
             TransactionParams,
             UnsignedTransaction,
         },
@@ -108,15 +113,18 @@ async fn app_execute_transaction_transfer() {
             .nonce(0)
             .chain_id("test")
             .build(),
-        actions: vec![
-            TransferAction {
-                to: bob_address,
-                amount: value,
-                asset: crate::test_utils::nria().into(),
-                fee_asset: crate::test_utils::nria().into(),
-            }
-            .into(),
-        ],
+        actions: BundlableGeneral {
+            actions: vec![
+                TransferAction {
+                    to: bob_address,
+                    amount: value,
+                    asset: crate::test_utils::nria().into(),
+                    fee_asset: crate::test_utils::nria().into(),
+                }
+                .into(),
+            ],
+        }
+        .into(),
     };
 
     let signed_tx = Arc::new(tx.into_signed(&alice));
@@ -165,15 +173,18 @@ async fn app_execute_transaction_transfer_not_native_token() {
             .nonce(0)
             .chain_id("test")
             .build(),
-        actions: vec![
-            TransferAction {
-                to: bob_address,
-                amount: value,
-                asset: test_asset(),
-                fee_asset: nria().into(),
-            }
-            .into(),
-        ],
+        actions: BundlableGeneral {
+            actions: vec![
+                TransferAction {
+                    to: bob_address,
+                    amount: value,
+                    asset: test_asset(),
+                    fee_asset: nria().into(),
+                }
+                .into(),
+            ],
+        }
+        .into(),
     };
 
     let signed_tx = Arc::new(tx.into_signed(&alice));
@@ -230,15 +241,18 @@ async fn app_execute_transaction_transfer_balance_too_low_for_fee() {
             .nonce(0)
             .chain_id("test")
             .build(),
-        actions: vec![
-            TransferAction {
-                to: bob,
-                amount: 0,
-                asset: nria().into(),
-                fee_asset: nria().into(),
-            }
-            .into(),
-        ],
+        actions: BundlableGeneral {
+            actions: vec![
+                TransferAction {
+                    to: bob,
+                    amount: 0,
+                    asset: nria().into(),
+                    fee_asset: nria().into(),
+                }
+                .into(),
+            ],
+        }
+        .into(),
     };
 
     let signed_tx = Arc::new(tx.into_signed(&keypair));
@@ -271,14 +285,17 @@ async fn app_execute_transaction_sequence() {
             .nonce(0)
             .chain_id("test")
             .build(),
-        actions: vec![
-            SequenceAction {
-                rollup_id: RollupId::from_unhashed_bytes(b"testchainid"),
-                data,
-                fee_asset: nria().into(),
-            }
-            .into(),
-        ],
+        actions: BundlableGeneral {
+            actions: vec![
+                SequenceAction {
+                    rollup_id: RollupId::from_unhashed_bytes(b"testchainid"),
+                    data,
+                    fee_asset: nria().into(),
+                }
+                .into(),
+            ],
+        }
+        .into(),
     };
 
     let signed_tx = Arc::new(tx.into_signed(&alice));
@@ -306,14 +323,17 @@ async fn app_execute_transaction_invalid_fee_asset() {
             .nonce(0)
             .chain_id("test")
             .build(),
-        actions: vec![
-            SequenceAction {
-                rollup_id: RollupId::from_unhashed_bytes(b"testchainid"),
-                data,
-                fee_asset: test_asset(),
-            }
-            .into(),
-        ],
+        actions: BundlableGeneral {
+            actions: vec![
+                SequenceAction {
+                    rollup_id: RollupId::from_unhashed_bytes(b"testchainid"),
+                    data,
+                    fee_asset: test_asset(),
+                }
+                .into(),
+            ],
+        }
+        .into(),
     };
 
     let signed_tx = Arc::new(tx.into_signed(&alice));
@@ -337,7 +357,10 @@ async fn app_execute_transaction_validator_update() {
             .nonce(0)
             .chain_id("test")
             .build(),
-        actions: vec![Action::ValidatorUpdate(update.clone())],
+        actions: BundlableGeneral {
+            actions: vec![update.clone().into()],
+        }
+        .into(),
     };
 
     let signed_tx = Arc::new(tx.into_signed(&alice));
@@ -364,7 +387,10 @@ async fn app_execute_transaction_ibc_relayer_change_addition() {
             .nonce(0)
             .chain_id("test")
             .build(),
-        actions: vec![IbcRelayerChangeAction::Addition(alice_address).into()],
+        actions: BundlableSudo {
+            actions: vec![IbcRelayerChangeAction::Addition(alice_address).into()],
+        }
+        .into(),
     };
 
     let signed_tx = Arc::new(tx.into_signed(&alice));
@@ -392,7 +418,10 @@ async fn app_execute_transaction_ibc_relayer_change_deletion() {
             .nonce(0)
             .chain_id("test")
             .build(),
-        actions: vec![IbcRelayerChangeAction::Removal(alice_address).into()],
+        actions: BundlableSudo {
+            actions: vec![IbcRelayerChangeAction::Removal(alice_address).into()],
+        }
+        .into(),
     };
 
     let signed_tx = Arc::new(tx.into_signed(&alice));
@@ -422,7 +451,10 @@ async fn app_execute_transaction_ibc_relayer_change_invalid() {
             .nonce(0)
             .chain_id("test")
             .build(),
-        actions: vec![IbcRelayerChangeAction::Removal(alice_address).into()],
+        actions: BundlableSudo {
+            actions: vec![IbcRelayerChangeAction::Removal(alice_address).into()],
+        }
+        .into(),
     };
 
     let signed_tx = Arc::new(tx.into_signed(&alice));
@@ -443,9 +475,13 @@ async fn app_execute_transaction_sudo_address_change() {
             .nonce(0)
             .chain_id("test")
             .build(),
-        actions: vec![Action::SudoAddressChange(SudoAddressChangeAction {
-            new_address,
-        })],
+        actions: Sudo {
+            actions: SudoAddressChangeAction {
+                new_address,
+            }
+            .into(),
+        }
+        .into(),
     };
 
     let signed_tx = Arc::new(tx.into_signed(&alice));
@@ -481,9 +517,13 @@ async fn app_execute_transaction_sudo_address_change_error() {
             .nonce(0)
             .chain_id("test")
             .build(),
-        actions: vec![Action::SudoAddressChange(SudoAddressChangeAction {
-            new_address: alice_address,
-        })],
+        actions: Sudo {
+            actions: SudoAddressChangeAction {
+                new_address: alice_address,
+            }
+            .into(),
+        }
+        .into(),
     };
 
     let signed_tx = Arc::new(tx.into_signed(&alice));
@@ -510,9 +550,10 @@ async fn app_execute_transaction_fee_asset_change_addition() {
             .nonce(0)
             .chain_id("test")
             .build(),
-        actions: vec![Action::FeeAssetChange(FeeAssetChangeAction::Addition(
-            test_asset(),
-        ))],
+        actions: BundlableSudo {
+            actions: vec![FeeAssetChangeAction::Addition(test_asset()).into()],
+        }
+        .into(),
     };
 
     let signed_tx = Arc::new(tx.into_signed(&alice));
@@ -543,9 +584,10 @@ async fn app_execute_transaction_fee_asset_change_removal() {
             .nonce(0)
             .chain_id("test")
             .build(),
-        actions: vec![Action::FeeAssetChange(FeeAssetChangeAction::Removal(
-            test_asset(),
-        ))],
+        actions: BundlableSudo {
+            actions: vec![FeeAssetChangeAction::Removal(test_asset()).into()],
+        }
+        .into(),
     };
 
     let signed_tx = Arc::new(tx.into_signed(&alice));
@@ -568,9 +610,10 @@ async fn app_execute_transaction_fee_asset_change_invalid() {
             .nonce(0)
             .chain_id("test")
             .build(),
-        actions: vec![Action::FeeAssetChange(FeeAssetChangeAction::Removal(
-            nria().into(),
-        ))],
+        actions: BundlableSudo {
+            actions: vec![FeeAssetChangeAction::Removal(nria().into()).into()],
+        }
+        .into(),
     };
 
     let signed_tx = Arc::new(tx.into_signed(&alice));
@@ -609,7 +652,10 @@ async fn app_execute_transaction_init_bridge_account_ok() {
             .nonce(0)
             .chain_id("test")
             .build(),
-        actions: vec![action.into()],
+        actions: General {
+            actions: action.into(),
+        }
+        .into(),
     };
 
     let signed_tx = Arc::new(tx.into_signed(&alice));
@@ -666,7 +712,10 @@ async fn app_execute_transaction_init_bridge_account_account_already_registered(
             .chain_id("test")
             .build(),
 
-        actions: vec![action.into()],
+        actions: General {
+            actions: action.into(),
+        }
+        .into(),
     };
 
     let signed_tx = Arc::new(tx.into_signed(&alice));
@@ -684,7 +733,10 @@ async fn app_execute_transaction_init_bridge_account_account_already_registered(
             .nonce(0)
             .chain_id("test")
             .build(),
-        actions: vec![action.into()],
+        actions: General {
+            actions: action.into(),
+        }
+        .into(),
     };
 
     let signed_tx = Arc::new(tx.into_signed(&alice));
@@ -721,7 +773,10 @@ async fn app_execute_transaction_bridge_lock_action_ok() {
             .nonce(0)
             .chain_id("test")
             .build(),
-        actions: vec![action.into()],
+        actions: BundlableGeneral {
+            actions: vec![action.into()],
+        }
+        .into(),
     };
 
     let signed_tx = Arc::new(tx.into_signed(&alice));
@@ -800,7 +855,10 @@ async fn app_execute_transaction_bridge_lock_action_invalid_for_eoa() {
             .nonce(0)
             .chain_id("test")
             .build(),
-        actions: vec![action.into()],
+        actions: BundlableGeneral {
+            actions: vec![action.into()],
+        }
+        .into(),
     };
 
     let signed_tx = Arc::new(tx.into_signed(&alice));
@@ -821,14 +879,17 @@ async fn app_execute_transaction_invalid_nonce() {
             .nonce(1)
             .chain_id("test")
             .build(),
-        actions: vec![
-            SequenceAction {
-                rollup_id: RollupId::from_unhashed_bytes(b"testchainid"),
-                data,
-                fee_asset: nria().into(),
-            }
-            .into(),
-        ],
+        actions: BundlableGeneral {
+            actions: vec![
+                SequenceAction {
+                    rollup_id: RollupId::from_unhashed_bytes(b"testchainid"),
+                    data,
+                    fee_asset: nria().into(),
+                }
+                .into(),
+            ],
+        }
+        .into(),
     };
 
     let signed_tx = Arc::new(tx.into_signed(&alice));
@@ -868,14 +929,17 @@ async fn app_execute_transaction_invalid_chain_id() {
             .nonce(0)
             .chain_id("wrong-chain")
             .build(),
-        actions: vec![
-            SequenceAction {
-                rollup_id: RollupId::from_unhashed_bytes(b"testchainid"),
-                data,
-                fee_asset: nria().into(),
-            }
-            .into(),
-        ],
+        actions: BundlableGeneral {
+            actions: vec![
+                SequenceAction {
+                    rollup_id: RollupId::from_unhashed_bytes(b"testchainid"),
+                    data,
+                    fee_asset: nria().into(),
+                }
+                .into(),
+            ],
+        }
+        .into(),
     };
 
     let signed_tx = Arc::new(tx.into_signed(&alice));
@@ -925,15 +989,18 @@ async fn app_stateful_check_fails_insufficient_total_balance() {
             .nonce(0)
             .chain_id("test")
             .build(),
-        actions: vec![
-            TransferAction {
-                to: keypair_address,
-                amount: fee,
-                asset: nria().into(),
-                fee_asset: nria().into(),
-            }
-            .into(),
-        ],
+        actions: BundlableGeneral {
+            actions: vec![
+                TransferAction {
+                    to: keypair_address,
+                    amount: fee,
+                    asset: nria().into(),
+                    fee_asset: nria().into(),
+                }
+                .into(),
+            ],
+        }
+        .into(),
     }
     .into_signed(&alice);
 
@@ -946,20 +1013,23 @@ async fn app_stateful_check_fails_insufficient_total_balance() {
             .nonce(0)
             .chain_id("test")
             .build(),
-        actions: vec![
-            SequenceAction {
-                rollup_id: RollupId::from_unhashed_bytes(b"testchainid"),
-                data: data.clone(),
-                fee_asset: nria().into(),
-            }
-            .into(),
-            SequenceAction {
-                rollup_id: RollupId::from_unhashed_bytes(b"testchainid"),
-                data: data.clone(),
-                fee_asset: nria().into(),
-            }
-            .into(),
-        ],
+        actions: BundlableGeneral {
+            actions: vec![
+                SequenceAction {
+                    rollup_id: RollupId::from_unhashed_bytes(b"testchainid"),
+                    data: data.clone(),
+                    fee_asset: nria().into(),
+                }
+                .into(),
+                SequenceAction {
+                    rollup_id: RollupId::from_unhashed_bytes(b"testchainid"),
+                    data: data.clone(),
+                    fee_asset: nria().into(),
+                }
+                .into(),
+            ],
+        }
+        .into(),
     }
     .into_signed(&keypair);
 
@@ -978,14 +1048,17 @@ async fn app_stateful_check_fails_insufficient_total_balance() {
             .nonce(0)
             .chain_id("test")
             .build(),
-        actions: vec![
-            SequenceAction {
-                rollup_id: RollupId::from_unhashed_bytes(b"testchainid"),
-                data,
-                fee_asset: nria().into(),
-            }
-            .into(),
-        ],
+        actions: BundlableGeneral {
+            actions: vec![
+                SequenceAction {
+                    rollup_id: RollupId::from_unhashed_bytes(b"testchainid"),
+                    data,
+                    fee_asset: nria().into(),
+                }
+                .into(),
+            ],
+        }
+        .into(),
     }
     .into_signed(&keypair);
 
@@ -1037,7 +1110,10 @@ async fn app_execute_transaction_bridge_lock_unlock_action_ok() {
             .nonce(0)
             .chain_id("test")
             .build(),
-        actions: vec![action.into()],
+        actions: BundlableGeneral {
+            actions: vec![action.into()],
+        }
+        .into(),
     };
 
     let signed_tx = Arc::new(tx.into_signed(&alice));
@@ -1061,7 +1137,10 @@ async fn app_execute_transaction_bridge_lock_unlock_action_ok() {
             .nonce(0)
             .chain_id("test")
             .build(),
-        actions: vec![action.into()],
+        actions: BundlableGeneral {
+            actions: vec![action.into()],
+        }
+        .into(),
     };
 
     let signed_tx = Arc::new(tx.into_signed(&bridge));
@@ -1108,7 +1187,10 @@ async fn app_execute_transaction_action_index_correctly_increments() {
             .nonce(0)
             .chain_id("test")
             .build(),
-        actions: vec![action.clone().into(), action.into()],
+        actions: BundlableGeneral {
+            actions: vec![action.clone().into(), action.into()],
+        }
+        .into(),
     };
 
     let signed_tx = Arc::new(tx.into_signed(&alice));
@@ -1144,16 +1226,19 @@ async fn transaction_execution_records_deposit_event() {
             .nonce(0)
             .chain_id("test")
             .build(),
-        actions: vec![
-            BridgeLockAction {
-                to: bob_address,
-                amount: 1,
-                asset: nria().into(),
-                fee_asset: nria().into(),
-                destination_chain_address: "test_chain_address".to_string(),
-            }
-            .into(),
-        ],
+        actions: BundlableGeneral {
+            actions: vec![
+                BridgeLockAction {
+                    to: bob_address,
+                    amount: 1,
+                    asset: nria().into(),
+                    fee_asset: nria().into(),
+                    destination_chain_address: "test_chain_address".to_string(),
+                }
+                .into(),
+            ],
+        }
+        .into(),
     };
 
     let signed_tx = Arc::new(tx.into_signed(&alice));

--- a/crates/astria-sequencer/src/proposal/commitment.rs
+++ b/crates/astria-sequencer/src/proposal/commitment.rs
@@ -98,6 +98,7 @@ mod test {
                 SequenceAction,
                 TransferAction,
             },
+            action_groups::BundlableGeneral,
             TransactionParams,
             UnsignedTransaction,
         },
@@ -126,7 +127,10 @@ mod test {
                 .nonce(0)
                 .chain_id("test-chain-1")
                 .build(),
-            actions: vec![sequence_action.clone().into(), transfer_action.into()],
+            actions: BundlableGeneral {
+                actions: vec![sequence_action.clone().into(), transfer_action.into()],
+            }
+            .into(),
         };
 
         let signed_tx = tx.into_signed(&signing_key);
@@ -142,7 +146,10 @@ mod test {
                 .nonce(0)
                 .chain_id("test-chain-1")
                 .build(),
-            actions: vec![sequence_action.into()],
+            actions: BundlableGeneral {
+                actions: vec![sequence_action.clone().into()],
+            }
+            .into(),
         };
 
         let signed_tx = tx.into_signed(&signing_key);
@@ -180,7 +187,10 @@ mod test {
                 .nonce(0)
                 .chain_id("test-chain-1")
                 .build(),
-            actions: vec![sequence_action.into(), transfer_action.into()],
+            actions: BundlableGeneral {
+                actions: vec![sequence_action.clone().into(), transfer_action.into()],
+            }
+            .into(),
         };
 
         let signed_tx = tx.into_signed(&signing_key);

--- a/crates/astria-sequencer/src/service/consensus.rs
+++ b/crates/astria-sequencer/src/service/consensus.rs
@@ -213,6 +213,7 @@ mod test {
         primitive::v1::RollupId,
         protocol::transaction::v1alpha1::{
             action::SequenceAction,
+            action_groups::BundlableGeneral,
             TransactionParams,
             UnsignedTransaction,
         },
@@ -244,14 +245,17 @@ mod test {
                 .nonce(0)
                 .chain_id("test")
                 .build(),
-            actions: vec![
-                SequenceAction {
-                    rollup_id: RollupId::from_unhashed_bytes(b"testchainid"),
-                    data: Bytes::from_static(b"hello world"),
-                    fee_asset: crate::test_utils::nria().into(),
-                }
-                .into(),
-            ],
+            actions: BundlableGeneral {
+                actions: vec![
+                    SequenceAction {
+                        rollup_id: RollupId::from_unhashed_bytes(b"testchainid"),
+                        data: Bytes::from_static(b"hello world"),
+                        fee_asset: crate::test_utils::nria().into(),
+                    }
+                    .into(),
+                ],
+            }
+            .into(),
         }
     }
 


### PR DESCRIPTION
## Summary
Introduces transaction 'types' that limit which types of Actions can be included in the same transaction.  

## Background
We want transactions that can affect the validity of other transactions to be ordered last in blocks to reduce the amount of failed transactions we process. These logic changes are the first code changes being made to realize this goal. 

## Testing
TODO

## Metrics
TODO

## Breaking Changelist
TODO, assuming that this is breaking 

## Related Issues
Initial steps for #1412

closes #1414, #1416