### PR TITLE
feat(cli): bridge sudo change command

### DIFF
--- a/charts/deploy.just
+++ b/charts/deploy.just
@@ -222,6 +222,8 @@ rollup_multiplier := "1000000000"
 # 10 RIA
 sequencer_transfer_amount := "10"
 sequencer_rpc_url := "http://rpc.sequencer.localdev.me"
+sequencer_funded_address:= "astria1qrt4kfc9ggyy548u7rg0d64sgq5c952kzk9tg9"
+sequencer_funded_pkey := "934ab488f9e1900f6a08f50605ce1409ca9d95ebdc400dafc2e8a4306419fd52"
 sequencer_bridge_address := "astria13ahqz4pjqfmynk9ylrqv4fwe4957x2p0h5782u"
 sequencer_bridge_pkey := "dfa7108e38ab71f89f356c72afc38600d5758f11a8c337164713e4471411d2e0"
 sequencer_chain_id := "sequencer-test-chain-0"
@@ -458,6 +460,44 @@ run-smoke-cli tag=defaultTag:
   done
   if (( $CHECKS >= $MAX_CHECKS )); then
     echo "Bridge Out Sequencer failure"
+    exit 1
+  fi
+
+  echo "Testing Bridge sudo address change"
+  docker run --rm --network host $ASTRIA_CLI_IMAGE sequencer bridge-sudo-change {{sequencer_bridge_address}} --private-key={{sequencer_bridge_pkey}} --new-sudo-address={{sequencer_funded_address}} --sequencer-url={{sequencer_rpc_url}} --sequencer.chain-id={{sequencer_chain_id}}
+  CHECKS=0
+  while (( $CHECKS < $MAX_CHECKS )); do
+    CHECKS=$((CHECKS+1))
+    SUDO_ADDRESS=$(docker run --rm --network host $ASTRIA_CLI_IMAGE sequencer bridge-account get {{sequencer_bridge_address}} --sequencer-url {{sequencer_rpc_url}}  | awk '/Sudo Address/{print $(NF)}')
+    echo "Check $CHECKS, Sudo address: $SUDO_ADDRESS, Expected: {{sequencer_funded_address}}"
+    if [ "$SUDO_ADDRESS" == "{{sequencer_funded_address}}" ]; then
+      echo "Bridge Sudo change success"
+      break
+    else
+      sleep 1
+    fi
+  done
+  if (( $CHECKS >= $MAX_CHECKS )); then
+    echo "Bridge Sudo Change failure"
+    exit 1
+  fi
+
+  echo "Reverting Bridge sudo address"
+  docker run --rm --network host $ASTRIA_CLI_IMAGE sequencer bridge-sudo-change {{sequencer_bridge_address}} --private-key={{sequencer_funded_pkey}} --new-sudo-address={{sequencer_bridge_address}} --sequencer-url={{sequencer_rpc_url}} --sequencer.chain-id={{sequencer_chain_id}}
+  CHECKS=0
+  while (( $CHECKS < $MAX_CHECKS )); do
+    CHECKS=$((CHECKS+1))
+    SUDO_ADDRESS=$(docker run --rm --network host $ASTRIA_CLI_IMAGE sequencer bridge-account get {{sequencer_bridge_address}} --sequencer-url {{sequencer_rpc_url}}  | awk '/Sudo Address/{print $(NF)}')
+    echo "Check $CHECKS, Sudo address: $SUDO_ADDRESS, Expected: {{sequencer_bridge_address}}"
+    if [ "$SUDO_ADDRESS" == "{{sequencer_bridge_address}}" ]; then
+        echo "Bridge Sudo change back success"
+        break
+    else
+        sleep 1
+    fi
+  done
+  if (( $CHECKS >= $MAX_CHECKS )); then
+    echo "Bridge Sudo Change failure"
     exit 1
   fi
 

--- a/charts/deploy.just
+++ b/charts/deploy.just
@@ -222,8 +222,6 @@ rollup_multiplier := "1000000000"
 # 10 RIA
 sequencer_transfer_amount := "10"
 sequencer_rpc_url := "http://rpc.sequencer.localdev.me"
-sequencer_funded_address:= "astria1qrt4kfc9ggyy548u7rg0d64sgq5c952kzk9tg9"
-sequencer_funded_pkey := "934ab488f9e1900f6a08f50605ce1409ca9d95ebdc400dafc2e8a4306419fd52"
 sequencer_bridge_address := "astria13ahqz4pjqfmynk9ylrqv4fwe4957x2p0h5782u"
 sequencer_bridge_pkey := "dfa7108e38ab71f89f356c72afc38600d5758f11a8c337164713e4471411d2e0"
 sequencer_chain_id := "sequencer-test-chain-0"
