### PR TITLE
Feature(cli): Add smoke tests for cli commands

### DIFF
--- a/charts/cli-test.just
+++ b/charts/cli-test.just
@@ -12,7 +12,6 @@ privKey1 := "2bd806c97f0e00af1a1fc3328fa763a9269723c8db8fac4f93af71db186d6e90"
 privKey2 := "dfa7108e38ab71f89f356c72afc38600d5758f11a8c337164713e4471411d2e0"
 ibcAddAddress := "astria13ahqz4pjqfmynk9ylrqv4fwe4957x2p0h5782u"
 pubKey := "88787e29db8d5247c6adfac9909b56e6b2705c3120b2e3885e8ec8aa416a10f1"
-# transferAddress := "astria13ahqz4pjqfmynk9ylrqv4fwe4957x2p0h5782u"
 newPower := "100"
 originalPower := "10"
 sequencerRpc := "http://rpc.sequencer.localdev.me"
@@ -110,17 +109,11 @@ run tag=defaultTag:
   echo "Output:"
   validate_output
 
-  # printf "\nRunning the 'sequencer sudo validator-update' command to update power...\n"
-  # output=$(just cli-test command {{ tag }} sequencer sudo validator-update --power {{newPower}} --validator-public-key {{pubKey}} --private-key {{privKey1}} --sequencer-url {{sequencerRpc}} --sequencer.chain-id {{sequencerChainId}})
-  # expected_format="^sending tx from address: astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm\nValidatorUpdate completed!\nIncluded in block: [0-9]+$"
-  # echo "Output:"
-  # validate_output
-
-  # printf "\nRunning the 'sequencer sudo validator-update' command to revert power...\n"
-  # output=$(just cli-test command {{ tag }} sequencer sudo validator-update --power 0 --validator-public-key {{pubKey}} --private-key {{privKey1}} --sequencer-url {{sequencerRpc}} --sequencer.chain-id {{sequencerChainId}})
-  # expected_format="^sending tx from address: astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm\nValidatorUpdate completed!\nIncluded in block: [0-9]+$"
-  # echo "Output:"
-  # validate_output
+  printf "\nRunning the 'sequencer sudo validator-update' command...\n"
+  output=$(just cli-test command {{ tag }} sequencer sudo validator-update --power 1 --validator-public-key {{pubKey}} --private-key {{privKey1}} --sequencer-url {{sequencerRpc}} --sequencer.chain-id {{sequencerChainId}})
+  expected_format="^sending tx from address: astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm\nValidatorUpdate completed!\nIncluded in block: [0-9]+$"
+  echo "Output:"
+  validate_output
 
   printf "\nRunning the 'sequencer transfer' command...\n"
   output=$(just cli-test command {{ tag }} sequencer transfer {{ibcAddAddress}} --amount 100 --private-key {{privKey1}} --sequencer-url {{sequencerRpc}} --sequencer.chain-id {{sequencerChainId}})

--- a/charts/cli-test.just
+++ b/charts/cli-test.just
@@ -52,16 +52,9 @@ bech32m tag=defaultTag:
   #!/usr/bin/env bash
   set -e 
 
-  # make a new account to get the address bytes
-  output=$(just cli-test command {{ tag }} sequencer account create)
-  expected_format="^Create Sequencer Account\n\nPrivate Key:\s+\"[0-9a-f]{64}\"\nPublic Key:\s+\"[0-9a-f]{64}\"\nAddress:\s+\"[0-9a-f]{40}\"$"
-  just cli-test validate-output "$output" "$expected_format"
-
   printf "\nRunning the 'sequencer address bech32' command...\n"
-  address=$(echo "$output" | perl -ne 'print $1 if /Address:\s+"([0-9a-f]{40})"/')
-  # Run the second command with the extracted address
-  output=$(just cli-test command {{ tag }} sequencer address bech32m --bytes "$address")
-  expected_format="^astria[0-9a-z]{39}$"
+  output=$(just cli-test command {{ tag }} sequencer address bech32m --bytes 25b2418bb3a1ac1799f17906579acb6230fbe9d2)
+  expected_format="^astria1ykeyrzan5xkp0x030yr90xktvgc0h6wjpdkgsm$"
   astria_address=$(echo "$output")
   just cli-test validate-output "$astria_address" "$expected_format"
 

--- a/charts/cli-test.just
+++ b/charts/cli-test.just
@@ -24,7 +24,6 @@ sequencerRpc := "http://rpc.sequencer.localdev.me"
 sequencerChainId := "sequencer-test-chain-0"
 asset := "test"
 defaultTag := "latest"
-run tag=defaultTag:
 
 validate-output output expected_format:
   #!/usr/bin/env bash

