### PR TITLE
fix: remove enable mint entry from example env config

### DIFF
--- a/crates/astria-sequencer/local.env.example
+++ b/crates/astria-sequencer/local.env.example
@@ -6,10 +6,6 @@ ASTRIA_SEQUENCER_LISTEN_ADDR="127.0.0.1:26658"
 # Path to rocksdb
 ASTRIA_SEQUENCER_DB_FILEPATH="/tmp/astria_db"
 
-# Set to true to enable the mint component
-# Only used if the "mint" feature is enabled
-ASTRIA_SEQUENCER_ENABLE_MINT=false
-
 # Set size of mempool's parked container
 ASTRIA_SEQUENCER_MEMPOOL_PARKED_MAX_TX_COUNT=200
 


### PR DESCRIPTION
## Summary
removes `ASTRIA_SEQUENCER_ENABLE_MINT` variable from example env config
## Background
Did not remove from example config in previous PR
