### PR TITLE
fix(sequencer): install astria-eyre hook

### DIFF
--- a/crates/astria-sequencer/src/main.rs
+++ b/crates/astria-sequencer/src/main.rs
@@ -15,7 +15,7 @@ const EX_CONFIG: u8 = 78;
 #[tokio::main]
 async fn main() -> ExitCode {
     astria_eyre::install().expect("astria eyre hook must be the first hook installed");
-    
+
     eprintln!(
         "{}",
         serde_json::to_string(&BUILD_INFO)

--- a/crates/astria-sequencer/src/main.rs
+++ b/crates/astria-sequencer/src/main.rs
@@ -14,6 +14,8 @@ const EX_CONFIG: u8 = 78;
 
 #[tokio::main]
 async fn main() -> ExitCode {
+    astria_eyre::install().expect("astria eyre hook must be the first hook installed");
+    
     eprintln!(
         "{}",
         serde_json::to_string(&BUILD_INFO)


### PR DESCRIPTION
## Summary
Added `astria_eyre::install()` call to `main.rs`.

## Background
https://github.com/astriaorg/astria/pull/1387 switched the sequencer from `anyhow` to `eyre` usage, but did not install the `astria-eyre` error hook.

## Changes
Added `astria_eyre::install()` call to `main.rs`.

## Testing
Passing all tests

## Related Issues
closes #1551 