--- a/charts/cli-test.just
+++ b/charts/cli-test.just
@@ -37,7 +37,7 @@ validate-output output expected_format:
   fi
 
 # Test the `create-account` command
-test-create-account tag=defaultTag:
+create-account tag=defaultTag:
   #!/usr/bin/env bash
   set -e 
 
@@ -48,7 +48,7 @@ test-create-account tag=defaultTag:
   just cli-test validate-output "$output" "$expected_format"
 
 # Test the `bech32m` command
-test-bech32m tag=defaultTag:
+bech32m tag=defaultTag:
   #!/usr/bin/env bash
   set -e 
 
@@ -65,7 +65,7 @@ test-bech32m tag=defaultTag:
   astria_address=$(echo "$output")
   just cli-test validate-output "$astria_address" "$expected_format"
 
-test-get-balance tag=defaultTag:
+get-balance tag=defaultTag:
   #!/usr/bin/env bash
   set -e 
 
@@ -81,7 +81,7 @@ test-get-balance tag=defaultTag:
   echo "Output:\n$output"
   just cli-test validate-output "$output" "$expected_format"
 
-test-get-nonce tag=defaultTag:
+get-nonce tag=defaultTag:
   #!/usr/bin/env bash
   set -e 
 
@@ -91,7 +91,7 @@ test-get-nonce tag=defaultTag:
   echo "Output:\n$output"
   just cli-test validate-output "$output" "$expected_format"
 
-test-get-blockheight tag=defaultTag:
+get-blockheight tag=defaultTag:
   #!/usr/bin/env bash
   set -e 
 
@@ -101,7 +101,7 @@ test-get-blockheight tag=defaultTag:
   echo "Output:\n$output"
   just cli-test validate-output "$output" "$expected_format"
 
-test-ibc-relayer tag=defaultTag:
+ibc-relayer tag=defaultTag:
   #!/usr/bin/env bash
   set -e
 
@@ -117,7 +117,7 @@ test-ibc-relayer tag=defaultTag:
   echo "Output:\n$output"
   just cli-test validate-output "$output" "$expected_format"
 
-test-fee-asset tag=defaultTag:
+fee-asset tag=defaultTag:
   #!/usr/bin/env bash
   set -e
 
@@ -133,7 +133,7 @@ test-fee-asset tag=defaultTag:
   echo "Output:\n$output"
   just cli-test validate-output "$output" "$expected_format"
 
-test-sudo-address-change tag=defaultTag:
+sudo-address-change tag=defaultTag:
   #!/usr/bin/env bash
   set -e
 
@@ -149,7 +149,7 @@ test-sudo-address-change tag=defaultTag:
   echo "Output:\n$output"
   just cli-test validate-output "$output" "$expected_format"
 
-test-validator-update tag=defaultTag:
+validator-update tag=defaultTag:
   #!/usr/bin/env bash
   set -e
 
@@ -165,7 +165,7 @@ test-validator-update tag=defaultTag:
   echo "Output:\n$output"
   just cli-test validate-output "$output" "$expected_format"
 
-test-transfer tag=defaultTag:
+transfer tag=defaultTag:
   #!/usr/bin/env bash
   set -e
 
@@ -181,13 +181,13 @@ run tag=defaultTag:
 
   printf "Testing the CLI with the tag: {{ tag }}\n"
 
-  just cli-test test-create-account
-  just cli-test test-bech32m
-  just cli-test test-get-balance
-  just cli-test test-get-nonce
-  just cli-test test-get-blockheight
-  just cli-test test-ibc-relayer
-  just cli-test test-fee-asset
-  just cli-test test-sudo-address-change
-  just cli-test test-validator-update
-  just cli-test test-transfer
+  just cli-test create-account
+  just cli-test bech32m
+  just cli-test get-balance
+  just cli-test get-nonce
+  just cli-test get-blockheight
+  just cli-test ibc-relayer
+  just cli-test fee-asset
+  just cli-test sudo-address-change
+  just cli-test validator-update
+  just cli-test transfer

