### PR TITLE
fix(conductor): fix flaky restart test

### DIFF
--- a/crates/astria-conductor/tests/blackbox/soft_and_firm.rs
+++ b/crates/astria-conductor/tests/blackbox/soft_and_firm.rs
@@ -488,6 +488,7 @@ async fn conductor_restarts_on_permission_denied() {
         test_conductor,
         celestia_height: 1,
         sequencer_heights: [3],
+        delay: Some(Duration::from_millis(250))
     );
 
     mount_sequencer_commit!(


### PR DESCRIPTION
## Summary
Fixed flaky conductor restart test.

## Background
`soft_and_firm::conductor_restart_on_permission_denied` would sometimes fail due to receiving the firm block first.

## Changes
- Added short delay to firm block response so the conductor will always receive the soft block first.

## Testing
Test now passing.

## Related Issues
closes #1566
