### PR TITLE
chore(bridge-withdrawer): better grpc client construction

### DIFF
--- a/crates/astria-bridge-withdrawer/src/bridge_withdrawer/mod.rs
+++ b/crates/astria-bridge-withdrawer/src/bridge_withdrawer/mod.rs
@@ -4,7 +4,7 @@ use std::{
     time::Duration,
 };
 
-use astria_core::generated::sequencerblock::v1alpha1::sequencer_service_client::SequencerServiceClient as SequencerGrpcClient;
+use astria_core::generated::sequencerblock::v1alpha1::sequencer_service_client::SequencerServiceClient;
 use astria_eyre::eyre::{
     self,
     WrapErr as _,
@@ -470,11 +470,11 @@ pub(crate) fn flatten_result<T>(res: Result<eyre::Result<T>, JoinError>) -> eyre
 
 fn connect_sequencer_grpc(
     sequencer_grpc_endpoint: &str,
-) -> eyre::Result<SequencerGrpcClient<tonic::transport::Channel>> {
+) -> eyre::Result<SequencerServiceClient<tonic::transport::Channel>> {
     let uri: Uri = sequencer_grpc_endpoint
         .parse()
         .wrap_err("failed to parse endpoint as URI")?;
-    Ok(SequencerGrpcClient::new(
+    Ok(SequencerServiceClient::new(
         tonic::transport::Endpoint::from(uri).connect_lazy(),
     ))
 }

--- a/crates/astria-bridge-withdrawer/src/bridge_withdrawer/mod.rs
+++ b/crates/astria-bridge-withdrawer/src/bridge_withdrawer/mod.rs
@@ -15,6 +15,7 @@ use axum::{
     Server,
 };
 use ethereum::watcher::Watcher;
+use http::Uri;
 use hyper::server::conn::AddrIncoming;
 use startup::Startup;
 use tokio::{
@@ -93,9 +94,11 @@ impl BridgeWithdrawer {
             .parse()
             .wrap_err("failed to parse sequencer bridge address")?;
 
-        let sequencer_grpc_connection = tonic::transport::Endpoint::new(sequencer_grpc_endpoint)
-            .wrap_err("failed constructing sequencer grpc endpoint")?
-            .connect_lazy();
+        let sequencer_grpc_uri = sequencer_grpc_endpoint
+            .parse::<Uri>()
+            .wrap_err("failed to parse sequencer grpc endpoint to Uri")?;
+        let sequencer_grpc_connection =
+            tonic::transport::Endpoint::from(sequencer_grpc_uri).connect_lazy();
         let sequencer_grpc_client =
             sequencer_service_client::SequencerServiceClient::new(sequencer_grpc_connection);
         let sequencer_cometbft_client =

--- a/crates/astria-bridge-withdrawer/src/bridge_withdrawer/mod.rs
+++ b/crates/astria-bridge-withdrawer/src/bridge_withdrawer/mod.rs
@@ -93,8 +93,9 @@ impl BridgeWithdrawer {
             .parse()
             .wrap_err("failed to parse sequencer bridge address")?;
 
-        let sequencer_grpc_connection =
-            tonic::transport::Endpoint::new(sequencer_grpc_endpoint)?.connect_lazy();
+        let sequencer_grpc_connection = tonic::transport::Endpoint::new(sequencer_grpc_endpoint)
+            .wrap_err("failed constructing sequencer grpc endpoint")?
+            .connect_lazy();
         let sequencer_grpc_client =
             sequencer_service_client::SequencerServiceClient::new(sequencer_grpc_connection);
         let sequencer_cometbft_client =


### PR DESCRIPTION
## Summary
Added error context to sequencer GRPC client construction.

## Background
https://github.com/astriaorg/astria/pull/1510/files#r1766478324

## Changes
- Added helper function for constructing the sequencer GRPC client and switched from using `Endpoint::new()` to `connect_lazy()`.
- Added error context to sequencer GRPC client construction.

## Testing
Passing all tests

## Related Issues
closes #1527
closes #1542 
