### PR TITLE
fix(docker): use target binary build param as name of image entrypoint

### DIFF
--- a/containerfiles/Dockerfile
+++ b/containerfiles/Dockerfile
@@ -82,5 +82,8 @@ RUN \
     apt-get clean; \
     rm -rf /var/lib/apt/lists/*;
 COPY --from=builder /build/release/$TARGETBINARY /usr/local/bin/$TARGETBINARY
-RUN ln -s /usr/local/bin/$TARGETBINARY /usr/local/bin/entrypoint
-ENTRYPOINT ["/usr/local/bin/entrypoint"]
+ENV TARGETBINARY=$TARGETBINARY
+RUN \
+  printf '#!/bin/sh\nexec /usr/local/bin/$TARGETBINARY $@\n' > /usr/local/bin/entrypoint.sh; \
+  chmod +x /usr/local/bin/entrypoint.sh;
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/containerfiles/Dockerfile
+++ b/containerfiles/Dockerfile
@@ -82,6 +82,8 @@ RUN \
     apt-get clean; \
     rm -rf /var/lib/apt/lists/*;
 COPY --from=builder /build/release/$TARGETBINARY /usr/local/bin/$TARGETBINARY
+
+# HACK: Ensure that $TARGETBINARY is the binary name.
 ENV TARGETBINARY=$TARGETBINARY
 RUN \
   printf '#!/bin/sh\nexec /usr/local/bin/$TARGETBINARY $@\n' > /usr/local/bin/entrypoint.sh; \


### PR DESCRIPTION
## Summary
Fixes container images to use the `$TARGETBINARY` build param as the name of the binary run in the image entrypoint.

## Background
Before this patch, the containerfile entrypoint used a symlinked `/usr/local/bin/entrypoint` as the entrypoint, which caused the name of the binary to be `"entrypoint"`. This itself was to workaround to the `ENTRYPOINT` command not allowing for variables in exec form. This patch instead creates an ad-hoc script which itself executes `$TARGETBINARY`, and uses this script as the entrypoint.

Together with the script using `exec` and the exec form of `ENTRYPOINT` the expected binary (and process) name are used.

Taking `astria-cli`'s help message as an example:

Before:
```
Get the balance of a Sequencer account

Usage: entrypoint sequencer balance get [OPTIONS] <ADDRESS>
```

After:
```
Get the balance of a Sequencer account

Usage: astria-cli sequencer balance get [OPTIONS] <ADDRESS>
```

## Changes
- Create an adhoc `/usr/local/bin/entrypoint.sh` script in `containerfiles/Dockerfile` which is used as a new entrypoint and executes `$TARGETBINARY`

## Testing
Built and ran images using the dockerfile. No functionality was changed but the binary is `$TARGETBINARY` and not `entrypoint` now.

## Related Issues
closes https://github.com/astriaorg/astria/issues/1571
