### PR TITLE
chore(proto): reserved only for what would be breaking change

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: run_checker
     if: needs.run_checker.outputs.run_lint_proto == 'true'
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: bufbuild/buf-setup-action@v1
@@ -23,25 +22,31 @@ jobs:
           github_token: ${{ github.token }}
       - uses: bufbuild/buf-lint-action@v1
       - run: buf format -d --exit-code
+        continue-on-error: true
       # Run breaking changes against each module, running against whole workspace
       # fails if new packages are added
       - uses: bufbuild/buf-breaking-action@v1
+        continue-on-error: true
         with:
           input: "proto/primitives"
           against: "buf.build/astria/primitives"
       - uses: bufbuild/buf-breaking-action@v1
+        continue-on-error: true
         with:
           input: "proto/executionapis"
           against: "buf.build/astria/execution-apis"
       - uses: bufbuild/buf-breaking-action@v1
+        continue-on-error: true
         with:
           input: "proto/sequencerblockapis"
           against: "buf.build/astria/sequencerblock-apis"
       - uses: bufbuild/buf-breaking-action@v1
+        continue-on-error: true
         with:
           input: "proto/protocolapis"
           against: "buf.build/astria/protocol-apis"
       - uses: bufbuild/buf-breaking-action@v1
+        continue-on-error: true
         with:
           input: "proto/composerapis"
           against: "buf.build/astria/composer-apis"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,7 @@ on:
       - synchronize
       - reopened
       - labeled
+      - unlabeled
   merge_group:
   push:
     branches:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -50,9 +50,6 @@ jobs:
         with:
           input: "proto/composerapis"
           against: "buf.build/astria/composer-apis"
-      - if: contains(github.event.pull_request.labels.*.name, 'allow-breaking-proto')
-        run: |
-          echo "OK: breaking changes allowed"
 
   rust:
     runs-on: ubuntu-22.04

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: run_checker
     if: needs.run_checker.outputs.run_lint_proto == 'true'
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: bufbuild/buf-setup-action@v1
@@ -22,39 +23,31 @@ jobs:
           github_token: ${{ github.token }}
       - uses: bufbuild/buf-lint-action@v1
       - run: buf format -d --exit-code
-        if: always()
       # Run breaking changes against each module, running against whole workspace
       # fails if new packages are added
       - uses: bufbuild/buf-breaking-action@v1
-        if: always()
-        continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'allow-breaking-proto') }}
         with:
           input: "proto/primitives"
           against: "buf.build/astria/primitives"
       - uses: bufbuild/buf-breaking-action@v1
-        if: always()
-        continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'allow-breaking-proto') }}
         with:
           input: "proto/executionapis"
           against: "buf.build/astria/execution-apis"
       - uses: bufbuild/buf-breaking-action@v1
-        if: always()
-        continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'allow-breaking-proto') }}
         with:
           input: "proto/sequencerblockapis"
           against: "buf.build/astria/sequencerblock-apis"
       - uses: bufbuild/buf-breaking-action@v1
-        if: always()
-        continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'allow-breaking-proto') }}
         with:
           input: "proto/protocolapis"
           against: "buf.build/astria/protocol-apis"
       - uses: bufbuild/buf-breaking-action@v1
-        if: always()
-        continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'allow-breaking-proto') }}
         with:
           input: "proto/composerapis"
           against: "buf.build/astria/composer-apis"
+      - if: contains(github.event.pull_request.labels.*.name, 'allow-breaking-proto')
+        run: |
+          echo "OK: breaking changes allowed"
 
   rust:
     runs-on: ubuntu-22.04

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,5 @@
 name: Lint
-on: 
+on:
   pull_request:
   merge_group:
   push:
@@ -22,25 +22,36 @@ jobs:
           github_token: ${{ github.token }}
       - uses: bufbuild/buf-lint-action@v1
       - run: buf format -d --exit-code
+        if: always()
       # Run breaking changes against each module, running against whole workspace
       # fails if new packages are added
       - uses: bufbuild/buf-breaking-action@v1
+        if: always()
+        continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'allow-breaking-proto') }}
         with:
           input: "proto/primitives"
           against: "buf.build/astria/primitives"
       - uses: bufbuild/buf-breaking-action@v1