--- a/charts/cli-test.just
+++ b/charts/cli-test.just
@@ -1,0 +1,54 @@
+_default:
+  @just --list cli-test
+
+deploy:
+  @just deploy astria-local
+
+command tag *ARGS:
+  docker run --rm --network host "ghcr.io/astriaorg/astria-cli{{ if tag != '' { replace(':#', '#', tag) } else { '' } }}" {{ ARGS }}
+
+fundedAccount := "astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm"
+sequencerRpc := "http://rpc.sequencer.localdev.me"
+defaultTag := "latest"
+run tag=defaultTag:
+  #!/usr/bin/env bash
+  set -e
+
+  validate_output() {
+    echo "$output"
+    if echo "$output" | perl -0777 -ne 'exit 0 if /'"$expected_format"'/; exit 1'; then
+      echo "Output matches the expected format."
+    else
+      echo "Output does not match the expected format."
+      exit 1
+    fi
+  }
+
+  printf "Testing the CLI with the tag: {{ tag }}\n"
+
+
+  printf "\nRunning the account create command...\n"
+  output=$(just cli-test command {{ tag }} sequencer account create)
+  expected_format="^Create Sequencer Account\n\nPrivate Key: \"[0-9a-f]{64}\"\nPublic Key:  \"[0-9a-f]{64}\"\nAddress:     \"[0-9a-f]{40}\"$"
+  validate_output
+
+  printf "\nRunning the address bech32 command...\n"
+  address=$(echo "$output" | perl -ne 'print $1 if /Address:\s+"([0-9a-f]{40})"/')
+  # Run the second command with the extracted address
+  output=$(just cli-test command {{ tag }} sequencer address bech32m --bytes "$address")
+  expected_format="^astria[0-9a-z]{39}$"
+  validate_output
+  astria_address=$(echo "$output")
+  
+  printf "\nRunning the account balance command...\n"
+  output=$(just cli-test command {{ tag }} sequencer account balance {{fundedAccount}} --sequencer-url {{sequencerRpc}})
+  expected_format="^Balances for address: astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm\n    333333333333333333 nria$"
+  validate_output
+
+  printf "\nRunning the account nonce command...\n"
+  output=$(just cli-test command {{ tag }} sequencer account nonce {{fundedAccount}} --sequencer-url {{sequencerRpc}})
+  expected_format="^Nonce for address astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm\n    0 at height [0-9]*$"
+  validate_output
+  
+  printf "\nRunning the transfer command...\n"
+  output=$(just cli-test command {{ tag }} sequencer transfer {{astria_address}} 1000000000000000000 --sequencer-url {{sequencerRpc}})

--- a/charts/cli-test.just
+++ b/charts/cli-test.just
@@ -13,7 +13,7 @@ deploy:
 command tag *ARGS:
   docker run --rm --network host "ghcr.io/astriaorg/astria-cli{{ if tag != '' { replace(':#', '#', tag) } else { '' } }}" {{ ARGS }}
 
-fundedAccount := "astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm"
+sudoAccount := "astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm"
 privKey1 := "2bd806c97f0e00af1a1fc3328fa763a9269723c8db8fac4f93af71db186d6e90"
 privKey2 := "dfa7108e38ab71f89f356c72afc38600d5758f11a8c337164713e4471411d2e0"
 ibcAddAddress := "astria13ahqz4pjqfmynk9ylrqv4fwe4957x2p0h5782u"
@@ -70,13 +70,13 @@ get-balance tag=defaultTag:
   set -e 
 
   printf "\nRunning the 'sequencer account balance' command...\n"
-  output=$(just cli-test command {{ tag }} sequencer account balance {{fundedAccount}} --sequencer-url {{sequencerRpc}})
+  output=$(just cli-test command {{ tag }} sequencer account balance {{sudoAccount}} --sequencer-url {{sequencerRpc}})
   expected_format="^Balances for address: astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm\n\s+[0-9]{18} nria$"
   echo "Output:\n$output"
   just cli-test validate-output "$output" "$expected_format"
 
   printf "\nRunning the 'sequencer balance get' command...\n"
-  output=$(just cli-test command {{ tag }} sequencer balance get {{fundedAccount}} --sequencer-url {{sequencerRpc}})
+  output=$(just cli-test command {{ tag }} sequencer balance get {{sudoAccount}} --sequencer-url {{sequencerRpc}})
   expected_format="^Balances for address: astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm\n\s+[0-9]{18} nria$"
   echo "Output:\n$output"
   just cli-test validate-output "$output" "$expected_format"
@@ -86,7 +86,7 @@ get-nonce tag=defaultTag:
   set -e 
 
   printf "\nRunning the 'sequencer account nonce' command...\n"
-  output=$(just cli-test command {{ tag }} sequencer account nonce {{fundedAccount}} --sequencer-url {{sequencerRpc}})
+  output=$(just cli-test command {{ tag }} sequencer account nonce {{sudoAccount}} --sequencer-url {{sequencerRpc}})
   expected_format="^Nonce for address astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm\n\s+[0-9]+ at height [0-9]*$"
   echo "Output:\n$output"
   just cli-test validate-output "$output" "$expected_format"
@@ -144,7 +144,7 @@ sudo-address-change tag=defaultTag:
   just cli-test validate-output "$output" "$expected_format"
 
   printf "\nRunning the 'sequencer sudo sudo-address-change' command to revert the sudo address to the original one...\n"
