### PR TITLE
feat(sequencer-util): get json from transaction base64

### DIFF
--- a/crates/astria-sequencer-utils/src/cli.rs
+++ b/crates/astria-sequencer-utils/src/cli.rs
@@ -7,6 +7,7 @@ use super::{
     blob_parser,
     genesis_example,
     genesis_parser,
+    transaction_parser,
 };
 
 /// Utilities for working with the Astria sequencer network
@@ -29,6 +30,9 @@ pub enum Command {
     /// Parse blob data from an arg, a file, or stdin
     #[command(arg_required_else_help = true)]
     ParseBlob(blob_parser::Args),
+
+    #[command(arg_required_else_help = true)]
+    ParseTransaction(transaction_parser::Args),
 }
 
 #[must_use]

--- a/crates/astria-sequencer-utils/src/lib.rs
+++ b/crates/astria-sequencer-utils/src/lib.rs
@@ -2,3 +2,4 @@ pub mod blob_parser;
 pub mod cli;
 pub mod genesis_example;
 pub mod genesis_parser;
+pub mod transaction_parser;

--- a/crates/astria-sequencer-utils/src/main.rs
+++ b/crates/astria-sequencer-utils/src/main.rs
@@ -7,6 +7,7 @@ use astria_sequencer_utils::{
     },
     genesis_example,
     genesis_parser,
+    transaction_parser,
 };
 
 fn main() -> Result<()> {
@@ -16,5 +17,6 @@ fn main() -> Result<()> {
         Command::CopyGenesisState(args) => genesis_parser::run(args),
         Command::GenerateGenesisState(args) => genesis_example::run(&args),
         Command::ParseBlob(args) => blob_parser::run(args),
+        Command::ParseTransaction(args) => transaction_parser::run(args),
     }
 }

--- a/crates/astria-sequencer-utils/src/transaction_parser.rs
+++ b/crates/astria-sequencer-utils/src/transaction_parser.rs
@@ -1,0 +1,81 @@
+use std::{
+    fs,
+    io,
+    path::{
+        Path,
+    },
+};
+
+use astria_eyre::eyre::{
+    Result,
+    WrapErr,
+};
+use base64::{
+    prelude::BASE64_STANDARD,
+    Engine,
+};
+use astria_core::{
+    generated::protocol::transaction::v1::Transaction as RawTransaction,
+    protocol::transaction::v1::Transaction,
+};
+
+#[derive(clap::Args, Debug)]
+pub struct Args {
+    /// Base64-encoded transaction data, or a file containing this, or stdin if `-`
+    #[arg(value_name = "TX|PATH")]
+    input: String,
+}
+
+/// Copies JSON application state from a file to a genesis JSON file,
+/// placing it at the key `app_state`.
+///
+/// # Errors
+///
+/// An `eyre::Result` is returned if either file cannot be opened,
+/// or if the destination genesis file cannot be saved.
+pub fn run(
+    Args {
+        input,
+    }: Args,
+) -> Result<()> {
+    let raw_transaction = parse(&input)?;
+    println!("Transaction:");
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&raw_transaction).wrap_err("failed to json-encode")?
+    );
+    println!();
+    println!("Transaction Body:");
+    let transaction = Transaction::try_from_raw(raw_transaction).wrap_err("failed to convert to transaction")?;
+    println!("{}", serde_json::to_string_pretty(&transaction.unsigned_transaction().to_raw()).wrap_err("failed to json-encode")?);
+
+    Ok(())
+}
+
+fn parse(input: &str) -> Result<RawTransaction> {
+    use prost::Message;
+    let data = get_base64_data(input)?;
+    let transaction = RawTransaction::decode(&*data).wrap_err("failed to decode transaction")?;
+    Ok(transaction)
+}
+
+fn get_base64_data(input: &str) -> Result<Vec<u8>> {
+    if input == "-" {
+        let encoded = io::read_to_string(io::stdin().lock()).wrap_err("failed to read stdin")?;
+        return BASE64_STANDARD
+            .decode(encoded.trim())
+            .wrap_err("failed to decode stdin data as base64");
+    }
+
+    if Path::new(input).is_file() {
+        let encoded =
+            fs::read_to_string(input).wrap_err_with(|| format!("failed to read file `{input}`"))?;
+        return BASE64_STANDARD
+            .decode(encoded.trim())
+            .wrap_err_with(|| format!("failed to decode contents of `{input}` as base64"));
+    }
+
+    BASE64_STANDARD
+        .decode(input.trim())
+        .wrap_err("failed to decode provided blob data as base64")
+}


### PR DESCRIPTION
## Summary
Add a utility to the `sequencer-transaction-utils` to parse a transaction protobuf data from the base64 of the transaction.

## Background
The mempool and rpc endpoints for sequencer give base64 bytes, and there is no clean way to interpret the transaciton information from this. This provides a utility which can be useful for testing to do this. 