+        if: always()
+        continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'allow-breaking-proto') }}
         with:
           input: "proto/executionapis"
           against: "buf.build/astria/execution-apis"
       - uses: bufbuild/buf-breaking-action@v1
+        if: always()
+        continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'allow-breaking-proto') }}
         with:
           input: "proto/sequencerblockapis"
           against: "buf.build/astria/sequencerblock-apis"
       - uses: bufbuild/buf-breaking-action@v1
+        if: always()
+        continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'allow-breaking-proto') }}
         with:
           input: "proto/protocolapis"
           against: "buf.build/astria/protocol-apis"
       - uses: bufbuild/buf-breaking-action@v1
+        if: always()
+        continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'allow-breaking-proto') }}
         with:
           input: "proto/composerapis"
           against: "buf.build/astria/composer-apis"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,11 @@
 name: Lint
 on:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
   merge_group:
   push:
     branches:
@@ -22,31 +27,36 @@ jobs:
           github_token: ${{ github.token }}
       - uses: bufbuild/buf-lint-action@v1
       - run: buf format -d --exit-code
-        continue-on-error: true
+        if: always()
       # Run breaking changes against each module, running against whole workspace
       # fails if new packages are added
       - uses: bufbuild/buf-breaking-action@v1
-        continue-on-error: true
+        if: always()
+        continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'allow-breaking-proto') }}
         with:
           input: "proto/primitives"
           against: "buf.build/astria/primitives"
       - uses: bufbuild/buf-breaking-action@v1
-        continue-on-error: true
+        if: always()
+        continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'allow-breaking-proto') }}
         with:
           input: "proto/executionapis"
           against: "buf.build/astria/execution-apis"
       - uses: bufbuild/buf-breaking-action@v1
-        continue-on-error: true
+        if: always()
+        continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'allow-breaking-proto') }}
         with:
           input: "proto/sequencerblockapis"
           against: "buf.build/astria/sequencerblock-apis"
       - uses: bufbuild/buf-breaking-action@v1
-        continue-on-error: true
+        if: always()
+        continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'allow-breaking-proto') }}
         with:
           input: "proto/protocolapis"
           against: "buf.build/astria/protocol-apis"
       - uses: bufbuild/buf-breaking-action@v1
-        continue-on-error: true
+        if: always()
+        continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'allow-breaking-proto') }}
         with:
           input: "proto/composerapis"
           against: "buf.build/astria/composer-apis"

--- a/proto/protocolapis/astria/protocol/transaction/v1/action.proto
+++ b/proto/protocolapis/astria/protocol/transaction/v1/action.proto
@@ -31,10 +31,6 @@ message Action {
     FeeChange fee_change = 55;
     IbcSudoChange ibc_sudo_change = 56;
   }
-  reserved 3 to 10;
-  reserved 15 to 20;
-  reserved 23 to 30;
-  reserved 57 to 60;
 
   // deprecated fields
   reserved 54; // deprecated "mint_action"

--- a/proto/protocolapis/astria/protocol/transaction/v1/action.proto
+++ b/proto/protocolapis/astria/protocol/transaction/v1/action.proto
@@ -31,10 +31,6 @@ message Action {
     FeeChange fee_change = 55;
     IbcSudoChange ibc_sudo_change = 56;
   }
-
-  // deprecated fields
-  reserved 54; // deprecated "mint_action"
-  reserved "mint_action";
 }
 
 // `TransferAction` represents a value transfer transaction.

--- a/proto/protocolapis/astria/protocol/transaction/v1alpha1/action.proto
+++ b/proto/protocolapis/astria/protocol/transaction/v1alpha1/action.proto
@@ -31,10 +31,6 @@ message Action {
     FeeChange fee_change = 55;
     IbcSudoChange ibc_sudo_change = 56;
   }
-  reserved 3 to 10;
-  reserved 15 to 20;
-  reserved 23 to 30;
-  reserved 57 to 60;
 
   // deprecated fields
   reserved 54; // deprecated "mint_action"


### PR DESCRIPTION
## Summary
We have been using reserved to highlight gaps, but reserved should ideally only be utilized for reserving previously used identifiers. 

## Changes
- removes reserved numbers that using were not actual breaking change
- updates workflow to allow override and to always run all breaking checks even if previous fails

## Breaking Changes
This has no real breaking changes, hence allowing override. The removal of the reserved makes it so that we don't have to do this in the future when adding new fields.