-  output=$(just cli-test command {{ tag }} sequencer sudo sudo-address-change --address {{fundedAccount}} --private-key {{privKey2}} --sequencer-url {{sequencerRpc}} --sequencer.chain-id {{sequencerChainId}})
+  output=$(just cli-test command {{ tag }} sequencer sudo sudo-address-change --address {{sudoAccount}} --private-key {{privKey2}} --sequencer-url {{sequencerRpc}} --sequencer.chain-id {{sequencerChainId}})
   expected_format="^sending tx from address: astria13ahqz4pjqfmynk9ylrqv4fwe4957x2p0h5782u\nSudoAddressChange completed!\nIncluded in block: [0-9]+$"
   echo "Output:\n$output"
   just cli-test validate-output "$output" "$expected_format"

--- a/charts/cli-test.just
+++ b/charts/cli-test.just
@@ -8,7 +8,16 @@ command tag *ARGS:
   docker run --rm --network host "ghcr.io/astriaorg/astria-cli{{ if tag != '' { replace(':#', '#', tag) } else { '' } }}" {{ ARGS }}
 
 fundedAccount := "astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm"
+privKey1 := "2bd806c97f0e00af1a1fc3328fa763a9269723c8db8fac4f93af71db186d6e90"
+privKey2 := "dfa7108e38ab71f89f356c72afc38600d5758f11a8c337164713e4471411d2e0"
+ibcAddAddress := "astria13ahqz4pjqfmynk9ylrqv4fwe4957x2p0h5782u"
+pubKey := "88787e29db8d5247c6adfac9909b56e6b2705c3120b2e3885e8ec8aa416a10f1"
+# transferAddress := "astria13ahqz4pjqfmynk9ylrqv4fwe4957x2p0h5782u"
+newPower := "100"
+originalPower := "10"
 sequencerRpc := "http://rpc.sequencer.localdev.me"
+sequencerChainId := "sequencer-test-chain-0"
+asset := "test"
 defaultTag := "latest"
 run tag=defaultTag:
   #!/usr/bin/env bash
@@ -17,38 +26,104 @@ run tag=defaultTag:
   validate_output() {
     echo "$output"
     if echo "$output" | perl -0777 -ne 'exit 0 if /'"$expected_format"'/; exit 1'; then
-      echo "Output matches the expected format."
+      printf "\e[32m✔\e[0m Output matches the expected format.\n"
     else
-      echo "Output does not match the expected format."
+      printf "❌ Output does not match the expected format.\n"
       exit 1
     fi
   }
 
   printf "Testing the CLI with the tag: {{ tag }}\n"
 
-
-  printf "\nRunning the account create command...\n"
+  printf "\nRunning the 'sequencer account create' command...\n"
   output=$(just cli-test command {{ tag }} sequencer account create)
-  expected_format="^Create Sequencer Account\n\nPrivate Key: \"[0-9a-f]{64}\"\nPublic Key:  \"[0-9a-f]{64}\"\nAddress:     \"[0-9a-f]{40}\"$"
+  expected_format="^Create Sequencer Account\n\nPrivate Key:\s+\"[0-9a-f]{64}\"\nPublic Key:\s+\"[0-9a-f]{64}\"\nAddress:\s+\"[0-9a-f]{40}\"$"
+  echo "Output:"
   validate_output
 
-  printf "\nRunning the address bech32 command...\n"
+  printf "\nRunning the 'sequencer address bech32' command...\n"
   address=$(echo "$output" | perl -ne 'print $1 if /Address:\s+"([0-9a-f]{40})"/')
   # Run the second command with the extracted address
   output=$(just cli-test command {{ tag }} sequencer address bech32m --bytes "$address")
   expected_format="^astria[0-9a-z]{39}$"
+  echo "Output:"
   validate_output
   astria_address=$(echo "$output")
   
-  printf "\nRunning the account balance command...\n"
+  printf "\nRunning the 'sequencer account balance' command...\n"
   output=$(just cli-test command {{ tag }} sequencer account balance {{fundedAccount}} --sequencer-url {{sequencerRpc}})
-  expected_format="^Balances for address: astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm\n    333333333333333333 nria$"
+  expected_format="^Balances for address: astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm\n\s+[0-9]{18} nria$"
+  echo "Output:"
   validate_output
 
