### PR TITLE
fix(ci): ibc bridge test timeout

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -217,7 +217,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup IBC Bridge Test Environment
-        timeout-minutes: 5
+        timeout-minutes: 8
         run: |
           TAG=sha-$(git rev-parse --short HEAD)
           just deploy cluster

--- a/charts/ibc-test.just
+++ b/charts/ibc-test.just
@@ -32,7 +32,7 @@ delete:
   just wait-for-rollup > /dev/null
   echo "Deploying Hermes"
   just deploy hermes-local > /dev/null
-  kubectl wait -n astria-dev-cluster deployment hermes-local-chart --for=condition=Available=True --timeout=300s
+  kubectl wait -n astria-dev-cluster deployment hermes-local-chart --for=condition=Available=True --timeout=480s
 
 [no-cd]
 run tag=defaultTag:


### PR DESCRIPTION
## Summary
Increases ibc-bridge-test and hermes deployment timeouts
## Background
The ibc-bridge-test fails occasionally, lacking time to setup hermes clients.  
## Changes
Increased timeouts both in github workflow and kubectl

## Related Issues

closes #1586 
