### PR TITLE
feat(proto): add bundle and optimistic block apis

### DIFF
--- a/crates/astria-core/src/generated/astria.bundle.v1alpha1.rs
+++ b/crates/astria-core/src/generated/astria.bundle.v1alpha1.rs
@@ -1,3 +1,373 @@
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetBundleStreamRequest {}
+impl ::prost::Name for GetBundleStreamRequest {
+    const NAME: &'static str = "GetBundleStreamRequest";
+    const PACKAGE: &'static str = "astria.bundle.v1alpha1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.bundle.v1alpha1.{}", Self::NAME)
+    }
+}
+/// Information for the bundle submitter to know how to submit the bundle.
+/// The fee and base_sequencer_block_hash are not necessarily strictly necessary
+/// it allows for the case where the server doesn't always send the highest fee
+/// bundles after the previous but could just stream any confirmed bundles.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Bundle {
+    /// The fee that can be expected to be received for submitting this bundle.
+    /// This allows the bundle producer to stream any confirmed bundles they would be ok
+    /// with submitting. Used to avoid race conditions in received bundle packets. Could
+    /// also be used by a bundle submitter to allow multiple entities to submit bundles.
+    #[prost(uint64, tag = "1")]
+    pub fee: u64,
+    /// The byte list of transactions to be included.
+    #[prost(bytes = "bytes", repeated, tag = "2")]
+    pub transactions: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
+    /// The base_sequencer_block_hash is the hash from the base block this bundle
+    /// is based on. This is used to verify that the bundle is based on the correct
+    /// Sequencer block.
+    #[prost(bytes = "bytes", tag = "3")]
+    pub base_sequencer_block_hash: ::prost::bytes::Bytes,
+    /// The hash of previous rollup block, on top of which the bundle will be executed as ToB.
+    #[prost(bytes = "bytes", tag = "4")]
+    pub prev_rollup_block_hash: ::prost::bytes::Bytes,
+}
+impl ::prost::Name for Bundle {
+    const NAME: &'static str = "Bundle";
+    const PACKAGE: &'static str = "astria.bundle.v1alpha1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.bundle.v1alpha1.{}", Self::NAME)
+    }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetBundleStreamResponse {
+    #[prost(message, optional, tag = "1")]
+    pub bundle: ::core::option::Option<Bundle>,
+}
+impl ::prost::Name for GetBundleStreamResponse {
+    const NAME: &'static str = "GetBundleStreamResponse";
+    const PACKAGE: &'static str = "astria.bundle.v1alpha1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.bundle.v1alpha1.{}", Self::NAME)
+    }
+}
+/// Generated client implementations.
+#[cfg(feature = "client")]
+pub mod bundle_service_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
+    #[derive(Debug, Clone)]
+    pub struct BundleServiceClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl BundleServiceClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> BundleServiceClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> BundleServiceClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
+        {
+            BundleServiceClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with the given encoding.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
+            self
+        }
+        /// Enable decompressing responses.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
+        /// A bundle submitter requests bundles given a new optimistic Sequencer block,
+        /// and receives a stream of potential bundles for submission, until either a timeout
+        /// or the connection is closed by the client.
+        pub async fn get_bundle_stream(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetBundleStreamRequest>,
+        ) -> std::result::Result<
+            tonic::Response<tonic::codec::Streaming<super::GetBundleStreamResponse>>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/astria.bundle.v1alpha1.BundleService/GetBundleStream",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "astria.bundle.v1alpha1.BundleService",
+                        "GetBundleStream",
+                    ),
+                );
+            self.inner.server_streaming(req, path, codec).await
+        }
+    }
+}
+/// Generated server implementations.
+#[cfg(feature = "server")]
+pub mod bundle_service_server {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    /// Generated trait containing gRPC methods that should be implemented for use with BundleServiceServer.
+    #[async_trait]
+    pub trait BundleService: Send + Sync + 'static {
+        /// Server streaming response type for the GetBundleStream method.
+        type GetBundleStreamStream: tonic::codegen::tokio_stream::Stream<
+                Item = std::result::Result<super::GetBundleStreamResponse, tonic::Status>,
+            >
+            + Send
+            + 'static;
+        /// A bundle submitter requests bundles given a new optimistic Sequencer block,
+        /// and receives a stream of potential bundles for submission, until either a timeout
+        /// or the connection is closed by the client.
+        async fn get_bundle_stream(
+            self: std::sync::Arc<Self>,
+            request: tonic::Request<super::GetBundleStreamRequest>,
+        ) -> std::result::Result<
+            tonic::Response<Self::GetBundleStreamStream>,
+            tonic::Status,
+        >;
+    }
+    #[derive(Debug)]
+    pub struct BundleServiceServer<T: BundleService> {
+        inner: _Inner<T>,
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
+    }
+    struct _Inner<T>(Arc<T>);
+    impl<T: BundleService> BundleServiceServer<T> {
+        pub fn new(inner: T) -> Self {
+            Self::from_arc(Arc::new(inner))
+        }
+        pub fn from_arc(inner: Arc<T>) -> Self {
+            let inner = _Inner(inner);
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
+            }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
+        where
+            F: tonic::service::Interceptor,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
+    }
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for BundleServiceServer<T>
+    where
+        T: BundleService,
+        B: Body + Send + 'static,
+        B::Error: Into<StdError> + Send + 'static,
+    {
+        type Response = http::Response<tonic::body::BoxBody>;
+        type Error = std::convert::Infallible;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<std::result::Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
+            let inner = self.inner.clone();
+            match req.uri().path() {
+                "/astria.bundle.v1alpha1.BundleService/GetBundleStream" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetBundleStreamSvc<T: BundleService>(pub Arc<T>);
+                    impl<
+                        T: BundleService,
+                    > tonic::server::ServerStreamingService<
+                        super::GetBundleStreamRequest,
+                    > for GetBundleStreamSvc<T> {
+                        type Response = super::GetBundleStreamResponse;
+                        type ResponseStream = T::GetBundleStreamStream;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::GetBundleStreamRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as BundleService>::get_bundle_stream(inner, request)
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = GetBundleStreamSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.server_streaming(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
+            }
+        }
+    }
+    impl<T: BundleService> Clone for BundleServiceServer<T> {
+        fn clone(&self) -> Self {
+            let inner = self.inner.clone();
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
+            }
+        }
+    }
+    impl<T: BundleService> Clone for _Inner<T> {
+        fn clone(&self) -> Self {
+            Self(Arc::clone(&self.0))
+        }
+    }
+    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.0)
+        }
+    }
+    impl<T: BundleService> tonic::server::NamedService for BundleServiceServer<T> {
+        const NAME: &'static str = "astria.bundle.v1alpha1.BundleService";
+    }
+}
 /// The "BaseBlock" is the information needed to simulate bundles on top of
 /// a Sequencer block which may not have been committed yet.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -50,61 +420,6 @@ pub struct ExecuteOptimisticBlockStreamResponse {
 }
 impl ::prost::Name for ExecuteOptimisticBlockStreamResponse {
     const NAME: &'static str = "ExecuteOptimisticBlockStreamResponse";
-    const PACKAGE: &'static str = "astria.bundle.v1alpha1";
-    fn full_name() -> ::prost::alloc::string::String {
-        ::prost::alloc::format!("astria.bundle.v1alpha1.{}", Self::NAME)
-    }
-}
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct GetBundleStreamRequest {}
-impl ::prost::Name for GetBundleStreamRequest {
-    const NAME: &'static str = "GetBundleStreamRequest";
-    const PACKAGE: &'static str = "astria.bundle.v1alpha1";
-    fn full_name() -> ::prost::alloc::string::String {
-        ::prost::alloc::format!("astria.bundle.v1alpha1.{}", Self::NAME)
-    }
-}
-/// Information for the bundle submitter to know how to submit the bundle.
-/// The fee and base_sequencer_block_hash are not necessarily strictly necessary
-/// it allows for the case where the server doesn't always send the highest fee
-/// bundles after the previous but could just stream any confirmed bundles.
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct Bundle {
-    /// The fee that can be expected to be received for submitting this bundle.
-    /// This allows the bundle producer to stream any confirmed bundles they would be ok
-    /// with submitting. Used to avoid race conditions in received bundle packets. Could
-    /// also be used by a bundle submitter to allow multiple entities to submit bundles.
-    #[prost(uint64, tag = "1")]
-    pub fee: u64,
-    /// The byte list of transactions to be included.
-    #[prost(bytes = "bytes", repeated, tag = "2")]
-    pub transactions: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
-    /// The base_sequencer_block_hash is the hash from the base block this bundle
-    /// is based on. This is used to verify that the bundle is based on the correct
-    /// Sequencer block.
-    #[prost(bytes = "bytes", tag = "3")]
-    pub base_sequencer_block_hash: ::prost::bytes::Bytes,
-    /// The hash of previous rollup block, on top of which the bundle will be executed as ToB.
-    #[prost(bytes = "bytes", tag = "4")]
-    pub prev_rollup_block_hash: ::prost::bytes::Bytes,
-}
-impl ::prost::Name for Bundle {
-    const NAME: &'static str = "Bundle";
-    const PACKAGE: &'static str = "astria.bundle.v1alpha1";
-    fn full_name() -> ::prost::alloc::string::String {
-        ::prost::alloc::format!("astria.bundle.v1alpha1.{}", Self::NAME)
-    }
-}
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct GetBundleStreamResponse {
-    #[prost(message, optional, tag = "1")]
-    pub bundle: ::core::option::Option<Bundle>,
-}
-impl ::prost::Name for GetBundleStreamResponse {
-    const NAME: &'static str = "GetBundleStreamResponse";
     const PACKAGE: &'static str = "astria.bundle.v1alpha1";
     fn full_name() -> ::prost::alloc::string::String {
         ::prost::alloc::format!("astria.bundle.v1alpha1.{}", Self::NAME)
@@ -233,127 +548,6 @@ pub mod optimistic_execution_service_client {
                     ),
                 );
             self.inner.streaming(req, path, codec).await
-        }
-    }
-}
-/// Generated client implementations.
-#[cfg(feature = "client")]
-pub mod bundle_service_client {
-    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::*;
-    use tonic::codegen::http::Uri;
-    #[derive(Debug, Clone)]
-    pub struct BundleServiceClient<T> {
-        inner: tonic::client::Grpc<T>,
-    }
-    impl BundleServiceClient<tonic::transport::Channel> {
-        /// Attempt to create a new client by connecting to a given endpoint.
-        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
-        where
-            D: TryInto<tonic::transport::Endpoint>,
-            D::Error: Into<StdError>,
-        {
-            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
-            Ok(Self::new(conn))
-        }
-    }
-    impl<T> BundleServiceClient<T>
-    where
-        T: tonic::client::GrpcService<tonic::body::BoxBody>,
-        T::Error: Into<StdError>,
-        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
-        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
-    {
-        pub fn new(inner: T) -> Self {
-            let inner = tonic::client::Grpc::new(inner);
-            Self { inner }
-        }
-        pub fn with_origin(inner: T, origin: Uri) -> Self {
-            let inner = tonic::client::Grpc::with_origin(inner, origin);
-            Self { inner }
-        }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> BundleServiceClient<InterceptedService<T, F>>
-        where
-            F: tonic::service::Interceptor,
-            T::ResponseBody: Default,
-            T: tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-                Response = http::Response<
-                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
-                >,
-            >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + Send + Sync,
-        {
-            BundleServiceClient::new(InterceptedService::new(inner, interceptor))
-        }
-        /// Compress requests with the given encoding.
-        ///
-        /// This requires the server to support it otherwise it might respond with an
-        /// error.
-        #[must_use]
-        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
-            self.inner = self.inner.send_compressed(encoding);
-            self
-        }
-        /// Enable decompressing responses.
-        #[must_use]
-        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
-            self.inner = self.inner.accept_compressed(encoding);
-            self
-        }
-        /// Limits the maximum size of a decoded message.
-        ///
-        /// Default: `4MB`
-        #[must_use]
-        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
-            self.inner = self.inner.max_decoding_message_size(limit);
-            self
-        }
-        /// Limits the maximum size of an encoded message.
-        ///
-        /// Default: `usize::MAX`
-        #[must_use]
-        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
-            self.inner = self.inner.max_encoding_message_size(limit);
-            self
-        }
-        /// A bundle submitter requests bundles given a new optimistic Sequencer block,
-        /// and receives a stream of potential bundles for submission, until either a timeout
-        /// or the connection is closed by the client.
-        pub async fn get_bundle_stream(
-            &mut self,
-            request: impl tonic::IntoRequest<super::GetBundleStreamRequest>,
-        ) -> std::result::Result<
-            tonic::Response<tonic::codec::Streaming<super::GetBundleStreamResponse>>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
-            let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/astria.bundle.v1alpha1.BundleService/GetBundleStream",
-            );
-            let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "astria.bundle.v1alpha1.BundleService",
-                        "GetBundleStream",
-                    ),
-                );
-            self.inner.server_streaming(req, path, codec).await
         }
     }
 }
