### PR TITLE
chore(charts): update back to latest after proto merge

### DIFF
--- a/charts/evm-rollup/Chart.yaml
+++ b/charts/evm-rollup/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.27.7
+version: 0.27.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/evm-rollup/values.yaml
+++ b/charts/evm-rollup/values.yaml
@@ -11,7 +11,7 @@ images:
     repo: ghcr.io/astriaorg/astria-geth
     pullPolicy: IfNotPresent
     tag: 0.14.3
-    devTag: pr-53
+    devTag: latest
     overrideTag: ""
   conductor:
     repo: ghcr.io/astriaorg/conductor

--- a/charts/evm-stack/Chart.lock
+++ b/charts/evm-stack/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.3.6
 - name: evm-rollup
   repository: file://../evm-rollup
-  version: 0.27.7
+  version: 0.27.8
 - name: composer
   repository: file://../composer
   version: 0.1.6
@@ -20,5 +20,5 @@ dependencies:
 - name: blockscout-stack
   repository: https://blockscout.github.io/helm-charts
   version: 1.6.2
-digest: sha256:0e27488ee37649eba58de6b3d8c840a69fcaade3f96d1af1713ecfb3437afd3d
-generated: "2024-10-16T13:23:06.935828-07:00"
+digest: sha256:05842ed4276a5eeb84b1743b2e48d8434f21fd5192fcef27d61eb3682ae918de
+generated: "2024-10-17T07:55:32.06074-07:00"

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.5
+version: 0.6.6
 
 dependencies:
   - name: celestia-node

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -23,7 +23,7 @@ dependencies:
     repository: "file://../celestia-node"
     condition: celestia-node.enabled
   - name: evm-rollup
-    version: 0.27.7
+    version: 0.27.8
     repository: "file://../evm-rollup"
   - name: composer
     version: 0.1.6

--- a/charts/hermes/Chart.yaml
+++ b/charts/hermes/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.3
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.8.2"
+appVersion: "0.3.0"
 
 maintainers:
   - name: wafflesvonmaple

--- a/charts/hermes/values.yaml
+++ b/charts/hermes/values.yaml
@@ -3,7 +3,7 @@ global:
   replicaCount: 1
   logLevel: debug
 
-image: ghcr.io/astriaorg/hermes:sha-f6189cd
+image: ghcr.io/astriaorg/hermes:0.3.0
 imagePullPolicy: IfNotPresent
 
 fullnameOverride: ""

--- a/dev/values/hermes/local.yaml
+++ b/dev/values/hermes/local.yaml
@@ -1,5 +1,3 @@
-image: "ghcr.io/astriaorg/hermes:pr-19"
-
 createChannel:
   enabled: true
   chainA: sequencer-test-chain-0


### PR DESCRIPTION
## Summary
We merged major proto updates, dependent charts have been updated in latest and releases to use those. 