@@ -460,44 +458,6 @@ run-smoke-cli tag=defaultTag:
   done
   if (( $CHECKS >= $MAX_CHECKS )); then
     echo "Bridge Out Sequencer failure"
-    exit 1
-  fi
-
-  echo "Testing Bridge sudo address change"
-  docker run --rm --network host $ASTRIA_CLI_IMAGE sequencer bridge-sudo-change {{sequencer_bridge_address}} --private-key={{sequencer_bridge_pkey}} --new-sudo-address={{sequencer_funded_address}} --sequencer-url={{sequencer_rpc_url}} --sequencer.chain-id={{sequencer_chain_id}}
-  CHECKS=0
-  while (( $CHECKS < $MAX_CHECKS )); do
-    CHECKS=$((CHECKS+1))
-    SUDO_ADDRESS=$(docker run --rm --network host $ASTRIA_CLI_IMAGE sequencer bridge-account get {{sequencer_bridge_address}} --sequencer-url {{sequencer_rpc_url}}  | awk '/Sudo Address/{print $(NF)}')
-    echo "Check $CHECKS, Sudo address: $SUDO_ADDRESS, Expected: {{sequencer_funded_address}}"
-    if [ "$SUDO_ADDRESS" == "{{sequencer_funded_address}}" ]; then
-      echo "Bridge Sudo change success"
-      break
-    else
-      sleep 1
-    fi
-  done
-  if (( $CHECKS >= $MAX_CHECKS )); then
-    echo "Bridge Sudo Change failure"
-    exit 1
-  fi
-
-  echo "Reverting Bridge sudo address"
-  docker run --rm --network host $ASTRIA_CLI_IMAGE sequencer bridge-sudo-change {{sequencer_bridge_address}} --private-key={{sequencer_funded_pkey}} --new-sudo-address={{sequencer_bridge_address}} --sequencer-url={{sequencer_rpc_url}} --sequencer.chain-id={{sequencer_chain_id}}
-  CHECKS=0
-  while (( $CHECKS < $MAX_CHECKS )); do
-    CHECKS=$((CHECKS+1))
-    SUDO_ADDRESS=$(docker run --rm --network host $ASTRIA_CLI_IMAGE sequencer bridge-account get {{sequencer_bridge_address}} --sequencer-url {{sequencer_rpc_url}}  | awk '/Sudo Address/{print $(NF)}')
-    echo "Check $CHECKS, Sudo address: $SUDO_ADDRESS, Expected: {{sequencer_bridge_address}}"
-    if [ "$SUDO_ADDRESS" == "{{sequencer_bridge_address}}" ]; then
-        echo "Bridge Sudo change back success"
-        break
-    else
-        sleep 1
-    fi
-  done
-  if (( $CHECKS >= $MAX_CHECKS )); then
-    echo "Bridge Sudo Change failure"
     exit 1
   fi
 

--- a/crates/astria-cli/src/sequencer/bridge_account.rs
+++ b/crates/astria-cli/src/sequencer/bridge_account.rs
@@ -1,0 +1,62 @@
+use astria_core::primitive::v1::Address;
+use astria_sequencer_client::{
+    HttpClient,
+    SequencerClientExt,
+};
+use color_eyre::eyre::{
+    self,
+    WrapErr as _,
+};
+
+#[derive(Debug, clap::Args)]
+pub(super) struct Command {
+    #[command(subcommand)]
+    command: SubCommand,
+}
+
+impl Command {
+    pub(super) async fn run(self) -> eyre::Result<()> {
+        let SubCommand::Get(get) = self.command;
+        get.run().await
+    }
+}
+
+#[derive(Debug, clap::Subcommand)]
+enum SubCommand {
+    /// Command for getting bridge account information
+    Get(Get),
+}
+
+#[derive(Debug, clap::Args)]
+struct Get {
+    /// The url of the Sequencer node
+    #[arg(
+        long,
+        env = "SEQUENCER_URL",
+        default_value = crate::DEFAULT_SEQUENCER_RPC
+    )]
+    pub(crate) sequencer_url: String,
+    /// The address of the Sequencer bridge account
+    pub(crate) address: Address,
+}
+
+impl Get {
+    async fn run(self) -> eyre::Result<()> {
+        let sequencer_client = HttpClient::new(self.sequencer_url.as_str())
+            .wrap_err("failed constructing http sequencer client")?;
+
+        let res = sequencer_client
+            .get_bridge_account_info(self.address)
+            .await
+            .wrap_err("failed to get bridge account")?;
+        let Some(info) = res.info else {
+            return Err(eyre::eyre!("no bridge account information found"));
+        };
+        println!("Bridge Account Information for address: {}", self.address);
+        println!("    Rollup Id: {}", info.rollup_id);
+        println!("    Asset: {}", info.asset);
+        println!("    Sudo Address: {}", info.sudo_address);
+        println!("    Withdrawer Address {}", info.withdrawer_address);
+        Ok(())
+    }
+}

