### PR TITLE
feat(cli): add command to perform ics20 withdrawals

### DIFF
--- a/crates/astria-cli/src/sequencer/ics20_withdrawal.rs
+++ b/crates/astria-cli/src/sequencer/ics20_withdrawal.rs
@@ -1,0 +1,116 @@
+use astria_core::{
+    primitive::v1::{
+        asset,
+        Address,
+    },
+    protocol::transaction::v1alpha1::{
+        action::Ics20Withdrawal,
+        Action,
+    },
+};
+use clap::ArgAction;
+use color_eyre::eyre::{
+    self,
+    WrapErr as _,
+};
+use ibc_types::core::{
+    channel::ChannelId,
+    client::Height,
+};
+
+use crate::utils::submit_transaction;
+
+fn now_plus_5_minutes() -> u64 {
+    use std::time::Duration;
+    tendermint::Time::now()
+        .checked_add(Duration::from_secs(300))
+        .expect("adding 5 minutes to the current time should never fail")
+        .unix_timestamp_nanos()
+        .try_into()
+        .expect("timestamp must be positive, so this conversion would only fail if negative")
+}
+
+#[derive(clap::Args, Debug)]
+pub(super) struct Command {
+    #[arg(long)]
+    pub(crate) amount: u128,
+    #[arg(long)]
+    pub(crate) destination_chain_address: String,
+    /// The source channel used for withdrawal
+    #[arg(long)]
+    pub(crate) source_channel: String,
+    /// The address to refund on timeout, if unset refunds the signer
+    #[arg(long)]
+    pub(crate) return_address: Address,
+    /// A memo to send with transaction
+    #[arg(long, default_value = "")]
+    pub(crate) memo: String,
+    /// The bridge account to transfer from
+    #[arg(long, default_value = None)]
+    pub(crate) bridge_address: Option<Address>,
+    #[arg(long, action(ArgAction::SetTrue))]
+    pub(crate) use_compact: bool,
+    /// The prefix to construct a bech32m address given the private key.
+    #[arg(long, default_value = "astria")]
+    pub(crate) prefix: String,
+    // TODO: https://github.com/astriaorg/astria/issues/594
+    // Don't use a plain text private, prefer wrapper like from
+    // the secrecy crate with specialized `Debug` and `Drop` implementations
+    // that overwrite the key on drop and don't reveal it when printing.
+    #[arg(long, env = "SEQUENCER_PRIVATE_KEY")]
+    pub(crate) private_key: String,
+    /// The url of the Sequencer node
+    #[arg(
+         long,
+         env = "SEQUENCER_URL",
+         default_value = crate::DEFAULT_SEQUENCER_RPC
+     )]
+    pub(crate) sequencer_url: String,
+    /// The chain id of the sequencing chain being used
+    #[arg(
+         long = "sequencer.chain-id",
+         env = "ROLLUP_SEQUENCER_CHAIN_ID",
+         default_value = crate::DEFAULT_SEQUENCER_CHAIN_ID
+     )]
+    pub(crate) sequencer_chain_id: String,
+    /// The asset to lock.
+    #[arg(long, default_value = "nria")]
+    pub(crate) asset: asset::Denom,
+    /// The asset to pay the transfer fees with.
+    #[arg(long, default_value = "nria")]
+    pub(crate) fee_asset: asset::Denom,
+}
+
+impl Command {
+    pub(super) async fn run(self) -> eyre::Result<()> {
+        println!("compact is: {}", self.use_compact);
+        let res = submit_transaction(
+            self.sequencer_url.as_str(),
+            self.sequencer_chain_id.clone(),
+            &self.prefix,
+            self.private_key.as_str(),
+            Action::Ics20Withdrawal(Ics20Withdrawal {
+                amount: self.amount,
+                denom: self.asset,
+                destination_chain_address: self.destination_chain_address,
+                return_address: self.return_address,
+                timeout_height: Height {
+                    revision_number: u64::MAX,
+                    revision_height: u64::MAX,
+                },
+                timeout_time: now_plus_5_minutes(),
+                source_channel: ChannelId(self.source_channel),
+                fee_asset: self.fee_asset,
+                memo: self.memo,
+                bridge_address: self.bridge_address,
+                use_compat_address: self.use_compact,
+            }),
+        )
+        .await
+        .wrap_err("failed to submit BridgeLock transaction")?;
+
+        println!("BridgeLock completed!");
+        println!("Included in block: {}", res.height);
+        Ok(())
+    }
+}

