### PR TITLE
chore(core, sequencer): add deposit builder

### DIFF
--- a/crates/astria-core/src/sequencerblock/v1alpha1/block.rs
+++ b/crates/astria-core/src/sequencerblock/v1alpha1/block.rs
@@ -1315,27 +1315,6 @@ impl From<Deposit> for crate::generated::sequencerblock::v1alpha1::Deposit {
 
 impl Deposit {
     #[must_use]
-    pub fn new(
-        bridge_address: Address,
-        rollup_id: RollupId,
-        amount: u128,
-        asset: asset::Denom,
-        destination_chain_address: String,
-        source_transaction_id: TransactionId,
-        source_action_index: u64,
-    ) -> Self {
-        Self {
-            bridge_address,
-            rollup_id,
-            amount,
-            asset,
-            destination_chain_address,
-            source_transaction_id,
-            source_action_index,
-        }
-    }
-
-    #[must_use]
     pub fn bridge_address(&self) -> &Address {
         &self.bridge_address
     }
@@ -1479,6 +1458,31 @@ enum DepositErrorKind {
     IncorrectAsset(#[source] asset::ParseDenomError),
     #[error("field `source_transaction_id` was invalid")]
     TransactionIdError(#[source] TransactionIdError),
+}
+
+pub struct DepositBuilder {
+    pub bridge_address: Address,
+    pub rollup_id: RollupId,
+    pub amount: u128,
+    pub asset: asset::Denom,
+    pub destination_chain_address: String,
+    pub source_transaction_id: TransactionId,
+    pub source_action_index: u64,
+}
+
+impl DepositBuilder {
+    #[must_use]
+    pub fn build(self) -> Deposit {
+        Deposit {
+            bridge_address: self.bridge_address,
+            rollup_id: self.rollup_id,
+            amount: self.amount,
+            asset: self.asset,
+            destination_chain_address: self.destination_chain_address,
+            source_transaction_id: self.source_transaction_id,
+            source_action_index: self.source_action_index,
+        }
+    }
 }
 
 /// A piece of data that is sent to a rollup execution node.

--- a/crates/astria-sequencer/src/api_state_ext.rs
+++ b/crates/astria-sequencer/src/api_state_ext.rs
@@ -398,7 +398,7 @@ mod test {
     use astria_core::{
         primitive::v1::TransactionId,
         protocol::test_utils::ConfigureSequencerBlock,
-        sequencerblock::v1alpha1::block::Deposit,
+        sequencerblock::v1alpha1::block::DepositBuilder,
     };
     use cnidarium::StateDelta;
     use rand::Rng;
@@ -419,15 +419,16 @@ mod test {
             let amount = rng.gen::<u128>();
             let asset = "testasset".parse().unwrap();
             let destination_chain_address = rng.gen::<u8>().to_string();
-            let deposit = Deposit::new(
+            let deposit = DepositBuilder {
                 bridge_address,
                 rollup_id,
                 amount,
                 asset,
                 destination_chain_address,
-                TransactionId::new([0; 32]),
-                0,
-            );
+                source_transaction_id: TransactionId::new([0; 32]),
+                source_action_index: 0,
+            }
+            .build();
             deposits.push(deposit);
         }
 

--- a/crates/astria-sequencer/src/app/tests_app/mod.rs
+++ b/crates/astria-sequencer/src/app/tests_app/mod.rs
@@ -19,7 +19,7 @@ use astria_core::{
             UnsignedTransaction,
         },
     },
-    sequencerblock::v1alpha1::block::Deposit,
+    sequencerblock::v1alpha1::block::DepositBuilder,
 };
 use cnidarium::StateDelta;
 use prost::{
@@ -331,15 +331,16 @@ async fn app_create_sequencer_block_with_sequenced_data_and_deposits() {
 
     let signed_tx = tx.into_signed(&alice);
 
-    let expected_deposit = Deposit::new(
+    let expected_deposit = DepositBuilder {
         bridge_address,
         rollup_id,
         amount,
-        nria().into(),
-        "nootwashere".to_string(),
-        signed_tx.id(),
-        starting_index_of_action,
-    );
+        asset: nria().into(),
+        destination_chain_address: "nootwashere".to_string(),
+        source_transaction_id: signed_tx.id(),
+        source_action_index: starting_index_of_action,
+    }
+    .build();
     let deposits = HashMap::from_iter(vec![(rollup_id, vec![expected_deposit.clone()])]);
     let commitments = generate_rollup_datas_commitment(&[signed_tx.clone()], deposits.clone());
 
@@ -424,15 +425,16 @@ async fn app_execution_results_match_proposal_vs_after_proposal() {
 
     let signed_tx = tx.into_signed(&alice);
 
-    let expected_deposit = Deposit::new(
+    let expected_deposit = DepositBuilder {
         bridge_address,
         rollup_id,
         amount,
-        nria().into(),
-        "nootwashere".to_string(),
-        signed_tx.id(),
-        starting_index_of_action,
-    );
+        asset: nria().into(),
+        destination_chain_address: "nootwashere".to_string(),
+        source_transaction_id: signed_tx.id(),
+        source_action_index: starting_index_of_action,
+    }
+    .build();
     let deposits = HashMap::from_iter(vec![(rollup_id, vec![expected_deposit.clone()])]);
     let commitments = generate_rollup_datas_commitment(&[signed_tx.clone()], deposits.clone());
 

--- a/crates/astria-sequencer/src/app/tests_block_fees.rs
+++ b/crates/astria-sequencer/src/app/tests_block_fees.rs
@@ -13,7 +13,7 @@ use astria_core::{
         TransactionParams,
         UnsignedTransaction,
     },
-    sequencerblock::v1alpha1::block::Deposit,
+    sequencerblock::v1alpha1::block::DepositBuilder,
 };
 use cnidarium::StateDelta;
 use tendermint::abci::EventAttributeIndexExt as _;
@@ -262,15 +262,16 @@ async fn ensure_correct_block_fees_bridge_lock() {
     let signed_tx = Arc::new(tx.into_signed(&alice));
     app.execute_transaction(signed_tx.clone()).await.unwrap();
 
-    let test_deposit = Deposit::new(
+    let test_deposit = DepositBuilder {
         bridge_address,
         rollup_id,
-        1,
-        nria().into(),
-        rollup_id.to_string(),
-        signed_tx.id(),
-        starting_index_of_action,
-    );
+        amount: 1,
+        asset: nria().into(),
+        destination_chain_address: rollup_id.to_string(),
+        source_transaction_id: signed_tx.id(),
+        source_action_index: starting_index_of_action,
+    }
+    .build();
 
     let total_block_fees: u128 = app
         .state

--- a/crates/astria-sequencer/src/app/tests_breaking_changes.rs
+++ b/crates/astria-sequencer/src/app/tests_breaking_changes.rs
@@ -33,7 +33,7 @@ use astria_core::{
             UnsignedTransaction,
         },
     },
-    sequencerblock::v1alpha1::block::Deposit,
+    sequencerblock::v1alpha1::block::DepositBuilder,
     Protobuf,
 };
 use cnidarium::StateDelta;
@@ -121,15 +121,16 @@ async fn app_finalize_block_snapshot() {
 
     let signed_tx = tx.into_signed(&alice);
 
-    let expected_deposit = Deposit::new(
+    let expected_deposit = DepositBuilder {
         bridge_address,
         rollup_id,
         amount,
-        nria().into(),
-        "nootwashere".to_string(),
-        signed_tx.id(),
-        starting_index_of_action,
-    );
+        asset: nria().into(),
+        destination_chain_address: "nootwashere".to_string(),
+        source_transaction_id: signed_tx.id(),
+        source_action_index: starting_index_of_action,
+    }
+    .build();
     let deposits = HashMap::from_iter(vec![(rollup_id, vec![expected_deposit.clone()])]);
     let commitments = generate_rollup_datas_commitment(&[signed_tx.clone()], deposits.clone());
 

--- a/crates/astria-sequencer/src/app/tests_execute_transaction.rs
+++ b/crates/astria-sequencer/src/app/tests_execute_transaction.rs
@@ -23,7 +23,7 @@ use astria_core::{
             UnsignedTransaction,
         },
     },
-    sequencerblock::v1alpha1::block::Deposit,
+    sequencerblock::v1alpha1::block::DepositBuilder,
     Protobuf as _,
 };
 use bytes::Bytes;
@@ -740,15 +740,16 @@ async fn app_execute_transaction_bridge_lock_action_ok() {
     app.execute_transaction(signed_tx.clone()).await.unwrap();
     assert_eq!(app.state.get_account_nonce(alice_address).await.unwrap(), 1);
     let transfer_fee = app.state.get_transfer_base_fee().await.unwrap();
-    let expected_deposit = Deposit::new(
+    let expected_deposit = DepositBuilder {
         bridge_address,
         rollup_id,
         amount,
-        nria().into(),
-        "nootwashere".to_string(),
-        signed_tx.id(),
-        starting_index_of_action,
-    );
+        asset: nria().into(),
+        destination_chain_address: "nootwashere".to_string(),
+        source_transaction_id: signed_tx.id(),
+        source_action_index: starting_index_of_action,
+    }
+    .build();
 
     let fee = transfer_fee
         + app
@@ -1158,15 +1159,16 @@ async fn transaction_execution_records_deposit_event() {
 
     let signed_tx = Arc::new(tx.into_signed(&alice));
 
-    let expected_deposit = Deposit::new(
-        bob_address,
-        [0; 32].into(),
-        1,
-        nria().into(),
-        "test_chain_address".to_string(),
-        signed_tx.id(),
-        0,
-    );
+    let expected_deposit = DepositBuilder {
+        bridge_address: bob_address,
+        rollup_id: [0; 32].into(),
+        amount: 1,
+        asset: nria().into(),
+        destination_chain_address: "test_chain_address".to_string(),
+        source_transaction_id: signed_tx.id(),
+        source_action_index: 0,
+    }
+    .build();
     let expected_deposit_event = create_deposit_event(&expected_deposit);
 
     signed_tx.check_and_execute(&mut state_tx).await.unwrap();

--- a/crates/astria-sequencer/src/bridge/state_ext.rs
+++ b/crates/astria-sequencer/src/bridge/state_ext.rs
@@ -575,7 +575,10 @@ mod test {
             RollupId,
             TransactionId,
         },
-        sequencerblock::v1alpha1::block::Deposit,
+        sequencerblock::v1alpha1::block::{
+            Deposit,
+            DepositBuilder,
+        },
     };
     use cnidarium::StateDelta;
     use insta::assert_snapshot;
@@ -855,16 +858,17 @@ mod test {
         let bridge_address = astria_address(&[42u8; 20]);
         let mut amount = 10u128;
         let asset = asset_0();
-        let destination_chain_address = "0xdeadbeef";
-        let mut deposit = Deposit::new(
+        let destination_chain_address = "0xdeadbeef".to_string();
+        let mut deposit = DepositBuilder {
             bridge_address,
             rollup_id,
             amount,
-            asset.clone(),
-            destination_chain_address.to_string(),
-            TransactionId::new([0; 32]),
-            0,
-        );
+            asset: asset.clone(),
+            destination_chain_address: destination_chain_address.clone(),
+            source_transaction_id: TransactionId::new([0; 32]),
+            source_action_index: 0,
+        }
+        .build();
 
         let mut deposits = vec![deposit.clone()];
 
@@ -893,15 +897,16 @@ mod test {
 
         // can write additional
         amount = 20u128;
-        deposit = Deposit::new(
+        deposit = DepositBuilder {
             bridge_address,
             rollup_id,
             amount,
-            asset.clone(),
-            destination_chain_address.to_string(),
-            TransactionId::new([0; 32]),
-            1,
-        );
+            asset: asset.clone(),
+            destination_chain_address: destination_chain_address.clone(),
+            source_transaction_id: TransactionId::new([0; 32]),
+            source_action_index: 1,
+        }
+        .build();
         deposits.append(&mut vec![deposit.clone()]);
         state
             .put_deposit_event(deposit)
@@ -929,15 +934,16 @@ mod test {
 
         // can write different rollup id and both ok
         let rollup_id_1 = RollupId::new([2u8; 32]);
-        deposit = Deposit::new(
+        deposit = DepositBuilder {
             bridge_address,
-            rollup_id_1,
+            rollup_id: rollup_id_1,
             amount,
             asset,
-            destination_chain_address.to_string(),
-            TransactionId::new([0; 32]),
-            2,
-        );
+            destination_chain_address,
+            source_transaction_id: TransactionId::new([0; 32]),
+            source_action_index: 2,
+        }
+        .build();
         let deposits_1 = vec![deposit.clone()];
         state
             .put_deposit_event(deposit)
@@ -973,16 +979,17 @@ mod test {
         let bridge_address = astria_address(&[42u8; 20]);
         let amount = 10u128;
         let asset = asset_0();
-        let destination_chain_address = "0xdeadbeef";
-        let mut deposit = Deposit::new(
+        let destination_chain_address = "0xdeadbeef".to_string();
+        let mut deposit = DepositBuilder {
             bridge_address,
-            rollup_id_0,
+            rollup_id: rollup_id_0,
             amount,
-            asset.clone(),
-            destination_chain_address.to_string(),
-            TransactionId::new([0; 32]),
-            0,
-        );
+            asset: asset.clone(),
+            destination_chain_address: destination_chain_address.clone(),
+            source_transaction_id: TransactionId::new([0; 32]),
+            source_action_index: 0,
+        }
+        .build();
 
         // write same rollup id twice
         state
@@ -998,15 +1005,16 @@ mod test {
 
         // writing additional different rollup id
         let rollup_id_1 = RollupId::new([2u8; 32]);
-        deposit = Deposit::new(
+        deposit = DepositBuilder {
             bridge_address,
-            rollup_id_1,
+            rollup_id: rollup_id_1,
             amount,
-            asset.clone(),
-            destination_chain_address.to_string(),
-            TransactionId::new([0; 32]),
-            1,
-        );
+            asset: asset.clone(),
+            destination_chain_address,
+            source_transaction_id: TransactionId::new([0; 32]),
+            source_action_index: 1,
+        }
+        .build();
         state
             .put_deposit_event(deposit)
             .await
@@ -1048,16 +1056,17 @@ mod test {
         let bridge_address = astria_address(&[42u8; 20]);
         let amount = 10u128;
         let asset = asset_0();
-        let destination_chain_address = "0xdeadbeef";
-        let deposit = Deposit::new(
+        let destination_chain_address = "0xdeadbeef".to_string();
+        let deposit = DepositBuilder {
             bridge_address,
             rollup_id,
             amount,
-            asset,
-            destination_chain_address.to_string(),
-            TransactionId::new([0; 32]),
-            0,
-        );
+            asset: asset.clone(),
+            destination_chain_address,
+            source_transaction_id: TransactionId::new([0; 32]),
+            source_action_index: 0,
+        }
+        .build();
 
         let deposits = vec![deposit.clone()];
 
@@ -1105,16 +1114,17 @@ mod test {
         let bridge_address = astria_address(&[42u8; 20]);
         let amount = 10u128;
         let asset = asset_0();
-        let destination_chain_address = "0xdeadbeef";
-        let mut deposit = Deposit::new(
+        let destination_chain_address = "0xdeadbeef".to_string();
+        let mut deposit = DepositBuilder {
             bridge_address,
             rollup_id,
             amount,
-            asset.clone(),
-            destination_chain_address.to_string(),
-            TransactionId::new([0; 32]),
-            0,
-        );
+            asset: asset.clone(),
+            destination_chain_address: destination_chain_address.clone(),
+            source_transaction_id: TransactionId::new([0; 32]),
+            source_action_index: 0,
+        }
+        .build();
 
         // write to first
         state
@@ -1124,15 +1134,16 @@ mod test {
 
         // write to second
         let rollup_id_1 = RollupId::new([2u8; 32]);
-        deposit = Deposit::new(
+        deposit = DepositBuilder {
             bridge_address,
-            rollup_id_1,
+            rollup_id: rollup_id_1,
             amount,
-            asset.clone(),
-            destination_chain_address.to_string(),
-            TransactionId::new([0; 32]),
-            1,
-        );
+            asset: asset.clone(),
+            destination_chain_address,
+            source_transaction_id: TransactionId::new([0; 32]),
+            source_action_index: 1,
+        }
+        .build();
         let deposits_1 = vec![deposit.clone()];
 
         state
@@ -1201,16 +1212,17 @@ mod test {
         let bridge_address = astria_address(&[42u8; 20]);
         let amount = 10u128;
         let asset = asset_0();
-        let destination_chain_address = "0xdeadbeef";
-        let mut deposit = Deposit::new(
+        let destination_chain_address = "0xdeadbeef".to_string();
+        let mut deposit = DepositBuilder {
             bridge_address,
             rollup_id,
             amount,
-            asset.clone(),
-            destination_chain_address.to_string(),
-            TransactionId::new([0; 32]),
-            0,
-        );
+            asset: asset.clone(),
+            destination_chain_address: destination_chain_address.clone(),
+            source_transaction_id: TransactionId::new([0; 32]),
+            source_action_index: 0,
+        }
+        .build();
 
         // write to first
         state
@@ -1220,15 +1232,16 @@ mod test {
 
         // write to second
         let rollup_id_1 = RollupId::new([2u8; 32]);
-        deposit = Deposit::new(
+        deposit = DepositBuilder {
             bridge_address,
-            rollup_id_1,
+            rollup_id: rollup_id_1,
             amount,
-            asset.clone(),
-            destination_chain_address.to_string(),
-            TransactionId::new([0; 32]),
-            1,
-        );
+            asset: asset.clone(),
+            destination_chain_address,
+            source_transaction_id: TransactionId::new([0; 32]),
+            source_action_index: 1,
+        }
+        .build();
         state
             .put_deposit_event(deposit)
             .await


### PR DESCRIPTION
## Summary
Added `DepositBuilder` to construct deposit events.

## Background
Constructor was previously relying on a constructor with 7 arguments, as pointed out here: https://github.com/astriaorg/astria/pull/1410#discussion_r1743729542

## Changes
- Added `DepositBuilder` to core, replaced all instances of `Deposit::new()` with `DepositBuilder::build`.

## Testing
Passing all tests

## Related Issues
Link any issues that are related, prefer full github links.

closes #1448 