@@ -564,199 +758,5 @@ pub mod optimistic_execution_service_server {
     impl<T: OptimisticExecutionService> tonic::server::NamedService
     for OptimisticExecutionServiceServer<T> {
         const NAME: &'static str = "astria.bundle.v1alpha1.OptimisticExecutionService";
-    }
-}
-/// Generated server implementations.
-#[cfg(feature = "server")]
-pub mod bundle_service_server {
-    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::*;
-    /// Generated trait containing gRPC methods that should be implemented for use with BundleServiceServer.
-    #[async_trait]
-    pub trait BundleService: Send + Sync + 'static {
-        /// Server streaming response type for the GetBundleStream method.
-        type GetBundleStreamStream: tonic::codegen::tokio_stream::Stream<
-                Item = std::result::Result<super::GetBundleStreamResponse, tonic::Status>,
-            >
-            + Send
-            + 'static;
-        /// A bundle submitter requests bundles given a new optimistic Sequencer block,
-        /// and receives a stream of potential bundles for submission, until either a timeout
-        /// or the connection is closed by the client.
-        async fn get_bundle_stream(
-            self: std::sync::Arc<Self>,
-            request: tonic::Request<super::GetBundleStreamRequest>,
-        ) -> std::result::Result<
-            tonic::Response<Self::GetBundleStreamStream>,
-            tonic::Status,
-        >;
-    }
-    #[derive(Debug)]
-    pub struct BundleServiceServer<T: BundleService> {
-        inner: _Inner<T>,
-        accept_compression_encodings: EnabledCompressionEncodings,
-        send_compression_encodings: EnabledCompressionEncodings,
-        max_decoding_message_size: Option<usize>,
-        max_encoding_message_size: Option<usize>,
-    }
-    struct _Inner<T>(Arc<T>);
-    impl<T: BundleService> BundleServiceServer<T> {
-        pub fn new(inner: T) -> Self {
-            Self::from_arc(Arc::new(inner))
-        }
-        pub fn from_arc(inner: Arc<T>) -> Self {
-            let inner = _Inner(inner);
-            Self {
-                inner,
-                accept_compression_encodings: Default::default(),
-                send_compression_encodings: Default::default(),
-                max_decoding_message_size: None,
-                max_encoding_message_size: None,
-            }
-        }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> InterceptedService<Self, F>
-        where
-            F: tonic::service::Interceptor,
-        {
-            InterceptedService::new(Self::new(inner), interceptor)
-        }
-        /// Enable decompressing requests with the given encoding.
-        #[must_use]
-        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
-            self.accept_compression_encodings.enable(encoding);
-            self
-        }
-        /// Compress responses with the given encoding, if the client supports it.
-        #[must_use]
-        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
-            self.send_compression_encodings.enable(encoding);
-            self
-        }
-        /// Limits the maximum size of a decoded message.
-        ///
-        /// Default: `4MB`
-        #[must_use]
-        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
-            self.max_decoding_message_size = Some(limit);
-            self
-        }
-        /// Limits the maximum size of an encoded message.
-        ///
-        /// Default: `usize::MAX`
-        #[must_use]
-        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
-            self.max_encoding_message_size = Some(limit);
-            self
-        }
-    }
-    impl<T, B> tonic::codegen::Service<http::Request<B>> for BundleServiceServer<T>
-    where
-        T: BundleService,
-        B: Body + Send + 'static,
-        B::Error: Into<StdError> + Send + 'static,
-    {
-        type Response = http::Response<tonic::body::BoxBody>;
-        type Error = std::convert::Infallible;
-        type Future = BoxFuture<Self::Response, Self::Error>;
-        fn poll_ready(
-            &mut self,
-            _cx: &mut Context<'_>,
-        ) -> Poll<std::result::Result<(), Self::Error>> {
-            Poll::Ready(Ok(()))
-        }
-        fn call(&mut self, req: http::Request<B>) -> Self::Future {
-            let inner = self.inner.clone();
-            match req.uri().path() {
-                "/astria.bundle.v1alpha1.BundleService/GetBundleStream" => {
-                    #[allow(non_camel_case_types)]
-                    struct GetBundleStreamSvc<T: BundleService>(pub Arc<T>);
-                    impl<
-                        T: BundleService,
-                    > tonic::server::ServerStreamingService<
-                        super::GetBundleStreamRequest,
-                    > for GetBundleStreamSvc<T> {
-                        type Response = super::GetBundleStreamResponse;
-                        type ResponseStream = T::GetBundleStreamStream;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::ResponseStream>,
-                            tonic::Status,
-                        >;
-                        fn call(
-                            &mut self,
-                            request: tonic::Request<super::GetBundleStreamRequest>,
-                        ) -> Self::Future {
-                            let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as BundleService>::get_bundle_stream(inner, request)
-                                    .await
-                            };
-                            Box::pin(fut)
-                        }
-                    }
-                    let accept_compression_encodings = self.accept_compression_encodings;
-                    let send_compression_encodings = self.send_compression_encodings;
-                    let max_decoding_message_size = self.max_decoding_message_size;
-                    let max_encoding_message_size = self.max_encoding_message_size;
-                    let inner = self.inner.clone();
-                    let fut = async move {
-                        let inner = inner.0;
-                        let method = GetBundleStreamSvc(inner);
-                        let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec)
-                            .apply_compression_config(
-                                accept_compression_encodings,
-                                send_compression_encodings,
-                            )
-                            .apply_max_message_size_config(
-                                max_decoding_message_size,
-                                max_encoding_message_size,
-                            );
-                        let res = grpc.server_streaming(method, req).await;
-                        Ok(res)
-                    };
-                    Box::pin(fut)
-                }
-                _ => {
-                    Box::pin(async move {
-                        Ok(
-                            http::Response::builder()
-                                .status(200)
-                                .header("grpc-status", "12")
-                                .header("content-type", "application/grpc")
-                                .body(empty_body())
-                                .unwrap(),
-                        )
-                    })
-                }
-            }
-        }
-    }
-    impl<T: BundleService> Clone for BundleServiceServer<T> {
-        fn clone(&self) -> Self {
-            let inner = self.inner.clone();
-            Self {
-                inner,
-                accept_compression_encodings: self.accept_compression_encodings,
-                send_compression_encodings: self.send_compression_encodings,
-                max_decoding_message_size: self.max_decoding_message_size,
-                max_encoding_message_size: self.max_encoding_message_size,
-            }
-        }
-    }
-    impl<T: BundleService> Clone for _Inner<T> {
-        fn clone(&self) -> Self {
-            Self(Arc::clone(&self.0))
-        }
-    }
-    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "{:?}", self.0)
-        }
-    }
-    impl<T: BundleService> tonic::server::NamedService for BundleServiceServer<T> {
-        const NAME: &'static str = "astria.bundle.v1alpha1.BundleService";
     }
 }

--- a/crates/astria-core/src/generated/astria.bundle.v1alpha1.rs
+++ b/crates/astria-core/src/generated/astria.bundle.v1alpha1.rs
@@ -1,0 +1,747 @@
+/// The "BaseBlock" is the information needed to simulate bundles on top of
+/// a Sequencer block which may not have been committed yet.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BaseBlock {
+    /// This is the block hash for the proposed block.
+    #[prost(bytes = "bytes", tag = "1")]
+    pub sequencer_block_hash: ::prost::bytes::Bytes,
+    /// List of transactions to include in the new block.
+    #[prost(message, repeated, tag = "2")]
+    pub transactions: ::prost::alloc::vec::Vec<
+        super::super::sequencerblock::v1alpha1::RollupData,
+    >,
+    /// Timestamp to be used for new block.
+    #[prost(message, optional, tag = "3")]
+    pub timestamp: ::core::option::Option<::pbjson_types::Timestamp>,
+}
+impl ::prost::Name for BaseBlock {
+    const NAME: &'static str = "BaseBlock";
+    const PACKAGE: &'static str = "astria.bundle.v1alpha1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.bundle.v1alpha1.{}", Self::NAME)
+    }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct StreamExecuteOptimisticBlockRequest {
+    #[prost(message, optional, tag = "1")]
+    pub block: ::core::option::Option<BaseBlock>,
+}
+impl ::prost::Name for StreamExecuteOptimisticBlockRequest {
+    const NAME: &'static str = "StreamExecuteOptimisticBlockRequest";
+    const PACKAGE: &'static str = "astria.bundle.v1alpha1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.bundle.v1alpha1.{}", Self::NAME)
+    }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct StreamExecuteOptimisticBlockResponse {
+    /// Metadata identifying the block resulting from executing a block. Includes number, hash,
+    /// parent hash and timestamp.
+    #[prost(message, optional, tag = "1")]
+    pub block: ::core::option::Option<super::super::execution::v1alpha2::Block>,
+    /// The base_sequencer_block_hash is the hash from the base sequencer block this block
+    /// is based on. This is used to associate an optimistic execution result with the hash
+    /// received once a sequencer block is committed.
+    #[prost(bytes = "bytes", tag = "2")]
+    pub base_sequencer_block_hash: ::prost::bytes::Bytes,
+}
+impl ::prost::Name for StreamExecuteOptimisticBlockResponse {
+    const NAME: &'static str = "StreamExecuteOptimisticBlockResponse";
+    const PACKAGE: &'static str = "astria.bundle.v1alpha1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.bundle.v1alpha1.{}", Self::NAME)
+    }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct StreamBundlesRequest {}
+impl ::prost::Name for StreamBundlesRequest {
+    const NAME: &'static str = "StreamBundlesRequest";
+    const PACKAGE: &'static str = "astria.bundle.v1alpha1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.bundle.v1alpha1.{}", Self::NAME)
+    }
+}
+/// Information for the bundle submitter to know how to submit the bundle.
+/// The fee and base_sequencer_block_hash are not necessarily strictly necessary
+/// it allows for the case where the server doesn't always send the highest fee
+/// bundles after the previous but could just stream any confirmed bundles.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Bundle {
+    /// The fee that can be expected to be received for submitting this bundle.
+    /// This allows the bundle producer to stream any confirmed bundles they would be ok
+    /// with submitting. Used to avoid race conditions in received bundle packets. Could
+    /// also be used by a bundle submitter to allow multiple entities to submit bundles.
+    #[prost(uint64, tag = "1")]
+    pub fee: u64,
+    /// The byte list of transactions to be included.
+    #[prost(bytes = "bytes", repeated, tag = "2")]
+    pub transactions: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
+    /// The base_sequencer_block_hash is the hash from the base block this bundle
+    /// is based on. This is used to verify that the bundle is based on the correct
+    /// Sequencer block.
+    #[prost(bytes = "bytes", tag = "3")]
+    pub base_sequencer_block_hash: ::prost::bytes::Bytes,
+    /// The hash of previous rollup block, on top of which the bundle will be executed as ToB.
+    #[prost(bytes = "bytes", tag = "4")]
+    pub prev_rollup_block_hash: ::prost::bytes::Bytes,
+}
+impl ::prost::Name for Bundle {
+    const NAME: &'static str = "Bundle";
+    const PACKAGE: &'static str = "astria.bundle.v1alpha1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.bundle.v1alpha1.{}", Self::NAME)
+    }
+}
+/// Generated client implementations.
+#[cfg(feature = "client")]
+pub mod optimistic_execution_service_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
+    #[derive(Debug, Clone)]
+    pub struct OptimisticExecutionServiceClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl OptimisticExecutionServiceClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> OptimisticExecutionServiceClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> OptimisticExecutionServiceClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
+        {
+            OptimisticExecutionServiceClient::new(
+                InterceptedService::new(inner, interceptor),
+            )
+        }
+        /// Compress requests with the given encoding.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
+            self
+        }
+        /// Enable decompressing responses.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
+        /// Stream blocks from the Auctioneer to Geth for optimistic execution. Geth will stream back
+        /// metadata from the executed blocks.
+        pub async fn stream_execute_optimistic_block(
+            &mut self,
+            request: impl tonic::IntoStreamingRequest<
+                Message = super::StreamExecuteOptimisticBlockRequest,
+            >,
+        ) -> std::result::Result<
+            tonic::Response<
+                tonic::codec::Streaming<super::StreamExecuteOptimisticBlockResponse>,
+            >,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/astria.bundle.v1alpha1.OptimisticExecutionService/StreamExecuteOptimisticBlock",
+            );
+            let mut req = request.into_streaming_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "astria.bundle.v1alpha1.OptimisticExecutionService",
+                        "StreamExecuteOptimisticBlock",
+                    ),
+                );
+            self.inner.streaming(req, path, codec).await
+        }
+    }
+}
+/// Generated client implementations.
+#[cfg(feature = "client")]
+pub mod bundle_service_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
+    #[derive(Debug, Clone)]
+    pub struct BundleServiceClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl BundleServiceClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> BundleServiceClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> BundleServiceClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
+        {
+            BundleServiceClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with the given encoding.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
+            self
+        }
+        /// Enable decompressing responses.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
+        /// A bundle submitter requests bundles given a new optimistic Sequencer block,
+        /// and receives a stream of potential bundles for submission, until either a timeout
+        /// or the connection is closed by the client.
+        pub async fn stream_bundles(
+            &mut self,
+            request: impl tonic::IntoRequest<super::StreamBundlesRequest>,
+        ) -> std::result::Result<
+            tonic::Response<tonic::codec::Streaming<super::Bundle>>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/astria.bundle.v1alpha1.BundleService/StreamBundles",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "astria.bundle.v1alpha1.BundleService",
+                        "StreamBundles",
+                    ),
+                );
+            self.inner.server_streaming(req, path, codec).await
+        }
+    }
+}
+/// Generated server implementations.
+#[cfg(feature = "server")]
+pub mod optimistic_execution_service_server {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    /// Generated trait containing gRPC methods that should be implemented for use with OptimisticExecutionServiceServer.
+    #[async_trait]
+    pub trait OptimisticExecutionService: Send + Sync + 'static {
+        /// Server streaming response type for the StreamExecuteOptimisticBlock method.
+        type StreamExecuteOptimisticBlockStream: tonic::codegen::tokio_stream::Stream<
+                Item = std::result::Result<
+                    super::StreamExecuteOptimisticBlockResponse,
+                    tonic::Status,
+                >,
+            >
+            + Send
+            + 'static;
+        /// Stream blocks from the Auctioneer to Geth for optimistic execution. Geth will stream back
+        /// metadata from the executed blocks.
+        async fn stream_execute_optimistic_block(
+            self: std::sync::Arc<Self>,
+            request: tonic::Request<
+                tonic::Streaming<super::StreamExecuteOptimisticBlockRequest>,
+            >,
+        ) -> std::result::Result<
+            tonic::Response<Self::StreamExecuteOptimisticBlockStream>,
+            tonic::Status,
+        >;
+    }
+    #[derive(Debug)]
+    pub struct OptimisticExecutionServiceServer<T: OptimisticExecutionService> {
+        inner: _Inner<T>,
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
+    }
+    struct _Inner<T>(Arc<T>);
+    impl<T: OptimisticExecutionService> OptimisticExecutionServiceServer<T> {
+        pub fn new(inner: T) -> Self {
+            Self::from_arc(Arc::new(inner))
+        }
+        pub fn from_arc(inner: Arc<T>) -> Self {
+            let inner = _Inner(inner);
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
+            }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
+        where
+            F: tonic::service::Interceptor,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
+    }
+    impl<T, B> tonic::codegen::Service<http::Request<B>>
+    for OptimisticExecutionServiceServer<T>
+    where
+        T: OptimisticExecutionService,
+        B: Body + Send + 'static,
+        B::Error: Into<StdError> + Send + 'static,
+    {
+        type Response = http::Response<tonic::body::BoxBody>;
+        type Error = std::convert::Infallible;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<std::result::Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
+            let inner = self.inner.clone();
+            match req.uri().path() {
+                "/astria.bundle.v1alpha1.OptimisticExecutionService/StreamExecuteOptimisticBlock" => {
+                    #[allow(non_camel_case_types)]
+                    struct StreamExecuteOptimisticBlockSvc<
+                        T: OptimisticExecutionService,
+                    >(
+                        pub Arc<T>,
+                    );
+                    impl<
+                        T: OptimisticExecutionService,
+                    > tonic::server::StreamingService<
+                        super::StreamExecuteOptimisticBlockRequest,
+                    > for StreamExecuteOptimisticBlockSvc<T> {
+                        type Response = super::StreamExecuteOptimisticBlockResponse;
+                        type ResponseStream = T::StreamExecuteOptimisticBlockStream;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<
+                                tonic::Streaming<super::StreamExecuteOptimisticBlockRequest>,
+                            >,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as OptimisticExecutionService>::stream_execute_optimistic_block(
+                                        inner,
+                                        request,
+                                    )
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = StreamExecuteOptimisticBlockSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.streaming(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
+            }
+        }
+    }
+    impl<T: OptimisticExecutionService> Clone for OptimisticExecutionServiceServer<T> {
+        fn clone(&self) -> Self {
+            let inner = self.inner.clone();
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
+            }
+        }
+    }
+    impl<T: OptimisticExecutionService> Clone for _Inner<T> {
+        fn clone(&self) -> Self {
+            Self(Arc::clone(&self.0))
+        }
+    }
+    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.0)
+        }
+    }
+    impl<T: OptimisticExecutionService> tonic::server::NamedService
+    for OptimisticExecutionServiceServer<T> {
+        const NAME: &'static str = "astria.bundle.v1alpha1.OptimisticExecutionService";
+    }
+}
+/// Generated server implementations.
+#[cfg(feature = "server")]
+pub mod bundle_service_server {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    /// Generated trait containing gRPC methods that should be implemented for use with BundleServiceServer.
+    #[async_trait]
+    pub trait BundleService: Send + Sync + 'static {
+        /// Server streaming response type for the StreamBundles method.
+        type StreamBundlesStream: tonic::codegen::tokio_stream::Stream<
+                Item = std::result::Result<super::Bundle, tonic::Status>,
+            >
+            + Send
+            + 'static;
+        /// A bundle submitter requests bundles given a new optimistic Sequencer block,
+        /// and receives a stream of potential bundles for submission, until either a timeout
+        /// or the connection is closed by the client.
+        async fn stream_bundles(
+            self: std::sync::Arc<Self>,
+            request: tonic::Request<super::StreamBundlesRequest>,
+        ) -> std::result::Result<
+            tonic::Response<Self::StreamBundlesStream>,
+            tonic::Status,
+        >;
+    }
+    #[derive(Debug)]
+    pub struct BundleServiceServer<T: BundleService> {
+        inner: _Inner<T>,
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
+    }
+    struct _Inner<T>(Arc<T>);
+    impl<T: BundleService> BundleServiceServer<T> {
+        pub fn new(inner: T) -> Self {
+            Self::from_arc(Arc::new(inner))
+        }
+        pub fn from_arc(inner: Arc<T>) -> Self {
+            let inner = _Inner(inner);
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
+            }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
+        where
+            F: tonic::service::Interceptor,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
+    }
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for BundleServiceServer<T>
+    where
+        T: BundleService,
+        B: Body + Send + 'static,
+        B::Error: Into<StdError> + Send + 'static,
+    {
+        type Response = http::Response<tonic::body::BoxBody>;
+        type Error = std::convert::Infallible;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<std::result::Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
+            let inner = self.inner.clone();
+            match req.uri().path() {
+                "/astria.bundle.v1alpha1.BundleService/StreamBundles" => {
+                    #[allow(non_camel_case_types)]
+                    struct StreamBundlesSvc<T: BundleService>(pub Arc<T>);
+                    impl<
+                        T: BundleService,
+                    > tonic::server::ServerStreamingService<super::StreamBundlesRequest>
+                    for StreamBundlesSvc<T> {
+                        type Response = super::Bundle;
+                        type ResponseStream = T::StreamBundlesStream;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::StreamBundlesRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as BundleService>::stream_bundles(inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = StreamBundlesSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.server_streaming(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
+            }
+        }
+    }
+    impl<T: BundleService> Clone for BundleServiceServer<T> {
+        fn clone(&self) -> Self {
+            let inner = self.inner.clone();
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
+            }
+        }
+    }
+    impl<T: BundleService> Clone for _Inner<T> {
+        fn clone(&self) -> Self {
+            Self(Arc::clone(&self.0))
+        }
+    }
+    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.0)
+        }
+    }
+    impl<T: BundleService> tonic::server::NamedService for BundleServiceServer<T> {
+        const NAME: &'static str = "astria.bundle.v1alpha1.BundleService";
+    }
+}

