### PR TITLE
feat(cli): feeChange commands

### DIFF
--- a/crates/astria-cli/src/sequencer/sudo/fee_change.rs
+++ b/crates/astria-cli/src/sequencer/sudo/fee_change.rs
@@ -44,7 +44,7 @@ impl Command {
             SubCommand::BridgeUnlockFee(bridge_unlock) => bridge_unlock.run().await,
             SubCommand::BridgeSudoChangeFee(bridge_sudo_change) => bridge_sudo_change.run().await,
             SubCommand::Ics20WithdrawalFee(ics20_withdrawal) => ics20_withdrawal.run().await,
-            SubCommand::IbcRelaeyFee(ibc_relay) => ibc_relay.run().await,
+            SubCommand::IbcRelayFee(ibc_relay) => ibc_relay.run().await,
             SubCommand::IbcRelayerChangeFee(ibc_relayer_change) => ibc_relayer_change.run().await,
             SubCommand::IbcSudoChangeFee(ics_sudo_change) => ics_sudo_change.run().await,
             SubCommand::FeeAssetChangeFee(fee_asset_change) => fee_asset_change.run().await,
@@ -57,14 +57,14 @@ impl Command {
     }
 }
 
-#[allow(clippy::enum_variant_names)]
+#[expect(clippy::enum_variant_names)]
 #[derive(Debug, Subcommand)]
 enum SubCommand {
-    /// Chnage Transfer Fee
+    /// Change Transfer Fee
     TransferFee(Transfer),
     /// Change Init Bridge Account Fee
     InitBridgeFee(BridgeInit),
-    /// Change Sequence Fee
+    /// Change Rollup Data Submission Fee
     RollupDataSubmissionFee(RollupDataSubmission),
     /// Change Bridge Lock Fee
     BridgeLockFee(BridgeLock),
@@ -75,7 +75,7 @@ enum SubCommand {
     /// Change ICS20 Withdrawal Fee
     Ics20WithdrawalFee(Ics20Withdrawal),
     /// Change IBC Relay Fee
-    IbcRelaeyFee(IbcRelay),
+    IbcRelayFee(IbcRelay),
     /// Change IBC Relayer Change Fee
     IbcRelayerChangeFee(IbcRelayerChange),
     /// Change IBC Sudo Change Fee

--- a/crates/astria-cli/src/sequencer/sudo/fee_change.rs
+++ b/crates/astria-cli/src/sequencer/sudo/fee_change.rs
@@ -1,0 +1,284 @@
+use astria_core::protocol::transaction::v1alpha1::{
+    action::{
+        FeeChange,
+        FeeChangeAction,
+    },
+    Action,
+};
+use clap::Subcommand;
+use color_eyre::eyre::{
+    self,
+    WrapErr as _,
+};
+
+use crate::utils::submit_transaction;
+
+#[derive(Debug, clap::Args)]
+pub(super) struct Command {
+    #[command(subcommand)]
+    command: SubCommand,
+}
+
+impl Command {
+    pub(super) async fn run(self) -> eyre::Result<()> {
+        match self.command {
+            SubCommand::TransferBaseFee(transfer) => transfer.run().await,
+            SubCommand::InitBridgeBaseFee(bridge_init) => bridge_init.run().await,
+            SubCommand::SequenceBaseFee(sequence_base) => sequence_base.run().await,
+            SubCommand::SequenceByteCostMul(sequence_byte_cost_mul) => {
+                sequence_byte_cost_mul.run().await
+            }
+            SubCommand::BridgeLockByteCostMul(bridge_lock_byte_cost_mul) => {
+                bridge_lock_byte_cost_mul.run().await
+            }
+            SubCommand::BridgeSudoChangeBaseFee(bridge_sudo_change) => {
+                bridge_sudo_change.run().await
+            }
+            SubCommand::Ics20WithdrawalBaseFee(ics20_withdrawal) => ics20_withdrawal.run().await,
+        }
+    }
+}
+
+#[derive(Debug, Subcommand)]
+enum SubCommand {
+    /// Chnage Transfer Base Fee
+    TransferBaseFee(Transfer),
+    /// Change Init Bridge Account Base Fee
+    InitBridgeBaseFee(BridgeInit),
+    /// Change Sequence Base Fee
+    SequenceBaseFee(SequenceBaseFee),
+    /// Change Sequence Byte Cost Multiplier
+    SequenceByteCostMul(SequenceByteCostMul),
+    /// Change Bridge Lock Byte Cost Multiplier
+    BridgeLockByteCostMul(BridgeLockByteCostMul),
+    /// Change Bridge Sudo Change Base Fee
+    BridgeSudoChangeBaseFee(BridgeSudoChange),
+    /// Change ICS20 Withdrawal Base Fee
+    Ics20WithdrawalBaseFee(Ics20Withdrawal),
+}
+
+#[derive(Clone, Debug, clap::Args)]
+struct Transfer {
+    #[command(flatten)]
+    inner: ArgsInner,
+}
+
+impl Transfer {
+    async fn run(self) -> eyre::Result<()> {
+        let args = self.inner;
+        let res = submit_transaction(
+            args.sequencer_url.as_str(),
+            args.sequencer_chain_id.clone(),
+            &args.prefix,
+            args.private_key.as_str(),
+            Action::FeeChange(FeeChangeAction {
+                fee_change: FeeChange::TransferBaseFee,
+                new_value: args.fee,
+            }),
+        )
+        .await
+        .wrap_err("failed to submit FeeChangeAction::TransferBaseFee transaction")?;
+
+        println!("FeeChangeAction completed!");
+        println!("Included in block: {}", res.height);
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, clap::Args)]
+struct BridgeInit {
+    #[command(flatten)]
+    inner: ArgsInner,
+}
+
+impl BridgeInit {
+    async fn run(self) -> eyre::Result<()> {
+        let args = self.inner;
+        let res = submit_transaction(
+            args.sequencer_url.as_str(),
+            args.sequencer_chain_id.clone(),
+            &args.prefix,
+            args.private_key.as_str(),
+            Action::FeeChange(FeeChangeAction {
+                fee_change: FeeChange::InitBridgeAccountBaseFee,
+                new_value: args.fee,
+            }),
+        )
+        .await
+        .wrap_err("failed to submit FeeChangeAction::InitBridgeAccountBaseFee transaction")?;
+
+        println!("FeeChangeAction completed!");
+        println!("Included in block: {}", res.height);
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, clap::Args)]
+struct SequenceBaseFee {
+    #[command(flatten)]
+    inner: ArgsInner,
+}
+
+impl SequenceBaseFee {
+    async fn run(self) -> eyre::Result<()> {
+        let args = self.inner;
+        let res = submit_transaction(
+            args.sequencer_url.as_str(),
+            args.sequencer_chain_id.clone(),
+            &args.prefix,
+            args.private_key.as_str(),
+            Action::FeeChange(FeeChangeAction {
+                fee_change: FeeChange::SequenceBaseFee,
+                new_value: args.fee,
+            }),
+        )
+        .await
+        .wrap_err("failed to submit FeeChangeAction::SequenceBaseFee transaction")?;
+
+        println!("FeeChangeAction completed!");
+        println!("Included in block: {}", res.height);
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, clap::Args)]
+struct SequenceByteCostMul {
+    #[command(flatten)]
+    inner: ArgsInner,
+}
+
+impl SequenceByteCostMul {
+    async fn run(self) -> eyre::Result<()> {
+        let args = self.inner;
+        let res = submit_transaction(
+            args.sequencer_url.as_str(),
+            args.sequencer_chain_id.clone(),
+            &args.prefix,
+            args.private_key.as_str(),
+            Action::FeeChange(FeeChangeAction {
+                fee_change: FeeChange::SequenceByteCostMultiplier,
+                new_value: args.fee,
+            }),
+        )
+        .await
+        .wrap_err("failed to submit FeeChangeAction::SequenceByteCostMultiplier transaction")?;
+
+        println!("FeeChangeAction completed!");
+        println!("Included in block: {}", res.height);
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, clap::Args)]
+struct BridgeLockByteCostMul {
+    #[command(flatten)]
+    inner: ArgsInner,
+}
+
+impl BridgeLockByteCostMul {
+    async fn run(self) -> eyre::Result<()> {
+        let args = self.inner;
+        let res = submit_transaction(
+            args.sequencer_url.as_str(),
+            args.sequencer_chain_id.clone(),
+            &args.prefix,
+            args.private_key.as_str(),
+            Action::FeeChange(FeeChangeAction {
+                fee_change: FeeChange::BridgeLockByteCostMultiplier,
+                new_value: args.fee,
+            }),
+        )
+        .await
+        .wrap_err("failed to submit FeeChangeAction::BridgeLockByteCostMultiplier transaction")?;
+
+        println!("FeeChangeAction completed!");
+        println!("Included in block: {}", res.height);
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, clap::Args)]
+struct BridgeSudoChange {
+    #[command(flatten)]
+    inner: ArgsInner,
+}
+
+impl BridgeSudoChange {
+    async fn run(self) -> eyre::Result<()> {
+        let args = self.inner;
+        let res = submit_transaction(
+            args.sequencer_url.as_str(),
+            args.sequencer_chain_id.clone(),
+            &args.prefix,
+            args.private_key.as_str(),
+            Action::FeeChange(FeeChangeAction {
+                fee_change: FeeChange::BridgeSudoChangeBaseFee,
+                new_value: args.fee,
+            }),
+        )
+        .await
+        .wrap_err("failed to submit FeeChangeAction::BridgeSudoChangeBaseFee transaction")?;
+
+        println!("FeeChangeAction completed!");
+        println!("Included in block: {}", res.height);
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, clap::Args)]
+struct Ics20Withdrawal {
+    #[command(flatten)]
+    inner: ArgsInner,
+}
+
+impl Ics20Withdrawal {
+    async fn run(self) -> eyre::Result<()> {
+        let args = self.inner;
+        let res = submit_transaction(
+            args.sequencer_url.as_str(),
+            args.sequencer_chain_id.clone(),
+            &args.prefix,
+            args.private_key.as_str(),
+            Action::FeeChange(FeeChangeAction {
+                fee_change: FeeChange::Ics20WithdrawalBaseFee,
+                new_value: args.fee,
+            }),
+        )
+        .await
+        .wrap_err("failed to submit FeeChangeAction::Ics20WithdrawalBaseFee transaction")?;
+
+        println!("FeeChangeAction completed!");
+        println!("Included in block: {}", res.height);
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, clap::Args)]
+struct ArgsInner {
+    /// The bech32m prefix that will be used for constructing addresses using the private key
+    #[arg(long, default_value = "astria")]
+    prefix: String,
+    // TODO: https://github.com/astriaorg/astria/issues/594
+    // Don't use a plain text private, prefer wrapper like from
+    // the secrecy crate with specialized `Debug` and `Drop` implementations
+    // that overwrite the key on drop and don't reveal it when printing.
+    #[arg(long, env = "SEQUENCER_PRIVATE_KEY")]
+    private_key: String,
+    /// The url of the Sequencer node
+    #[arg(
+        long,
+        env = "SEQUENCER_URL",
+        default_value = crate::DEFAULT_SEQUENCER_RPC
+    )]
+    sequencer_url: String,
+    /// The chain id of the sequencing chain being used
+    #[arg(
+        long = "sequencer.chain-id",
+        env = "ROLLUP_SEQUENCER_CHAIN_ID",
+        default_value = crate::DEFAULT_SEQUENCER_CHAIN_ID
+    )]
+    sequencer_chain_id: String,
+    /// The new fee value
+    #[arg(long)]
+    pub(crate) fee: u128,
+}

