### PR TITLE
fix(ci): workflow file issue

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.tag }}
-        uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUSTUP_TOOLCHAIN }}
       - uses: arduino/setup-protoc@v3


### PR DESCRIPTION
## Summary
We accidentally broke the reusable build script with a poorly formatted workflow file in https://github.com/astriaorg/astria/pull/1523/ this fixes it.