--- a/crates/astria-cli/src/sequencer/ics20_withdrawal.rs
+++ b/crates/astria-cli/src/sequencer/ics20_withdrawal.rs
@@ -110,9 +110,9 @@ impl Command {
             }),
         )
         .await
-        .wrap_err("failed to submit BridgeLock transaction")?;
+        .wrap_err("failed to perform ics20 withdrawal")?;
 
-        info!(hash = % res.hash, at_height = %res.height, "BridgeLock completed!");
+        info!(hash = % res.hash, at_height = %res.height, "ics20 withdrawal completed");
 
         Ok(())
     }

--- a/crates/astria-cli/src/sequencer/mod.rs
+++ b/crates/astria-cli/src/sequencer/mod.rs
@@ -6,6 +6,7 @@ mod address;
 mod balance;
 mod block_height;
 mod bridge_lock;
+mod ics20_withdrawal;
 mod init_bridge_account;
 mod sudo;
 mod transfer;
@@ -27,6 +28,7 @@ impl Command {
             SubCommand::InitBridgeAccount(init_bridge_account) => init_bridge_account.run().await,
             SubCommand::Sudo(sudo) => sudo.run().await,
             SubCommand::Transfer(transfer) => transfer.run().await,
+            SubCommand::Ics20Withdrawal(ics20_withdrawal) => ics20_withdrawal.run().await,
         }
     }
 }
@@ -51,4 +53,6 @@ enum SubCommand {
     Sudo(sudo::Command),
     /// Command for sending balance between accounts
     Transfer(transfer::Command),
+    /// Command for withdrawing an ICS20 asset
+    Ics20Withdrawal(ics20_withdrawal::Command),
 }

--- a/crates/astria-cli/src/utils.rs
+++ b/crates/astria-cli/src/utils.rs
@@ -28,17 +28,9 @@ pub(crate) async fn submit_transaction(
     let sequencer_client =
         HttpClient::new(sequencer_url).wrap_err("failed constructing http sequencer client")?;
 
-    let private_key_bytes: [u8; 32] = hex::decode(private_key)
-        .wrap_err("failed to decode private key bytes from hex string")?
-        .try_into()
-        .map_err(|_| eyre!("invalid private key length; must be 32 bytes"))?;
-    let sequencer_key = SigningKey::from(private_key_bytes);
+    let sequencer_key = signing_key_from_private_key(private_key)?;
 
-    let from_address = Address::builder()
-        .array(*sequencer_key.verification_key().address_bytes())
-        .prefix(prefix)
-        .try_build()
-        .wrap_err("failed constructing a valid from address from the provided prefix")?;
+    let from_address = address_from_signing_key(&sequencer_key, prefix)?;
     println!("sending tx from address: {from_address}");
 
     let nonce_res = sequencer_client
@@ -68,4 +60,30 @@ pub(crate) async fn submit_transaction(
         tx_response.tx_result.log
     );
     Ok(tx_response)
+}
+
+pub(crate) fn signing_key_from_private_key(private_key: &str) -> eyre::Result<SigningKey> {
+    // Decode the hex string to get the private key bytes
+    let private_key_bytes: [u8; 32] = hex::decode(private_key)
+        .wrap_err("failed to decode private key bytes from hex string")?
+        .try_into()
+        .map_err(|_| eyre!("invalid private key length; must be 32 bytes"))?;
+
+    // Create and return a signing key from the private key bytes
+    Ok(SigningKey::from(private_key_bytes))
+}
+
+pub(crate) fn address_from_signing_key(
+    signing_key: &SigningKey,
+    prefix: &str,
+) -> eyre::Result<Address> {
+    // Build the address using the public key from the signing key
+    let from_address = Address::builder()
+        .array(*signing_key.verification_key().address_bytes())
+        .prefix(prefix)
+        .try_build()
+        .wrap_err("failed constructing a valid from address from the provided prefix")?;
+
+    // Return the generated address
+    Ok(from_address)
 }


### PR DESCRIPTION
## Summary
Adds Ics20Withdrawal command to the cli for [Ics20Withdrawal](https://buf.build/astria/protocol-apis/docs/main:astria.protocol.transactions.v1alpha1#astria.protocol.transactions.v1alpha1.Ics20Withdrawal) action

## Background
part of adding all sequencer actions as cli commands.
## Changes
- adds `astria-cli sequencer ics20-withdrawal` command

## Testing
- There will be a follow-up PR to add CLI test after the ongoing test refactor is completed.
- Tested by performing a manual withdrawal to an IBC chain. Refunds the sender address on failure, which was tested by sending an Ics20Withdrawal with an invalid asset.

## Related Issues
part of #1474 
closes #1623 
