### PR TITLE
chore(sequencer): remove unused enable mint env

### DIFF
--- a/charts/sequencer/Chart.yaml
+++ b/charts/sequencer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.25.0
+version: 0.25.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/sequencer/templates/configmaps.yaml
+++ b/charts/sequencer/templates/configmaps.yaml
@@ -57,7 +57,6 @@ data:
   ASTRIA_SEQUENCER_LOG: "astria_sequencer=debug"
   ASTRIA_SEQUENCER_LISTEN_ADDR: "127.0.0.1:{{ .Values.ports.sequencerABCI }}"
   ASTRIA_SEQUENCER_DB_FILEPATH: "/sequencer/penumbra.db"
-  ASTRIA_SEQUENCER_ENABLE_MINT: "false"
   # Socket address for GRPC server
   ASTRIA_SEQUENCER_GRPC_ADDR: "0.0.0.0:{{ .Values.ports.sequencerGrpc }}"
   ASTRIA_SEQUENCER_NO_METRICS: "{{ not .Values.sequencer.metrics.enabled }}"

--- a/crates/astria-sequencer/src/config.rs
+++ b/crates/astria-sequencer/src/config.rs
@@ -18,9 +18,6 @@ pub struct Config {
     pub db_filepath: PathBuf,
     /// Log level: debug, info, warn, or error
     pub log: String,
-    /// Set to true to enable the mint component
-    /// Only used if the "mint" feature is enabled
-    pub enable_mint: bool,
     /// The gRPC endpoint
     pub grpc_addr: String,
     /// Forces writing trace data to stdout no matter if connected to a tty or not.


### PR DESCRIPTION
## Summary
remove unused enable mint env. We removed the mint module in https://github.com/astriaorg/astria/pull/1134, the config var was unused but left in. 