### PR TITLE
ci: code freeze through github actions

### DIFF
--- a/.github/code-freeze-filter.yaml
+++ b/.github/code-freeze-filter.yaml
@@ -4,11 +4,15 @@
 
 # Please provide a reasoning for each component that is frozen.
 
-# Conductor is frozen for zellic audit.
+# Frozen for audit.
 conductor: &conductor
   - crates/astria-conductor/src/**
+# Frozen for audit.
 sequencer-relayer: &sequencer-relayer
   - crates/astria-sequencer-relayer/src/**
+
+# if new components are added above update the list below to get better
+# gh pr level visibility into which files are frozen.
 changed:
   - *conductor
   - *sequencer-relayer

--- a/.github/code-freeze-filter.yaml
+++ b/.github/code-freeze-filter.yaml
@@ -1,0 +1,14 @@
+# Each component that is being frozen should have a section in this file.
+# The `changed` section should pull all the files that are changed
+# in order to put an error on the given file if it is changed.
+
+# Please provide a reasoning for each component that is frozen.
+
+# Conductor is frozen for zellic audit.
+conductor: &conductor
+  - crates/astria-conductor/src/**
+sequencer-relayer: &sequencer-relayer
+  - crates/astria-sequencer-relayer/src/**
+changed:
+  - *conductor
+  - *sequencer-relayer

--- a/.github/workflows/code-freeze.yml
+++ b/.github/workflows/code-freeze.yml
@@ -26,8 +26,8 @@ jobs:
         if: steps.filters.outputs.changes != '' && !contains(github.event.pull_request.labels.*.name, 'override-freeze')
         run: |
           TITLE="Code Freeze in Effect"
-          SUMMARY_MESSAGE_BODY=""
           LEGIBLE_CHANGES=$(echo "${{ steps.filters.outputs.changes }}" | sed 's/,changed//g' | sed 's/,/, /g' | sed 's/[][]//g')
+          echo "### ${TITLE}" >> $GITHUB_STEP_SUMMARY
           echo "This PR updates the following components which are code frozen: ${LEGIBLE_CHANGES}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "The following files are modified and frozen:" >> $GITHUB_STEP_SUMMARY
@@ -39,5 +39,4 @@ jobs:
           done
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Freeze can be overriden by adding the 'override-freeze' label to the PR." >> $GITHUB_STEP_SUMMARY
-          echo "::error title=$TITLE::$GITHUB_STEP_SUMMARY"
           exit 1

--- a/.github/workflows/code-freeze.yml
+++ b/.github/workflows/code-freeze.yml
@@ -29,17 +29,17 @@ jobs:
                    "$LEGIBLE_CHANGES"
                    "Freeze can be overriden by adding the 'override-freeze' label to the PR."
                    )
-          echo "### ${TITLE}" >> $GITHUB_ENV
+          echo "### ${TITLE}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_ENV
-          echo "This PR updates the following components which are code frozen: ${LEGIBLE_CHANGES}" >> $GITHUB_ENV
-          echo "" >> $GITHUB_ENV
-          echo "The following files are modified and frozen:" >> $GITHUB_ENV
+          echo "This PR updates the following components which are code frozen: ${LEGIBLE_CHANGES}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "The following files are modified and frozen:" >> $GITHUB_STEP_SUMMARY
           IFS="," read -ra FILE_LIST <<< "${{ steps.filters.outputs.changed_files }}"
           FILE_MESSAGE="This file is under code freeze."
           for FILE in "${FILE_LIST[@]}"; do
-            echo " - ${FILE}" >> $GITHUB_ENV
+            echo " - ${FILE}" >> $GITHUB_STEP_SUMMARY
             echo "::error file=$FILE,title=$TITLE::$FILE_MESSAGE"
           done
-          echo "" >> $GITHUB_ENV
-          echo "Freeze can be overriden by adding the 'override-freeze' label to the PR." >> $GITHUB_ENV
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Freeze can be overriden by adding the 'override-freeze' label to the PR." >> $GITHUB_STEP_SUMMARY
           exit 1

--- a/.github/workflows/code-freeze.yml
+++ b/.github/workflows/code-freeze.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           list-files: shell
           filters: .github/code-freeze-filter.yaml
-      - name: Output
+      - name: Output Failure
         if: steps.filters.outputs.changes != '' && !contains(github.event.pull_request.labels.*.name, 'override-freeze')
         run: |
           TITLE="Code Freeze in Effect"
@@ -40,3 +40,21 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Freeze can be overriden by adding the 'override-freeze' label to the PR." >> $GITHUB_STEP_SUMMARY
           exit 1
+      - name: Output Bypass
+        if: steps.filters.outputs.changes != '' && !contains(github.event.pull_request.labels.*.name, 'override-freeze')
+        run: |
+          TITLE="Code Freeze in Effect - Bypassed"
+          LEGIBLE_CHANGES=$(echo "${{ steps.filters.outputs.changes }}" | sed 's/,changed//g' | sed 's/,/, /g' | sed 's/[][]//g')
+          echo "### ${TITLE}" >> $GITHUB_STEP_SUMMARY
+          echo "This PR updates the following components which are code frozen: ${LEGIBLE_CHANGES}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "The following files are modified and frozen:" >> $GITHUB_STEP_SUMMARY
+          IFS="," read -ra FILE_LIST <<< "${{ steps.filters.outputs.changed_files }}"
+          FILE_MESSAGE="This file is under code freeze."
+          for FILE in "${FILE_LIST[@]}"; do
+            echo " - ${FILE}" >> $GITHUB_STEP_SUMMARY
+            echo "::warning file=$FILE,title=$TITLE::$FILE_MESSAGE"
+          done
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Freeze has been overriden by adding the 'override-freeze' label to the PR." >> $GITHUB_STEP_SUMMARY
+          exit 0

--- a/.github/workflows/code-freeze.yml
+++ b/.github/workflows/code-freeze.yml
@@ -24,15 +24,22 @@ jobs:
         if: steps.filters.outputs.changes != '' && !contains(github.event.pull_request.labels.*.name, 'override-freeze')
         run: |
           TITLE="Code Freeze in Effect"
-          LEGIBLE_CHANGES=$(echo "${{ steps.filters.outputs.changes }}" | sed 's/,/, /g')
+          LEGIBLE_CHANGES=$(echo "${{ steps.filters.outputs.changes }}" | sed 's/[][]//g' | sed 's/,/, /g' | grep -v 'changed')
           MESSAGE=("This PR updates the following components which are code frozen:"
                    "$LEGIBLE_CHANGES"
                    "Freeze can be overriden by adding the 'override-freeze' label to the PR."
                    )
-          echo "::error title=$TITLE::${MESSAGE[*]}"
+          echo "### ${TITLE}" >> $GITHUB_ENV
+          echo "" >> $GITHUB_ENV
+          echo "This PR updates the following components which are code frozen: ${LEGIBLE_CHANGES}" >> $GITHUB_ENV
+          echo "" >> $GITHUB_ENV
+          echo "The following files are modified and frozen:" >> $GITHUB_ENV
           IFS="," read -ra FILE_LIST <<< "${{ steps.filters.outputs.changed_files }}"
           FILE_MESSAGE="This file is under code freeze."
           for FILE in "${FILE_LIST[@]}"; do
+            echo " - ${FILE}" >> $GITHUB_ENV
             echo "::error file=$FILE,title=$TITLE::$FILE_MESSAGE"
           done
+          echo "" >> $GITHUB_ENV
+          echo "Freeze can be overriden by adding the 'override-freeze' label to the PR." >> $GITHUB_ENV
           exit 1

--- a/.github/workflows/code-freeze.yml
+++ b/.github/workflows/code-freeze.yml
@@ -24,7 +24,7 @@ jobs:
         if: steps.filters.outputs.changes != '' && !contains(github.event.pull_request.labels.*.name, 'override-freeze')
         run: |
           TITLE="Code Freeze in Effect"
-          LEGIBLE_CHANGES=$(echo "${{ steps.filters.outputs.changes }}" | sed 's/[][]//g' | sed 's/,/, /g' | grep -v 'changed')
+          LEGIBLE_CHANGES=$(echo "${{ steps.filters.outputs.changes }}" sed 's/,/, /g')
           MESSAGE=("This PR updates the following components which are code frozen:"
                    "$LEGIBLE_CHANGES"
                    "Freeze can be overriden by adding the 'override-freeze' label to the PR."

--- a/.github/workflows/code-freeze.yml
+++ b/.github/workflows/code-freeze.yml
@@ -24,22 +24,20 @@ jobs:
         if: steps.filters.outputs.changes != '' && !contains(github.event.pull_request.labels.*.name, 'override-freeze')
         run: |
           TITLE="Code Freeze in Effect"
-          LEGIBLE_CHANGES=$(echo "${{ steps.filters.outputs.changes }}" sed 's/,/, /g')
-          MESSAGE=("This PR updates the following components which are code frozen:"
-                   "$LEGIBLE_CHANGES"
-                   "Freeze can be overriden by adding the 'override-freeze' label to the PR."
-                   )
+          SUMMARY_MESSAGE_BODY=""
+          LEGIBLE_CHANGES=$(echo "${{ steps.filters.outputs.changes }}" | sed 's/,changed//g' | sed 's/,/, /g' | sed 's/[][]//g')
           echo "### ${TITLE}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_ENV
-          echo "This PR updates the following components which are code frozen: ${LEGIBLE_CHANGES}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "The following files are modified and frozen:" >> $GITHUB_STEP_SUMMARY
+          echo "This PR updates the following components which are code frozen: ${LEGIBLE_CHANGES}" >> $SUMMARY_MESSAGE_BODY
+          echo "" >> $SUMMARY_MESSAGE_BODY
+          echo "The following files are modified and frozen:" >> $SUMMARY_MESSAGE_BODY
           IFS="," read -ra FILE_LIST <<< "${{ steps.filters.outputs.changed_files }}"
           FILE_MESSAGE="This file is under code freeze."
           for FILE in "${FILE_LIST[@]}"; do
-            echo " - ${FILE}" >> $GITHUB_STEP_SUMMARY
+            echo " - ${FILE}" >> $SUMMARY_MESSAGE_BODY
             echo "::error file=$FILE,title=$TITLE::$FILE_MESSAGE"
           done
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Freeze can be overriden by adding the 'override-freeze' label to the PR." >> $GITHUB_STEP_SUMMARY
+          echo "Freeze can be overriden by adding the 'override-freeze' label to the PR." >> $SUMMARY_MESSAGE_BODY
+          echo "::error title=$TITLE::$SUMMARY_MESSAGE_BODY"
           exit 1

--- a/.github/workflows/code-freeze.yml
+++ b/.github/workflows/code-freeze.yml
@@ -30,7 +30,7 @@ jobs:
                    "Freeze can be overriden by adding the 'override-freeze' label to the PR."
                    )
           echo "::error title=$TITLE::${MESSAGE[*]}"
-          IFS="," read -ra FILE_LIST <<< "${{ steps.filters.outputs.changes }}"
+          IFS="," read -ra FILE_LIST <<< "${{ steps.filters.outputs.changed_files }}"
           FILE_MESSAGE="This file is under code freeze."
           for FILE in "${FILE_LIST[@]}"; do
             echo "::error file=$FILE,title=$TITLE::$FILE_MESSAGE"

--- a/.github/workflows/code-freeze.yml
+++ b/.github/workflows/code-freeze.yml
@@ -1,6 +1,6 @@
 name: Code Freeze
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - synchronize

--- a/.github/workflows/code-freeze.yml
+++ b/.github/workflows/code-freeze.yml
@@ -1,5 +1,5 @@
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - synchronize

--- a/.github/workflows/code-freeze.yml
+++ b/.github/workflows/code-freeze.yml
@@ -1,0 +1,38 @@
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+    branches:
+      - main
+
+jobs:
+  code_freeze:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Filter Check
+        id: filters
+        uses: dorny/paths-filter@v3
+        with:
+          list-files: shell
+          filters: .github/code-freeze-filter.yaml
+      - name: Code Freeze
+        if: steps.filters.outputs.changes != '' && !contains(github.event.pull_request.labels.*.name, 'override-freeze')
+        run: |
+          TITLE="Code Freeze in Effect"
+          LEGIBLE_CHANGES=$(echo "${{ steps.filters.outputs.changes }}" | sed 's/,/, /g')
+          MESSAGE=("This PR updates the following components which are code frozen:"
+                   "$LEGIBLE_CHANGES"
+                   "Freeze can be overriden by adding the 'override-freeze' label to the PR."
+                   )
+          echo "::error title=$TITLE::${MESSAGE[*]}"
+          IFS="," read -ra FILE_LIST <<< "${{ steps.filters.outputs.changes }}"
+          FILE_MESSAGE="This file is under code freeze."
+          for FILE in "${FILE_LIST[@]}"; do
+            echo "::error file=$FILE,title=$TITLE::$FILE_MESSAGE"
+          done
+          exit 1

--- a/.github/workflows/code-freeze.yml
+++ b/.github/workflows/code-freeze.yml
@@ -1,3 +1,4 @@
+name: Code Freeze
 on:
   pull_request:
     types:
@@ -11,6 +12,7 @@ on:
 
 jobs:
   code_freeze:
+    name: Code Freeze
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -20,24 +22,22 @@ jobs:
         with:
           list-files: shell
           filters: .github/code-freeze-filter.yaml
-      - name: Code Freeze
+      - name: Output
         if: steps.filters.outputs.changes != '' && !contains(github.event.pull_request.labels.*.name, 'override-freeze')
         run: |
           TITLE="Code Freeze in Effect"
           SUMMARY_MESSAGE_BODY=""
           LEGIBLE_CHANGES=$(echo "${{ steps.filters.outputs.changes }}" | sed 's/,changed//g' | sed 's/,/, /g' | sed 's/[][]//g')
-          echo "### ${TITLE}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_ENV
-          echo "This PR updates the following components which are code frozen: ${LEGIBLE_CHANGES}" >> $SUMMARY_MESSAGE_BODY
-          echo "" >> $SUMMARY_MESSAGE_BODY
-          echo "The following files are modified and frozen:" >> $SUMMARY_MESSAGE_BODY
+          echo "This PR updates the following components which are code frozen: ${LEGIBLE_CHANGES}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "The following files are modified and frozen:" >> $GITHUB_STEP_SUMMARY
           IFS="," read -ra FILE_LIST <<< "${{ steps.filters.outputs.changed_files }}"
           FILE_MESSAGE="This file is under code freeze."
           for FILE in "${FILE_LIST[@]}"; do
-            echo " - ${FILE}" >> $SUMMARY_MESSAGE_BODY
+            echo " - ${FILE}" >> $GITHUB_STEP_SUMMARY
             echo "::error file=$FILE,title=$TITLE::$FILE_MESSAGE"
           done
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Freeze can be overriden by adding the 'override-freeze' label to the PR." >> $SUMMARY_MESSAGE_BODY
-          echo "::error title=$TITLE::$SUMMARY_MESSAGE_BODY"
+          echo "Freeze can be overriden by adding the 'override-freeze' label to the PR." >> $GITHUB_STEP_SUMMARY
+          echo "::error title=$TITLE::$GITHUB_STEP_SUMMARY"
           exit 1

--- a/crates/astria-sequencer-relayer/src/main.rs
+++ b/crates/astria-sequencer-relayer/src/main.rs
@@ -16,6 +16,7 @@ use tracing::{
     warn,
 };
 
+// Testing
 #[tokio::main]
 async fn main() -> ExitCode {
     astria_eyre::install().expect("astria eyre hook must be the first hook installed");

--- a/crates/astria-sequencer-relayer/src/main.rs
+++ b/crates/astria-sequencer-relayer/src/main.rs
@@ -16,7 +16,6 @@ use tracing::{
     warn,
 };
 
-// Testing
 #[tokio::main]
 async fn main() -> ExitCode {
     astria_eyre::install().expect("astria eyre hook must be the first hook installed");


### PR DESCRIPTION
## Summary
Adds functionality to block PRs into sections of code under code freeze within the CI workflow

## Background
We are moving towards mainnet & undergoing audits. During past audits we have not had a firm mechanism to ensure we are not making changes to code under audit. This provides a stopper, but can be overriden still.

## Changes
- New CI workflow that checks for changes to code frozen pathways, fails and adds errors to those files as well as building an error summary. Using the `override-freeze` tag disables the check and changes reports to warnings.

## Testing
Ran against this PR with multiple changes, tested both adding and removing the label to override.
