### PR TITLE
ci(cli): astria-cli image for smoke tests

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -157,7 +157,9 @@ jobs:
           just deploy smoke-test $TAG
       - name: Run Smoke test
         timeout-minutes: 3
-        run: just run-smoke-test
+        run: |
+          TAG=sha-$(git rev-parse --short HEAD)
+          just run-smoke-test $TAG
 
   smoke-cli:
     needs: [run_checker, composer, conductor, sequencer, sequencer-relayer, evm-bridge-withdrawer, cli]

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -130,7 +130,7 @@ jobs:
     secrets: inherit
 
   smoke-test:
-    needs: [run_checker, composer, conductor, sequencer, sequencer-relayer, evm-bridge-withdrawer]
+    needs: [run_checker, composer, conductor, sequencer, sequencer-relayer, evm-bridge-withdrawer, cli]
     if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'astriaorg/astria') && (github.event_name == 'merge_group' || needs.run_checker.outputs.run_docker == 'true')
     runs-on: buildjet-8vcpu-ubuntu-2204
     steps:
@@ -163,7 +163,7 @@ jobs:
         run: just run-smoke-test
 
   smoke-cli:
-    needs: [run_checker, composer, conductor, sequencer, sequencer-relayer, evm-bridge-withdrawer]
+    needs: [run_checker, composer, conductor, sequencer, sequencer-relayer, evm-bridge-withdrawer, cli]
     if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'astriaorg/astria') && (github.event_name == 'merge_group' || needs.run_checker.outputs.run_docker == 'true')
     runs-on: buildjet-8vcpu-ubuntu-2204
     steps:
@@ -198,7 +198,7 @@ jobs:
           just run-smoke-cli $TAG
 
   ibc-bridge-test:
-    needs: [ run_checker, composer, conductor, sequencer, sequencer-relayer ]
+    needs: [ run_checker, composer, conductor, sequencer, sequencer-relayer, evm-bridge-withdrawer, cli ]
     if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'astriaorg/astria') && (github.event_name == 'merge_group' || needs.run_checker.outputs.run_docker == 'true')
     runs-on: buildjet-8vcpu-ubuntu-2204
     steps:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -124,7 +124,7 @@ jobs:
       packages: write
     with:
       depot-project-id: kcchkd09m0
-      package-name: cli
+      package-name: astria-cli
       binary-name: cli
       tag: ${{ inputs.tag }}
     secrets: inherit

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -193,7 +193,9 @@ jobs:
           just deploy smoke-cli $TAG
       - name: Run Smoke test
         timeout-minutes: 3
-        run: just run-smoke-cli
+        run: |
+          TAG=sha-$(git rev-parse --short HEAD)
+          just run-smoke-cli $TAG
 
   ibc-bridge-test:
     needs: [ run_checker, composer, conductor, sequencer, sequencer-relayer ]
@@ -225,7 +227,9 @@ jobs:
           just ibc-test deploy $TAG
       - name: Run IBC ICS20 Transfer test
         timeout-minutes: 3
