### PR TITLE
fix(sequencer): provide context in checktx response log

### DIFF
--- a/crates/astria-sequencer/src/service/mempool.rs
+++ b/crates/astria-sequencer/src/service/mempool.rs
@@ -147,7 +147,7 @@ async fn handle_check_tx<S: accounts::StateReadExt + address::StateReadExt + 'st
         Err(e) => {
             return response::CheckTx {
                 code: Code::Err(AbciErrorCode::INVALID_PARAMETER.value()),
-                log: e.to_string(),
+                log: format!("{e:#}"),
                 info: "failed decoding bytes as a protobuf SignedTransaction".into(),
                 ..response::CheckTx::default()
             };
@@ -161,7 +161,7 @@ async fn handle_check_tx<S: accounts::StateReadExt + address::StateReadExt + 'st
                 info: "the provided bytes was not a valid protobuf-encoded SignedTransaction, or \
                        the signature was invalid"
                     .into(),
-                log: e.to_string(),
+                log: format!("{e:#}"),
                 ..response::CheckTx::default()
             };
         }
@@ -177,7 +177,7 @@ async fn handle_check_tx<S: accounts::StateReadExt + address::StateReadExt + 'st
         return response::CheckTx {
             code: Code::Err(AbciErrorCode::INVALID_PARAMETER.value()),
             info: "transaction failed stateless check".into(),
-            log: e.to_string(),
+            log: format!("{e:#}"),
             ..response::CheckTx::default()
         };
     };
@@ -192,7 +192,7 @@ async fn handle_check_tx<S: accounts::StateReadExt + address::StateReadExt + 'st
         return response::CheckTx {
             code: Code::Err(AbciErrorCode::INVALID_NONCE.value()),
             info: "failed verifying transaction nonce".into(),
-            log: e.to_string(),
+            log: format!("{e:#}"),
             ..response::CheckTx::default()
         };
     };
@@ -206,7 +206,7 @@ async fn handle_check_tx<S: accounts::StateReadExt + address::StateReadExt + 'st
         return response::CheckTx {
             code: Code::Err(AbciErrorCode::INVALID_CHAIN_ID.value()),
             info: "failed verifying chain id".into(),
-            log: e.to_string(),
+            log: format!("{e:#}"),
             ..response::CheckTx::default()
         };
     }


### PR DESCRIPTION
## Summary
We were using `e.to_string` to provide error messages in `CheckTx` responses. This results in dropping the context that the error objects carry around, only providing the top level error. This uses `anyhow`'s `format!("{e:#}")` to format the error with its context.

## Background
For example, the following snippet:
```rust
use anyhow::anyhow;
use astria_eyre::anyhow_to_eyre;

fn main() {
    let _ = astria_eyre::install();

    let anyhow_err = anyhow!("anyhow 0").context("anyhow 1");
    let combined = anyhow_to_eyre(anyhow_err)
        .wrap_err("astria eyre 0")
        .wrap_err("astria eyre 1");
    println!("err context: {combined:#}");
}
```

Will produce the following output:
```
err context: {"0": "astria eyre 1", "1": "astria eyre 0", "2": "anyhow 1", "3": "anyhow 0"}
```

## Changes
- changed all instances of `e.to_string()` to `format("{e:#}") in the sequencer's mempool service

## Related Issues
Link any issues that are related, prefer full github links.

closes #1464