### PR TITLE
chore(charts): genesis template to support latest changes

### DIFF
--- a/charts/evm-rollup/Chart.yaml
+++ b/charts/evm-rollup/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.27.4
+version: 0.27.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.14.2"
+appVersion: "0.14.3"
 
 maintainers:
   - name: wafflesvonmaple

--- a/charts/evm-rollup/files/genesis/geth-genesis.json
+++ b/charts/evm-rollup/files/genesis/geth-genesis.json
@@ -38,9 +38,9 @@
         "astriaBridgeAddresses": {{ toPrettyJson .Values.genesis.bridgeAddresses | indent 8 | trim }},
         "astriaFeeCollectors": {{ toPrettyJson .Values.genesis.feeCollectors | indent 8 | trim }},
         "astriaEIP1559Params": {{ toPrettyJson .Values.genesis.eip1559Params | indent 8 | trim }},
-        "astriaBridgeSenderAddress": "{{ .Values.genesis.bridgeSenderAddress }}",
         "astriaSequencerAddressPrefix": "{{ .Values.genesis.sequencerAddressPrefix }}"
         {{- if not .Values.global.dev }}
+        "astriaBridgeSenderAddress": "{{ .Values.genesis.bridgeSenderAddress }}",
         {{- else }}
         {{- end }}
     },

--- a/charts/evm-rollup/values.yaml
+++ b/charts/evm-rollup/values.yaml
@@ -10,7 +10,7 @@ images:
   geth:
     repo: ghcr.io/astriaorg/astria-geth
     pullPolicy: IfNotPresent
-    tag: 0.14.1
+    tag: 0.14.3
     devTag: latest
     overrideTag: ""
   conductor:
@@ -48,15 +48,13 @@ genesis:
   ## These values are used to configure astria native bridging
   ## Many of the fields have commented out example fields
 
-  # When using an erc20 canonical bridge, the address from which tokens will
-  # be sent via the bridge contract
-  bridgeSenderAddress: "0x0000000000000000000000000000000000000000"
   # Configure the sequencer bridge addresses and allowed assets if using
   # the astria canonical bridge. Recommend removing alloc values if so.
   bridgeAddresses: []
     # - address: "684ae50c49a434199199c9c698115391152d7b3f"
     #   startHeight: 1
     #   assetDenom: "nria"
+    #   senderAddress: "0x0000000000000000000000000000000000000000"
     #   assetPrecision: 9
 
 

--- a/charts/evm-stack/Chart.lock
+++ b/charts/evm-stack/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.3.6
 - name: evm-rollup
   repository: file://../evm-rollup
-  version: 0.27.4
+  version: 0.27.5
 - name: composer
   repository: file://../composer
   version: 0.1.4
@@ -20,5 +20,5 @@ dependencies:
 - name: blockscout-stack
   repository: https://blockscout.github.io/helm-charts
   version: 1.6.2
-digest: sha256:b086adf099e986e3a5c1f7f25481aaf42ebf597029a70ee0bd3ff6711e6bdccf
-generated: "2024-09-25T14:31:21.35488-05:00"
+digest: sha256:2d7e2f23cd9bbdb43b7cf42112db9ede0a7d5eee9e426b0b2344e43fcf52e1b1
+generated: "2024-10-02T09:43:51.238571-04:00"

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.1
+version: 0.6.2
 
 dependencies:
   - name: celestia-node
@@ -23,7 +23,7 @@ dependencies:
     repository: "file://../celestia-node"
     condition: celestia-node.enabled
   - name: evm-rollup
-    version: 0.27.4
+    version: 0.27.5
     repository: "file://../evm-rollup"
   - name: composer
     version: 0.1.4

--- a/dev/values/rollup/dev.yaml
+++ b/dev/values/rollup/dev.yaml
@@ -35,14 +35,12 @@ evm-rollup:
     ## These values are used to configure astria native bridging
     ## Many of the fields have commented out example fields
 
-    # When using an erc20 canonical bridge, the address from which tokens will
-    # be sent via the bridge contract
-    bridgeSenderAddress: "0x0000000000000000000000000000000000000000"
     # Configure the sequencer bridge addresses and allowed assets if using
     # the astria canonical bridge. Recommend removing alloc values if so.
     bridgeAddresses:
       - bridgeAddress: "astria13ahqz4pjqfmynk9ylrqv4fwe4957x2p0h5782u"
         startHeight: 1
+        senderAddress: "0x0000000000000000000000000000000000000000"
         assetDenom: "nria"
         assetPrecision: 9
 


### PR DESCRIPTION
## Summary
BridgeSenderAddress now configured per bridge
## Background
Follow up on production deployment, bridgeSenderAddress should be configurable per bridge account. This PR adjusts evm-rollup chart to support such change.
## Changes
- remove `astriaBridgeSenderAddress`
- update `astriaBridgeAddresses`
non breaking, genesis template changes. set `global.dev=false` to run older versions
## Testing
against dusk-10, locally

