### PR TITLE
chore: rename all modules named `test` to `tests`

### DIFF
--- a/crates/astria-cli/src/commands/sequencer.rs
+++ b/crates/astria-cli/src/commands/sequencer.rs
@@ -501,7 +501,7 @@ async fn submit_transaction(
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
 
     #[test]

--- a/crates/astria-conductor/src/celestia/block_verifier.rs
+++ b/crates/astria-conductor/src/celestia/block_verifier.rs
@@ -217,7 +217,7 @@ fn verify_vote_signature(
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use std::collections::BTreeMap;
 
     use astria_core::{

--- a/crates/astria-conductor/src/conductor/inner.rs
+++ b/crates/astria-conductor/src/conductor/inner.rs
@@ -306,7 +306,7 @@ fn check_for_restart(name: &str, err: &eyre::ErrReport) -> bool {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use astria_eyre::eyre::WrapErr as _;
 
     #[test]

--- a/crates/astria-core/src/protocol/memos/snapshots/astria_core__protocol__memos__v1alpha1__tests__ics20_transfer_deposit_memo_snapshot.snap
+++ b/crates/astria-core/src/protocol/memos/snapshots/astria_core__protocol__memos__v1alpha1__tests__ics20_transfer_deposit_memo_snapshot.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/astria-core/src/protocol/memos/v1alpha1.rs
+assertion_line: 28
 expression: memo
 ---
 {

--- a/crates/astria-core/src/protocol/memos/snapshots/astria_core__protocol__memos__v1alpha1__tests__ics20_withdrawal_from_rollup_memo_snapshot.snap
+++ b/crates/astria-core/src/protocol/memos/snapshots/astria_core__protocol__memos__v1alpha1__tests__ics20_withdrawal_from_rollup_memo_snapshot.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/astria-core/src/protocol/memos/v1alpha1.rs
+assertion_line: 19
 expression: memo
 ---
 {

--- a/crates/astria-core/src/protocol/memos/v1alpha1.rs
+++ b/crates/astria-core/src/protocol/memos/v1alpha1.rs
@@ -4,7 +4,7 @@ pub use crate::generated::protocol::memos::v1alpha1::{
 };
 
 #[cfg(all(feature = "serde", test))]
-mod test {
+mod tests {
     use super::*;
 
     #[test]

--- a/crates/astria-core/src/protocol/transaction/v1alpha1/mod.rs
+++ b/crates/astria-core/src/protocol/transaction/v1alpha1/mod.rs
@@ -554,7 +554,7 @@ enum TransactionFeeResponseErrorKind {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     use crate::{
         primitive::v1::{

--- a/crates/astria-core/src/protocol/transaction/v1alpha1/snapshots/astria_core__protocol__transaction__v1alpha1__tests__signed_transaction_hash.snap
+++ b/crates/astria-core/src/protocol/transaction/v1alpha1/snapshots/astria_core__protocol__transaction__v1alpha1__tests__signed_transaction_hash.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/astria-core/src/protocol/transaction/v1alpha1/mod.rs
+assertion_line: 613
 expression: tx.id()
 ---
 {

--- a/crates/astria-eyre/src/lib.rs
+++ b/crates/astria-eyre/src/lib.rs
@@ -105,7 +105,7 @@ mod anyhow_conversion {
     }
 
     #[cfg(test)]
-    mod test {
+    mod tests {
         #[test]
         fn anyhow_to_eyre_preserves_source_chain() {
             let mut errs = ["foo", "bar", "baz", "qux"];

--- a/crates/astria-sequencer/src/address/state_ext.rs
+++ b/crates/astria-sequencer/src/address/state_ext.rs
@@ -102,7 +102,7 @@ pub(crate) trait StateWriteExt: StateWrite {
 impl<T: StateWrite> StateWriteExt for T {}
 
 #[cfg(test)]
-mod test {
+mod tests {
     use cnidarium::StateDelta;
 
     use super::{

--- a/crates/astria-sequencer/src/api_state_ext.rs
+++ b/crates/astria-sequencer/src/api_state_ext.rs
@@ -395,7 +395,7 @@ pub(crate) trait StateWriteExt: StateWrite {
 impl<T: StateWrite> StateWriteExt for T {}
 
 #[cfg(test)]
-mod test {
+mod tests {
     use astria_core::{
         primitive::v1::TransactionId,
         protocol::test_utils::ConfigureSequencerBlock,

--- a/crates/astria-sequencer/src/authority/action.rs
+++ b/crates/astria-sequencer/src/authority/action.rs
@@ -185,7 +185,7 @@ impl ActionHandler for IbcSudoChangeAction {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use astria_core::primitive::v1::TransactionId;
     use cnidarium::StateDelta;
 

--- a/crates/astria-sequencer/src/bridge/query.rs
+++ b/crates/astria-sequencer/src/bridge/query.rs
@@ -291,7 +291,7 @@ fn preprocess_request(params: &[(String, String)]) -> Result<Address, response::
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use astria_core::{
         generated::protocol::bridge::v1alpha1::BridgeAccountInfoResponse as RawBridgeAccountInfoResponse,
         primitive::v1::RollupId,

--- a/crates/astria-sequencer/src/bridge/snapshots/astria_sequencer__bridge__state_ext__tests__storage_keys_have_not_changed-2.snap
+++ b/crates/astria-sequencer/src/bridge/snapshots/astria_sequencer__bridge__state_ext__tests__storage_keys_have_not_changed-2.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/astria-sequencer/src/bridge/state_ext.rs
+assertion_line: 812
 expression: asset_id_storage_key(&address)
 ---
 bridgeacc/1c0c490f1b5528d8173c5de46d131160e4b2c0c3/assetid

--- a/crates/astria-sequencer/src/bridge/snapshots/astria_sequencer__bridge__state_ext__tests__storage_keys_have_not_changed-3.snap
+++ b/crates/astria-sequencer/src/bridge/snapshots/astria_sequencer__bridge__state_ext__tests__storage_keys_have_not_changed-3.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/astria-sequencer/src/bridge/state_ext.rs
+assertion_line: 813
 expression: bridge_account_sudo_address_storage_key(&address)
 ---
 bsudo/1c0c490f1b5528d8173c5de46d131160e4b2c0c3

--- a/crates/astria-sequencer/src/bridge/snapshots/astria_sequencer__bridge__state_ext__tests__storage_keys_have_not_changed-4.snap
+++ b/crates/astria-sequencer/src/bridge/snapshots/astria_sequencer__bridge__state_ext__tests__storage_keys_have_not_changed-4.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/astria-sequencer/src/bridge/state_ext.rs
+assertion_line: 814
 expression: bridge_account_withdrawer_address_storage_key(&address)
 ---
 bwithdrawer/1c0c490f1b5528d8173c5de46d131160e4b2c0c3

--- a/crates/astria-sequencer/src/bridge/snapshots/astria_sequencer__bridge__state_ext__tests__storage_keys_have_not_changed.snap
+++ b/crates/astria-sequencer/src/bridge/snapshots/astria_sequencer__bridge__state_ext__tests__storage_keys_have_not_changed.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/astria-sequencer/src/bridge/state_ext.rs
+assertion_line: 811
 expression: rollup_id_storage_key(&address)
 ---
 bridgeacc/1c0c490f1b5528d8173c5de46d131160e4b2c0c3/rollupid

--- a/crates/astria-sequencer/src/bridge/state_ext.rs
+++ b/crates/astria-sequencer/src/bridge/state_ext.rs
@@ -514,7 +514,7 @@ pub(crate) trait StateWriteExt: StateWrite {
 impl<T: StateWrite> StateWriteExt for T {}
 
 #[cfg(test)]
-mod test {
+mod tests {
     use astria_core::{
         primitive::v1::{
             asset,

--- a/crates/astria-sequencer/src/grpc/sequencer.rs
+++ b/crates/astria-sequencer/src/grpc/sequencer.rs
@@ -215,7 +215,7 @@ impl SequencerService for SequencerServer {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use astria_core::{
         protocol::test_utils::ConfigureSequencerBlock,
         sequencerblock::v1alpha1::SequencerBlock,

--- a/crates/astria-sequencer/src/mempool/mod.rs
+++ b/crates/astria-sequencer/src/mempool/mod.rs
@@ -409,7 +409,7 @@ impl Mempool {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use astria_core::crypto::SigningKey;
 
     use super::*;

--- a/crates/astria-sequencer/src/mempool/transactions_container.rs
+++ b/crates/astria-sequencer/src/mempool/transactions_container.rs
@@ -779,7 +779,7 @@ impl<const MAX_TX_COUNT: usize> TransactionsContainer<ParkedTransactionsForAccou
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use astria_core::crypto::SigningKey;
 
     use super::*;

--- a/crates/astria-sequencer/src/proposal/commitment.rs
+++ b/crates/astria-sequencer/src/proposal/commitment.rs
@@ -90,7 +90,7 @@ pub(crate) fn generate_rollup_datas_commitment(
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use astria_core::{
         crypto::SigningKey,
         protocol::transaction::v1alpha1::{

--- a/crates/astria-sequencer/src/sequence/action.rs
+++ b/crates/astria-sequencer/src/sequence/action.rs
@@ -100,7 +100,7 @@ fn calculate_fee(data: &[u8], fee_per_byte: u128, base_fee: u128) -> Option<u128
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
 
     #[test]

--- a/crates/astria-sequencer/src/sequence/state_ext.rs
+++ b/crates/astria-sequencer/src/sequence/state_ext.rs
@@ -75,7 +75,7 @@ pub(crate) trait StateWriteExt: StateWrite {
 impl<T: StateWrite> StateWriteExt for T {}
 
 #[cfg(test)]
-mod test {
+mod tests {
     use cnidarium::StateDelta;
 
     use super::{

--- a/crates/astria-sequencer/src/service/consensus.rs
+++ b/crates/astria-sequencer/src/service/consensus.rs
@@ -196,7 +196,7 @@ impl Consensus {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use std::{
         collections::HashMap,
         str::FromStr,

--- a/crates/astria-sequencer/src/service/info/mod.rs
+++ b/crates/astria-sequencer/src/service/info/mod.rs
@@ -177,7 +177,7 @@ impl Service<InfoRequest> for Info {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use astria_core::{
         primitive::v1::asset,
         protocol::{


### PR DESCRIPTION
## Summary
A trivial rename of some modules.

## Background
It's canonical to name unit test modules as `tests`.  We currently have a mixture of `test` and `tests` throughout the codebase.

## Changes
- Renamed all `test` modules to `tests`.  No actual tests were changed.

