### PR TITLE
fix(cli): ensure checkTx passes before waiting for inclusion

### DIFF
--- a/crates/astria-cli/src/utils.rs
+++ b/crates/astria-cli/src/utils.rs
@@ -58,9 +58,9 @@ pub(crate) async fn submit_transaction(
         .await
         .wrap_err("failed to submit transaction")?;
 
-    let tx_response = sequencer_client.wait_for_tx_inclusion(res.hash).await;
-
     ensure!(res.code.is_ok(), "failed to check tx: {}", res.log);
+
+    let tx_response = sequencer_client.wait_for_tx_inclusion(res.hash).await;
 
     ensure!(
         tx_response.tx_result.code.is_ok(),


### PR DESCRIPTION
## Summary
Ensuring checkTx passes before waiting for inclusion
## Background
When using `submit_transaction_sync` method, cli should exit on `checkTx` error code. Currently, cli first waits for inclusion which will never happen as the transaction failed `checkTx`

## Related Issues
Link any issues that are related, prefer full github links.

closes #1635 