--- a/crates/astria-cli/src/sequencer/sudo/fee_change.rs
+++ b/crates/astria-cli/src/sequencer/sudo/fee_change.rs
@@ -57,7 +57,10 @@ impl Command {
     }
 }
 
-#[expect(clippy::enum_variant_names)]
+#[expect(
+    clippy::enum_variant_names,
+    reason = "Enum variant names intentionally include 'Fee' for clarity and consistency"
+)]
 #[derive(Debug, Subcommand)]
 enum SubCommand {
     /// Change Transfer Fee

--- a/crates/astria-cli/src/sequencer/sudo/mod.rs
+++ b/crates/astria-cli/src/sequencer/sudo/mod.rs
@@ -1,6 +1,7 @@
 use color_eyre::eyre;
 
 mod fee_asset;
+mod fee_change;
 mod ibc_relayer;
 mod sudo_address_change;
 mod validator_update;
@@ -18,6 +19,7 @@ impl Command {
             SubCommand::FeeAsset(fee_asset) => fee_asset.run().await,
             SubCommand::SudoAddressChange(sudo_address_change) => sudo_address_change.run().await,
             SubCommand::ValidatorUpdate(validator_update) => validator_update.run().await,
+            SubCommand::FeeChange(fee_change) => fee_change.run().await,
         }
     }
 }
@@ -28,4 +30,5 @@ enum SubCommand {
     FeeAsset(fee_asset::Command),
     SudoAddressChange(sudo_address_change::Command),
     ValidatorUpdate(validator_update::Command),
+    FeeChange(fee_change::Command),
 }


### PR DESCRIPTION
## Summary
Adds `FeeChangeAction` to the cli as a sudo command
## Background
The ability to change fees required by different actions is not supported by the cli, should be added as part of adding all sequencer actions as cli commands.

## Changes
- adds `fee-change` sudo Subcommand with all fee change actions

## Testing
There will be a follow-up PR to add CLI test after the ongoing test refactor is completed.
## Related Issues
part of #1474 
closes #1615 