-  printf "\nRunning the account nonce command...\n"
+  printf "\nRunning the 'sequencer balance get' command...\n"
+  output=$(just cli-test command {{ tag }} sequencer balance get {{fundedAccount}} --sequencer-url {{sequencerRpc}})
+  expected_format="^Balances for address: astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm\n\s+[0-9]{18} nria$"
+  echo "Output:"
+  validate_output
+
+  printf "\nRunning the 'sequencer account nonce' command...\n"
   output=$(just cli-test command {{ tag }} sequencer account nonce {{fundedAccount}} --sequencer-url {{sequencerRpc}})
-  expected_format="^Nonce for address astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm\n    0 at height [0-9]*$"
+  expected_format="^Nonce for address astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm\n\s+[0-9]+ at height [0-9]*$"
+  echo "Output:"
   validate_output
   
-  printf "\nRunning the transfer command...\n"
-  output=$(just cli-test command {{ tag }} sequencer transfer {{astria_address}} 1000000000000000000 --sequencer-url {{sequencerRpc}})
+  printf "\nRunning the 'sequencer blockheight get' command...\n"
+  output=$(just cli-test command {{ tag }} sequencer blockheight get --sequencer-url {{sequencerRpc}})
+  expected_format="^Block Height:\n\s+[0-9]*$"
+  echo "Output:"
+  validate_output
+
+  printf "\nRunning the 'sequencer sudo ibc-relayer add' command...\n"
+  output=$(just cli-test command {{ tag }} sequencer sudo ibc-relayer add --address {{ibcAddAddress}} --private-key {{privKey1}} --sequencer-url {{sequencerRpc}} --sequencer.chain-id {{sequencerChainId}})
+  expected_format="^sending tx from address: astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm\nIbcRelayerChangeAction::Addition completed!\nIncluded in block: [0-9]+$"
+  echo "Output:"
+  validate_output
+
+  printf "\nRunning the 'sequencer sudo ibc-relayer remove' command...\n"
+  output=$(just cli-test command {{ tag }} sequencer sudo ibc-relayer remove --address {{ibcAddAddress}} --private-key {{privKey1}} --sequencer-url {{sequencerRpc}} --sequencer.chain-id {{sequencerChainId}})
+  expected_format="^sending tx from address: astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm\nIbcRelayerChangeAction::Removal completed!\nIncluded in block: [0-9]+$"
+  echo "Output:"
+  validate_output
+
+  printf "\nRunning the 'sequencer sudo fee-asset add' command...\n"
+  output=$(just cli-test command {{ tag }} sequencer sudo fee-asset add --asset {{asset}} --private-key {{privKey1}} --sequencer-url {{sequencerRpc}} --sequencer.chain-id {{sequencerChainId}})
+  expected_format="^sending tx from address: astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm\nFeeAssetChangeAction::Addition completed!\nIncluded in block: [0-9]+$"
+  echo "Output:"
+  validate_output
+
+  printf "\nRunning the 'sequencer sudo fee-asset remove' command...\n"
+  output=$(just cli-test command {{ tag }} sequencer sudo fee-asset remove --asset {{asset}} --private-key {{privKey1}} --sequencer-url {{sequencerRpc}} --sequencer.chain-id {{sequencerChainId}})
+  expected_format="^sending tx from address: astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm\nFeeAssetChangeAction::Removal completed!\nIncluded in block: [0-9]+$"
+  echo "Output:"
+  validate_output
+
+  printf "\nRunning the 'sequencer sudo sudo-address-change' command...\n"
+  output=$(just cli-test command {{ tag }} sequencer sudo sudo-address-change --address {{ibcAddAddress}} --private-key {{privKey1}} --sequencer-url {{sequencerRpc}} --sequencer.chain-id {{sequencerChainId}})
+  expected_format="^sending tx from address: astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm\nSudoAddressChange completed!\nIncluded in block: [0-9]+$"
+  echo "Output:"
+  validate_output
+
+  printf "\nRunning the 'sequencer sudo sudo-address-change' command to revert the sudo address to the original one...\n"
+  output=$(just cli-test command {{ tag }} sequencer sudo sudo-address-change --address {{fundedAccount}} --private-key {{privKey2}} --sequencer-url {{sequencerRpc}} --sequencer.chain-id {{sequencerChainId}})
+  expected_format="^sending tx from address: astria13ahqz4pjqfmynk9ylrqv4fwe4957x2p0h5782u\nSudoAddressChange completed!\nIncluded in block: [0-9]+$"
+  echo "Output:"
+  validate_output
+
+  # printf "\nRunning the 'sequencer sudo validator-update' command to update power...\n"
+  # output=$(just cli-test command {{ tag }} sequencer sudo validator-update --power {{newPower}} --validator-public-key {{pubKey}} --private-key {{privKey1}} --sequencer-url {{sequencerRpc}} --sequencer.chain-id {{sequencerChainId}})
+  # expected_format="^sending tx from address: astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm\nValidatorUpdate completed!\nIncluded in block: [0-9]+$"
+  # echo "Output:"
+  # validate_output
+
+  # printf "\nRunning the 'sequencer sudo validator-update' command to revert power...\n"
+  # output=$(just cli-test command {{ tag }} sequencer sudo validator-update --power 0 --validator-public-key {{pubKey}} --private-key {{privKey1}} --sequencer-url {{sequencerRpc}} --sequencer.chain-id {{sequencerChainId}})
+  # expected_format="^sending tx from address: astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm\nValidatorUpdate completed!\nIncluded in block: [0-9]+$"
+  # echo "Output:"
+  # validate_output
+
+  printf "\nRunning the 'sequencer transfer' command...\n"
+  output=$(just cli-test command {{ tag }} sequencer transfer {{ibcAddAddress}} --amount 100 --private-key {{privKey1}} --sequencer-url {{sequencerRpc}} --sequencer.chain-id {{sequencerChainId}})
+  expected_format="^sending tx from address: astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm\nTransfer completed!\nIncluded in block: [0-9]+$"
+  echo "Output:"
+  validate_output

