### PR TITLE
chore(charts): disable locals in geth

### DIFF
--- a/charts/evm-rollup/Chart.yaml
+++ b/charts/evm-rollup/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.28.1
+version: 0.28.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/evm-rollup/values.yaml
+++ b/charts/evm-rollup/values.yaml
@@ -157,6 +157,8 @@ config:
       - name: metrics.port
         value: "{{ .Values.ports.metrics }}"
         condition: .Values.metrics.enabled
+      - name: txpool.nolocals
+        value: "true"
 
 
   conductor:

--- a/charts/evm-stack/Chart.lock
+++ b/charts/evm-stack/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.3.6
 - name: evm-rollup
   repository: file://../evm-rollup
-  version: 0.28.1
+  version: 0.28.2
 - name: composer
   repository: file://../composer
   version: 1.0.0-rc.2
@@ -20,5 +20,5 @@ dependencies:
 - name: blockscout-stack
   repository: https://blockscout.github.io/helm-charts
   version: 1.6.2
-digest: sha256:117d452966a5efe4e5809c8f21b4966a29a616b333cef566b20ec259c0268a0d
-generated: "2024-10-24T20:13:17.502491+03:00"
+digest: sha256:9970e9614b9147ad9c178e255610399746d667300b66fd69fcf77ec3357622db
+generated: "2024-10-27T09:51:36.847655-07:00"

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.4
+version: 0.7.5
 
 dependencies:
   - name: celestia-node
@@ -23,7 +23,7 @@ dependencies:
     repository: "file://../celestia-node"
     condition: celestia-node.enabled
   - name: evm-rollup
-    version: 0.28.1
+    version: 0.28.2
     repository: "file://../evm-rollup"
   - name: composer
     version: 1.0.0-rc.2


### PR DESCRIPTION
## Summary
Updates default geth deployement to disable locals pricing

## Background
Treating txs as local is really intended for a truly local instance, where the source is the person running the node but in our case treats every tx coming through RPC as local. We don't want this. 