-        run: just ibc-test run
+        run: |
+          TAG=sha-$(git rev-parse --short HEAD)
+          just ibc-test run $TAG
 
   docker:
     if: ${{ always() && !cancelled() }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -17,6 +17,7 @@ on:
           - sequencer
           - sequencer-relayer
           - evm-bridge-withdrawer
+          - cli
   merge_group:
   push:
     branches:
@@ -110,6 +111,21 @@ jobs:
       depot-project-id: dl81f3fc6x
       package-name: evm-bridge-withdrawer
       binary-name: bridge-withdrawer
+      tag: ${{ inputs.tag }}
+    secrets: inherit
+
+  cli:
+    needs: run_checker
+    if: needs.run_checker.outputs.run_docker == 'true' || (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'cli')
+    uses: "./.github/workflows/reusable-docker-build.yml"
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    with:
+      depot-project-id: kcchkd09m0
+      package-name: cli
+      binary-name: cli
       tag: ${{ inputs.tag }}
     secrets: inherit
 
@@ -213,7 +229,7 @@ jobs:
 
   docker:
     if: ${{ always() && !cancelled() }}
-    needs: [composer, conductor, sequencer, sequencer-relayer, evm-bridge-withdrawer, smoke-test, smoke-cli, ibc-bridge-test]
+    needs: [composer, conductor, sequencer, sequencer-relayer, evm-bridge-withdrawer, cli, smoke-test, smoke-cli, ibc-bridge-test]
     uses: ./.github/workflows/reusable-success.yml
     with:
       success: ${{ !contains(needs.*.result, 'failure') }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -141,9 +141,6 @@ jobs:
         uses: helm/kind-action@v1
         with:
           install_only: true
-      - name: Install astria cli (rust)
-        run: |
-          just install-cli
       - name: Log in to GHCR
         uses: docker/login-action@v2
         with:
@@ -174,9 +171,6 @@ jobs:
         uses: helm/kind-action@v1
         with:
           install_only: true
-      - name: Install astria cli (rust)
-        run: |
-          just install-cli
       - name: Log in to GHCR
         uses: docker/login-action@v2
         with:
@@ -209,8 +203,6 @@ jobs:
         uses: helm/kind-action@v1
         with:
           install_only: true
-      - name: Install astria cli (rust)
-        run: just install-cli
       - name: Log in to GHCR
         uses: docker/login-action@v2
         with:

--- a/charts/deploy.just
+++ b/charts/deploy.just
@@ -16,7 +16,7 @@ init tool *ARGS:
 run-smoke type *ARGS:
   @just run-smoke-{{type}} {{ARGS}}
 
-load-image image_name repo=default_repo_name tag=default_docker_tag:
+load-image image_name tag=default_docker_tag repo=default_repo_name:
   kind load docker-image {{repo}}/{{image_name}}:{{tag}} --name astria-dev-cluster
 
 deploy-all: deploy-cluster deploy-ingress-controller wait-for-ingress-controller deploy-astria-local wait-for-sequencer (deploy-chart "sequencer-faucet") deploy-rollup
@@ -410,20 +410,20 @@ run-smoke-cli tag=defaultTag:
 
   echo "passing ${withdrawals_dst} to astria-cli"
 
-  docker run --network host $ASTRIA_CLI_IMAGE bridge collect-withdrawals \
+  docker run -v $withdrawals_dst:/astria/tempfile --network host $ASTRIA_CLI_IMAGE bridge collect-withdrawals \
     --rollup-endpoint {{eth_ws_url}} \
     --contract-address {{evm_contract_address}} \
     --from-rollup-height 1 \
     --to-rollup-height $CURRENT_BLOCK \
     --sequencer-asset-to-withdraw nria \
     --bridge-address {{sequencer_bridge_address}} \
-    --output "${withdrawals_dst}" \
+    --output "/astria/tempfile" \
     --force
    docker run --network host $ASTRIA_CLI_IMAGE bridge submit-withdrawals \
     --signing-key <(printf "%s" "{{sequencer_bridge_pkey}}") \
     --sequencer-chain-id {{sequencer_chain_id}} \
     --sequencer-url {{sequencer_rpc_url}} \
-    --input "${withdrawals_dst}"
+    --input "/astria/tempfile"
 
   CHECKS=0
   EXPECTED_BALANCE=$(echo "1 * {{sequencer_base_amount}}" | bc)

--- a/charts/deploy.just
+++ b/charts/deploy.just
@@ -362,7 +362,7 @@ run-smoke-cli tag=defaultTag:
   fi
 
   echo "Testing Bridge In..."
-  just init rollup-bridge
+  just init rollup-bridge {{tag}}
   CHECKS=0
   EXPECTED_BALANCE=$(echo "{{sequencer_transfer_amount}} * {{sequencer_base_amount}} * {{rollup_multiplier}}" | bc)
   while (( $CHECKS < $MAX_CHECKS )); do

--- a/charts/deploy.just
+++ b/charts/deploy.just
@@ -16,8 +16,8 @@ init tool *ARGS:
 run-smoke type *ARGS:
   @just run-smoke-{{type}} {{ARGS}}
 
-load-image image:
-  kind load docker-image {{image}} --name astria-dev-cluster
+load-image image_name repo=default_repo_name tag=default_docker_tag:
+  kind load docker-image {{repo}}/{{image_name}}:{{tag}} --name astria-dev-cluster
 
 deploy-all: deploy-cluster deploy-ingress-controller wait-for-ingress-controller deploy-astria-local wait-for-sequencer (deploy-chart "sequencer-faucet") deploy-rollup
 delete-all: clean clean-persisted-data
@@ -207,7 +207,7 @@ sequencer_rpc_url := "http://rpc.sequencer.localdev.me"
 sequencer_bridge_address := "astria13ahqz4pjqfmynk9ylrqv4fwe4957x2p0h5782u"
 sequencer_bridge_pkey := "dfa7108e38ab71f89f356c72afc38600d5758f11a8c337164713e4471411d2e0"
 sequencer_chain_id := "sequencer-test-chain-0"
-cli_image := "astria-cli"
+cli_image := "ghcr.io/astriaorg/astria-cli"
 init-rollup-bridge tag=defaultTag rollupName=defaultRollupName evmDestinationAddress=evm_destination_address transferAmount=sequencer_transfer_amount:
   #!/usr/bin/env bash
   set -e

--- a/charts/deploy.just
+++ b/charts/deploy.just
@@ -207,7 +207,8 @@ sequencer_rpc_url := "http://rpc.sequencer.localdev.me"
 sequencer_bridge_address := "astria13ahqz4pjqfmynk9ylrqv4fwe4957x2p0h5782u"
 sequencer_bridge_pkey := "dfa7108e38ab71f89f356c72afc38600d5758f11a8c337164713e4471411d2e0"
 sequencer_chain_id := "sequencer-test-chain-0"
-init-rollup-bridge rollupName=defaultRollupName evmDestinationAddress=evm_destination_address transferAmount=sequencer_transfer_amount:
+cli_image := "astria-cli"
+init-rollup-bridge tag=defaultTag rollupName=defaultRollupName evmDestinationAddress=evm_destination_address transferAmount=sequencer_transfer_amount:
   #!/usr/bin/env bash
   set -e
 
@@ -216,13 +217,15 @@ init-rollup-bridge rollupName=defaultRollupName evmDestinationAddress=evm_destin
   FEE_ASSET="nria"
   TRANSFER_AMOUNT=$(echo "{{transferAmount}} * {{sequencer_base_amount}}" | bc)
 
-  astria-cli sequencer init-bridge-account \
+  IMAGE="{{cli_image}}{{ if tag != '' { replace(':#', '#', tag) } else { '' } }}"
+
+  docker run --network host $IMAGE sequencer init-bridge-account \
     --rollup-name {{rollupName}} \
     --private-key {{sequencer_bridge_pkey}} \
     --sequencer.chain-id {{sequencer_chain_id}} \
     --sequencer-url {{sequencer_rpc_url}} \
     --fee-asset=$FEE_ASSET --asset=$ASSET || exit 1
-  astria-cli sequencer bridge-lock {{sequencer_bridge_address}} \
+  docker run --network host $IMAGE sequencer bridge-lock {{sequencer_bridge_address}} \
     --amount $TRANSFER_AMOUNT \
     --destination-chain-address {{evmDestinationAddress}} \
     --private-key $SEQUENCER_FUNDS_PKEY \
@@ -231,8 +234,9 @@ init-rollup-bridge rollupName=defaultRollupName evmDestinationAddress=evm_destin
     --fee-asset=$FEE_ASSET --asset=$ASSET
 
 
-init-ibc-bridge privateKey asset feeAsset rollupName=defaultRollupName:
-  astria-cli sequencer init-bridge-account \
+init-ibc-bridge privateKey asset feeAsset rollupName=defaultRollupName tag=defaultTag:
+  IMAGE="{{cli_image}}{{ if tag != '' { replace(':#', '#', tag) } else { '' } }}"
+  docker run $IMAGE sequencer init-bridge-account \
     --rollup-name {{ rollupName }} \
     --private-key {{ privateKey }} \
     --sequencer.chain-id {{ sequencer_chain_id }} \
@@ -244,10 +248,10 @@ eth_rpc_url := "http://executor.astria.localdev.me/"
 eth_ws_url := "ws://ws-executor.astria.localdev.me/"
 bridge_tx_bytes := "0xf8f280843c54e7f182898594a58639fb5458e65e4fa917ff951c390292c24a15880de0b6b3a7640000b884bab916d00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000002d617374726961313777306164656736346b7930646178776432756779756e65656c6c6d6a676e786c333935303400000000000000000000000000000000000000820a96a086b85348c9816f6d34533669db3d3626cf55eecea6a380d4d072efb1839df443a04b8b60c8b91dd30add1ca4a96097238d73bab29b0a958322d9a51755d5a5f287"
 bridge_tx_hash := "0x67db5b0825e8f60b926234e209d54e0336cd94defe6720e7acadf871e0377150"
-run-smoke-test:
+run-smoke-test tag=defaultTag:
   #!/usr/bin/env bash
   set -e
-
+  ASTRIA_CLI_IMAGE="{{cli_image}}{{ if tag != '' { replace(':#', '#', tag) } else { '' } }}"
   MAX_CHECKS=30
 
   # Checking starting balance
@@ -258,7 +262,7 @@ run-smoke-test:
   fi
 
   echo "Testing Bridge In..."
-  just init rollup-bridge
+  just init rollup-bridge {{tag}}
   CHECKS=0
   EXPECTED_BALANCE=$(echo "{{sequencer_transfer_amount}} * {{sequencer_base_amount}} * {{rollup_multiplier}}" | bc)
   while (( $CHECKS < $MAX_CHECKS )); do
@@ -301,7 +305,7 @@ run-smoke-test:
   EXPECTED_BALANCE=$(echo "1 * {{sequencer_base_amount}}" | bc)
   while (( $CHECKS < $MAX_CHECKS )); do
     CHECKS=$((CHECKS+1))
-    BALANCE=$(astria-cli sequencer account balance astria17w0adeg64ky0daxwd2ugyuneellmjgnxl39504 --sequencer-url {{sequencer_rpc_url}}  | awk '/nria/{print $(NF-1)}')
+    BALANCE=$(docker run --network host $ASTRIA_CLI_IMAGE sequencer account balance astria17w0adeg64ky0daxwd2ugyuneellmjgnxl39504 --sequencer-url {{sequencer_rpc_url}}  | awk '/nria/{print $(NF-1)}')
     echo "Check $CHECKS, Balance: $BALANCE, Expected: $EXPECTED_BALANCE"
     if [ "$BALANCE" == "$EXPECTED_BALANCE" ]; then
       echo "Bridge Out Sequencer success"
@@ -343,10 +347,11 @@ delete-smoke-test:
   just delete rollup
 
 evm_contract_address := "0xA58639fB5458e65E4fA917FF951C390292C24A15"
-run-smoke-cli:
+run-smoke-cli tag=defaultTag:
   #!/usr/bin/env bash
   set -e
 
+  ASTRIA_CLI_IMAGE="{{cli_image}}{{ if tag != '' { replace(':#', '#', tag) } else { '' } }}"
   MAX_CHECKS=30
 
   # Checking starting balance
@@ -406,7 +411,7 @@ run-smoke-cli:
 
   echo "passing ${withdrawals_dst} to astria-cli"
 
-  astria-cli bridge collect-withdrawals \
+  docker run --network host $ASTRIA_CLI_IMAGE bridge collect-withdrawals \
     --rollup-endpoint {{eth_ws_url}} \
     --contract-address {{evm_contract_address}} \
     --from-rollup-height 1 \
@@ -415,7 +420,7 @@ run-smoke-cli:
     --bridge-address {{sequencer_bridge_address}} \
     --output "${withdrawals_dst}" \
     --force
-   astria-cli bridge submit-withdrawals \
+   docker run --network host $ASTRIA_CLI_IMAGE bridge submit-withdrawals \
     --signing-key <(printf "%s" "{{sequencer_bridge_pkey}}") \
     --sequencer-chain-id {{sequencer_chain_id}} \
     --sequencer-url {{sequencer_rpc_url}} \
@@ -425,7 +430,7 @@ run-smoke-cli:
   EXPECTED_BALANCE=$(echo "1 * {{sequencer_base_amount}}" | bc)
   while (( $CHECKS < $MAX_CHECKS )); do
     CHECKS=$((CHECKS+1))
-    BALANCE=$(astria-cli sequencer account balance astria17w0adeg64ky0daxwd2ugyuneellmjgnxl39504 --sequencer-url {{sequencer_rpc_url}}  | awk '/nria/{print $(NF-1)}')
+    BALANCE=$(docker run --network host $ASTRIA_CLI_IMAGE sequencer account balance astria17w0adeg64ky0daxwd2ugyuneellmjgnxl39504 --sequencer-url {{sequencer_rpc_url}}  | awk '/nria/{print $(NF-1)}')
     echo "Check $CHECKS, Balance: $BALANCE, Expected: $EXPECTED_BALANCE"
     if [ "$BALANCE" == "$EXPECTED_BALANCE" ]; then
       echo "Bridge Out Sequencer success"

--- a/charts/deploy.just
+++ b/charts/deploy.just
@@ -234,8 +234,8 @@ init-rollup-bridge tag=defaultTag rollupName=defaultRollupName evmDestinationAdd
     --fee-asset=$FEE_ASSET --asset=$ASSET
 
 
-init-ibc-bridge privateKey asset feeAsset rollupName=defaultRollupName tag=defaultTag:
-  docker run {{cli_image}}{{ if tag != '' { replace(':#', '#', tag) } else { '' } }} sequencer init-bridge-account \
+init-ibc-bridge privateKey asset feeAsset tag=defaultTag rollupName=defaultRollupName:
+  docker run --network host {{cli_image}}{{ if tag != '' { replace(':#', '#', tag) } else { '' } }} sequencer init-bridge-account \
     --rollup-name {{ rollupName }} \
     --private-key {{ privateKey }} \
     --sequencer.chain-id {{ sequencer_chain_id }} \

--- a/charts/deploy.just
+++ b/charts/deploy.just
@@ -235,8 +235,7 @@ init-rollup-bridge tag=defaultTag rollupName=defaultRollupName evmDestinationAdd
 
 
 init-ibc-bridge privateKey asset feeAsset rollupName=defaultRollupName tag=defaultTag:
-  IMAGE="{{cli_image}}{{ if tag != '' { replace(':#', '#', tag) } else { '' } }}"
-  docker run $IMAGE sequencer init-bridge-account \
+  docker run {{cli_image}}{{ if tag != '' { replace(':#', '#', tag) } else { '' } }} sequencer init-bridge-account \
     --rollup-name {{ rollupName }} \
     --private-key {{ privateKey }} \
     --sequencer.chain-id {{ sequencer_chain_id }} \

--- a/charts/deploy.just
+++ b/charts/deploy.just
@@ -219,13 +219,13 @@ init-rollup-bridge tag=defaultTag rollupName=defaultRollupName evmDestinationAdd
 
   IMAGE="{{cli_image}}{{ if tag != '' { replace(':#', '#', tag) } else { '' } }}"
 
-  docker run --network host $IMAGE sequencer init-bridge-account \
+  docker run --rm --network host $IMAGE sequencer init-bridge-account \
     --rollup-name {{rollupName}} \
     --private-key {{sequencer_bridge_pkey}} \
     --sequencer.chain-id {{sequencer_chain_id}} \
     --sequencer-url {{sequencer_rpc_url}} \
     --fee-asset=$FEE_ASSET --asset=$ASSET || exit 1
-  docker run --network host $IMAGE sequencer bridge-lock {{sequencer_bridge_address}} \
+  docker run --rm --network host $IMAGE sequencer bridge-lock {{sequencer_bridge_address}} \
     --amount $TRANSFER_AMOUNT \
     --destination-chain-address {{evmDestinationAddress}} \
     --private-key $SEQUENCER_FUNDS_PKEY \
@@ -235,7 +235,7 @@ init-rollup-bridge tag=defaultTag rollupName=defaultRollupName evmDestinationAdd
 
 
 init-ibc-bridge privateKey asset feeAsset tag=defaultTag rollupName=defaultRollupName:
-  docker run --network host {{cli_image}}{{ if tag != '' { replace(':#', '#', tag) } else { '' } }} sequencer init-bridge-account \
+  docker run --rm --network host {{cli_image}}{{ if tag != '' { replace(':#', '#', tag) } else { '' } }} sequencer init-bridge-account \
     --rollup-name {{ rollupName }} \
     --private-key {{ privateKey }} \
     --sequencer.chain-id {{ sequencer_chain_id }} \
@@ -304,7 +304,7 @@ run-smoke-test tag=defaultTag:
   EXPECTED_BALANCE=$(echo "1 * {{sequencer_base_amount}}" | bc)
   while (( $CHECKS < $MAX_CHECKS )); do
     CHECKS=$((CHECKS+1))
-    BALANCE=$(docker run --network host $ASTRIA_CLI_IMAGE sequencer account balance astria17w0adeg64ky0daxwd2ugyuneellmjgnxl39504 --sequencer-url {{sequencer_rpc_url}}  | awk '/nria/{print $(NF-1)}')
+    BALANCE=$(docker run --rm --network host $ASTRIA_CLI_IMAGE sequencer account balance astria17w0adeg64ky0daxwd2ugyuneellmjgnxl39504 --sequencer-url {{sequencer_rpc_url}}  | awk '/nria/{print $(NF-1)}')
     echo "Check $CHECKS, Balance: $BALANCE, Expected: $EXPECTED_BALANCE"
     if [ "$BALANCE" == "$EXPECTED_BALANCE" ]; then
       echo "Bridge Out Sequencer success"
@@ -404,13 +404,10 @@ run-smoke-cli tag=defaultTag:
   CURRENT_BLOCK_HEX=$(just evm-get-block-by-number latest | jq -r '.number')
   CURRENT_BLOCK=$(just hex-to-dec $CURRENT_BLOCK_HEX)
 
-  withdrawals_dst="$(mktemp)"
-  # uncomment this line if you want to inspect `withdrawals_dst`
-  trap "rm -f ${withdrawals_dst@Q}" EXIT
-
-  echo "passing ${withdrawals_dst} to astria-cli"
-
-  docker run -v $withdrawals_dst:/astria/tempfile --network host $ASTRIA_CLI_IMAGE bridge collect-withdrawals \
+  # Using a docker volume to handle both passing in a private key & the output file
+  docker volume create cli-test-withdrawals
+  docker run --rm -v cli-test-withdrawals:/data alpine sh -c "echo '{{sequencer_bridge_pkey}}' > /data/key"
+  docker run --rm -v cli-test-withdrawals:/astria --network host $ASTRIA_CLI_IMAGE bridge collect-withdrawals \
     --rollup-endpoint {{eth_ws_url}} \
     --contract-address {{evm_contract_address}} \
     --from-rollup-height 1 \
@@ -419,17 +416,20 @@ run-smoke-cli tag=defaultTag:
     --bridge-address {{sequencer_bridge_address}} \
     --output "/astria/tempfile" \
     --force
-   docker run --network host $ASTRIA_CLI_IMAGE bridge submit-withdrawals \
-    --signing-key <(printf "%s" "{{sequencer_bridge_pkey}}") \
+   docker run --rm -v cli-test-withdrawals:/astria --network host $ASTRIA_CLI_IMAGE bridge submit-withdrawals \
+    --signing-key "/astria/key"  \
     --sequencer-chain-id {{sequencer_chain_id}} \
     --sequencer-url {{sequencer_rpc_url}} \
     --input "/astria/tempfile"
+
+  # Can inspect the file by removing and looking in volume
+  docker volume remove cli-test-withdrawals
 
   CHECKS=0
   EXPECTED_BALANCE=$(echo "1 * {{sequencer_base_amount}}" | bc)
   while (( $CHECKS < $MAX_CHECKS )); do
     CHECKS=$((CHECKS+1))
-    BALANCE=$(docker run --network host $ASTRIA_CLI_IMAGE sequencer account balance astria17w0adeg64ky0daxwd2ugyuneellmjgnxl39504 --sequencer-url {{sequencer_rpc_url}}  | awk '/nria/{print $(NF-1)}')
+    BALANCE=$(docker run --rm --network host $ASTRIA_CLI_IMAGE sequencer account balance astria17w0adeg64ky0daxwd2ugyuneellmjgnxl39504 --sequencer-url {{sequencer_rpc_url}}  | awk '/nria/{print $(NF-1)}')
     echo "Check $CHECKS, Balance: $BALANCE, Expected: $EXPECTED_BALANCE"
     if [ "$BALANCE" == "$EXPECTED_BALANCE" ]; then
       echo "Bridge Out Sequencer success"

--- a/charts/ibc-test.just
+++ b/charts/ibc-test.just
@@ -43,7 +43,7 @@ run tag=defaultTag:
   initial_celestia_balance=$(just ibc-test get-celestia-balance)
 
   # Create a bridge account on the sequencer
-  just init-ibc-bridge {{tag}} {{sequencer_tia_bridge_pkey}} transfer/channel-0/utia nria
+  just init-ibc-bridge {{sequencer_tia_bridge_pkey}} transfer/channel-0/utia nria {{tag}}
 
   # Execute the transfer from Celestia to the Rollup
   just ibc-test _do-ibc-transfer
@@ -223,5 +223,5 @@ cb address=celestia_dev_account_address namespace=defaultNamespace:
   'celestia-appd query bank balances {{address}}'
 
 # init sequencer bridge account
-init-bridge-acct:
-  just init-ibc-bridge {{sequencer_tia_bridge_pkey}} transfer/channel-0/utia nria
+init-bridge-acct tag=defaultTag:
+  just init-ibc-bridge {{sequencer_tia_bridge_pkey}} transfer/channel-0/utia nria {{tag}}

--- a/charts/ibc-test.just
+++ b/charts/ibc-test.just
@@ -35,7 +35,7 @@ delete:
   kubectl wait -n astria-dev-cluster deployment hermes-local-chart --for=condition=Available=True --timeout=300s
 
 [no-cd]
-run:
+run tag=defaultTag:
   #!/usr/bin/env bash
   set -e
 
@@ -43,7 +43,7 @@ run:
   initial_celestia_balance=$(just ibc-test get-celestia-balance)
 
   # Create a bridge account on the sequencer
-  just init-ibc-bridge {{sequencer_tia_bridge_pkey}} transfer/channel-0/utia nria
+  just init-ibc-bridge {{tag}} {{sequencer_tia_bridge_pkey}} transfer/channel-0/utia nria
 
   # Execute the transfer from Celestia to the Rollup
   just ibc-test _do-ibc-transfer

--- a/justfile
+++ b/justfile
@@ -10,12 +10,12 @@ default_docker_tag := 'local'
 default_repo_name := 'ghcr.io/astriaorg'
 
 # Builds docker image for the crate. Defaults to 'local' tag.
-docker-build crate repo_name=default_repo_name tag=default_docker_tag:
+docker-build crate tag=default_docker_tag repo_name=default_repo_name:
   docker buildx build --load --build-arg TARGETBINARY={{crate}} -f containerfiles/Dockerfile -t {{repo_name}}/{{crate}}:{{tag}} .
 
-docker-build-and-load crate repo_name=default_repo_name tag=default_docker_tag:
-  @just docker-build {{crate}} {{repo_name}} {{tag}}
-  @just load-image {{crate}} {{repo_name}} {{tag}}
+docker-build-and-load crate tag=default_docker_tag repo_name=default_repo_name:
+  @just docker-build {{crate}} {{tag}} {{repo_name}}
+  @just load-image {{crate}} {{tag}} {{repo_name}}
 
 # Installs the astria rust cli from local codebase
 install-cli:

--- a/justfile
+++ b/justfile
@@ -7,10 +7,15 @@ default:
   @just --list
 
 default_docker_tag := 'local'
+default_repo_name := 'ghcr.io/astriaorg'
 
 # Builds docker image for the crate. Defaults to 'local' tag.
-docker-build crate tag=default_docker_tag:
-  docker buildx build --load --build-arg TARGETBINARY={{crate}} -f containerfiles/Dockerfile -t {{crate}}:{{tag}} .
+docker-build crate repo_name=default_repo_name tag=default_docker_tag:
+  docker buildx build --load --build-arg TARGETBINARY={{crate}} -f containerfiles/Dockerfile -t {{repo_name}}/{{crate}}:{{tag}} .
+
+docker-build-and-load crate repo_name=default_repo_name tag=default_docker_tag:
+  @just docker-build {{crate}} {{repo_name}} {{tag}}
+  @just load-image {{crate}} {{repo_name}} {{tag}}
 
 # Installs the astria rust cli from local codebase
 install-cli:


### PR DESCRIPTION
## Summary
Adds a image build for the cli tool, and updates the justfiles to utilize it.

## Background
There are two workflows which this fixes: 1) Users running the repo locally and running smoke tests could encounter issues by not having the cli installed or not having it updated. Now we just need to have docker. Additionally, we have been needing to build the `just-cli` for each of our smoke test runs. Instead all can now rely on the docker image.

## Changes
- Starts creating a new CLI image
- Updates the smoke tests to utilize CLI image in place of installing the cli
- Update docker build scripts to make it easier to use a local image locally

## Testing
CI/CD on this PR

## Related Issues

closes #1475