--- a/charts/cli-test.just
+++ b/charts/cli-test.just
@@ -1,7 +1,13 @@
 _default:
-  @just --list cli-test
+  @just --list
+
+cli-test *ARGS:
+  @just {{ARGS}}
 
 deploy:
+  @just deploy cluster
+  @just deploy ingress-controller
+  @just wait-for-ingress-controller
   @just deploy astria-local
 
 command tag *ARGS:
@@ -19,104 +25,170 @@ sequencerChainId := "sequencer-test-chain-0"
 asset := "test"
 defaultTag := "latest"
 run tag=defaultTag:
+
+validate-output output expected_format:
   #!/usr/bin/env bash
-  set -e
+  set -e 
+  
+  if echo "$output" | perl -0777 -ne 'exit 0 if /'"$expected_format"'/; exit 1'; then
+    printf "\e[32m✔\e[0m Output matches the expected format.\n"
+  else
+    printf "❌ Output does not match the expected format.\n"
+    exit 1
+  fi
 
-  validate_output() {
-    echo "$output"
-    if echo "$output" | perl -0777 -ne 'exit 0 if /'"$expected_format"'/; exit 1'; then
-      printf "\e[32m✔\e[0m Output matches the expected format.\n"
-    else
-      printf "❌ Output does not match the expected format.\n"
-      exit 1
-    fi
-  }
-
-  printf "Testing the CLI with the tag: {{ tag }}\n"
+# Test the `create-account` command
+test-create-account tag=defaultTag:
+  #!/usr/bin/env bash
+  set -e 
 
   printf "\nRunning the 'sequencer account create' command...\n"
   output=$(just cli-test command {{ tag }} sequencer account create)
   expected_format="^Create Sequencer Account\n\nPrivate Key:\s+\"[0-9a-f]{64}\"\nPublic Key:\s+\"[0-9a-f]{64}\"\nAddress:\s+\"[0-9a-f]{40}\"$"
-  echo "Output:"
-  validate_output
+  echo "Output:\n$output"
+  just cli-test validate-output "$output" "$expected_format"
+
+# Test the `bech32m` command
+test-bech32m tag=defaultTag:
+  #!/usr/bin/env bash
+  set -e 
+
+  # make a new account to get the address bytes
+  output=$(just cli-test command {{ tag }} sequencer account create)
+  expected_format="^Create Sequencer Account\n\nPrivate Key:\s+\"[0-9a-f]{64}\"\nPublic Key:\s+\"[0-9a-f]{64}\"\nAddress:\s+\"[0-9a-f]{40}\"$"
+  just cli-test validate-output "$output" "$expected_format"
 
   printf "\nRunning the 'sequencer address bech32' command...\n"
   address=$(echo "$output" | perl -ne 'print $1 if /Address:\s+"([0-9a-f]{40})"/')
   # Run the second command with the extracted address
   output=$(just cli-test command {{ tag }} sequencer address bech32m --bytes "$address")
   expected_format="^astria[0-9a-z]{39}$"
-  echo "Output:"
-  validate_output
   astria_address=$(echo "$output")
-  
+  just cli-test validate-output "$astria_address" "$expected_format"
+
+test-get-balance tag=defaultTag:
+  #!/usr/bin/env bash
+  set -e 
+
   printf "\nRunning the 'sequencer account balance' command...\n"
   output=$(just cli-test command {{ tag }} sequencer account balance {{fundedAccount}} --sequencer-url {{sequencerRpc}})
   expected_format="^Balances for address: astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm\n\s+[0-9]{18} nria$"
