### PR TITLE
chore(proto)!: remove source channel field from ics20 withdrawal action

### DIFF
--- a/crates/astria-bridge-withdrawer/tests/blackbox/helpers/test_bridge_withdrawer.rs
+++ b/crates/astria-bridge-withdrawer/tests/blackbox/helpers/test_bridge_withdrawer.rs
@@ -34,10 +34,7 @@ use ethers::{
     types::TransactionReceipt,
 };
 use futures::Future;
-use ibc_types::core::{
-    channel::ChannelId,
-    client::Height as IbcHeight,
-};
+use ibc_types::core::client::Height as IbcHeight;
 use sequencer_client::{
     Address,
     NonceResponse,
@@ -394,7 +391,6 @@ struct SubsetOfIcs20Withdrawal {
     destination_chain_address: String,
     return_address: Address,
     timeout_height: IbcHeight,
-    source_channel: ChannelId,
     fee_asset: asset::Denom,
     memo: String,
     bridge_address: Option<Address>,
@@ -409,7 +405,6 @@ impl From<Ics20Withdrawal> for SubsetOfIcs20Withdrawal {
             return_address,
             timeout_height,
             timeout_time: _timeout_time,
-            source_channel,
             fee_asset,
             memo,
             bridge_address,
@@ -421,7 +416,6 @@ impl From<Ics20Withdrawal> for SubsetOfIcs20Withdrawal {
             destination_chain_address,
             return_address,
             timeout_height,
-            source_channel,
             fee_asset,
             memo,
             bridge_address,
@@ -470,7 +464,6 @@ pub fn make_native_ics20_withdrawal_action(receipt: &TransactionReceipt) -> Acti
         fee_asset: denom,
         timeout_height,
         timeout_time,
-        source_channel: "channel-0".parse().unwrap(),
         bridge_address: Some(default_bridge_address()),
         use_compat_address: false,
     };
@@ -521,7 +514,6 @@ pub fn make_erc20_ics20_withdrawal_action(receipt: &TransactionReceipt) -> Actio
         fee_asset: denom,
         timeout_height,
         timeout_time,
-        source_channel: "channel-0".parse().unwrap(),
         bridge_address: Some(default_bridge_address()),
         use_compat_address: false,
     };

--- a/crates/astria-cli/src/sequencer/ics20_withdrawal.rs
+++ b/crates/astria-cli/src/sequencer/ics20_withdrawal.rs
@@ -12,10 +12,7 @@ use color_eyre::eyre::{
     self,
     WrapErr as _,
 };
-use ibc_types::core::{
-    channel::ChannelId,
-    client::Height,
-};
+use ibc_types::core::client::Height;
 use tracing::info;
 
 use crate::utils::{
@@ -42,9 +39,6 @@ pub(super) struct Command {
     /// The address on the destination chain
     #[arg(long)]
     destination_chain_address: String,
-    /// The source channel used for withdrawal
-    #[arg(long)]
-    source_channel: String,
     /// The address to refund on timeout, if unset refunds the signer
     #[arg(long)]
     return_address: Option<Address>,
@@ -107,7 +101,6 @@ impl Command {
                     revision_height: u64::MAX,
                 },
                 timeout_time: now_plus_5_minutes(),
-                source_channel: ChannelId(self.source_channel),
                 fee_asset: self.fee_asset,
                 memo: self.memo.unwrap_or_default(),
                 bridge_address: self.bridge_address,

--- a/crates/astria-core/src/generated/astria.protocol.transaction.v1alpha1.rs
+++ b/crates/astria-core/src/generated/astria.protocol.transaction.v1alpha1.rs
@@ -146,14 +146,11 @@ pub struct Ics20Withdrawal {
     /// the unix timestamp (in nanoseconds) at which this transfer expires.
     #[prost(uint64, tag = "6")]
     pub timeout_time: u64,
-    /// the source channel used for the withdrawal.
-    #[prost(string, tag = "7")]
-    pub source_channel: ::prost::alloc::string::String,
     /// the asset used to pay the transaction fee
-    #[prost(string, tag = "8")]
+    #[prost(string, tag = "7")]
     pub fee_asset: ::prost::alloc::string::String,
     /// a memo to include with the transfer
-    #[prost(string, tag = "9")]
+    #[prost(string, tag = "8")]
     pub memo: ::prost::alloc::string::String,
     /// the address of the bridge account to transfer from, if this is a withdrawal
     /// from a bridge account and the sender of the tx is the bridge's withdrawer,
@@ -164,14 +161,14 @@ pub struct Ics20Withdrawal {
     ///
     /// if unset, and the transaction sender is a bridge account, the withdrawal is
     /// treated as a bridge withdrawal (ie. the bridge account's withdrawer address is checked).
-    #[prost(message, optional, tag = "10")]
+    #[prost(message, optional, tag = "9")]
     pub bridge_address: ::core::option::Option<
         super::super::super::primitive::v1::Address,
     >,
     /// whether to use a bech32-compatible format of the `.return_address` when generating
     /// fungible token packets (as opposed to Astria-native bech32m addresses). This is
     /// necessary for chains like noble which enforce a strict bech32 format.
-    #[prost(bool, tag = "11")]
+    #[prost(bool, tag = "10")]
     pub use_compat_address: bool,
 }
 impl ::prost::Name for Ics20Withdrawal {

--- a/crates/astria-core/src/generated/astria.protocol.transaction.v1alpha1.serde.rs
+++ b/crates/astria-core/src/generated/astria.protocol.transaction.v1alpha1.serde.rs
@@ -1508,9 +1508,6 @@ impl serde::Serialize for Ics20Withdrawal {
         if self.timeout_time != 0 {
             len += 1;
         }
-        if !self.source_channel.is_empty() {
-            len += 1;
-        }
         if !self.fee_asset.is_empty() {
             len += 1;
         }
@@ -1542,9 +1539,6 @@ impl serde::Serialize for Ics20Withdrawal {
         if self.timeout_time != 0 {
             #[allow(clippy::needless_borrow)]
             struct_ser.serialize_field("timeoutTime", ToString::to_string(&self.timeout_time).as_str())?;
-        }
-        if !self.source_channel.is_empty() {
-            struct_ser.serialize_field("sourceChannel", &self.source_channel)?;
         }
         if !self.fee_asset.is_empty() {
             struct_ser.serialize_field("feeAsset", &self.fee_asset)?;
@@ -1578,8 +1572,6 @@ impl<'de> serde::Deserialize<'de> for Ics20Withdrawal {
             "timeoutHeight",
             "timeout_time",
             "timeoutTime",
-            "source_channel",
-            "sourceChannel",
             "fee_asset",
             "feeAsset",
             "memo",
@@ -1597,7 +1589,6 @@ impl<'de> serde::Deserialize<'de> for Ics20Withdrawal {
             ReturnAddress,
             TimeoutHeight,
             TimeoutTime,
-            SourceChannel,
             FeeAsset,
             Memo,
             BridgeAddress,
@@ -1629,7 +1620,6 @@ impl<'de> serde::Deserialize<'de> for Ics20Withdrawal {
                             "returnAddress" | "return_address" => Ok(GeneratedField::ReturnAddress),
                             "timeoutHeight" | "timeout_height" => Ok(GeneratedField::TimeoutHeight),
                             "timeoutTime" | "timeout_time" => Ok(GeneratedField::TimeoutTime),
-                            "sourceChannel" | "source_channel" => Ok(GeneratedField::SourceChannel),
                             "feeAsset" | "fee_asset" => Ok(GeneratedField::FeeAsset),
                             "memo" => Ok(GeneratedField::Memo),
                             "bridgeAddress" | "bridge_address" => Ok(GeneratedField::BridgeAddress),
@@ -1659,7 +1649,6 @@ impl<'de> serde::Deserialize<'de> for Ics20Withdrawal {
                 let mut return_address__ = None;
                 let mut timeout_height__ = None;
                 let mut timeout_time__ = None;
-                let mut source_channel__ = None;
                 let mut fee_asset__ = None;
                 let mut memo__ = None;
                 let mut bridge_address__ = None;
@@ -1704,12 +1693,6 @@ impl<'de> serde::Deserialize<'de> for Ics20Withdrawal {
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
                         }
-                        GeneratedField::SourceChannel => {
-                            if source_channel__.is_some() {
-                                return Err(serde::de::Error::duplicate_field("sourceChannel"));
-                            }
-                            source_channel__ = Some(map_.next_value()?);
-                        }
                         GeneratedField::FeeAsset => {
                             if fee_asset__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("feeAsset"));
@@ -1743,7 +1726,6 @@ impl<'de> serde::Deserialize<'de> for Ics20Withdrawal {
                     return_address: return_address__,
                     timeout_height: timeout_height__,
                     timeout_time: timeout_time__.unwrap_or_default(),
-                    source_channel: source_channel__.unwrap_or_default(),
                     fee_asset: fee_asset__.unwrap_or_default(),
                     memo: memo__.unwrap_or_default(),
                     bridge_address: bridge_address__,

--- a/crates/astria-core/src/primitive/v1/asset/denom.rs
+++ b/crates/astria-core/src/primitive/v1/asset/denom.rs
@@ -282,6 +282,10 @@ impl TracePrefixed {
         self.trace.leading_channel() == Some(channel.as_ref())
     }
 
+    pub fn leading_channel(&self) -> Option<&str> {
+        self.trace.leading_channel()
+    }
+
     #[must_use]
     pub fn last_channel(&self) -> Option<&str> {
         self.trace.last_channel()

--- a/crates/astria-core/src/protocol/transaction/v1alpha1/action/group/tests.rs
+++ b/crates/astria-core/src/protocol/transaction/v1alpha1/action/group/tests.rs
@@ -82,7 +82,6 @@ fn try_from_list_of_actions_bundleable_general() {
             fee_asset: asset.clone(),
             timeout_height: Height::new(1, 1).unwrap(),
             timeout_time: 0,
-            source_channel: "channel-0".parse().unwrap(),
             bridge_address: Some(address),
             use_compat_address: false,
         }),

--- a/proto/protocolapis/astria/protocol/transaction/v1alpha1/action.proto
+++ b/proto/protocolapis/astria/protocol/transaction/v1alpha1/action.proto
@@ -90,12 +90,10 @@ message Ics20Withdrawal {
   IbcHeight timeout_height = 5;
   // the unix timestamp (in nanoseconds) at which this transfer expires.
   uint64 timeout_time = 6;
-  // the source channel used for the withdrawal.
-  string source_channel = 7;
   // the asset used to pay the transaction fee
-  string fee_asset = 8;
+  string fee_asset = 7;
   // a memo to include with the transfer
-  string memo = 9;
+  string memo = 8;
   // the address of the bridge account to transfer from, if this is a withdrawal
   // from a bridge account and the sender of the tx is the bridge's withdrawer,
   // which differs from the bridge account's address.
@@ -105,12 +103,12 @@ message Ics20Withdrawal {
   //
   // if unset, and the transaction sender is a bridge account, the withdrawal is
   // treated as a bridge withdrawal (ie. the bridge account's withdrawer address is checked).
-  astria.primitive.v1.Address bridge_address = 10;
+  astria.primitive.v1.Address bridge_address = 9;
 
   // whether to use a bech32-compatible format of the `.return_address` when generating
   // fungible token packets (as opposed to Astria-native bech32m addresses). This is
   // necessary for chains like noble which enforce a strict bech32 format.
-  bool use_compat_address = 11;
+  bool use_compat_address = 10;
 }
 
 message IbcHeight {


### PR DESCRIPTION
## Summary
Removes the field `astria.protocol.transaction.v1alpha1.Ics20Withdrawal.source_channel`.

## Background
The source channel of an asset in an ics20 transfer is part of the assets name. To take the example of sequencer, if a counterparty sends an asset to sequencer, sequencer will prepend the asset by `<dest_port>` and `<dest_channel>`. This is the port/channel pair on sequencer for the connection with the counterparty. The `source_channel` field then is actually this `<dest_channel>` that astria is prepending to the asset before storing it locally.

Looking at the `astria-bridge-contracts` library (also changed in this patch), `source_channel` is actually parsed out of the asset to be transferred and then placed into the action. This is not necessary.

Instead, sequencer will now be concerned with determining the source channel from the asset. If the asset is an ibc-prefixed asset, it will look up its full trace in its state.

This allows rollups to withdraw assets even if only the ibc prefixed denom is known.

## Changes
- Remove field `astria.protocol.transaction.v1alpha1.Ics20Withdrawal.source_channel`.
- Remove all source channel logic from astria cli, astria bridge contracts
- Have sequencer determine the source channel from the asset to be withdrawn.

## Testing
This must be tested through a smoke test.

## Breaking Changelist
The shape of an action was changed. This is a network breaking change.

## Related Issues
Closes https://github.com/astriaorg/astria/issues/1668.