--- a/crates/astria-core/src/generated/astria.bundle.v1alpha1.rs
+++ b/crates/astria-core/src/generated/astria.bundle.v1alpha1.rs
@@ -24,12 +24,12 @@ impl ::prost::Name for BaseBlock {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct StreamExecuteOptimisticBlockRequest {
+pub struct ExecuteOptimisticBlockStreamRequest {
     #[prost(message, optional, tag = "1")]
-    pub block: ::core::option::Option<BaseBlock>,
+    pub base_block: ::core::option::Option<BaseBlock>,
 }
-impl ::prost::Name for StreamExecuteOptimisticBlockRequest {
-    const NAME: &'static str = "StreamExecuteOptimisticBlockRequest";
+impl ::prost::Name for ExecuteOptimisticBlockStreamRequest {
+    const NAME: &'static str = "ExecuteOptimisticBlockStreamRequest";
     const PACKAGE: &'static str = "astria.bundle.v1alpha1";
     fn full_name() -> ::prost::alloc::string::String {
         ::prost::alloc::format!("astria.bundle.v1alpha1.{}", Self::NAME)
@@ -37,7 +37,7 @@ impl ::prost::Name for StreamExecuteOptimisticBlockRequest {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct StreamExecuteOptimisticBlockResponse {
+pub struct ExecuteOptimisticBlockStreamResponse {
     /// Metadata identifying the block resulting from executing a block. Includes number, hash,
     /// parent hash and timestamp.
     #[prost(message, optional, tag = "1")]
@@ -48,8 +48,8 @@ pub struct StreamExecuteOptimisticBlockResponse {
     #[prost(bytes = "bytes", tag = "2")]
     pub base_sequencer_block_hash: ::prost::bytes::Bytes,
 }
-impl ::prost::Name for StreamExecuteOptimisticBlockResponse {
-    const NAME: &'static str = "StreamExecuteOptimisticBlockResponse";
+impl ::prost::Name for ExecuteOptimisticBlockStreamResponse {
+    const NAME: &'static str = "ExecuteOptimisticBlockStreamResponse";
     const PACKAGE: &'static str = "astria.bundle.v1alpha1";
     fn full_name() -> ::prost::alloc::string::String {
         ::prost::alloc::format!("astria.bundle.v1alpha1.{}", Self::NAME)
@@ -57,9 +57,9 @@ impl ::prost::Name for StreamExecuteOptimisticBlockResponse {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct StreamBundlesRequest {}
-impl ::prost::Name for StreamBundlesRequest {
-    const NAME: &'static str = "StreamBundlesRequest";
+pub struct GetBundleStreamRequest {}
+impl ::prost::Name for GetBundleStreamRequest {
+    const NAME: &'static str = "GetBundleStreamRequest";
     const PACKAGE: &'static str = "astria.bundle.v1alpha1";
     fn full_name() -> ::prost::alloc::string::String {
         ::prost::alloc::format!("astria.bundle.v1alpha1.{}", Self::NAME)
@@ -92,6 +92,19 @@ pub struct Bundle {
 }
 impl ::prost::Name for Bundle {
     const NAME: &'static str = "Bundle";
+    const PACKAGE: &'static str = "astria.bundle.v1alpha1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.bundle.v1alpha1.{}", Self::NAME)
+    }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetBundleStreamResponse {
+    #[prost(message, optional, tag = "1")]
+    pub bundle: ::core::option::Option<Bundle>,
+}
+impl ::prost::Name for GetBundleStreamResponse {
+    const NAME: &'static str = "GetBundleStreamResponse";
     const PACKAGE: &'static str = "astria.bundle.v1alpha1";
     fn full_name() -> ::prost::alloc::string::String {
         ::prost::alloc::format!("astria.bundle.v1alpha1.{}", Self::NAME)
@@ -187,14 +200,14 @@ pub mod optimistic_execution_service_client {
         }
         /// Stream blocks from the Auctioneer to Geth for optimistic execution. Geth will stream back
         /// metadata from the executed blocks.
-        pub async fn stream_execute_optimistic_block(
+        pub async fn execute_optimistic_block_stream(
             &mut self,
             request: impl tonic::IntoStreamingRequest<
-                Message = super::StreamExecuteOptimisticBlockRequest,
+                Message = super::ExecuteOptimisticBlockStreamRequest,
             >,
         ) -> std::result::Result<
             tonic::Response<
-                tonic::codec::Streaming<super::StreamExecuteOptimisticBlockResponse>,
+                tonic::codec::Streaming<super::ExecuteOptimisticBlockStreamResponse>,
             >,
             tonic::Status,
         > {
@@ -209,14 +222,14 @@ pub mod optimistic_execution_service_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/astria.bundle.v1alpha1.OptimisticExecutionService/StreamExecuteOptimisticBlock",
+                "/astria.bundle.v1alpha1.OptimisticExecutionService/ExecuteOptimisticBlockStream",
             );
             let mut req = request.into_streaming_request();
             req.extensions_mut()
                 .insert(
                     GrpcMethod::new(
                         "astria.bundle.v1alpha1.OptimisticExecutionService",
-                        "StreamExecuteOptimisticBlock",
+                        "ExecuteOptimisticBlockStream",
                     ),
                 );
             self.inner.streaming(req, path, codec).await
@@ -312,11 +325,11 @@ pub mod bundle_service_client {
         /// A bundle submitter requests bundles given a new optimistic Sequencer block,
         /// and receives a stream of potential bundles for submission, until either a timeout
         /// or the connection is closed by the client.
-        pub async fn stream_bundles(
+        pub async fn get_bundle_stream(
             &mut self,
-            request: impl tonic::IntoRequest<super::StreamBundlesRequest>,
+            request: impl tonic::IntoRequest<super::GetBundleStreamRequest>,
         ) -> std::result::Result<
-            tonic::Response<tonic::codec::Streaming<super::Bundle>>,
+            tonic::Response<tonic::codec::Streaming<super::GetBundleStreamResponse>>,
             tonic::Status,
         > {
             self.inner
@@ -330,14 +343,14 @@ pub mod bundle_service_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/astria.bundle.v1alpha1.BundleService/StreamBundles",
+                "/astria.bundle.v1alpha1.BundleService/GetBundleStream",
             );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(
                     GrpcMethod::new(
                         "astria.bundle.v1alpha1.BundleService",
-                        "StreamBundles",
+                        "GetBundleStream",
                     ),
                 );
             self.inner.server_streaming(req, path, codec).await
@@ -352,10 +365,10 @@ pub mod optimistic_execution_service_server {
     /// Generated trait containing gRPC methods that should be implemented for use with OptimisticExecutionServiceServer.
     #[async_trait]
     pub trait OptimisticExecutionService: Send + Sync + 'static {
-        /// Server streaming response type for the StreamExecuteOptimisticBlock method.
-        type StreamExecuteOptimisticBlockStream: tonic::codegen::tokio_stream::Stream<
+        /// Server streaming response type for the ExecuteOptimisticBlockStream method.
+        type ExecuteOptimisticBlockStreamStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<
-                    super::StreamExecuteOptimisticBlockResponse,
+                    super::ExecuteOptimisticBlockStreamResponse,
                     tonic::Status,
                 >,
             >
@@ -363,13 +376,13 @@ pub mod optimistic_execution_service_server {
             + 'static;
         /// Stream blocks from the Auctioneer to Geth for optimistic execution. Geth will stream back
         /// metadata from the executed blocks.
-        async fn stream_execute_optimistic_block(
+        async fn execute_optimistic_block_stream(
             self: std::sync::Arc<Self>,
             request: tonic::Request<
-                tonic::Streaming<super::StreamExecuteOptimisticBlockRequest>,
+                tonic::Streaming<super::ExecuteOptimisticBlockStreamRequest>,
             >,
         ) -> std::result::Result<
-            tonic::Response<Self::StreamExecuteOptimisticBlockStream>,
+            tonic::Response<Self::ExecuteOptimisticBlockStreamStream>,
             tonic::Status,
         >;
     }
@@ -453,9 +466,9 @@ pub mod optimistic_execution_service_server {
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
             let inner = self.inner.clone();
             match req.uri().path() {
-                "/astria.bundle.v1alpha1.OptimisticExecutionService/StreamExecuteOptimisticBlock" => {
+                "/astria.bundle.v1alpha1.OptimisticExecutionService/ExecuteOptimisticBlockStream" => {
                     #[allow(non_camel_case_types)]
-                    struct StreamExecuteOptimisticBlockSvc<
+                    struct ExecuteOptimisticBlockStreamSvc<
                         T: OptimisticExecutionService,
                     >(
                         pub Arc<T>,
@@ -463,10 +476,10 @@ pub mod optimistic_execution_service_server {
                     impl<
                         T: OptimisticExecutionService,
                     > tonic::server::StreamingService<
-                        super::StreamExecuteOptimisticBlockRequest,
-                    > for StreamExecuteOptimisticBlockSvc<T> {
-                        type Response = super::StreamExecuteOptimisticBlockResponse;
-                        type ResponseStream = T::StreamExecuteOptimisticBlockStream;
+                        super::ExecuteOptimisticBlockStreamRequest,
+                    > for ExecuteOptimisticBlockStreamSvc<T> {
+                        type Response = super::ExecuteOptimisticBlockStreamResponse;
+                        type ResponseStream = T::ExecuteOptimisticBlockStreamStream;
                         type Future = BoxFuture<
                             tonic::Response<Self::ResponseStream>,
                             tonic::Status,
@@ -474,12 +487,12 @@ pub mod optimistic_execution_service_server {
                         fn call(
                             &mut self,
                             request: tonic::Request<
-                                tonic::Streaming<super::StreamExecuteOptimisticBlockRequest>,
+                                tonic::Streaming<super::ExecuteOptimisticBlockStreamRequest>,
                             >,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as OptimisticExecutionService>::stream_execute_optimistic_block(
+                                <T as OptimisticExecutionService>::execute_optimistic_block_stream(
                                         inner,
                                         request,
                                     )
@@ -495,7 +508,7 @@ pub mod optimistic_execution_service_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
-                        let method = StreamExecuteOptimisticBlockSvc(inner);
+                        let method = ExecuteOptimisticBlockStreamSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
@@ -561,20 +574,20 @@ pub mod bundle_service_server {
     /// Generated trait containing gRPC methods that should be implemented for use with BundleServiceServer.
     #[async_trait]
     pub trait BundleService: Send + Sync + 'static {
-        /// Server streaming response type for the StreamBundles method.
-        type StreamBundlesStream: tonic::codegen::tokio_stream::Stream<
-                Item = std::result::Result<super::Bundle, tonic::Status>,
+        /// Server streaming response type for the GetBundleStream method.
+        type GetBundleStreamStream: tonic::codegen::tokio_stream::Stream<
+                Item = std::result::Result<super::GetBundleStreamResponse, tonic::Status>,
             >
             + Send
             + 'static;
         /// A bundle submitter requests bundles given a new optimistic Sequencer block,
         /// and receives a stream of potential bundles for submission, until either a timeout
         /// or the connection is closed by the client.
-        async fn stream_bundles(
+        async fn get_bundle_stream(
             self: std::sync::Arc<Self>,
-            request: tonic::Request<super::StreamBundlesRequest>,
+            request: tonic::Request<super::GetBundleStreamRequest>,
         ) -> std::result::Result<
-            tonic::Response<Self::StreamBundlesStream>,
+            tonic::Response<Self::GetBundleStreamStream>,
             tonic::Status,
         >;
     }
@@ -657,26 +670,28 @@ pub mod bundle_service_server {
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
             let inner = self.inner.clone();
             match req.uri().path() {
-                "/astria.bundle.v1alpha1.BundleService/StreamBundles" => {
+                "/astria.bundle.v1alpha1.BundleService/GetBundleStream" => {
                     #[allow(non_camel_case_types)]
-                    struct StreamBundlesSvc<T: BundleService>(pub Arc<T>);
+                    struct GetBundleStreamSvc<T: BundleService>(pub Arc<T>);
                     impl<
                         T: BundleService,
-                    > tonic::server::ServerStreamingService<super::StreamBundlesRequest>
-                    for StreamBundlesSvc<T> {
-                        type Response = super::Bundle;
-                        type ResponseStream = T::StreamBundlesStream;
+                    > tonic::server::ServerStreamingService<
+                        super::GetBundleStreamRequest,
+                    > for GetBundleStreamSvc<T> {
+                        type Response = super::GetBundleStreamResponse;
+                        type ResponseStream = T::GetBundleStreamStream;
                         type Future = BoxFuture<
                             tonic::Response<Self::ResponseStream>,
                             tonic::Status,
                         >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::StreamBundlesRequest>,
+                            request: tonic::Request<super::GetBundleStreamRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as BundleService>::stream_bundles(inner, request).await
+                                <T as BundleService>::get_bundle_stream(inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -688,7 +703,7 @@ pub mod bundle_service_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
-                        let method = StreamBundlesSvc(inner);
+                        let method = GetBundleStreamSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/crates/astria-core/src/generated/astria.bundle.v1alpha1.serde.rs
+++ b/crates/astria-core/src/generated/astria.bundle.v1alpha1.serde.rs
@@ -1,0 +1,559 @@
+impl serde::Serialize for BaseBlock {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.sequencer_block_hash.is_empty() {
+            len += 1;
+        }
+        if !self.transactions.is_empty() {
+            len += 1;
+        }
+        if self.timestamp.is_some() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.bundle.v1alpha1.BaseBlock", len)?;
+        if !self.sequencer_block_hash.is_empty() {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("sequencerBlockHash", pbjson::private::base64::encode(&self.sequencer_block_hash).as_str())?;
+        }
+        if !self.transactions.is_empty() {
+            struct_ser.serialize_field("transactions", &self.transactions)?;
+        }
+        if let Some(v) = self.timestamp.as_ref() {
+            struct_ser.serialize_field("timestamp", v)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for BaseBlock {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "sequencer_block_hash",
+            "sequencerBlockHash",
+            "transactions",
+            "timestamp",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            SequencerBlockHash,
+            Transactions,
+            Timestamp,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "sequencerBlockHash" | "sequencer_block_hash" => Ok(GeneratedField::SequencerBlockHash),
+                            "transactions" => Ok(GeneratedField::Transactions),
+                            "timestamp" => Ok(GeneratedField::Timestamp),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = BaseBlock;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.bundle.v1alpha1.BaseBlock")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<BaseBlock, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut sequencer_block_hash__ = None;
+                let mut transactions__ = None;
+                let mut timestamp__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::SequencerBlockHash => {
+                            if sequencer_block_hash__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("sequencerBlockHash"));
+                            }
+                            sequencer_block_hash__ = 
+                                Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::Transactions => {
+                            if transactions__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("transactions"));
+                            }
+                            transactions__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Timestamp => {
+                            if timestamp__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("timestamp"));
+                            }
+                            timestamp__ = map_.next_value()?;
+                        }
+                    }
+                }
+                Ok(BaseBlock {
+                    sequencer_block_hash: sequencer_block_hash__.unwrap_or_default(),
+                    transactions: transactions__.unwrap_or_default(),
+                    timestamp: timestamp__,
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.bundle.v1alpha1.BaseBlock", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for Bundle {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.fee != 0 {
+            len += 1;
+        }
+        if !self.transactions.is_empty() {
+            len += 1;
+        }
+        if !self.base_sequencer_block_hash.is_empty() {
+            len += 1;
+        }
+        if !self.prev_rollup_block_hash.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.bundle.v1alpha1.Bundle", len)?;
+        if self.fee != 0 {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("fee", ToString::to_string(&self.fee).as_str())?;
+        }
+        if !self.transactions.is_empty() {
+            struct_ser.serialize_field("transactions", &self.transactions.iter().map(pbjson::private::base64::encode).collect::<Vec<_>>())?;
+        }
+        if !self.base_sequencer_block_hash.is_empty() {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("baseSequencerBlockHash", pbjson::private::base64::encode(&self.base_sequencer_block_hash).as_str())?;
+        }
+        if !self.prev_rollup_block_hash.is_empty() {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("prevRollupBlockHash", pbjson::private::base64::encode(&self.prev_rollup_block_hash).as_str())?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for Bundle {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "fee",
+            "transactions",
+            "base_sequencer_block_hash",
+            "baseSequencerBlockHash",
+            "prev_rollup_block_hash",
+            "prevRollupBlockHash",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Fee,
+            Transactions,
+            BaseSequencerBlockHash,
+            PrevRollupBlockHash,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "fee" => Ok(GeneratedField::Fee),
+                            "transactions" => Ok(GeneratedField::Transactions),
+                            "baseSequencerBlockHash" | "base_sequencer_block_hash" => Ok(GeneratedField::BaseSequencerBlockHash),
+                            "prevRollupBlockHash" | "prev_rollup_block_hash" => Ok(GeneratedField::PrevRollupBlockHash),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = Bundle;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.bundle.v1alpha1.Bundle")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Bundle, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut fee__ = None;
+                let mut transactions__ = None;
+                let mut base_sequencer_block_hash__ = None;
+                let mut prev_rollup_block_hash__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Fee => {
+                            if fee__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("fee"));
+                            }
+                            fee__ = 
+                                Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::Transactions => {
+                            if transactions__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("transactions"));
+                            }
+                            transactions__ = 
+                                Some(map_.next_value::<Vec<::pbjson::private::BytesDeserialize<_>>>()?
+                                    .into_iter().map(|x| x.0).collect())
+                            ;
+                        }
+                        GeneratedField::BaseSequencerBlockHash => {
+                            if base_sequencer_block_hash__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("baseSequencerBlockHash"));
+                            }
+                            base_sequencer_block_hash__ = 
+                                Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::PrevRollupBlockHash => {
+                            if prev_rollup_block_hash__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("prevRollupBlockHash"));
+                            }
+                            prev_rollup_block_hash__ = 
+                                Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
+                            ;
+                        }
+                    }
+                }
+                Ok(Bundle {
+                    fee: fee__.unwrap_or_default(),
+                    transactions: transactions__.unwrap_or_default(),
+                    base_sequencer_block_hash: base_sequencer_block_hash__.unwrap_or_default(),
+                    prev_rollup_block_hash: prev_rollup_block_hash__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.bundle.v1alpha1.Bundle", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for StreamBundlesRequest {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let len = 0;
+        let struct_ser = serializer.serialize_struct("astria.bundle.v1alpha1.StreamBundlesRequest", len)?;
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for StreamBundlesRequest {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                            Err(serde::de::Error::unknown_field(value, FIELDS))
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = StreamBundlesRequest;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.bundle.v1alpha1.StreamBundlesRequest")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<StreamBundlesRequest, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                while map_.next_key::<GeneratedField>()?.is_some() {
+                    let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                }
+                Ok(StreamBundlesRequest {
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.bundle.v1alpha1.StreamBundlesRequest", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for StreamExecuteOptimisticBlockRequest {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.block.is_some() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.bundle.v1alpha1.StreamExecuteOptimisticBlockRequest", len)?;
+        if let Some(v) = self.block.as_ref() {
+            struct_ser.serialize_field("block", v)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for StreamExecuteOptimisticBlockRequest {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "block",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Block,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "block" => Ok(GeneratedField::Block),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = StreamExecuteOptimisticBlockRequest;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.bundle.v1alpha1.StreamExecuteOptimisticBlockRequest")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<StreamExecuteOptimisticBlockRequest, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut block__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Block => {
+                            if block__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("block"));
+                            }
+                            block__ = map_.next_value()?;
+                        }
+                    }
+                }
+                Ok(StreamExecuteOptimisticBlockRequest {
+                    block: block__,
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.bundle.v1alpha1.StreamExecuteOptimisticBlockRequest", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for StreamExecuteOptimisticBlockResponse {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.block.is_some() {
+            len += 1;
+        }
+        if !self.base_sequencer_block_hash.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.bundle.v1alpha1.StreamExecuteOptimisticBlockResponse", len)?;
+        if let Some(v) = self.block.as_ref() {
+            struct_ser.serialize_field("block", v)?;
+        }
+        if !self.base_sequencer_block_hash.is_empty() {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("baseSequencerBlockHash", pbjson::private::base64::encode(&self.base_sequencer_block_hash).as_str())?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for StreamExecuteOptimisticBlockResponse {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "block",
+            "base_sequencer_block_hash",
+            "baseSequencerBlockHash",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Block,
+            BaseSequencerBlockHash,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "block" => Ok(GeneratedField::Block),
+                            "baseSequencerBlockHash" | "base_sequencer_block_hash" => Ok(GeneratedField::BaseSequencerBlockHash),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = StreamExecuteOptimisticBlockResponse;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.bundle.v1alpha1.StreamExecuteOptimisticBlockResponse")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<StreamExecuteOptimisticBlockResponse, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut block__ = None;
+                let mut base_sequencer_block_hash__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Block => {
+                            if block__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("block"));
+                            }
+                            block__ = map_.next_value()?;
+                        }
+                        GeneratedField::BaseSequencerBlockHash => {
+                            if base_sequencer_block_hash__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("baseSequencerBlockHash"));
+                            }
+                            base_sequencer_block_hash__ = 
+                                Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
+                            ;
+                        }
+                    }
+                }
+                Ok(StreamExecuteOptimisticBlockResponse {
+                    block: block__,
+                    base_sequencer_block_hash: base_sequencer_block_hash__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.bundle.v1alpha1.StreamExecuteOptimisticBlockResponse", FIELDS, GeneratedVisitor)
+    }
+}

--- a/crates/astria-core/src/generated/astria.bundle.v1alpha1.serde.rs
+++ b/crates/astria-core/src/generated/astria.bundle.v1alpha1.serde.rs
@@ -283,78 +283,7 @@ impl<'de> serde::Deserialize<'de> for Bundle {
         deserializer.deserialize_struct("astria.bundle.v1alpha1.Bundle", FIELDS, GeneratedVisitor)
     }
 }
-impl serde::Serialize for StreamBundlesRequest {
-    #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        use serde::ser::SerializeStruct;
-        let len = 0;
-        let struct_ser = serializer.serialize_struct("astria.bundle.v1alpha1.StreamBundlesRequest", len)?;
-        struct_ser.end()
-    }
-}
-impl<'de> serde::Deserialize<'de> for StreamBundlesRequest {
-    #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        const FIELDS: &[&str] = &[
-        ];
-
-        #[allow(clippy::enum_variant_names)]
-        enum GeneratedField {
-        }
-        impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
-            where
-                D: serde::Deserializer<'de>,
-            {
-                struct GeneratedVisitor;
-
-                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
-                    type Value = GeneratedField;
-
-                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                        write!(formatter, "expected one of: {:?}", &FIELDS)
-                    }
-
-                    #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
-                    where
-                        E: serde::de::Error,
-                    {
-                            Err(serde::de::Error::unknown_field(value, FIELDS))
-                    }
-                }
-                deserializer.deserialize_identifier(GeneratedVisitor)
-            }
-        }
-        struct GeneratedVisitor;
-        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
-            type Value = StreamBundlesRequest;
-
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                formatter.write_str("struct astria.bundle.v1alpha1.StreamBundlesRequest")
-            }
-
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<StreamBundlesRequest, V::Error>
-                where
-                    V: serde::de::MapAccess<'de>,
-            {
-                while map_.next_key::<GeneratedField>()?.is_some() {
-                    let _ = map_.next_value::<serde::de::IgnoredAny>()?;
-                }
-                Ok(StreamBundlesRequest {
-                })
-            }
-        }
-        deserializer.deserialize_struct("astria.bundle.v1alpha1.StreamBundlesRequest", FIELDS, GeneratedVisitor)
-    }
-}
-impl serde::Serialize for StreamExecuteOptimisticBlockRequest {
+impl serde::Serialize for ExecuteOptimisticBlockStreamRequest {
     #[allow(deprecated)]
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where
@@ -362,29 +291,30 @@ impl serde::Serialize for StreamExecuteOptimisticBlockRequest {
     {
         use serde::ser::SerializeStruct;
         let mut len = 0;
-        if self.block.is_some() {
+        if self.base_block.is_some() {
             len += 1;
         }
-        let mut struct_ser = serializer.serialize_struct("astria.bundle.v1alpha1.StreamExecuteOptimisticBlockRequest", len)?;
-        if let Some(v) = self.block.as_ref() {
-            struct_ser.serialize_field("block", v)?;
+        let mut struct_ser = serializer.serialize_struct("astria.bundle.v1alpha1.ExecuteOptimisticBlockStreamRequest", len)?;
+        if let Some(v) = self.base_block.as_ref() {
+            struct_ser.serialize_field("baseBlock", v)?;
         }
         struct_ser.end()
     }
 }
-impl<'de> serde::Deserialize<'de> for StreamExecuteOptimisticBlockRequest {
+impl<'de> serde::Deserialize<'de> for ExecuteOptimisticBlockStreamRequest {
     #[allow(deprecated)]
     fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
         const FIELDS: &[&str] = &[
-            "block",
+            "base_block",
+            "baseBlock",
         ];
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
-            Block,
+            BaseBlock,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -406,7 +336,7 @@ impl<'de> serde::Deserialize<'de> for StreamExecuteOptimisticBlockRequest {
                         E: serde::de::Error,
                     {
                         match value {
-                            "block" => Ok(GeneratedField::Block),
+                            "baseBlock" | "base_block" => Ok(GeneratedField::BaseBlock),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -416,36 +346,36 @@ impl<'de> serde::Deserialize<'de> for StreamExecuteOptimisticBlockRequest {
         }
         struct GeneratedVisitor;
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
-            type Value = StreamExecuteOptimisticBlockRequest;
+            type Value = ExecuteOptimisticBlockStreamRequest;
 
             fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                formatter.write_str("struct astria.bundle.v1alpha1.StreamExecuteOptimisticBlockRequest")
+                formatter.write_str("struct astria.bundle.v1alpha1.ExecuteOptimisticBlockStreamRequest")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<StreamExecuteOptimisticBlockRequest, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<ExecuteOptimisticBlockStreamRequest, V::Error>
                 where
                     V: serde::de::MapAccess<'de>,
             {
-                let mut block__ = None;
+                let mut base_block__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
-                        GeneratedField::Block => {
-                            if block__.is_some() {
-                                return Err(serde::de::Error::duplicate_field("block"));
+                        GeneratedField::BaseBlock => {
+                            if base_block__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("baseBlock"));
                             }
-                            block__ = map_.next_value()?;
+                            base_block__ = map_.next_value()?;
                         }
                     }
                 }
-                Ok(StreamExecuteOptimisticBlockRequest {
-                    block: block__,
+                Ok(ExecuteOptimisticBlockStreamRequest {
+                    base_block: base_block__,
                 })
             }
         }
-        deserializer.deserialize_struct("astria.bundle.v1alpha1.StreamExecuteOptimisticBlockRequest", FIELDS, GeneratedVisitor)
+        deserializer.deserialize_struct("astria.bundle.v1alpha1.ExecuteOptimisticBlockStreamRequest", FIELDS, GeneratedVisitor)
     }
 }
-impl serde::Serialize for StreamExecuteOptimisticBlockResponse {
+impl serde::Serialize for ExecuteOptimisticBlockStreamResponse {
     #[allow(deprecated)]
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where
@@ -459,7 +389,7 @@ impl serde::Serialize for StreamExecuteOptimisticBlockResponse {
         if !self.base_sequencer_block_hash.is_empty() {
             len += 1;
         }
-        let mut struct_ser = serializer.serialize_struct("astria.bundle.v1alpha1.StreamExecuteOptimisticBlockResponse", len)?;
+        let mut struct_ser = serializer.serialize_struct("astria.bundle.v1alpha1.ExecuteOptimisticBlockStreamResponse", len)?;
         if let Some(v) = self.block.as_ref() {
             struct_ser.serialize_field("block", v)?;
         }
@@ -470,7 +400,7 @@ impl serde::Serialize for StreamExecuteOptimisticBlockResponse {
         struct_ser.end()
     }
 }
-impl<'de> serde::Deserialize<'de> for StreamExecuteOptimisticBlockResponse {
+impl<'de> serde::Deserialize<'de> for ExecuteOptimisticBlockStreamResponse {
     #[allow(deprecated)]
     fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
     where
@@ -518,13 +448,13 @@ impl<'de> serde::Deserialize<'de> for StreamExecuteOptimisticBlockResponse {
         }
         struct GeneratedVisitor;
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
-            type Value = StreamExecuteOptimisticBlockResponse;
+            type Value = ExecuteOptimisticBlockStreamResponse;
 
             fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                formatter.write_str("struct astria.bundle.v1alpha1.StreamExecuteOptimisticBlockResponse")
+                formatter.write_str("struct astria.bundle.v1alpha1.ExecuteOptimisticBlockStreamResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<StreamExecuteOptimisticBlockResponse, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<ExecuteOptimisticBlockStreamResponse, V::Error>
                 where
                     V: serde::de::MapAccess<'de>,
             {
@@ -548,12 +478,174 @@ impl<'de> serde::Deserialize<'de> for StreamExecuteOptimisticBlockResponse {
                         }
                     }
                 }
-                Ok(StreamExecuteOptimisticBlockResponse {
+                Ok(ExecuteOptimisticBlockStreamResponse {
                     block: block__,
                     base_sequencer_block_hash: base_sequencer_block_hash__.unwrap_or_default(),
                 })
             }
         }
-        deserializer.deserialize_struct("astria.bundle.v1alpha1.StreamExecuteOptimisticBlockResponse", FIELDS, GeneratedVisitor)
+        deserializer.deserialize_struct("astria.bundle.v1alpha1.ExecuteOptimisticBlockStreamResponse", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for GetBundleStreamRequest {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let len = 0;
+        let struct_ser = serializer.serialize_struct("astria.bundle.v1alpha1.GetBundleStreamRequest", len)?;
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for GetBundleStreamRequest {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                            Err(serde::de::Error::unknown_field(value, FIELDS))
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = GetBundleStreamRequest;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.bundle.v1alpha1.GetBundleStreamRequest")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<GetBundleStreamRequest, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                while map_.next_key::<GeneratedField>()?.is_some() {
+                    let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                }
+                Ok(GetBundleStreamRequest {
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.bundle.v1alpha1.GetBundleStreamRequest", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for GetBundleStreamResponse {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.bundle.is_some() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.bundle.v1alpha1.GetBundleStreamResponse", len)?;
+        if let Some(v) = self.bundle.as_ref() {
+            struct_ser.serialize_field("bundle", v)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for GetBundleStreamResponse {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "bundle",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Bundle,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "bundle" => Ok(GeneratedField::Bundle),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = GetBundleStreamResponse;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.bundle.v1alpha1.GetBundleStreamResponse")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<GetBundleStreamResponse, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut bundle__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Bundle => {
+                            if bundle__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("bundle"));
+                            }
+                            bundle__ = map_.next_value()?;
+                        }
+                    }
+                }
+                Ok(GetBundleStreamResponse {
+                    bundle: bundle__,
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.bundle.v1alpha1.GetBundleStreamResponse", FIELDS, GeneratedVisitor)
     }
 }

--- a/crates/astria-core/src/generated/astria.sequencerblock.v1alpha1.rs
+++ b/crates/astria-core/src/generated/astria.sequencerblock.v1alpha1.rs
@@ -330,6 +330,490 @@ impl ::prost::Name for SubmittedMetadata {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct StreamBlockCommitmentsRequest {}
+impl ::prost::Name for StreamBlockCommitmentsRequest {
+    const NAME: &'static str = "StreamBlockCommitmentsRequest";
+    const PACKAGE: &'static str = "astria.sequencerblock.v1alpha1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.sequencerblock.v1alpha1.{}", Self::NAME)
+    }
+}
+/// Identifying metadata for blocks that have been successfully committed in the Sequencer.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SequencerBlockCommit {
+    /// Height of the sequencer block that was committed.
+    #[prost(uint64, tag = "1")]
+    pub height: u64,
+    /// Hash of the sequencer block that was committed.
+    #[prost(bytes = "bytes", tag = "2")]
+    pub block_hash: ::prost::bytes::Bytes,
+}
+impl ::prost::Name for SequencerBlockCommit {
+    const NAME: &'static str = "SequencerBlockCommit";
+    const PACKAGE: &'static str = "astria.sequencerblock.v1alpha1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.sequencerblock.v1alpha1.{}", Self::NAME)
+    }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct StreamOptimisticBlockRequest {
+    /// The rollup id for which the Sequencer block is being streamed.
+    #[prost(message, optional, tag = "1")]
+    pub rollup_id: ::core::option::Option<super::super::primitive::v1::RollupId>,
+}
+impl ::prost::Name for StreamOptimisticBlockRequest {
+    const NAME: &'static str = "StreamOptimisticBlockRequest";
+    const PACKAGE: &'static str = "astria.sequencerblock.v1alpha1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.sequencerblock.v1alpha1.{}", Self::NAME)
+    }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct StreamOptimisticBlockResponse {
+    /// The optimistic Sequencer block that is being streamed, filtered for the provided rollup id.
+    #[prost(message, optional, tag = "1")]
+    pub block: ::core::option::Option<FilteredSequencerBlock>,
+}
+impl ::prost::Name for StreamOptimisticBlockResponse {
+    const NAME: &'static str = "StreamOptimisticBlockResponse";
+    const PACKAGE: &'static str = "astria.sequencerblock.v1alpha1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.sequencerblock.v1alpha1.{}", Self::NAME)
+    }
+}
+/// Generated client implementations.
+#[cfg(feature = "client")]
+pub mod optimistic_block_service_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
+    /// The Sequencer will serve this to the aucitoneer
+    #[derive(Debug, Clone)]
+    pub struct OptimisticBlockServiceClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl OptimisticBlockServiceClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> OptimisticBlockServiceClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> OptimisticBlockServiceClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
+        {
+            OptimisticBlockServiceClient::new(
+                InterceptedService::new(inner, interceptor),
+            )
+        }
+        /// Compress requests with the given encoding.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
+            self
+        }
+        /// Enable decompressing responses.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
+        /// The Sequencer will stream the optimistic Sequencer block (filtered for the provided
+        /// rollup id) to the Auctioneer.
+        pub async fn stream_optimistic_block(
+            &mut self,
+            request: impl tonic::IntoRequest<super::StreamOptimisticBlockRequest>,
+        ) -> std::result::Result<
+            tonic::Response<
+                tonic::codec::Streaming<super::StreamOptimisticBlockResponse>,
+            >,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/astria.sequencerblock.v1alpha1.OptimisticBlockService/StreamOptimisticBlock",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "astria.sequencerblock.v1alpha1.OptimisticBlockService",
+                        "StreamOptimisticBlock",
+                    ),
+                );
+            self.inner.server_streaming(req, path, codec).await
+        }
+        /// The Sequencer will stream the block commits to the Auctioneer.
+        pub async fn stream_block_commitments(
+            &mut self,
+            request: impl tonic::IntoRequest<super::StreamBlockCommitmentsRequest>,
+        ) -> std::result::Result<
+            tonic::Response<tonic::codec::Streaming<super::SequencerBlockCommit>>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/astria.sequencerblock.v1alpha1.OptimisticBlockService/StreamBlockCommitments",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "astria.sequencerblock.v1alpha1.OptimisticBlockService",
+                        "StreamBlockCommitments",
+                    ),
+                );
+            self.inner.server_streaming(req, path, codec).await
+        }
+    }
+}
+/// Generated server implementations.
+#[cfg(feature = "server")]
+pub mod optimistic_block_service_server {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    /// Generated trait containing gRPC methods that should be implemented for use with OptimisticBlockServiceServer.
+    #[async_trait]
+    pub trait OptimisticBlockService: Send + Sync + 'static {
+        /// Server streaming response type for the StreamOptimisticBlock method.
+        type StreamOptimisticBlockStream: tonic::codegen::tokio_stream::Stream<
+                Item = std::result::Result<
+                    super::StreamOptimisticBlockResponse,
+                    tonic::Status,
+                >,
+            >
+            + Send
+            + 'static;
+        /// The Sequencer will stream the optimistic Sequencer block (filtered for the provided
+        /// rollup id) to the Auctioneer.
+        async fn stream_optimistic_block(
+            self: std::sync::Arc<Self>,
+            request: tonic::Request<super::StreamOptimisticBlockRequest>,
+        ) -> std::result::Result<
+            tonic::Response<Self::StreamOptimisticBlockStream>,
+            tonic::Status,
+        >;
+        /// Server streaming response type for the StreamBlockCommitments method.
+        type StreamBlockCommitmentsStream: tonic::codegen::tokio_stream::Stream<
+                Item = std::result::Result<super::SequencerBlockCommit, tonic::Status>,
+            >
+            + Send
+            + 'static;
+        /// The Sequencer will stream the block commits to the Auctioneer.
+        async fn stream_block_commitments(
+            self: std::sync::Arc<Self>,
+            request: tonic::Request<super::StreamBlockCommitmentsRequest>,
+        ) -> std::result::Result<
+            tonic::Response<Self::StreamBlockCommitmentsStream>,
+            tonic::Status,
+        >;
+    }
+    /// The Sequencer will serve this to the aucitoneer
+    #[derive(Debug)]
+    pub struct OptimisticBlockServiceServer<T: OptimisticBlockService> {
+        inner: _Inner<T>,
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
+    }
+    struct _Inner<T>(Arc<T>);
+    impl<T: OptimisticBlockService> OptimisticBlockServiceServer<T> {
+        pub fn new(inner: T) -> Self {
+            Self::from_arc(Arc::new(inner))
+        }
+        pub fn from_arc(inner: Arc<T>) -> Self {
+            let inner = _Inner(inner);
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
+            }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
+        where
+            F: tonic::service::Interceptor,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
+    }
+    impl<T, B> tonic::codegen::Service<http::Request<B>>
+    for OptimisticBlockServiceServer<T>
+    where
+        T: OptimisticBlockService,
+        B: Body + Send + 'static,
+        B::Error: Into<StdError> + Send + 'static,
+    {
+        type Response = http::Response<tonic::body::BoxBody>;
+        type Error = std::convert::Infallible;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<std::result::Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
+            let inner = self.inner.clone();
+            match req.uri().path() {
+                "/astria.sequencerblock.v1alpha1.OptimisticBlockService/StreamOptimisticBlock" => {
+                    #[allow(non_camel_case_types)]
+                    struct StreamOptimisticBlockSvc<T: OptimisticBlockService>(
+                        pub Arc<T>,
+                    );
+                    impl<
+                        T: OptimisticBlockService,
+                    > tonic::server::ServerStreamingService<
+                        super::StreamOptimisticBlockRequest,
+                    > for StreamOptimisticBlockSvc<T> {
+                        type Response = super::StreamOptimisticBlockResponse;
+                        type ResponseStream = T::StreamOptimisticBlockStream;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::StreamOptimisticBlockRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as OptimisticBlockService>::stream_optimistic_block(
+                                        inner,
+                                        request,
+                                    )
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = StreamOptimisticBlockSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.server_streaming(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/astria.sequencerblock.v1alpha1.OptimisticBlockService/StreamBlockCommitments" => {
+                    #[allow(non_camel_case_types)]
+                    struct StreamBlockCommitmentsSvc<T: OptimisticBlockService>(
+                        pub Arc<T>,
+                    );
+                    impl<
+                        T: OptimisticBlockService,
+                    > tonic::server::ServerStreamingService<
+                        super::StreamBlockCommitmentsRequest,
+                    > for StreamBlockCommitmentsSvc<T> {
+                        type Response = super::SequencerBlockCommit;
+                        type ResponseStream = T::StreamBlockCommitmentsStream;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::StreamBlockCommitmentsRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as OptimisticBlockService>::stream_block_commitments(
+                                        inner,
+                                        request,
+                                    )
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = StreamBlockCommitmentsSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.server_streaming(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
+            }
+        }
+    }
+    impl<T: OptimisticBlockService> Clone for OptimisticBlockServiceServer<T> {
+        fn clone(&self) -> Self {
+            let inner = self.inner.clone();
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
+            }
+        }
+    }
+    impl<T: OptimisticBlockService> Clone for _Inner<T> {
+        fn clone(&self) -> Self {
+            Self(Arc::clone(&self.0))
+        }
+    }
+    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.0)
+        }
+    }
+    impl<T: OptimisticBlockService> tonic::server::NamedService
+    for OptimisticBlockServiceServer<T> {
+        const NAME: &'static str = "astria.sequencerblock.v1alpha1.OptimisticBlockService";
+    }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetSequencerBlockRequest {
     /// The height of the block to retrieve.
     #[prost(uint64, tag = "1")]

--- a/crates/astria-core/src/generated/astria.sequencerblock.v1alpha1.rs
+++ b/crates/astria-core/src/generated/astria.sequencerblock.v1alpha1.rs
@@ -330,9 +330,9 @@ impl ::prost::Name for SubmittedMetadata {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct StreamBlockCommitmentsRequest {}
-impl ::prost::Name for StreamBlockCommitmentsRequest {
-    const NAME: &'static str = "StreamBlockCommitmentsRequest";
+pub struct GetBlockCommitmentStreamRequest {}
+impl ::prost::Name for GetBlockCommitmentStreamRequest {
+    const NAME: &'static str = "GetBlockCommitmentStreamRequest";
     const PACKAGE: &'static str = "astria.sequencerblock.v1alpha1";
     fn full_name() -> ::prost::alloc::string::String {
         ::prost::alloc::format!("astria.sequencerblock.v1alpha1.{}", Self::NAME)
@@ -358,13 +358,12 @@ impl ::prost::Name for SequencerBlockCommit {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct StreamOptimisticBlockRequest {
-    /// The rollup id for which the Sequencer block is being streamed.
+pub struct GetBlockCommitmentStreamResponse {
     #[prost(message, optional, tag = "1")]
-    pub rollup_id: ::core::option::Option<super::super::primitive::v1::RollupId>,
+    pub commitment: ::core::option::Option<SequencerBlockCommit>,
 }
-impl ::prost::Name for StreamOptimisticBlockRequest {
-    const NAME: &'static str = "StreamOptimisticBlockRequest";
+impl ::prost::Name for GetBlockCommitmentStreamResponse {
+    const NAME: &'static str = "GetBlockCommitmentStreamResponse";
     const PACKAGE: &'static str = "astria.sequencerblock.v1alpha1";
     fn full_name() -> ::prost::alloc::string::String {
         ::prost::alloc::format!("astria.sequencerblock.v1alpha1.{}", Self::NAME)
@@ -372,13 +371,27 @@ impl ::prost::Name for StreamOptimisticBlockRequest {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct StreamOptimisticBlockResponse {
+pub struct GetOptimisticBlockStreamRequest {
+    /// The rollup id for which the Sequencer block is being streamed.
+    #[prost(message, optional, tag = "1")]
+    pub rollup_id: ::core::option::Option<super::super::primitive::v1::RollupId>,
+}
+impl ::prost::Name for GetOptimisticBlockStreamRequest {
+    const NAME: &'static str = "GetOptimisticBlockStreamRequest";
+    const PACKAGE: &'static str = "astria.sequencerblock.v1alpha1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.sequencerblock.v1alpha1.{}", Self::NAME)
+    }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetOptimisticBlockStreamResponse {
     /// The optimistic Sequencer block that is being streamed, filtered for the provided rollup id.
     #[prost(message, optional, tag = "1")]
     pub block: ::core::option::Option<FilteredSequencerBlock>,
 }
-impl ::prost::Name for StreamOptimisticBlockResponse {
-    const NAME: &'static str = "StreamOptimisticBlockResponse";
+impl ::prost::Name for GetOptimisticBlockStreamResponse {
+    const NAME: &'static str = "GetOptimisticBlockStreamResponse";
     const PACKAGE: &'static str = "astria.sequencerblock.v1alpha1";
     fn full_name() -> ::prost::alloc::string::String {
         ::prost::alloc::format!("astria.sequencerblock.v1alpha1.{}", Self::NAME)
@@ -475,12 +488,12 @@ pub mod optimistic_block_service_client {
         }
         /// The Sequencer will stream the optimistic Sequencer block (filtered for the provided
         /// rollup id) to the Auctioneer.
-        pub async fn stream_optimistic_block(
+        pub async fn get_optimistic_block_stream(
             &mut self,
-            request: impl tonic::IntoRequest<super::StreamOptimisticBlockRequest>,
+            request: impl tonic::IntoRequest<super::GetOptimisticBlockStreamRequest>,
         ) -> std::result::Result<
             tonic::Response<
-                tonic::codec::Streaming<super::StreamOptimisticBlockResponse>,
+                tonic::codec::Streaming<super::GetOptimisticBlockStreamResponse>,
             >,
             tonic::Status,
         > {
@@ -495,24 +508,26 @@ pub mod optimistic_block_service_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/astria.sequencerblock.v1alpha1.OptimisticBlockService/StreamOptimisticBlock",
+                "/astria.sequencerblock.v1alpha1.OptimisticBlockService/GetOptimisticBlockStream",
             );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(
                     GrpcMethod::new(
                         "astria.sequencerblock.v1alpha1.OptimisticBlockService",
-                        "StreamOptimisticBlock",
+                        "GetOptimisticBlockStream",
                     ),
                 );
             self.inner.server_streaming(req, path, codec).await
         }
         /// The Sequencer will stream the block commits to the Auctioneer.
-        pub async fn stream_block_commitments(
+        pub async fn get_block_commitment_stream(
             &mut self,
-            request: impl tonic::IntoRequest<super::StreamBlockCommitmentsRequest>,
+            request: impl tonic::IntoRequest<super::GetBlockCommitmentStreamRequest>,
         ) -> std::result::Result<
-            tonic::Response<tonic::codec::Streaming<super::SequencerBlockCommit>>,
+            tonic::Response<
+                tonic::codec::Streaming<super::GetBlockCommitmentStreamResponse>,
+            >,
             tonic::Status,
         > {
             self.inner
@@ -526,14 +541,14 @@ pub mod optimistic_block_service_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/astria.sequencerblock.v1alpha1.OptimisticBlockService/StreamBlockCommitments",
+                "/astria.sequencerblock.v1alpha1.OptimisticBlockService/GetBlockCommitmentStream",
             );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(
                     GrpcMethod::new(
                         "astria.sequencerblock.v1alpha1.OptimisticBlockService",
-                        "StreamBlockCommitments",
+                        "GetBlockCommitmentStream",
                     ),
                 );
             self.inner.server_streaming(req, path, codec).await
@@ -548,10 +563,10 @@ pub mod optimistic_block_service_server {
     /// Generated trait containing gRPC methods that should be implemented for use with OptimisticBlockServiceServer.
     #[async_trait]
     pub trait OptimisticBlockService: Send + Sync + 'static {
-        /// Server streaming response type for the StreamOptimisticBlock method.
-        type StreamOptimisticBlockStream: tonic::codegen::tokio_stream::Stream<
+        /// Server streaming response type for the GetOptimisticBlockStream method.
+        type GetOptimisticBlockStreamStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<
-                    super::StreamOptimisticBlockResponse,
+                    super::GetOptimisticBlockStreamResponse,
                     tonic::Status,
                 >,
             >
@@ -559,25 +574,28 @@ pub mod optimistic_block_service_server {
             + 'static;
         /// The Sequencer will stream the optimistic Sequencer block (filtered for the provided
         /// rollup id) to the Auctioneer.
-        async fn stream_optimistic_block(
+        async fn get_optimistic_block_stream(
             self: std::sync::Arc<Self>,
-            request: tonic::Request<super::StreamOptimisticBlockRequest>,
+            request: tonic::Request<super::GetOptimisticBlockStreamRequest>,
         ) -> std::result::Result<
-            tonic::Response<Self::StreamOptimisticBlockStream>,
+            tonic::Response<Self::GetOptimisticBlockStreamStream>,
             tonic::Status,
         >;
-        /// Server streaming response type for the StreamBlockCommitments method.
-        type StreamBlockCommitmentsStream: tonic::codegen::tokio_stream::Stream<
-                Item = std::result::Result<super::SequencerBlockCommit, tonic::Status>,
+        /// Server streaming response type for the GetBlockCommitmentStream method.
+        type GetBlockCommitmentStreamStream: tonic::codegen::tokio_stream::Stream<
+                Item = std::result::Result<
+                    super::GetBlockCommitmentStreamResponse,
+                    tonic::Status,
+                >,
             >
             + Send
             + 'static;
         /// The Sequencer will stream the block commits to the Auctioneer.
-        async fn stream_block_commitments(
+        async fn get_block_commitment_stream(
             self: std::sync::Arc<Self>,
-            request: tonic::Request<super::StreamBlockCommitmentsRequest>,
+            request: tonic::Request<super::GetBlockCommitmentStreamRequest>,
         ) -> std::result::Result<
-            tonic::Response<Self::StreamBlockCommitmentsStream>,
+            tonic::Response<Self::GetBlockCommitmentStreamStream>,
             tonic::Status,
         >;
     }
@@ -662,29 +680,31 @@ pub mod optimistic_block_service_server {
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
             let inner = self.inner.clone();
             match req.uri().path() {
-                "/astria.sequencerblock.v1alpha1.OptimisticBlockService/StreamOptimisticBlock" => {
+                "/astria.sequencerblock.v1alpha1.OptimisticBlockService/GetOptimisticBlockStream" => {
                     #[allow(non_camel_case_types)]
-                    struct StreamOptimisticBlockSvc<T: OptimisticBlockService>(
+                    struct GetOptimisticBlockStreamSvc<T: OptimisticBlockService>(
                         pub Arc<T>,
                     );
                     impl<
                         T: OptimisticBlockService,
                     > tonic::server::ServerStreamingService<
-                        super::StreamOptimisticBlockRequest,
-                    > for StreamOptimisticBlockSvc<T> {
-                        type Response = super::StreamOptimisticBlockResponse;
-                        type ResponseStream = T::StreamOptimisticBlockStream;
+                        super::GetOptimisticBlockStreamRequest,
+                    > for GetOptimisticBlockStreamSvc<T> {
+                        type Response = super::GetOptimisticBlockStreamResponse;
+                        type ResponseStream = T::GetOptimisticBlockStreamStream;
                         type Future = BoxFuture<
                             tonic::Response<Self::ResponseStream>,
                             tonic::Status,
                         >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::StreamOptimisticBlockRequest>,
+                            request: tonic::Request<
+                                super::GetOptimisticBlockStreamRequest,
+                            >,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as OptimisticBlockService>::stream_optimistic_block(
+                                <T as OptimisticBlockService>::get_optimistic_block_stream(
                                         inner,
                                         request,
                                     )
@@ -700,7 +720,7 @@ pub mod optimistic_block_service_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
-                        let method = StreamOptimisticBlockSvc(inner);
+                        let method = GetOptimisticBlockStreamSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(
@@ -716,29 +736,31 @@ pub mod optimistic_block_service_server {
                     };
                     Box::pin(fut)
                 }
-                "/astria.sequencerblock.v1alpha1.OptimisticBlockService/StreamBlockCommitments" => {
+                "/astria.sequencerblock.v1alpha1.OptimisticBlockService/GetBlockCommitmentStream" => {
                     #[allow(non_camel_case_types)]
-                    struct StreamBlockCommitmentsSvc<T: OptimisticBlockService>(
+                    struct GetBlockCommitmentStreamSvc<T: OptimisticBlockService>(
                         pub Arc<T>,
                     );
                     impl<
                         T: OptimisticBlockService,
                     > tonic::server::ServerStreamingService<
-                        super::StreamBlockCommitmentsRequest,
-                    > for StreamBlockCommitmentsSvc<T> {
-                        type Response = super::SequencerBlockCommit;
-                        type ResponseStream = T::StreamBlockCommitmentsStream;
+                        super::GetBlockCommitmentStreamRequest,
+                    > for GetBlockCommitmentStreamSvc<T> {
+                        type Response = super::GetBlockCommitmentStreamResponse;
+                        type ResponseStream = T::GetBlockCommitmentStreamStream;
                         type Future = BoxFuture<
                             tonic::Response<Self::ResponseStream>,
                             tonic::Status,
                         >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::StreamBlockCommitmentsRequest>,
+                            request: tonic::Request<
+                                super::GetBlockCommitmentStreamRequest,
+                            >,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as OptimisticBlockService>::stream_block_commitments(
+                                <T as OptimisticBlockService>::get_block_commitment_stream(
                                         inner,
                                         request,
                                     )
@@ -754,7 +776,7 @@ pub mod optimistic_block_service_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
-                        let method = StreamBlockCommitmentsSvc(inner);
+                        let method = GetBlockCommitmentStreamSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/crates/astria-core/src/generated/astria.sequencerblock.v1alpha1.serde.rs
+++ b/crates/astria-core/src/generated/astria.sequencerblock.v1alpha1.serde.rs
@@ -386,6 +386,168 @@ impl<'de> serde::Deserialize<'de> for FilteredSequencerBlock {
         deserializer.deserialize_struct("astria.sequencerblock.v1alpha1.FilteredSequencerBlock", FIELDS, GeneratedVisitor)
     }
 }
+impl serde::Serialize for GetBlockCommitmentStreamRequest {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let len = 0;
+        let struct_ser = serializer.serialize_struct("astria.sequencerblock.v1alpha1.GetBlockCommitmentStreamRequest", len)?;
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for GetBlockCommitmentStreamRequest {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                            Err(serde::de::Error::unknown_field(value, FIELDS))
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = GetBlockCommitmentStreamRequest;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.sequencerblock.v1alpha1.GetBlockCommitmentStreamRequest")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<GetBlockCommitmentStreamRequest, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                while map_.next_key::<GeneratedField>()?.is_some() {
+                    let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                }
+                Ok(GetBlockCommitmentStreamRequest {
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.sequencerblock.v1alpha1.GetBlockCommitmentStreamRequest", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for GetBlockCommitmentStreamResponse {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.commitment.is_some() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.sequencerblock.v1alpha1.GetBlockCommitmentStreamResponse", len)?;
+        if let Some(v) = self.commitment.as_ref() {
+            struct_ser.serialize_field("commitment", v)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for GetBlockCommitmentStreamResponse {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "commitment",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Commitment,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "commitment" => Ok(GeneratedField::Commitment),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = GetBlockCommitmentStreamResponse;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.sequencerblock.v1alpha1.GetBlockCommitmentStreamResponse")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<GetBlockCommitmentStreamResponse, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut commitment__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Commitment => {
+                            if commitment__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("commitment"));
+                            }
+                            commitment__ = map_.next_value()?;
+                        }
+                    }
+                }
+                Ok(GetBlockCommitmentStreamResponse {
+                    commitment: commitment__,
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.sequencerblock.v1alpha1.GetBlockCommitmentStreamResponse", FIELDS, GeneratedVisitor)
+    }
+}
 impl serde::Serialize for GetFilteredSequencerBlockRequest {
     #[allow(deprecated)]
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
@@ -496,6 +658,189 @@ impl<'de> serde::Deserialize<'de> for GetFilteredSequencerBlockRequest {
             }
         }
         deserializer.deserialize_struct("astria.sequencerblock.v1alpha1.GetFilteredSequencerBlockRequest", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for GetOptimisticBlockStreamRequest {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.rollup_id.is_some() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.sequencerblock.v1alpha1.GetOptimisticBlockStreamRequest", len)?;
+        if let Some(v) = self.rollup_id.as_ref() {
+            struct_ser.serialize_field("rollupId", v)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for GetOptimisticBlockStreamRequest {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "rollup_id",
+            "rollupId",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            RollupId,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "rollupId" | "rollup_id" => Ok(GeneratedField::RollupId),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = GetOptimisticBlockStreamRequest;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.sequencerblock.v1alpha1.GetOptimisticBlockStreamRequest")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<GetOptimisticBlockStreamRequest, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut rollup_id__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::RollupId => {
+                            if rollup_id__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("rollupId"));
+                            }
+                            rollup_id__ = map_.next_value()?;
+                        }
+                    }
+                }
+                Ok(GetOptimisticBlockStreamRequest {
+                    rollup_id: rollup_id__,
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.sequencerblock.v1alpha1.GetOptimisticBlockStreamRequest", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for GetOptimisticBlockStreamResponse {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.block.is_some() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.sequencerblock.v1alpha1.GetOptimisticBlockStreamResponse", len)?;
+        if let Some(v) = self.block.as_ref() {
+            struct_ser.serialize_field("block", v)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for GetOptimisticBlockStreamResponse {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "block",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Block,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "block" => Ok(GeneratedField::Block),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = GetOptimisticBlockStreamResponse;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.sequencerblock.v1alpha1.GetOptimisticBlockStreamResponse")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<GetOptimisticBlockStreamResponse, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut block__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Block => {
+                            if block__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("block"));
+                            }
+                            block__ = map_.next_value()?;
+                        }
+                    }
+                }
+                Ok(GetOptimisticBlockStreamResponse {
+                    block: block__,
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.sequencerblock.v1alpha1.GetOptimisticBlockStreamResponse", FIELDS, GeneratedVisitor)
     }
 }
 impl serde::Serialize for GetPendingNonceRequest {
@@ -1486,260 +1831,6 @@ impl<'de> serde::Deserialize<'de> for SequencerBlockHeader {
             }
         }
         deserializer.deserialize_struct("astria.sequencerblock.v1alpha1.SequencerBlockHeader", FIELDS, GeneratedVisitor)
-    }
-}
-impl serde::Serialize for StreamBlockCommitmentsRequest {
-    #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        use serde::ser::SerializeStruct;
-        let len = 0;
-        let struct_ser = serializer.serialize_struct("astria.sequencerblock.v1alpha1.StreamBlockCommitmentsRequest", len)?;
-        struct_ser.end()
-    }
-}
-impl<'de> serde::Deserialize<'de> for StreamBlockCommitmentsRequest {
-    #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        const FIELDS: &[&str] = &[
-        ];
-
-        #[allow(clippy::enum_variant_names)]
-        enum GeneratedField {
-        }
-        impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
-            where
-                D: serde::Deserializer<'de>,
-            {
-                struct GeneratedVisitor;
-
-                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
-                    type Value = GeneratedField;
-
-                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                        write!(formatter, "expected one of: {:?}", &FIELDS)
-                    }
-
-                    #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
-                    where
-                        E: serde::de::Error,
-                    {
-                            Err(serde::de::Error::unknown_field(value, FIELDS))
-                    }
-                }
-                deserializer.deserialize_identifier(GeneratedVisitor)
-            }
-        }
-        struct GeneratedVisitor;
-        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
-            type Value = StreamBlockCommitmentsRequest;
-
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                formatter.write_str("struct astria.sequencerblock.v1alpha1.StreamBlockCommitmentsRequest")
-            }
-
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<StreamBlockCommitmentsRequest, V::Error>
-                where
-                    V: serde::de::MapAccess<'de>,
-            {
-                while map_.next_key::<GeneratedField>()?.is_some() {
-                    let _ = map_.next_value::<serde::de::IgnoredAny>()?;
-                }
-                Ok(StreamBlockCommitmentsRequest {
-                })
-            }
-        }
-        deserializer.deserialize_struct("astria.sequencerblock.v1alpha1.StreamBlockCommitmentsRequest", FIELDS, GeneratedVisitor)
-    }
-}
-impl serde::Serialize for StreamOptimisticBlockRequest {
-    #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        use serde::ser::SerializeStruct;
-        let mut len = 0;
-        if self.rollup_id.is_some() {
-            len += 1;
-        }
-        let mut struct_ser = serializer.serialize_struct("astria.sequencerblock.v1alpha1.StreamOptimisticBlockRequest", len)?;
-        if let Some(v) = self.rollup_id.as_ref() {
-            struct_ser.serialize_field("rollupId", v)?;
-        }
-        struct_ser.end()
-    }
-}
-impl<'de> serde::Deserialize<'de> for StreamOptimisticBlockRequest {
-    #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        const FIELDS: &[&str] = &[
-            "rollup_id",
-            "rollupId",
-        ];
-
-        #[allow(clippy::enum_variant_names)]
-        enum GeneratedField {
-            RollupId,
-        }
-        impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
-            where
-                D: serde::Deserializer<'de>,
-            {
-                struct GeneratedVisitor;
-
-                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
-                    type Value = GeneratedField;
-
-                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                        write!(formatter, "expected one of: {:?}", &FIELDS)
-                    }
-
-                    #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
-                    where
-                        E: serde::de::Error,
-                    {
-                        match value {
-                            "rollupId" | "rollup_id" => Ok(GeneratedField::RollupId),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
-                        }
-                    }
-                }
-                deserializer.deserialize_identifier(GeneratedVisitor)
-            }
-        }
-        struct GeneratedVisitor;
-        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
-            type Value = StreamOptimisticBlockRequest;
-
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                formatter.write_str("struct astria.sequencerblock.v1alpha1.StreamOptimisticBlockRequest")
-            }
-
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<StreamOptimisticBlockRequest, V::Error>
-                where
-                    V: serde::de::MapAccess<'de>,
-            {
-                let mut rollup_id__ = None;
-                while let Some(k) = map_.next_key()? {
-                    match k {
-                        GeneratedField::RollupId => {
-                            if rollup_id__.is_some() {
-                                return Err(serde::de::Error::duplicate_field("rollupId"));
-                            }
-                            rollup_id__ = map_.next_value()?;
-                        }
-                    }
-                }
-                Ok(StreamOptimisticBlockRequest {
-                    rollup_id: rollup_id__,
-                })
-            }
-        }
-        deserializer.deserialize_struct("astria.sequencerblock.v1alpha1.StreamOptimisticBlockRequest", FIELDS, GeneratedVisitor)
-    }
-}
-impl serde::Serialize for StreamOptimisticBlockResponse {
-    #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        use serde::ser::SerializeStruct;
-        let mut len = 0;
-        if self.block.is_some() {
-            len += 1;
-        }
-        let mut struct_ser = serializer.serialize_struct("astria.sequencerblock.v1alpha1.StreamOptimisticBlockResponse", len)?;
-        if let Some(v) = self.block.as_ref() {
-            struct_ser.serialize_field("block", v)?;
-        }
-        struct_ser.end()
-    }
-}
-impl<'de> serde::Deserialize<'de> for StreamOptimisticBlockResponse {
-    #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        const FIELDS: &[&str] = &[
-            "block",
-        ];
-
-        #[allow(clippy::enum_variant_names)]
-        enum GeneratedField {
-            Block,
-        }
-        impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
-            where
-                D: serde::Deserializer<'de>,
-            {
-                struct GeneratedVisitor;
-
-                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
-                    type Value = GeneratedField;
-
-                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                        write!(formatter, "expected one of: {:?}", &FIELDS)
-                    }
-
-                    #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
-                    where
-                        E: serde::de::Error,
-                    {
-                        match value {
-                            "block" => Ok(GeneratedField::Block),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
-                        }
-                    }
-                }
-                deserializer.deserialize_identifier(GeneratedVisitor)
-            }
-        }
-        struct GeneratedVisitor;
-        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
-            type Value = StreamOptimisticBlockResponse;
-
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                formatter.write_str("struct astria.sequencerblock.v1alpha1.StreamOptimisticBlockResponse")
-            }
-
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<StreamOptimisticBlockResponse, V::Error>
-                where
-                    V: serde::de::MapAccess<'de>,
-            {
-                let mut block__ = None;
-                while let Some(k) = map_.next_key()? {
-                    match k {
-                        GeneratedField::Block => {
-                            if block__.is_some() {
-                                return Err(serde::de::Error::duplicate_field("block"));
-                            }
-                            block__ = map_.next_value()?;
-                        }
-                    }
-                }
-                Ok(StreamOptimisticBlockResponse {
-                    block: block__,
-                })
-            }
-        }
-        deserializer.deserialize_struct("astria.sequencerblock.v1alpha1.StreamOptimisticBlockResponse", FIELDS, GeneratedVisitor)
     }
 }
 impl serde::Serialize for SubmittedMetadata {

--- a/crates/astria-core/src/generated/astria.sequencerblock.v1alpha1.serde.rs
+++ b/crates/astria-core/src/generated/astria.sequencerblock.v1alpha1.serde.rs
@@ -1181,6 +1181,121 @@ impl<'de> serde::Deserialize<'de> for SequencerBlock {
         deserializer.deserialize_struct("astria.sequencerblock.v1alpha1.SequencerBlock", FIELDS, GeneratedVisitor)
     }
 }
+impl serde::Serialize for SequencerBlockCommit {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.height != 0 {
+            len += 1;
+        }
+        if !self.block_hash.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.sequencerblock.v1alpha1.SequencerBlockCommit", len)?;
+        if self.height != 0 {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("height", ToString::to_string(&self.height).as_str())?;
+        }
+        if !self.block_hash.is_empty() {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("blockHash", pbjson::private::base64::encode(&self.block_hash).as_str())?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for SequencerBlockCommit {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "height",
+            "block_hash",
+            "blockHash",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Height,
+            BlockHash,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "height" => Ok(GeneratedField::Height),
+                            "blockHash" | "block_hash" => Ok(GeneratedField::BlockHash),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = SequencerBlockCommit;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.sequencerblock.v1alpha1.SequencerBlockCommit")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<SequencerBlockCommit, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut height__ = None;
+                let mut block_hash__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Height => {
+                            if height__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("height"));
+                            }
+                            height__ = 
+                                Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::BlockHash => {
+                            if block_hash__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("blockHash"));
+                            }
+                            block_hash__ = 
+                                Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
+                            ;
+                        }
+                    }
+                }
+                Ok(SequencerBlockCommit {
+                    height: height__.unwrap_or_default(),
+                    block_hash: block_hash__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.sequencerblock.v1alpha1.SequencerBlockCommit", FIELDS, GeneratedVisitor)
+    }
+}
 impl serde::Serialize for SequencerBlockHeader {
     #[allow(deprecated)]
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
@@ -1371,6 +1486,260 @@ impl<'de> serde::Deserialize<'de> for SequencerBlockHeader {
             }
         }
         deserializer.deserialize_struct("astria.sequencerblock.v1alpha1.SequencerBlockHeader", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for StreamBlockCommitmentsRequest {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let len = 0;
+        let struct_ser = serializer.serialize_struct("astria.sequencerblock.v1alpha1.StreamBlockCommitmentsRequest", len)?;
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for StreamBlockCommitmentsRequest {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                            Err(serde::de::Error::unknown_field(value, FIELDS))
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = StreamBlockCommitmentsRequest;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.sequencerblock.v1alpha1.StreamBlockCommitmentsRequest")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<StreamBlockCommitmentsRequest, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                while map_.next_key::<GeneratedField>()?.is_some() {
+                    let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                }
+                Ok(StreamBlockCommitmentsRequest {
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.sequencerblock.v1alpha1.StreamBlockCommitmentsRequest", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for StreamOptimisticBlockRequest {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.rollup_id.is_some() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.sequencerblock.v1alpha1.StreamOptimisticBlockRequest", len)?;
+        if let Some(v) = self.rollup_id.as_ref() {
+            struct_ser.serialize_field("rollupId", v)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for StreamOptimisticBlockRequest {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "rollup_id",
+            "rollupId",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            RollupId,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "rollupId" | "rollup_id" => Ok(GeneratedField::RollupId),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = StreamOptimisticBlockRequest;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.sequencerblock.v1alpha1.StreamOptimisticBlockRequest")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<StreamOptimisticBlockRequest, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut rollup_id__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::RollupId => {
+                            if rollup_id__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("rollupId"));
+                            }
+                            rollup_id__ = map_.next_value()?;
+                        }
+                    }
+                }
+                Ok(StreamOptimisticBlockRequest {
+                    rollup_id: rollup_id__,
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.sequencerblock.v1alpha1.StreamOptimisticBlockRequest", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for StreamOptimisticBlockResponse {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.block.is_some() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.sequencerblock.v1alpha1.StreamOptimisticBlockResponse", len)?;
+        if let Some(v) = self.block.as_ref() {
+            struct_ser.serialize_field("block", v)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for StreamOptimisticBlockResponse {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "block",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Block,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "block" => Ok(GeneratedField::Block),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = StreamOptimisticBlockResponse;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.sequencerblock.v1alpha1.StreamOptimisticBlockResponse")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<StreamOptimisticBlockResponse, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut block__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Block => {
+                            if block__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("block"));
+                            }
+                            block__ = map_.next_value()?;
+                        }
+                    }
+                }
+                Ok(StreamOptimisticBlockResponse {
+                    block: block__,
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.sequencerblock.v1alpha1.StreamOptimisticBlockResponse", FIELDS, GeneratedVisitor)
     }
 }
 impl serde::Serialize for SubmittedMetadata {

--- a/crates/astria-core/src/generated/mod.rs
+++ b/crates/astria-core/src/generated/mod.rs
@@ -38,6 +38,19 @@ pub mod astria_vendored {
 }
 
 #[path = ""]
+pub mod bundle {
+    pub mod v1lapha1 {
+        include!("astria.bundle.v1alpha1.rs");
+
+        #[cfg(feature = "serde")]
+        mod _serde_impl {
+            use super::*;
+            include!("astria.bundle.v1alpha1.serde.rs");
+        }
+    }
+}
+
+#[path = ""]
 pub mod execution {
     #[path = "astria.execution.v1alpha1.rs"]
     pub mod v1alpha1;

--- a/crates/astria-core/src/generated/mod.rs
+++ b/crates/astria-core/src/generated/mod.rs
@@ -39,7 +39,7 @@ pub mod astria_vendored {
 
 #[path = ""]
 pub mod bundle {
-    pub mod v1lapha1 {
+    pub mod v1alpha1 {
         include!("astria.bundle.v1alpha1.rs");
 
         #[cfg(feature = "serde")]

--- a/proto/executionapis/astria/bundle/v1alpha1/bundle.proto
+++ b/proto/executionapis/astria/bundle/v1alpha1/bundle.proto
@@ -1,0 +1,67 @@
+syntax = "proto3";
+
+package astria.bundle.v1alpha1;
+
+import "astria/execution/v1alpha2/execution.proto";
+import "astria/sequencerblock/v1alpha1/block.proto";
+import "google/protobuf/timestamp.proto";
+
+// The "BaseBlock" is the information needed to simulate bundles on top of
+// a Sequencer block which may not have been committed yet.
+message BaseBlock {
+  // This is the block hash for the proposed block.
+  bytes sequencer_block_hash = 1;
+  // List of transactions to include in the new block.
+  repeated astria.sequencerblock.v1alpha1.RollupData transactions = 2;
+  // Timestamp to be used for new block.
+  google.protobuf.Timestamp timestamp = 3;
+}
+
+message StreamExecuteOptimisticBlockRequest {
+  BaseBlock block = 1;
+}
+
+message StreamExecuteOptimisticBlockResponse {
+  // Metadata identifying the block resulting from executing a block. Includes number, hash,
+  // parent hash and timestamp.
+  astria.execution.v1alpha2.Block block = 1;
+  // The base_sequencer_block_hash is the hash from the base sequencer block this block
+  // is based on. This is used to associate an optimistic execution result with the hash
+  // received once a sequencer block is committed.
+  bytes base_sequencer_block_hash = 2;
+}
+
+message StreamBundlesRequest {}
+
+// Information for the bundle submitter to know how to submit the bundle.
+// The fee and base_sequencer_block_hash are not necessarily strictly necessary
+// it allows for the case where the server doesn't always send the highest fee
+// bundles after the previous but could just stream any confirmed bundles.
+message Bundle {
+  // The fee that can be expected to be received for submitting this bundle.
+  // This allows the bundle producer to stream any confirmed bundles they would be ok
+  // with submitting. Used to avoid race conditions in received bundle packets. Could
+  // also be used by a bundle submitter to allow multiple entities to submit bundles.
+  uint64 fee = 1;
+  // The byte list of transactions to be included.
+  repeated bytes transactions = 2;
+  // The base_sequencer_block_hash is the hash from the base block this bundle
+  // is based on. This is used to verify that the bundle is based on the correct
+  // Sequencer block.
+  bytes base_sequencer_block_hash = 3;
+  // The hash of previous rollup block, on top of which the bundle will be executed as ToB.
+  bytes prev_rollup_block_hash = 4;
+}
+
+service OptimisticExecutionService {
+  // Stream blocks from the Auctioneer to Geth for optimistic execution. Geth will stream back
+  // metadata from the executed blocks.
+  rpc StreamExecuteOptimisticBlock(stream StreamExecuteOptimisticBlockRequest) returns (stream StreamExecuteOptimisticBlockResponse);
+}
+
+service BundleService {
+  // A bundle submitter requests bundles given a new optimistic Sequencer block,
+  // and receives a stream of potential bundles for submission, until either a timeout
+  // or the connection is closed by the client.
+  rpc StreamBundles(StreamBundlesRequest) returns (stream Bundle);
+}

--- a/proto/executionapis/astria/bundle/v1alpha1/bundle.proto
+++ b/proto/executionapis/astria/bundle/v1alpha1/bundle.proto
@@ -17,11 +17,11 @@ message BaseBlock {
   google.protobuf.Timestamp timestamp = 3;
 }
 
-message StreamExecuteOptimisticBlockRequest {
-  BaseBlock block = 1;
+message ExecuteOptimisticBlockStreamRequest {
+  BaseBlock base_block = 1;
 }
 
-message StreamExecuteOptimisticBlockResponse {
+message ExecuteOptimisticBlockStreamResponse {
   // Metadata identifying the block resulting from executing a block. Includes number, hash,
   // parent hash and timestamp.
   astria.execution.v1alpha2.Block block = 1;
@@ -31,7 +31,7 @@ message StreamExecuteOptimisticBlockResponse {
   bytes base_sequencer_block_hash = 2;
 }
 
-message StreamBundlesRequest {}
+message GetBundleStreamRequest {}
 
 // Information for the bundle submitter to know how to submit the bundle.
 // The fee and base_sequencer_block_hash are not necessarily strictly necessary
@@ -53,15 +53,19 @@ message Bundle {
   bytes prev_rollup_block_hash = 4;
 }
 
+message GetBundleStreamResponse {
+  Bundle bundle = 1;
+}
+
 service OptimisticExecutionService {
   // Stream blocks from the Auctioneer to Geth for optimistic execution. Geth will stream back
   // metadata from the executed blocks.
-  rpc StreamExecuteOptimisticBlock(stream StreamExecuteOptimisticBlockRequest) returns (stream StreamExecuteOptimisticBlockResponse);
+  rpc ExecuteOptimisticBlockStream(stream ExecuteOptimisticBlockStreamRequest) returns (stream ExecuteOptimisticBlockStreamResponse);
 }
 
 service BundleService {
   // A bundle submitter requests bundles given a new optimistic Sequencer block,
   // and receives a stream of potential bundles for submission, until either a timeout
   // or the connection is closed by the client.
-  rpc StreamBundles(StreamBundlesRequest) returns (stream Bundle);
+  rpc GetBundleStream(GetBundleStreamRequest) returns (stream GetBundleStreamResponse);
 }

--- a/proto/executionapis/astria/bundle/v1alpha1/bundle.proto
+++ b/proto/executionapis/astria/bundle/v1alpha1/bundle.proto
@@ -2,35 +2,6 @@ syntax = "proto3";
 
 package astria.bundle.v1alpha1;
 
-import "astria/execution/v1alpha2/execution.proto";
-import "astria/sequencerblock/v1alpha1/block.proto";
-import "google/protobuf/timestamp.proto";
-
-// The "BaseBlock" is the information needed to simulate bundles on top of
-// a Sequencer block which may not have been committed yet.
-message BaseBlock {
-  // This is the block hash for the proposed block.
-  bytes sequencer_block_hash = 1;
-  // List of transactions to include in the new block.
-  repeated astria.sequencerblock.v1alpha1.RollupData transactions = 2;
-  // Timestamp to be used for new block.
-  google.protobuf.Timestamp timestamp = 3;
-}
-
-message ExecuteOptimisticBlockStreamRequest {
-  BaseBlock base_block = 1;
-}
-
-message ExecuteOptimisticBlockStreamResponse {
-  // Metadata identifying the block resulting from executing a block. Includes number, hash,
-  // parent hash and timestamp.
-  astria.execution.v1alpha2.Block block = 1;
-  // The base_sequencer_block_hash is the hash from the base sequencer block this block
-  // is based on. This is used to associate an optimistic execution result with the hash
-  // received once a sequencer block is committed.
-  bytes base_sequencer_block_hash = 2;
-}
-
 message GetBundleStreamRequest {}
 
 // Information for the bundle submitter to know how to submit the bundle.
@@ -55,12 +26,6 @@ message Bundle {
 
 message GetBundleStreamResponse {
   Bundle bundle = 1;
-}
-
-service OptimisticExecutionService {
-  // Stream blocks from the Auctioneer to Geth for optimistic execution. Geth will stream back
-  // metadata from the executed blocks.
-  rpc ExecuteOptimisticBlockStream(stream ExecuteOptimisticBlockStreamRequest) returns (stream ExecuteOptimisticBlockStreamResponse);
 }
 
 service BundleService {

--- a/proto/executionapis/astria/bundle/v1alpha1/optimistic_execution.proto
+++ b/proto/executionapis/astria/bundle/v1alpha1/optimistic_execution.proto
@@ -1,0 +1,38 @@
+syntax = "proto3";
+
+package astria.bundle.v1alpha1;
+
+import "astria/execution/v1alpha2/execution.proto";
+import "astria/sequencerblock/v1alpha1/block.proto";
+import "google/protobuf/timestamp.proto";
+
+// The "BaseBlock" is the information needed to simulate bundles on top of
+// a Sequencer block which may not have been committed yet.
+message BaseBlock {
+  // This is the block hash for the proposed block.
+  bytes sequencer_block_hash = 1;
+  // List of transactions to include in the new block.
+  repeated astria.sequencerblock.v1alpha1.RollupData transactions = 2;
+  // Timestamp to be used for new block.
+  google.protobuf.Timestamp timestamp = 3;
+}
+
+message ExecuteOptimisticBlockStreamRequest {
+  BaseBlock base_block = 1;
+}
+
+message ExecuteOptimisticBlockStreamResponse {
+  // Metadata identifying the block resulting from executing a block. Includes number, hash,
+  // parent hash and timestamp.
+  astria.execution.v1alpha2.Block block = 1;
+  // The base_sequencer_block_hash is the hash from the base sequencer block this block
+  // is based on. This is used to associate an optimistic execution result with the hash
+  // received once a sequencer block is committed.
+  bytes base_sequencer_block_hash = 2;
+}
+
+service OptimisticExecutionService {
+  // Stream blocks from the Auctioneer to Geth for optimistic execution. Geth will stream back
+  // metadata from the executed blocks.
+  rpc ExecuteOptimisticBlockStream(stream ExecuteOptimisticBlockStreamRequest) returns (stream ExecuteOptimisticBlockStreamResponse);
+}

--- a/proto/sequencerblockapis/astria/sequencerblock/v1alpha1/optimistic_block.proto
+++ b/proto/sequencerblockapis/astria/sequencerblock/v1alpha1/optimistic_block.proto
@@ -1,0 +1,35 @@
+syntax = "proto3";
+
+package astria.sequencerblock.v1alpha1;
+
+import "astria/primitive/v1/types.proto";
+import "astria/sequencerblock/v1alpha1/block.proto";
+
+message StreamBlockCommitmentsRequest {}
+
+// Identifying metadata for blocks that have been successfully committed in the Sequencer.
+message SequencerBlockCommit {
+  // Height of the sequencer block that was committed.
+  uint64 height = 1;
+  // Hash of the sequencer block that was committed.
+  bytes block_hash = 2;
+}
+
+message StreamOptimisticBlockRequest {
+  // The rollup id for which the Sequencer block is being streamed.
+  astria.primitive.v1.RollupId rollup_id = 1;
+}
+
+message StreamOptimisticBlockResponse {
+  // The optimistic Sequencer block that is being streamed, filtered for the provided rollup id.
+  astria.sequencerblock.v1alpha1.FilteredSequencerBlock block = 1;
+}
+
+// The Sequencer will serve this to the aucitoneer
+service OptimisticBlockService {
+  // The Sequencer will stream the optimistic Sequencer block (filtered for the provided
+  // rollup id) to the Auctioneer.
+  rpc StreamOptimisticBlock(StreamOptimisticBlockRequest) returns (stream StreamOptimisticBlockResponse);
+  // The Sequencer will stream the block commits to the Auctioneer.
+  rpc StreamBlockCommitments(StreamBlockCommitmentsRequest) returns (stream SequencerBlockCommit);
+}

--- a/proto/sequencerblockapis/astria/sequencerblock/v1alpha1/optimistic_block.proto
+++ b/proto/sequencerblockapis/astria/sequencerblock/v1alpha1/optimistic_block.proto
@@ -5,7 +5,7 @@ package astria.sequencerblock.v1alpha1;
 import "astria/primitive/v1/types.proto";
 import "astria/sequencerblock/v1alpha1/block.proto";
 
-message StreamBlockCommitmentsRequest {}
+message GetBlockCommitmentStreamRequest {}
 
 // Identifying metadata for blocks that have been successfully committed in the Sequencer.
 message SequencerBlockCommit {
@@ -15,12 +15,16 @@ message SequencerBlockCommit {
   bytes block_hash = 2;
 }
 
-message StreamOptimisticBlockRequest {
+message GetBlockCommitmentStreamResponse {
+  SequencerBlockCommit commitment = 1;
+}
+
+message GetOptimisticBlockStreamRequest {
   // The rollup id for which the Sequencer block is being streamed.
   astria.primitive.v1.RollupId rollup_id = 1;
 }
 
-message StreamOptimisticBlockResponse {
+message GetOptimisticBlockStreamResponse {
   // The optimistic Sequencer block that is being streamed, filtered for the provided rollup id.
   astria.sequencerblock.v1alpha1.FilteredSequencerBlock block = 1;
 }
@@ -29,7 +33,7 @@ message StreamOptimisticBlockResponse {
 service OptimisticBlockService {
   // The Sequencer will stream the optimistic Sequencer block (filtered for the provided
   // rollup id) to the Auctioneer.
-  rpc StreamOptimisticBlock(StreamOptimisticBlockRequest) returns (stream StreamOptimisticBlockResponse);
+  rpc GetOptimisticBlockStream(GetOptimisticBlockStreamRequest) returns (stream GetOptimisticBlockStreamResponse);
   // The Sequencer will stream the block commits to the Auctioneer.
-  rpc StreamBlockCommitments(StreamBlockCommitmentsRequest) returns (stream SequencerBlockCommit);
+  rpc GetBlockCommitmentStream(GetBlockCommitmentStreamRequest) returns (stream GetBlockCommitmentStreamResponse);
 }


### PR DESCRIPTION
## Summary
This adds the protobuf definitions for optimistic block stream and the bundle stream.

## Background
The Auctioneer will auction off a bundle slot which will be placed at the top of the rollup block deterministically during execution. The APIs in this PR are used to drive the bundle auction (detailed in [this document](https://www.notion.so/astria-org/20240919-Status-Update-1066bd31a90c80b68bb2ea9b898645d0)). At a high level:

The Auctioneer receives blocks optimistically from the sequencer in order to maximize the auction duration.

While the auction is running, the Auctioneer receives orders from the rollup node that have been validated against the optimistic block.

After a block is committed, the Auctioneer will submit the highest paying bundle for inclusion by the sequencer.

### Optimistic Block Stream
1. The Sequencer will stream blocks to the Auctioneer optimistically, i.e. before they are finalized (ProcessProposal).
2. The Sequencer will also stream block commitments to the Auctioneer, which mark blocks as final thanks to CometBFT's single slot finality. 

### Bundle Stream
1. The Auctioneer will stream optimistic blocks to the rollup node for execution. The rollup will execute the block and return the resulting header info.
2. The rollup node will stream bundles (indexed by parent block hash) to the Auctioneer.

## Changes
- Add the bundle service to the composer apis
- Add the optimistic block service to the sequencer block apis

## Breaking Changelist
- Bulleted list of breaking changes, any notes on migration. Delete section if none.

## Related Issues
closes https://github.com/astriaorg/astria/issues/1553