-  echo "Output:"
-  validate_output
+  echo "Output:\n$output"
+  just cli-test validate-output "$output" "$expected_format"
 
   printf "\nRunning the 'sequencer balance get' command...\n"
   output=$(just cli-test command {{ tag }} sequencer balance get {{fundedAccount}} --sequencer-url {{sequencerRpc}})
   expected_format="^Balances for address: astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm\n\s+[0-9]{18} nria$"
-  echo "Output:"
-  validate_output
+  echo "Output:\n$output"
+  just cli-test validate-output "$output" "$expected_format"
+
+test-get-nonce tag=defaultTag:
+  #!/usr/bin/env bash
+  set -e 
 
   printf "\nRunning the 'sequencer account nonce' command...\n"
   output=$(just cli-test command {{ tag }} sequencer account nonce {{fundedAccount}} --sequencer-url {{sequencerRpc}})
   expected_format="^Nonce for address astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm\n\s+[0-9]+ at height [0-9]*$"
-  echo "Output:"
-  validate_output
-  
+  echo "Output:\n$output"
+  just cli-test validate-output "$output" "$expected_format"
+
+test-get-blockheight tag=defaultTag:
+  #!/usr/bin/env bash
+  set -e 
+
   printf "\nRunning the 'sequencer blockheight get' command...\n"
   output=$(just cli-test command {{ tag }} sequencer blockheight get --sequencer-url {{sequencerRpc}})
   expected_format="^Block Height:\n\s+[0-9]*$"
-  echo "Output:"
-  validate_output
+  echo "Output:\n$output"
+  just cli-test validate-output "$output" "$expected_format"
+
+test-ibc-relayer tag=defaultTag:
+  #!/usr/bin/env bash
+  set -e
 
   printf "\nRunning the 'sequencer sudo ibc-relayer add' command...\n"
   output=$(just cli-test command {{ tag }} sequencer sudo ibc-relayer add --address {{ibcAddAddress}} --private-key {{privKey1}} --sequencer-url {{sequencerRpc}} --sequencer.chain-id {{sequencerChainId}})
   expected_format="^sending tx from address: astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm\nIbcRelayerChangeAction::Addition completed!\nIncluded in block: [0-9]+$"
-  echo "Output:"
-  validate_output
+  echo "Output:\n$output"
+  just cli-test validate-output "$output" "$expected_format"
 
   printf "\nRunning the 'sequencer sudo ibc-relayer remove' command...\n"
   output=$(just cli-test command {{ tag }} sequencer sudo ibc-relayer remove --address {{ibcAddAddress}} --private-key {{privKey1}} --sequencer-url {{sequencerRpc}} --sequencer.chain-id {{sequencerChainId}})
   expected_format="^sending tx from address: astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm\nIbcRelayerChangeAction::Removal completed!\nIncluded in block: [0-9]+$"
-  echo "Output:"
-  validate_output
+  echo "Output:\n$output"
+  just cli-test validate-output "$output" "$expected_format"
+
+test-fee-asset tag=defaultTag:
+  #!/usr/bin/env bash
+  set -e
 
   printf "\nRunning the 'sequencer sudo fee-asset add' command...\n"
   output=$(just cli-test command {{ tag }} sequencer sudo fee-asset add --asset {{asset}} --private-key {{privKey1}} --sequencer-url {{sequencerRpc}} --sequencer.chain-id {{sequencerChainId}})
   expected_format="^sending tx from address: astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm\nFeeAssetChangeAction::Addition completed!\nIncluded in block: [0-9]+$"
-  echo "Output:"
-  validate_output
+  echo "Output:\n$output"
+  just cli-test validate-output "$output" "$expected_format"
 
   printf "\nRunning the 'sequencer sudo fee-asset remove' command...\n"
   output=$(just cli-test command {{ tag }} sequencer sudo fee-asset remove --asset {{asset}} --private-key {{privKey1}} --sequencer-url {{sequencerRpc}} --sequencer.chain-id {{sequencerChainId}})
   expected_format="^sending tx from address: astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm\nFeeAssetChangeAction::Removal completed!\nIncluded in block: [0-9]+$"
-  echo "Output:"
-  validate_output
+  echo "Output:\n$output"
+  just cli-test validate-output "$output" "$expected_format"
+
+test-sudo-address-change tag=defaultTag:
+  #!/usr/bin/env bash
+  set -e
 
   printf "\nRunning the 'sequencer sudo sudo-address-change' command...\n"
   output=$(just cli-test command {{ tag }} sequencer sudo sudo-address-change --address {{ibcAddAddress}} --private-key {{privKey1}} --sequencer-url {{sequencerRpc}} --sequencer.chain-id {{sequencerChainId}})
   expected_format="^sending tx from address: astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm\nSudoAddressChange completed!\nIncluded in block: [0-9]+$"
