### PR TITLE
chore(charts): celestia versions bump

### DIFF
--- a/charts/celestia-local/Chart.yaml
+++ b/charts/celestia-local/Chart.yaml
@@ -21,7 +21,7 @@ version: 0.7.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.2.0"
+appVersion: "2.3.1"
 
 maintainers:
   - name: wafflesvonmaple

--- a/charts/celestia-local/Chart.yaml
+++ b/charts/celestia-local/Chart.yaml
@@ -15,18 +15,20 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.4
+version: 0.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.9.0"
+appVersion: "2.2.0"
 
 maintainers:
   - name: wafflesvonmaple
     url: astria.org
   - name: steezeburger
+    url: astria.org
+  - name: quasystaty1
     url: astria.org
   - name: joroshiba
     url: astria.org

--- a/charts/celestia-local/values.yaml
+++ b/charts/celestia-local/values.yaml
@@ -15,8 +15,8 @@ storage:
       persistentVolumeName: "celestia-shared-storage"
       path: "/data/celestia-data"
 
-celestiaAppImage: "ghcr.io/celestiaorg/celestia-app:v2.2.0"
-celestiaNodeImage: "ghcr.io/celestiaorg/celestia-node:v0.18.2-mocha"
+celestiaAppImage: "ghcr.io/celestiaorg/celestia-app:v2.3.1"
+celestiaNodeImage: "ghcr.io/celestiaorg/celestia-node:v0.18.3-mocha"
 
 podSecurityContext:
   runAsUser: 10001

--- a/charts/celestia-local/values.yaml
+++ b/charts/celestia-local/values.yaml
@@ -15,8 +15,8 @@ storage:
       persistentVolumeName: "celestia-shared-storage"
       path: "/data/celestia-data"
 
-celestiaAppImage: "ghcr.io/celestiaorg/celestia-app:v2.0.0"
-celestiaNodeImage: "ghcr.io/celestiaorg/celestia-node:v0.16.0-rc0"
+celestiaAppImage: "ghcr.io/celestiaorg/celestia-app:v2.2.0"
+celestiaNodeImage: "ghcr.io/celestiaorg/celestia-node:v0.18.2-mocha"
 
 podSecurityContext:
   runAsUser: 10001

--- a/charts/celestia-node/Chart.yaml
+++ b/charts/celestia-node/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.6
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.14.1"
+appVersion: "0.18.2"
 
 maintainers:
   - name: wafflesvonmaple

--- a/charts/celestia-node/Chart.yaml
+++ b/charts/celestia-node/Chart.yaml
@@ -21,7 +21,7 @@ version: 0.4.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.18.2"
+appVersion: "0.18.3"
 
 maintainers:
   - name: wafflesvonmaple

--- a/charts/celestia-node/files/config.toml
+++ b/charts/celestia-node/files/config.toml
@@ -13,8 +13,8 @@
   GRPCPort = "9090"
 
 [State]
-  KeyringAccName = ""
-  KeyringBackend = "test"
+  DefaultKeyName = "my_celes_key"
+  DefaultBackendName = "test"
 
 [P2P]
   ListenAddresses = ["/ip4/0.0.0.0/udp/2121/quic-v1", "/ip6/::/udp/2121/quic-v1", "/ip4/0.0.0.0/tcp/2121", "/ip6/::/tcp/2121"]
@@ -46,7 +46,10 @@
   Enabled = false
 
 [Share]
+  BlockStoreCacheSize = 128
   UseShareExchange = true
+  [Share.EDSStoreParams]
+    RecentBlocksCacheSize = 10
   [Share.ShrExEDSParams]
     ServerReadTimeout = "5s"
     ServerWriteTimeout = "1m0s"
@@ -103,4 +106,5 @@
   SampleTimeout = "3m0s"  
 {{- end }}
 
-
+[Pruner]
+  EnableService = {{ .Values.config.enablePruner }}

--- a/charts/celestia-node/values.yaml
+++ b/charts/celestia-node/values.yaml
@@ -20,7 +20,7 @@ config:
 
 images:
   pullPolicy: IfNotPresent
-  node: ghcr.io/celestiaorg/celestia-node:v0.18.2-mocha
+  node: ghcr.io/celestiaorg/celestia-node:v0.18.3-mocha
 
 ports:
   celestia:

--- a/charts/celestia-node/values.yaml
+++ b/charts/celestia-node/values.yaml
@@ -10,6 +10,7 @@ config:
   network: mocha-4
   chainId: mocha-4
   coreIp: "full.consensus.mocha-4.celestia-mocha.com"
+  enablePruner: false
   type: light
   tokenAuthLevel: read  # can set to nil or false to disable rpc auth
   coreGrpcPort: 9090
@@ -19,7 +20,7 @@ config:
 
 images:
   pullPolicy: IfNotPresent
-  node: ghcr.io/celestiaorg/celestia-node:v0.16.0-rc0
+  node: ghcr.io/celestiaorg/celestia-node:v0.18.2-mocha
 
 ports:
   celestia:

--- a/charts/evm-stack/Chart.lock
+++ b/charts/evm-stack/Chart.lock
@@ -20,5 +20,5 @@ dependencies:
 - name: blockscout-stack
   repository: https://blockscout.github.io/helm-charts
   version: 1.6.8
-digest: sha256:d7d13d546b7c02594756cc24511f95316bd9e8664a5d336b551e22e70332a0d8
-generated: "2024-11-07T11:31:10.563322+02:00"
+digest: sha256:618d0978ce1fa169bffa360010e8afeb06f21ffb7574e8a298d1d561bbcee05b
+generated: "2024-11-11T13:27:42.868678+02:00"

--- a/charts/evm-stack/Chart.lock
+++ b/charts/evm-stack/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: celestia-node
   repository: file://../celestia-node
-  version: 0.3.6
+  version: 0.4.0
 - name: evm-rollup
   repository: file://../evm-rollup
   version: 1.0.0

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -19,7 +19,7 @@ version: 1.0.2
 
 dependencies:
   - name: celestia-node
-    version: 0.3.6
+    version: 0.4.0
     repository: "file://../celestia-node"
     condition: celestia-node.enabled
   - name: evm-rollup

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.2
+version: 1.0.3
 
 dependencies:
   - name: celestia-node


### PR DESCRIPTION
## Summary
updates celestia-node and celestia-local charts to support the new versions.
## Background
Celestia mocha-4 testnet went through an upgrade, nodes should upgrade by nov 7th

## Changes
- celestia-app `v2.0.0 -> v2.3.1`
- celestia-node `v0.16.0-rc -> v0.18.3-mocha`
- adjusts celestia-node` config.toml` env variables
- adds pruner service to configs
## Testing
celestia-local tested locally running smoke-tests, celestia-node sync tested locally & against flame.

## Breaking Changelist
- celestia environment variable changes