--- a/crates/astria-cli/src/sequencer/bridge_account.rs
+++ b/crates/astria-cli/src/sequencer/bridge_account.rs
@@ -56,7 +56,7 @@ impl Get {
         println!("    Rollup Id: {}", info.rollup_id);
         println!("    Asset: {}", info.asset);
         println!("    Sudo Address: {}", info.sudo_address);
-        println!("    Withdrawer Address {}", info.withdrawer_address);
+        println!("    Withdrawer Address: {}", info.withdrawer_address);
         Ok(())
     }
 }

--- a/crates/astria-cli/src/sequencer/bridge_account.rs
+++ b/crates/astria-cli/src/sequencer/bridge_account.rs
@@ -36,7 +36,7 @@ struct Get {
         default_value = crate::DEFAULT_SEQUENCER_RPC
     )]
     pub(crate) sequencer_url: String,
-    /// The address of the Sequencer bridge account
+    /// The bridge account address on the Sequencer
     pub(crate) address: Address,
 }
 
@@ -48,9 +48,9 @@ impl Get {
         let res = sequencer_client
             .get_bridge_account_info(self.address)
             .await
-            .wrap_err("failed to get bridge account")?;
+            .wrap_err("failed getting bridge account")?;
         let Some(info) = res.info else {
-            return Err(eyre::eyre!("no bridge account information found"));
+            return Err(eyre::eyre!("bridge account information not found"));
         };
         println!("Bridge Account Information for address: {}", self.address);
         println!("    Rollup Id: {}", info.rollup_id);

--- a/crates/astria-cli/src/sequencer/bridge_sudo_change.rs
+++ b/crates/astria-cli/src/sequencer/bridge_sudo_change.rs
@@ -1,11 +1,11 @@
 use astria_core::{
     primitive::v1::{
-        Address,
         asset,
+        Address,
     },
     protocol::transaction::v1::{
-        Action,
         action::BridgeSudoChange,
+        Action,
     },
 };
 use color_eyre::eyre::{

--- a/crates/astria-cli/src/sequencer/bridge_sudo_change.rs
+++ b/crates/astria-cli/src/sequencer/bridge_sudo_change.rs
@@ -72,9 +72,9 @@ impl Command {
             }),
         )
         .await
-        .wrap_err("failed to submit BridgeLock transaction")?;
+        .wrap_err("failed to submit BridgeSudoChange transaction")?;
 
-        println!("BridgeLock completed!");
+        println!("BridgeSudoChange completed!");
         println!("Included in block: {}", res.height);
         Ok(())
     }