-  echo "Output:"
-  validate_output
+  echo "Output:\n$output"
+  just cli-test validate-output "$output" "$expected_format"
 
   printf "\nRunning the 'sequencer sudo sudo-address-change' command to revert the sudo address to the original one...\n"
   output=$(just cli-test command {{ tag }} sequencer sudo sudo-address-change --address {{fundedAccount}} --private-key {{privKey2}} --sequencer-url {{sequencerRpc}} --sequencer.chain-id {{sequencerChainId}})
   expected_format="^sending tx from address: astria13ahqz4pjqfmynk9ylrqv4fwe4957x2p0h5782u\nSudoAddressChange completed!\nIncluded in block: [0-9]+$"
-  echo "Output:"
-  validate_output
+  echo "Output:\n$output"
+  just cli-test validate-output "$output" "$expected_format"
 
-  printf "\nRunning the 'sequencer sudo validator-update' command...\n"
+test-validator-update tag=defaultTag:
+  #!/usr/bin/env bash
+  set -e
+
+  printf "\nRunning the 'sequencer sudo validator-update' command to update power...\n"
+  output=$(just cli-test command {{ tag }} sequencer sudo validator-update --power 10 --validator-public-key {{pubKey}} --private-key {{privKey1}} --sequencer-url {{sequencerRpc}} --sequencer.chain-id {{sequencerChainId}})
+  expected_format="^sending tx from address: astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm\nValidatorUpdate completed!\nIncluded in block: [0-9]+$"
+  echo "Output:\n$output"
+  just cli-test validate-output "$output" "$expected_format"
+
+  printf "\nRunning the 'sequencer sudo validator-update' command to revert power...\n"
   output=$(just cli-test command {{ tag }} sequencer sudo validator-update --power 1 --validator-public-key {{pubKey}} --private-key {{privKey1}} --sequencer-url {{sequencerRpc}} --sequencer.chain-id {{sequencerChainId}})
   expected_format="^sending tx from address: astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm\nValidatorUpdate completed!\nIncluded in block: [0-9]+$"
-  echo "Output:"
-  validate_output
+  echo "Output:\n$output"
+  just cli-test validate-output "$output" "$expected_format"
+
+test-transfer tag=defaultTag:
+  #!/usr/bin/env bash
+  set -e
 
   printf "\nRunning the 'sequencer transfer' command...\n"
   output=$(just cli-test command {{ tag }} sequencer transfer {{ibcAddAddress}} --amount 100 --private-key {{privKey1}} --sequencer-url {{sequencerRpc}} --sequencer.chain-id {{sequencerChainId}})
   expected_format="^sending tx from address: astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm\nTransfer completed!\nIncluded in block: [0-9]+$"
-  echo "Output:"
-  validate_output
+  echo "Output:\n$output"
+  just cli-test validate-output "$output" "$expected_format"
+
+run tag=defaultTag:
+  #!/usr/bin/env bash
+  set -e
+
+  printf "Testing the CLI with the tag: {{ tag }}\n"
+
+  just cli-test test-create-account
+  just cli-test test-bech32m
+  just cli-test test-get-balance
+  just cli-test test-get-nonce
+  just cli-test test-get-blockheight
+  just cli-test test-ibc-relayer
+  just cli-test test-fee-asset
+  just cli-test test-sudo-address-change
+  just cli-test test-validator-update
+  just cli-test test-transfer

--- a/charts/deploy.just
+++ b/charts/deploy.just
@@ -1,4 +1,5 @@
 mod ibc-test
+mod cli-test
 
 ##############################################
 ## Deploying and Running using Helm and K8s ##

--- a/dev/values/validators/single.yml
+++ b/dev/values/validators/single.yml
@@ -5,7 +5,7 @@ moniker: node0
 genesis:
   validators:
     - name: core
-      power: '1'
+      power: '100'
       address: 091E47761C58C474534F4D414AF104A6CAF90C22
       pubKey: lV57+rGs2vac7mvkGHP1oBFGHPJM3a+WoAzeFDCJDNU=
 


### PR DESCRIPTION
Add smoke tests for all existing sequencer commands for the cli.
Tests added:
- `account create`
- `address bech32m`
- `account balance`
- `balance get`
- `account nonce`
- `blockheight get`
- `sudo ibc-relayer add`
- `sudo ibc-relayer remove`
- `sudo fee-asset add`
- `sudo fee-asset remove`
- `sudo sudo-address-change`
- `sudo validator-update`
- `transfer`

┆Issue Number: ENG-868

closes #1570 
