### PR TITLE
feat(cli): sudo commands generate only

### DIFF
--- a/crates/astria-cli/src/sequencer/sudo/fee_asset.rs
+++ b/crates/astria-cli/src/sequencer/sudo/fee_asset.rs
@@ -45,12 +45,21 @@ struct Add {
 impl Add {
     async fn run(self) -> eyre::Result<()> {
         let args = self.inner;
+        let action = Action::FeeAssetChange(FeeAssetChange::Addition(args.asset.clone()));
+        if args.generate_only {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&action)
+                    .wrap_err("failed to serialize FeeAssetChangeAction::Addition action")?
+            );
+            return Ok(());
+        }
         let res = submit_transaction(
             args.sequencer_url.as_str(),
             args.sequencer_chain_id.clone(),
             &args.prefix,
             args.private_key.as_str(),
-            Action::FeeAssetChange(FeeAssetChange::Addition(args.asset.clone())),
+            action,
         )
         .await
         .wrap_err("failed to submit FeeAssetChangeAction::Addition transaction")?;
@@ -70,12 +79,21 @@ struct Remove {
 impl Remove {
     async fn run(self) -> eyre::Result<()> {
         let args = self.inner;
+        let action = Action::FeeAssetChange(FeeAssetChange::Removal(args.asset.clone()));
+        if args.generate_only {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&action)
+                    .wrap_err("failed to serialize FeeAssetChangeAction::Removal action")?
+            );
+            return Ok(());
+        }
         let res = submit_transaction(
             args.sequencer_url.as_str(),
             args.sequencer_chain_id.clone(),
             &args.prefix,
             args.private_key.as_str(),
-            Action::FeeAssetChange(FeeAssetChange::Removal(args.asset.clone())),
+            action,
         )
         .await
         .wrap_err("failed to submit FeeAssetChangeAction::Removal transaction")?;
@@ -114,4 +132,8 @@ struct ArgsInner {
     /// Asset's denomination string
     #[arg(long)]
     asset: asset::Denom,
+    /// If set this will only generate the transaction body and print out
+    /// in pbjson format. Will not sign or send the transaction.
+    #[arg(long)]
+    generate_only: bool,
 }

--- a/crates/astria-cli/src/sequencer/sudo/ibc_relayer.rs
+++ b/crates/astria-cli/src/sequencer/sudo/ibc_relayer.rs
@@ -42,12 +42,21 @@ struct Add {
 impl Add {
     async fn run(self) -> eyre::Result<()> {
         let args = self.inner;
+        let action = Action::IbcRelayerChange(IbcRelayerChange::Addition(args.address));
+        if args.generate_only {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&action)
+                    .wrap_err("failed to serialize IbcRelayerChangeAction::Addition action")?
+            );
+            return Ok(());
+        }
         let res = submit_transaction(
             args.sequencer_url.as_str(),
             args.sequencer_chain_id.clone(),
             &args.prefix,
             args.private_key.as_str(),
-            Action::IbcRelayerChange(IbcRelayerChange::Addition(args.address)),
+            action,
         )
         .await
         .wrap_err("failed to submit IbcRelayerChangeAction::Addition transaction")?;
@@ -67,12 +76,21 @@ struct Remove {
 impl Remove {
     async fn run(self) -> eyre::Result<()> {
         let args = self.inner;
+        let action = Action::IbcRelayerChange(IbcRelayerChange::Removal(args.address));
+        if args.generate_only {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&action)
+                    .wrap_err("failed to serialize IbcRelayerChangeAction::Removal action")?
+            );
+            return Ok(());
+        }
         let res = submit_transaction(
             args.sequencer_url.as_str(),
             args.sequencer_chain_id.clone(),
             &args.prefix,
             args.private_key.as_str(),
-            Action::IbcRelayerChange(IbcRelayerChange::Removal(args.address)),
+            action,
         )
         .await
         .wrap_err("failed to submit IbcRelayerChangeAction::Removal transaction")?;
@@ -111,4 +129,8 @@ struct ArgsInner {
     /// The address to add or remove as an IBC relayer
     #[arg(long)]
     address: Address,
+    /// If set this will only generate the transaction body and print out
+    /// in pbjson format. Will not sign or send the transaction.
+    #[arg(long, action = clap::ArgAction::SetTrue)]
+    generate_only: bool,
 }


### PR DESCRIPTION
## Summary
Adds functionality to cli sudo actions to generate a pbjson output without signing or making any network requests.

## Background
Related to adding threshold signing, this can make it easier to generate json file which can be signed seperately. I considered making this generate a whole tx body but that requires making calls to sequencer with an address to determine nonce, just generating the action can be done without making any requests.

## Changes
- Add `--generate-only` flag to all sudo commands

## Testing
Ran locally.