--- a/crates/astria-cli/src/sequencer/bridge_sudo_change.rs
+++ b/crates/astria-cli/src/sequencer/bridge_sudo_change.rs
@@ -1,0 +1,84 @@
+use astria_core::{
+    primitive::v1::{
+        Address,
+        asset,
+    },
+    protocol::transaction::v1::{
+        Action,
+        action::BridgeSudoChange,
+    },
+};
+use color_eyre::eyre::{
+    self,
+    WrapErr as _,
+};
+
+use crate::utils::submit_transaction;
+
+#[derive(clap::Args, Debug)]
+#[command(group(clap::ArgGroup::new("new_address")
+    .required(true)
+    .multiple(true)
+    .args(&["new_sudo_address", "new_withdrawer_address"])))]
+pub(crate) struct Command {
+    /// The bridge account whose privileges will be modified.
+    pub(crate) bridge_address: Address,
+    /// The new address to receive sudo privileges.
+    #[arg(long, default_value = None)]
+    pub(crate) new_sudo_address: Option<Address>,
+    /// The new address to receive withdrawer privileges.
+    #[arg(long, default_value = None)]
+    pub(crate) new_withdrawer_address: Option<Address>,
+    /// The prefix to construct a bech32m address given the private key.
+    #[arg(long, default_value = "astria")]
+    pub(crate) prefix: String,
+    // TODO: https://github.com/astriaorg/astria/issues/594
+    // Don't use a plain text private, prefer wrapper like from
+    // the secrecy crate with specialized `Debug` and `Drop` implementations
+    // that overwrite the key on drop and don't reveal it when printing.
+    #[arg(long, env = "SEQUENCER_PRIVATE_KEY")]
+    pub(crate) private_key: String,
+    /// The url of the Sequencer node
+    #[arg(
+        long,
+        env = "SEQUENCER_URL",
+        default_value = crate::DEFAULT_SEQUENCER_RPC
+    )]
+    pub(crate) sequencer_url: String,
+    /// The chain id of the sequencing chain being used
+    #[arg(
+        long = "sequencer.chain-id",
+        env = "ROLLUP_SEQUENCER_CHAIN_ID",
+        default_value = crate::DEFAULT_SEQUENCER_CHAIN_ID
+    )]
+    pub(crate) sequencer_chain_id: String,
+    /// The asset to lock.
+    #[arg(long, default_value = "nria")]
+    pub(crate) asset: asset::Denom,
+    /// The asset to pay the transfer fees with.
+    #[arg(long, default_value = "nria")]
+    pub(crate) fee_asset: asset::Denom,
+}
+
+impl Command {
+    pub(super) async fn run(self) -> eyre::Result<()> {
+        let res = submit_transaction(
+            self.sequencer_url.as_str(),
+            self.sequencer_chain_id.clone(),
+            &self.prefix,
+            self.private_key.as_str(),
+            Action::BridgeSudoChange(BridgeSudoChange {
+                bridge_address: self.bridge_address,
+                new_sudo_address: self.new_sudo_address,
+                new_withdrawer_address: self.new_withdrawer_address,
+                fee_asset: self.fee_asset.clone(),
+            }),
+        )
+        .await
+        .wrap_err("failed to submit BridgeLock transaction")?;
+
+        println!("BridgeLock completed!");
+        println!("Included in block: {}", res.height);
+        Ok(())
+    }
+}

--- a/crates/astria-cli/src/sequencer/bridge_sudo_change.rs
+++ b/crates/astria-cli/src/sequencer/bridge_sudo_change.rs
@@ -52,9 +52,6 @@ pub(crate) struct Command {
         default_value = crate::DEFAULT_SEQUENCER_CHAIN_ID
     )]
     pub(crate) sequencer_chain_id: String,
-    /// The asset to lock.
-    #[arg(long, default_value = "nria")]
-    pub(crate) asset: asset::Denom,
     /// The asset to pay the transfer fees with.
     #[arg(long, default_value = "nria")]
     pub(crate) fee_asset: asset::Denom,

--- a/crates/astria-cli/src/sequencer/mod.rs
+++ b/crates/astria-cli/src/sequencer/mod.rs
@@ -5,7 +5,9 @@ mod account;
 mod address;
 mod balance;
 mod block_height;
+mod bridge_account;
 mod bridge_lock;
+mod bridge_sudo_change;
 mod ics20_withdrawal;
 mod init_bridge_account;
 mod sign;
@@ -35,6 +37,8 @@ impl Command {
             SubCommand::Ics20Withdrawal(ics20_withdrawal) => ics20_withdrawal.run().await,
             SubCommand::Submit(submit) => submit.run().await,
             SubCommand::Sign(sign) => sign.run(),
+            SubCommand::BridgeSudoChange(bridge_sudo_change) => bridge_sudo_change.run().await,
+            SubCommand::BridgeAccount(bridge_account) => bridge_account.run().await,
         }
     }
 }
@@ -72,4 +76,8 @@ enum SubCommand {
                   backticks"
     )]
     Sign(sign::Command),
+    /// Command for changing sudo and withdrawer addresses
+    BridgeSudoChange(bridge_sudo_change::Command),
+    /// Commands for interacting with the bridge account
+    BridgeAccount(bridge_account::Command),
 }


### PR DESCRIPTION
Summary
Adds bridge-sudo-change command for changing bridge privileges addresses

Background
Part of adding more actions to the cli

Changes
- adds `bridge-sudo-change`  command setting bridge account privileges addresses
- adds `bridge-account get` command querying bridge account information
Testing
Locally against a cluster

Related Issues
Part of https://github.com/astriaorg/astria/issues/1474

closes https://github.com/astriaorg/astria/issues/1547