### PR TITLE
chore(proto)!: prefer astria.primitive.v1.RollupId over bytes

### DIFF
--- a/crates/astria-composer/src/collectors/grpc.rs
+++ b/crates/astria-composer/src/collectors/grpc.rs
@@ -58,9 +58,12 @@ impl GrpcCollectorService for Grpc {
     ) -> Result<Response<SubmitRollupTransactionResponse>, Status> {
         let submit_rollup_tx_request = request.into_inner();
 
-        let Ok(rollup_id) = RollupId::try_from_slice(&submit_rollup_tx_request.rollup_id) else {
-            return Err(Status::invalid_argument("invalid rollup id"));
-        };
+        let rollup_id = RollupId::try_from_raw(
+            submit_rollup_tx_request
+                .rollup_id
+                .ok_or_else(|| Status::invalid_argument("rollup ID not set"))?,
+        )
+        .map_err(|err| Status::invalid_argument(format!("invalid rollup ID: {err}")))?;
 
         let sequence_action = Sequence {
             rollup_id,

--- a/crates/astria-composer/tests/blackbox/grpc_collector.rs
+++ b/crates/astria-composer/tests/blackbox/grpc_collector.rs
@@ -36,7 +36,7 @@ async fn tx_from_one_rollup_is_received_by_sequencer() {
     .unwrap();
     composer_client
         .submit_rollup_transaction(SubmitRollupTransactionRequest {
-            rollup_id: Bytes::copy_from_slice(rollup_id.as_ref()),
+            rollup_id: Some(rollup_id.into_raw()),
             data: Bytes::copy_from_slice(&tx.rlp()),
         })
         .await
@@ -85,7 +85,7 @@ async fn invalid_nonce_causes_resubmission_under_different_nonce() {
     .unwrap();
     composer_client
         .submit_rollup_transaction(SubmitRollupTransactionRequest {
-            rollup_id: Bytes::copy_from_slice(rollup_id.as_ref()),
+            rollup_id: Some(rollup_id.into_raw()),
             data: Bytes::copy_from_slice(&tx.rlp()),
         })
         .await
@@ -127,7 +127,7 @@ async fn single_rollup_tx_payload_integrity() {
     .unwrap();
     composer_client
         .submit_rollup_transaction(SubmitRollupTransactionRequest {
-            rollup_id: Bytes::copy_from_slice(rollup_id.as_ref()),
+            rollup_id: Some(rollup_id.into_raw()),
             data: Bytes::copy_from_slice(&tx.rlp()),
         })
         .await

--- a/crates/astria-core/src/execution/v1alpha2/mod.rs
+++ b/crates/astria-core/src/execution/v1alpha2/mod.rs
@@ -90,8 +90,8 @@ impl Protobuf for GenesisInfo {
         let Some(rollup_id) = rollup_id else {
             return Err(Self::Error::no_rollup_id());
         };
-        let rollup_id =
-            RollupId::try_from_raw(rollup_id).map_err(Self::Error::incorrect_rollup_id_length)?;
+        let rollup_id = RollupId::try_from_raw_ref(rollup_id)
+            .map_err(Self::Error::incorrect_rollup_id_length)?;
 
         Ok(Self {
             rollup_id,

--- a/crates/astria-core/src/generated/astria.composer.v1alpha1.rs
+++ b/crates/astria-core/src/generated/astria.composer.v1alpha1.rs
@@ -4,8 +4,8 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SubmitRollupTransactionRequest {
     /// the unhashed rollup id
-    #[prost(bytes = "bytes", tag = "1")]
-    pub rollup_id: ::prost::bytes::Bytes,
+    #[prost(message, optional, tag = "1")]
+    pub rollup_id: ::core::option::Option<super::super::primitive::v1::RollupId>,
     /// the raw data bytes of the rollup transaction
     #[prost(bytes = "bytes", tag = "2")]
     pub data: ::prost::bytes::Bytes,

--- a/crates/astria-core/src/generated/astria.composer.v1alpha1.serde.rs
+++ b/crates/astria-core/src/generated/astria.composer.v1alpha1.serde.rs
@@ -6,16 +6,15 @@ impl serde::Serialize for SubmitRollupTransactionRequest {
     {
         use serde::ser::SerializeStruct;
         let mut len = 0;
-        if !self.rollup_id.is_empty() {
+        if self.rollup_id.is_some() {
             len += 1;
         }
         if !self.data.is_empty() {
             len += 1;
         }
         let mut struct_ser = serializer.serialize_struct("astria.composer.v1alpha1.SubmitRollupTransactionRequest", len)?;
-        if !self.rollup_id.is_empty() {
-            #[allow(clippy::needless_borrow)]
-            struct_ser.serialize_field("rollupId", pbjson::private::base64::encode(&self.rollup_id).as_str())?;
+        if let Some(v) = self.rollup_id.as_ref() {
+            struct_ser.serialize_field("rollupId", v)?;
         }
         if !self.data.is_empty() {
             #[allow(clippy::needless_borrow)]
@@ -90,9 +89,7 @@ impl<'de> serde::Deserialize<'de> for SubmitRollupTransactionRequest {
                             if rollup_id__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("rollupId"));
                             }
-                            rollup_id__ = 
-                                Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
-                            ;
+                            rollup_id__ = map_.next_value()?;
                         }
                         GeneratedField::Data => {
                             if data__.is_some() {
@@ -105,7 +102,7 @@ impl<'de> serde::Deserialize<'de> for SubmitRollupTransactionRequest {
                     }
                 }
                 Ok(SubmitRollupTransactionRequest {
-                    rollup_id: rollup_id__.unwrap_or_default(),
+                    rollup_id: rollup_id__,
                     data: data__.unwrap_or_default(),
                 })
             }

--- a/crates/astria-core/src/generated/astria.sequencerblock.v1alpha1.rs
+++ b/crates/astria-core/src/generated/astria.sequencerblock.v1alpha1.rs
@@ -171,8 +171,8 @@ pub struct FilteredSequencerBlock {
     /// and is extracted from `astria.SequencerBlock.rollup_transactions`.
     /// Note that these are all the rollup IDs in the sequencer block, not merely those in
     /// `rollup_transactions` field. This is necessary to prove that no rollup IDs were omitted.
-    #[prost(bytes = "bytes", repeated, tag = "5")]
-    pub all_rollup_ids: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
+    #[prost(message, repeated, tag = "5")]
+    pub all_rollup_ids: ::prost::alloc::vec::Vec<super::super::primitive::v1::RollupId>,
     /// The proof that the `rollup_ids` are included
     /// in the CometBFT block this sequencer block is derived form.
     ///

--- a/crates/astria-core/src/generated/astria.sequencerblock.v1alpha1.serde.rs
+++ b/crates/astria-core/src/generated/astria.sequencerblock.v1alpha1.serde.rs
@@ -240,7 +240,7 @@ impl serde::Serialize for FilteredSequencerBlock {
             struct_ser.serialize_field("rollupTransactionsProof", v)?;
         }
         if !self.all_rollup_ids.is_empty() {
-            struct_ser.serialize_field("allRollupIds", &self.all_rollup_ids.iter().map(pbjson::private::base64::encode).collect::<Vec<_>>())?;
+            struct_ser.serialize_field("allRollupIds", &self.all_rollup_ids)?;
         }
         if let Some(v) = self.rollup_ids_proof.as_ref() {
             struct_ser.serialize_field("rollupIdsProof", v)?;
@@ -360,10 +360,7 @@ impl<'de> serde::Deserialize<'de> for FilteredSequencerBlock {
                             if all_rollup_ids__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("allRollupIds"));
                             }
-                            all_rollup_ids__ = 
-                                Some(map_.next_value::<Vec<::pbjson::private::BytesDeserialize<_>>>()?
-                                    .into_iter().map(|x| x.0).collect())
-                            ;
+                            all_rollup_ids__ = Some(map_.next_value()?);
                         }
                         GeneratedField::RollupIdsProof => {
                             if rollup_ids_proof__.is_some() {

--- a/crates/astria-core/src/primitive/v1/mod.rs
+++ b/crates/astria-core/src/primitive/v1/mod.rs
@@ -196,7 +196,20 @@ impl RollupId {
     /// # Errors
     ///
     /// Returns an error if the byte slice was not 32 bytes long.
-    pub fn try_from_raw(raw: &raw::RollupId) -> Result<Self, IncorrectRollupIdLength> {
+    #[expect(
+        clippy::needless_pass_by_value,
+        reason = "for symmetry with other domain type conversions"
+    )]
+    pub fn try_from_raw(raw: raw::RollupId) -> Result<Self, IncorrectRollupIdLength> {
+        Self::try_from_raw_ref(&raw)
+    }
+
+    /// Converts from protobuf type to rust type for a rollup ID.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the byte slice was not 32 bytes long.
+    pub fn try_from_raw_ref(raw: &raw::RollupId) -> Result<Self, IncorrectRollupIdLength> {
         Self::try_from_slice(&raw.inner)
     }
 }

--- a/crates/astria-core/src/protocol/bridge/v1alpha1/mod.rs
+++ b/crates/astria-core/src/protocol/bridge/v1alpha1/mod.rs
@@ -156,7 +156,7 @@ impl BridgeAccountInfoResponse {
         Ok(Self {
             height,
             info: Some(BridgeAccountInfo {
-                rollup_id: RollupId::try_from_raw(&rollup_id)
+                rollup_id: RollupId::try_from_raw(rollup_id)
                     .map_err(BridgeAccountInfoResponseError::invalid_rollup_id)?,
                 asset,
                 sudo_address: Address::try_from_raw(&sudo_address)

--- a/crates/astria-core/src/protocol/transaction/v1alpha1/action/mod.rs
+++ b/crates/astria-core/src/protocol/transaction/v1alpha1/action/mod.rs
@@ -480,7 +480,7 @@ impl Protobuf for Sequence {
             return Err(SequenceError::field_not_set("rollup_id"));
         };
         let rollup_id =
-            RollupId::try_from_raw(rollup_id).map_err(SequenceError::rollup_id_length)?;
+            RollupId::try_from_raw_ref(rollup_id).map_err(SequenceError::rollup_id_length)?;
         let fee_asset = fee_asset.parse().map_err(SequenceError::fee_asset)?;
         let data = data.clone();
         Ok(Self {
@@ -1409,8 +1409,8 @@ impl Protobuf for InitBridgeAccount {
         let Some(rollup_id) = proto.rollup_id else {
             return Err(InitBridgeAccountError::field_not_set("rollup_id"));
         };
-        let rollup_id = RollupId::try_from_raw(&rollup_id)
-            .map_err(InitBridgeAccountError::invalid_rollup_id)?;
+        let rollup_id =
+            RollupId::try_from_raw(rollup_id).map_err(InitBridgeAccountError::invalid_rollup_id)?;
         let asset = proto
             .asset
             .parse()

--- a/crates/astria-core/src/sequencerblock/v1alpha1/block.rs
+++ b/crates/astria-core/src/sequencerblock/v1alpha1/block.rs
@@ -140,7 +140,7 @@ impl RollupTransactions {
             return Err(RollupTransactionsError::field_not_set("rollup_id"));
         };
         let rollup_id =
-            RollupId::try_from_raw(&rollup_id).map_err(RollupTransactionsError::rollup_id)?;
+            RollupId::try_from_raw(rollup_id).map_err(RollupTransactionsError::rollup_id)?;
         let proof = 'proof: {
             let Some(proof) = proof else {
                 break 'proof Err(RollupTransactionsError::field_not_set("proof"));
@@ -1127,11 +1127,7 @@ impl FilteredSequencerBlock {
                 .map(RollupTransactions::into_raw)
                 .collect(),
             rollup_transactions_proof: Some(rollup_transactions_proof.into_raw()),
-            all_rollup_ids: self
-                .all_rollup_ids
-                .iter()
-                .map(|id| Bytes::copy_from_slice(id.as_ref()))
-                .collect(),
+            all_rollup_ids: self.all_rollup_ids.iter().map(RollupId::to_raw).collect(),
             rollup_ids_proof: Some(rollup_ids_proof.into_raw()),
         }
     }
@@ -1216,7 +1212,7 @@ impl FilteredSequencerBlock {
 
         let all_rollup_ids: Vec<RollupId> = all_rollup_ids
             .into_iter()
-            .map(|bytes| RollupId::try_from_slice(&bytes))
+            .map(RollupId::try_from_raw)
             .collect::<Result<_, _>>()
             .map_err(FilteredSequencerBlockError::invalid_rollup_id)?;
 
@@ -1445,7 +1441,7 @@ impl Deposit {
             return Err(DepositError::field_not_set("rollup_id"));
         };
         let rollup_id =
-            RollupId::try_from_raw(&rollup_id).map_err(DepositError::incorrect_rollup_id_length)?;
+            RollupId::try_from_raw(rollup_id).map_err(DepositError::incorrect_rollup_id_length)?;
         let asset = asset.parse().map_err(DepositError::incorrect_asset)?;
         let Some(source_transaction_id) = source_transaction_id else {
             return Err(DepositError::field_not_set("transaction_id"));

--- a/crates/astria-core/src/sequencerblock/v1alpha1/celestia.rs
+++ b/crates/astria-core/src/sequencerblock/v1alpha1/celestia.rs
@@ -257,7 +257,7 @@ impl SubmittedRollupData {
             return Err(SubmittedRollupDataError::field_not_set("rollup_id"));
         };
         let rollup_id =
-            RollupId::try_from_raw(&rollup_id).map_err(SubmittedRollupDataError::rollup_id)?;
+            RollupId::try_from_raw(rollup_id).map_err(SubmittedRollupDataError::rollup_id)?;
         let sequencer_block_hash = sequencer_block_hash.as_ref().try_into().map_err(|_| {
             SubmittedRollupDataError::sequencer_block_hash(sequencer_block_hash.len())
         })?;
@@ -433,7 +433,7 @@ impl UncheckedSubmittedMetadata {
             SequencerBlockHeader::try_from_raw(header).map_err(SubmittedMetadataError::header)
         }?;
         let rollup_ids: Vec<_> = rollup_ids
-            .iter()
+            .into_iter()
             .map(RollupId::try_from_raw)
             .collect::<Result<_, _>>()
             .map_err(SubmittedMetadataError::rollup_ids)?;

--- a/crates/astria-sequencer/src/grpc/sequencer.rs
+++ b/crates/astria-sequencer/src/grpc/sequencer.rs
@@ -100,7 +100,7 @@ impl SequencerService for SequencerServer {
         let rollup_ids = request
             .rollup_ids
             .iter()
-            .map(RollupId::try_from_raw)
+            .map(RollupId::try_from_raw_ref)
             .collect::<Result<Vec<_>, _>>()
             .map_err(|e| Status::invalid_argument(format!("invalid rollup ID: {e}")))?;
 
@@ -157,10 +157,7 @@ impl SequencerService for SequencerServer {
             rollup_transactions.push(rollup_data.into_raw());
         }
 
-        let all_rollup_ids = all_rollup_ids
-            .into_iter()
-            .map(|rollup_id| Bytes::copy_from_slice(rollup_id.as_ref()))
-            .collect();
+        let all_rollup_ids = all_rollup_ids.into_iter().map(RollupId::into_raw).collect();
 
         let block = RawFilteredSequencerBlock {
             block_hash: Bytes::copy_from_slice(&block_hash),

--- a/proto/composerapis/astria/composer/v1alpha1/grpc_collector.proto
+++ b/proto/composerapis/astria/composer/v1alpha1/grpc_collector.proto
@@ -2,11 +2,13 @@ syntax = 'proto3';
 
 package astria.composer.v1alpha1;
 
+import "astria/primitive/v1/types.proto";
+
 // SubmitRollupTransactionRequest contains a rollup transaction to be submitted to the Shared Sequencer Network
 // via the Composer
 message SubmitRollupTransactionRequest {
   // the unhashed rollup id
-  bytes rollup_id = 1;
+  astria.primitive.v1.RollupId rollup_id = 1;
   // the raw data bytes of the rollup transaction
   bytes data = 2;
 }

--- a/proto/sequencerblockapis/astria/sequencerblock/v1alpha1/block.proto
+++ b/proto/sequencerblockapis/astria/sequencerblock/v1alpha1/block.proto
@@ -113,7 +113,7 @@ message FilteredSequencerBlock {
   // and is extracted from `astria.SequencerBlock.rollup_transactions`.
   // Note that these are all the rollup IDs in the sequencer block, not merely those in
   // `rollup_transactions` field. This is necessary to prove that no rollup IDs were omitted.
-  repeated bytes all_rollup_ids = 5;
+  repeated astria.primitive.v1.RollupId all_rollup_ids = 5;
   // The proof that the `rollup_ids` are included
   // in the CometBFT block this sequencer block is derived form.
   //


### PR DESCRIPTION
## Summary
Replaces `bytes` with `astria.primitive.v1.RollupId` in all protobuf types that were still outstanding.

## Background
When we introduced the `astria.primitive.v1.RollupId` type the goal was to use it in all places where previously we had bare `bytes`. Some places were overlooked, this patch fixes that.

## Changes
- Update `astria.composer.v1alpha1.SubmitRollupTransactionRequest.rollup_id` and `astria.sequencerblock.v1alpha1.FilteredSequencerBlock.all_rollup_ids` to be `astria.primitive.v1.RollupId` rather than bytes.

## Testing
All tests still pass which shows that smoke tests and blackbox tests understand the new format.

## Breaking Changelist
This is a breaking change because all downstream users of filtered sequencer blocks must understand the new format.

The author of this patch believes that it is not consensus breaking.

## Related Issues
Closes https://github.com/astriaorg/astria/issues/1658