### PR TITLE
chore(sequencer): more detailed decrease balance error statement

### DIFF
--- a/crates/astria-sequencer/src/accounts/state_ext.rs
+++ b/crates/astria-sequencer/src/accounts/state_ext.rs
@@ -317,9 +317,10 @@ pub(crate) trait StateWriteExt: StateWrite {
         self.put_account_balance(
             &address,
             asset,
-            balance
-                .checked_sub(amount)
-                .ok_or_eyre("subtracting from account balance failed due to insufficient funds")?,
+            balance.checked_sub(amount).ok_or_eyre(format!(
+                "subtracting amount ({amount}) from account balance ({balance}) failed due to \
+                 insufficient funds"
+            ))?,
         )
         .wrap_err("failed to store updated account balance in database")?;
         Ok(())


### PR DESCRIPTION
## Summary
Added more detailed error statement to `accounts::StateWriteExt::decrease_balance()`.

## Background
Error was previously quite non-descriptive, found this change useful when testing for breaking changes to fees.

## Changes
- Added subtraction and balance amounts to subtraction error in `accounts::StateWriteExt::decrease_balance()`.

## Related Issues
closes #1529
