### PR TITLE
refactor(sequencer): use builder pattern for transaction container tests

### DIFF
--- a/crates/astria-sequencer/src/grpc/sequencer.rs
+++ b/crates/astria-sequencer/src/grpc/sequencer.rs
@@ -270,7 +270,9 @@ mod tests {
         let alice_address = astria_address(&alice.address_bytes());
         // insert a transaction with a nonce gap
         let gapped_nonce = 99;
-        let tx = crate::app::test_utils::mock_tx(gapped_nonce, &get_alice_signing_key(), "test");
+        let tx = crate::app::test_utils::MockTxBuilder::new()
+            .nonce(gapped_nonce)
+            .build();
         mempool
             .insert(tx, 0, mock_balances(0, 0), mock_tx_cost(0, 0, 0))
             .await
@@ -278,7 +280,10 @@ mod tests {
 
         // insert a transaction at the current nonce
         let account_nonce = 0;
-        let tx = crate::app::test_utils::mock_tx(account_nonce, &get_alice_signing_key(), "test");
+        let tx = crate::app::test_utils::MockTxBuilder::new()
+            .nonce(account_nonce)
+            .build();
+
         mempool
             .insert(tx, 0, mock_balances(0, 0), mock_tx_cost(0, 0, 0))
             .await
@@ -287,7 +292,9 @@ mod tests {
         // insert a transactions one above account nonce (not gapped)
         let sequential_nonce = 1;
         let tx: Arc<astria_core::protocol::transaction::v1alpha1::SignedTransaction> =
-            crate::app::test_utils::mock_tx(sequential_nonce, &get_alice_signing_key(), "test");
+            crate::app::test_utils::MockTxBuilder::new()
+                .nonce(sequential_nonce)
+                .build();
         mempool
             .insert(tx, 0, mock_balances(0, 0), mock_tx_cost(0, 0, 0))
             .await

--- a/crates/astria-sequencer/src/mempool/transactions_container.rs
+++ b/crates/astria-sequencer/src/mempool/transactions_container.rs
@@ -1528,7 +1528,7 @@ mod test {
     }
 
     #[tokio::test]
-    #[allow(clippy::too_many_lines)]
+    #[expect(clippy::too_many_lines, reason = "it's a test")]
     async fn transactions_container_clean_account_stale_expired() {
         let mut pending_txs = PendingTransactions::new(TX_TTL);
         let signing_key_0 = SigningKey::from([1; 32]);

--- a/crates/astria-sequencer/src/mempool/transactions_container.rs
+++ b/crates/astria-sequencer/src/mempool/transactions_container.rs
@@ -1528,6 +1528,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[allow(clippy::too_many_lines)]
     async fn transactions_container_clean_account_stale_expired() {
         let mut pending_txs = PendingTransactions::new(TX_TTL);
         let signing_key_0 = SigningKey::from([1; 32]);


### PR DESCRIPTION
## Summary
Switched the method of constructing transactions from a constructor to a builder pattern. 

## Background
We're about to add more relevant transaction fields (ActionGroup type, valid block number), and this change will make it possible to add these extra fields without having to change all of the other tests. 

## Testing
The changes are contained to the unit tests to `crates/astria-sequencer/mempool/transaction_container.rs`. All unit tests still pass. 
