### PR TITLE
chore(all): add changelogs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,12 @@ Brief background on why these changes were made, ie "why?"
 ## Testing
 How are these changes tested?
 
+## Changelogs
+Ensure all relevant changelog files are updated as necessary. See
+[keepachangelog](https://keepachangelog.com/en/1.1.0/#how) for change
+categories. Replace this text with e.g. "Changelogs updated." or "No updates
+required." to acknowledge changelogs have been considered.
+
 ## Metrics
 - List out metrics added by PR, delete section if none. 
 
@@ -17,6 +23,6 @@ How are these changes tested?
 - Bulleted list of breaking changes, any notes on migration. Delete section if none.
 
 ## Related Issues
-Link any issues that are related, prefer full github links.
+Link any issues that are related, prefer full GitHub links.
 
 closes <!-- list any issues closed here -->

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,5 @@
 name: Lint
-on: 
+on:
   pull_request:
   merge_group:
   push:
@@ -83,6 +83,7 @@ jobs:
           globs: |
             **/*.md
             #.github
+            #**/CHANGELOG.md
 
   charts:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -79,11 +79,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: DavidAnson/markdownlint-cli2-action@v11
-        with:
-          globs: |
-            **/*.md
-            #.github
-            #**/CHANGELOG.md
 
   charts:
     runs-on: ubuntu-latest

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,10 @@
+{
+  "globs": [
+    "**/*.md"
+  ],
+  "ignores": [
+    "target",
+    ".github",
+    "**/*/astria-bridge-contracts/lib/**/*.md"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -115,8 +115,7 @@ npm install markdownlint-cli2 --global
 just lint md
 
 # Run with docker
-docker run -v $PWD:/workdir davidanson/markdownlint-cli2:v0.8.1 /
-    "**/*.md" "#.github" "#**/CHANGELOG.md"
+docker run -v $PWD:/workdir davidanson/markdownlint-cli2:v0.8.1
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -115,7 +115,8 @@ npm install markdownlint-cli2 --global
 just lint md
 
 # Run with docker
-docker run -v $PWD:/workdir davidanson/markdownlint-cli2:v0.8.1 "**/*.md" "#.github"
+docker run -v $PWD:/workdir davidanson/markdownlint-cli2:v0.8.1 /
+    "**/*.md" "#.github" "#**/CHANGELOG.md"
 ```
 
 ## Contributing

--- a/crates/astria-bridge-contracts/CHANGELOG.md
+++ b/crates/astria-bridge-contracts/CHANGELOG.md
@@ -1,0 +1,14 @@
+<!-- markdownlint-disable no-duplicate-heading -->
+
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Added
+
+- Initial release.

--- a/crates/astria-bridge-withdrawer/CHANGELOG.md
+++ b/crates/astria-bridge-withdrawer/CHANGELOG.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable no-duplicate-heading -->
+
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/crates/astria-bridge-withdrawer/CHANGELOG.md
+++ b/crates/astria-bridge-withdrawer/CHANGELOG.md
@@ -1,0 +1,81 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0-rc.1] - 2024-10-17
+
+### Added
+
+- Add traceability to rollup deposits [#1410](https://github.com/astriaorg/astria/pull/1410).
+
+### Changed
+
+- Pass GRPC and CometBFT clients to consumers directly [#1510](https://github.com/astriaorg/astria/pull/1510).
+- Better grpc client construction [#1528](https://github.com/astriaorg/astria/pull/1528).
+- Replace `once_cell` with `LazyLock` [#1576](https://github.com/astriaorg/astria/pull/1576).
+- Remove action suffix from all action types [#1630](https://github.com/astriaorg/astria/pull/1630).
+- Update `futures-util` dependency based on cargo audit warning [#1644](https://github.com/astriaorg/astria/pull/1644).
+- Call transactions `Transaction`, contents `TransactionBody` [#1650](https://github.com/astriaorg/astria/pull/1650).
+- Rename sequence action to rollup data submission [#1665](https://github.com/astriaorg/astria/pull/1665).
+- Upgrade to proto `v1`s throughout [#1672](https://github.com/astriaorg/astria/pull/1672).
+
+### Fixed
+
+- Migrate from `broadcast_tx_commit` to `broadcast_tx_sync` [#1376](https://github.com/astriaorg/astria/pull/1376).
+- Fix memo transaction hash encoding [#1428](https://github.com/astriaorg/astria/pull/1428).
+
+## [0.3.0] - 2024-09-06
+
+### Added
+
+- Add instrumentation [#1324](https://github.com/astriaorg/astria/pull/1324).
+
+### Changed
+
+- Enforce withdrawals consumed [#1391](https://github.com/astriaorg/astria/pull/1391).
+
+### Fixed
+
+- Don't fail entire block due to bad withdraw event [#1409](https://github.com/astriaorg/astria/pull/1409).
+
+## [0.2.1] - 2024-08-22
+
+### Changed
+
+- Improve nonce handling [#1292](https://github.com/astriaorg/astria/pull/1292).
+- Update `bytemark` dependency based on cargo audit warning [#1350](https://github.com/astriaorg/astria/pull/1350)
+
+## [0.2.0] - 2024-07-26
+
+### Changed
+
+- Move generated contract bindings to crate [#1237](https://github.com/astriaorg/astria/pull/1237).
+- Move bridge-unlock memo to core [#1245](https://github.com/astriaorg/astria/pull/1245).
+- Refactor startup to a separate subtask and remove balance check from startup [#1190](https://github.com/astriaorg/astria/pull/1190).
+- Make bridge unlock memo string [#1244](https://github.com/astriaorg/astria/pull/1244).
+- Share code between cli and service [#1270](https://github.com/astriaorg/astria/pull/1270).
+- Define bridge memos in proto [#1285](https://github.com/astriaorg/astria/pull/1285).
+
+### Fixed
+
+- Support withdrawer address that differs from bridge address   [#1262](https://github.com/astriaorg/astria/pull/1262).
+- Disambiguate return addresses [#1266](https://github.com/astriaorg/astria/pull/1266).
+- Fix nonce handling [#1215](https://github.com/astriaorg/astria/pull/1215).
+- Don't panic on init [#1281](https://github.com/astriaorg/astria/pull/1281).
+
+## 0.1.0 - 2024-06-27
+
+### Added
+
+- Initial release of EVM Withdrawer.
+
+[unreleased]: https://github.com/astriaorg/astria/compare/bridge-withdrawer-v1.0.0-rc.1...HEAD
+[1.0.0-rc.1]: https://github.com/astriaorg/astria/compare/bridge-withdrawer-v0.3.0...bridge-withdrawer-v1.0.0-rc.1
+[0.3.0]: https://github.com/astriaorg/astria/compare/bridge-withdrawer-v0.2.1...bridge-withdrawer-v0.3.0
+[0.2.1]: https://github.com/astriaorg/astria/compare/bridge-withdrawer-v0.2.0...bridge-withdrawer-v0.2.1
+[0.2.0]: https://github.com/astriaorg/astria/compare/bridge-withdrawer-v0.1.0...bridge-withdrawer-v0.2.0

--- a/crates/astria-bridge-withdrawer/CHANGELOG.md
+++ b/crates/astria-bridge-withdrawer/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-rc.2] - 2024-10-23
+
+### Added
+
+- Add `use_compat_address` configuration value [#1671](https://github.com/astriaorg/astria/pull/1671).
+- Metric to track total settled funds [#1693](https://github.com/astriaorg/astria/pull/1693).
+
+### Fixed
+
+- Correctly identify rollup return address in ics20 withdrawal actions [#1714](https://github.com/astriaorg/astria/pull/1714).
+
 ## [1.0.0-rc.1] - 2024-10-17
 
 ### Added
@@ -76,7 +87,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release of EVM Withdrawer.
 
-[unreleased]: https://github.com/astriaorg/astria/compare/bridge-withdrawer-v1.0.0-rc.1...HEAD
+[unreleased]: https://github.com/astriaorg/astria/compare/bridge-withdrawer-v1.0.0-rc.2...HEAD
+[1.0.0-rc.2]: https://github.com/astriaorg/astria/compare/bridge-withdrawer-v1.0.0-rc.1...bridge-withdrawer-v1.0.0-rc.2
 [1.0.0-rc.1]: https://github.com/astriaorg/astria/compare/bridge-withdrawer-v0.3.0...bridge-withdrawer-v1.0.0-rc.1
 [0.3.0]: https://github.com/astriaorg/astria/compare/bridge-withdrawer-v0.2.1...bridge-withdrawer-v0.3.0
 [0.2.1]: https://github.com/astriaorg/astria/compare/bridge-withdrawer-v0.2.0...bridge-withdrawer-v0.2.1

--- a/crates/astria-cli/CHANGELOG.md
+++ b/crates/astria-cli/CHANGELOG.md
@@ -1,0 +1,90 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.5.0] - 2024-10-17
+
+### Added
+
+- Add command to perform ics20 withdrawals [#1631](https://github.com/astriaorg/astria/pull/1631).
+
+### Changed
+
+- Replace `once_cell` with `LazyLock` [#1576](https://github.com/astriaorg/astria/pull/1576).
+- Migrate all instances of `#[allow]` to `#[expect]` [#1561](https://github.com/astriaorg/astria/pull/1561).
+- Merge argument parsing and command execution [#1568](https://github.com/astriaorg/astria/pull/1568).
+- Remove action suffix from all action types [#1630](https://github.com/astriaorg/astria/pull/1630).
+- Prefer `astria.primitive.v1.RollupId` over bytes [#1661](https://github.com/astriaorg/astria/pull/1661).
+- Call transactions `Transaction`, contents `TransactionBody` [#1650](https://github.com/astriaorg/astria/pull/1650).
+- Rename sequence action to rollup data submission [#1665](https://github.com/astriaorg/astria/pull/1665).
+- Upgrade to proto `v1`s throughout [#1672](https://github.com/astriaorg/astria/pull/1672).
+
+### Fixed
+
+- Migrate from `broadcast_tx_commit` to `broadcast_tx_sync` [#1376](https://github.com/astriaorg/astria/pull/1376).
+- Ensure `checkTx` passes before waiting for inclusion [#1636](https://github.com/astriaorg/astria/pull/1636).
+
+## [0.4.1] - 2024-09-06
+
+### Fixed
+
+- Don't fail entire block due to bad withdraw event [#1409](https://github.com/astriaorg/astria/pull/1409).
+
+## [0.4.0] - 2024-08-28
+
+### Changed
+
+- Update to support dusk-10 as default network [#1418](https://github.com/astriaorg/astria/pull/1418).
+
+## [0.3.1] - 2024-01-23
+
+### Changed
+
+- Bump rpc websocket for dusk-3 [#705](https://github.com/astriaorg/astria/pull/705).
+
+## [0.3.0] - 2024-01-23
+
+### Changed
+
+- Update licenses [#706](https://github.com/astriaorg/astria/pull/706).
+
+### Fixed
+
+- Refactor yaml serialization to match format in rollup's values.yaml [#707](https://github.com/astriaorg/astria/pull/707).
+
+## [0.2.2] - 2024-01-18
+
+### Changed
+
+- Bump for dusk-3 [#689](https://github.com/astriaorg/astria/pull/689).
+
+## [0.2.1] - 2023-12-19
+
+### Changed
+
+- New release with new chart version [#658](https://github.com/astriaorg/astria/pull/658).
+
+## 0.2.0 - 2023-12-11
+
+### Changed
+
+- Update to work with latest rollup charts, and utilize dusk-2 network.
+
+## 0.1.0 - 2023-12-11
+
+### Added
+
+- Dusk 1 CLI release
+
+[unreleased]: https://github.com/astriaorg/astria/compare/cli-v0.5.0...HEAD
+[0.5.0]: https://github.com/astriaorg/astria/compare/cli-v0.4.1...cli-v0.5.0
+[0.4.1]: https://github.com/astriaorg/astria/compare/cli-v0.4.0...cli-v0.4.1
+[0.3.1]: https://github.com/astriaorg/astria/compare/cli-v0.3.0...cli-v0.3.1
+[0.3.0]: https://github.com/astriaorg/astria/compare/cli-v0.2.2...cli-v0.3.0
+[0.2.2]: https://github.com/astriaorg/astria/compare/cli-v0.2.1...cli-v0.2.2
+[0.2.1]: https://github.com/astriaorg/astria/compare/cli-v0.2.0...cli-v0.2.1

--- a/crates/astria-cli/CHANGELOG.md
+++ b/crates/astria-cli/CHANGELOG.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable no-duplicate-heading -->
+
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/crates/astria-cli/CHANGELOG.md
+++ b/crates/astria-cli/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2024-10-23
+
+### Added
+
+- Implement frost_ed25519 threshold signing CLI [#1654](https://github.com/astriaorg/astria/pull/1654).
+- Add `sign` and `submit` subcommands to `sequencer` CLI [#1696](https://github.com/astriaorg/astria/pull/1696).
+
+### Changed
+
+- Return Bech32m Prefixed Address [#1621](https://github.com/astriaorg/astria/pull/1621).
+
 ## [0.5.0] - 2024-10-17
 
 ### Added
@@ -83,7 +94,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Dusk 1 CLI release
 
-[unreleased]: https://github.com/astriaorg/astria/compare/cli-v0.5.0...HEAD
+[unreleased]: https://github.com/astriaorg/astria/compare/cli-v0.5.1...HEAD
+[0.5.1]: https://github.com/astriaorg/astria/compare/cli-v0.5.0...cli-v0.5.1
 [0.5.0]: https://github.com/astriaorg/astria/compare/cli-v0.4.1...cli-v0.5.0
 [0.4.1]: https://github.com/astriaorg/astria/compare/cli-v0.4.0...cli-v0.4.1
 [0.3.1]: https://github.com/astriaorg/astria/compare/cli-v0.3.0...cli-v0.3.1

--- a/crates/astria-composer/CHANGELOG.md
+++ b/crates/astria-composer/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-rc.2] - 2024-10-23
+
+### Changed
+
+- Make native asset optional [#1703](https://github.com/astriaorg/astria/pull/1703).
+
 ## [1.0.0-rc.1] - 2024-10-17
 
 ### Changed
@@ -197,7 +203,8 @@ TransferAction` [#719](https://github.com/astriaorg/astria/pull/719).
 
 - Initial release.
 
-[unreleased]: https://github.com/astriaorg/astria/compare/composer-v1.0.0-rc.1...HEAD
+[unreleased]: https://github.com/astriaorg/astria/compare/composer-v1.0.0-rc.2...HEAD
+[1.0.0-rc.2]: https://github.com/astriaorg/astria/compare/composer-v1.0.0-rc.1...composer-v1.0.0-rc.2
 [1.0.0-rc.1]: https://github.com/astriaorg/astria/compare/composer-v0.8.3...composer-v1.0.0-rc.1
 [0.8.3]: https://github.com/astriaorg/astria/compare/composer-v0.8.2...composer-v0.8.3
 [0.8.2]: https://github.com/astriaorg/astria/compare/composer-v0.8.1...composer-v0.8.2

--- a/crates/astria-composer/CHANGELOG.md
+++ b/crates/astria-composer/CHANGELOG.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable no-duplicate-heading -->
+
 # Changelog
 
 All notable changes to this project will be documented in this file.
@@ -115,7 +117,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update licenses [#706](https://github.com/astriaorg/astria/pull/706).
 - Bundle multiple rollup transactions into a single sequencer transaction [#651](https://github.com/astriaorg/astria/pull/651).
-- Move fee asset from `UnsignedTransaction` to `SequenceAction` and `TransferAction` [#719](https://github.com/astriaorg/astria/pull/719).
+- Move fee asset from `UnsignedTransaction` to `SequenceAction` and
+TransferAction` [#719](https://github.com/astriaorg/astria/pull/719).
 - Bump rust to 1.76, cargo-chef to 0.1.63 [#744](https://github.com/astriaorg/astria/pull/744).
 - Add some information to crates update msrv [#754](https://github.com/astriaorg/astria/pull/754).
 

--- a/crates/astria-composer/CHANGELOG.md
+++ b/crates/astria-composer/CHANGELOG.md
@@ -1,0 +1,212 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0-rc.1] - 2024-10-17
+
+### Changed
+
+- Replace `once_cell` with `LazyLock` [#1576](https://github.com/astriaorg/astria/pull/1576).
+- Migrate all instances of `#[allow]` to `#[expect]` [#1561](https://github.com/astriaorg/astria/pull/1561).
+- Remove action suffix from all action types [#1630](https://github.com/astriaorg/astria/pull/1630).
+- Update `futures-util` dependency based on cargo audit warning [#1644](https://github.com/astriaorg/astria/pull/1644).
+- Prefer `astria.primitive.v1.RollupId` over bytes [#1661](https://github.com/astriaorg/astria/pull/1661).
+- Call transactions `Transaction`, contents `TransactionBody` [#1650](https://github.com/astriaorg/astria/pull/1650).
+- Rename sequence action to rollup data submission [#1665](https://github.com/astriaorg/astria/pull/1665).
+- Upgrade to proto `v1`s throughout [#1672](https://github.com/astriaorg/astria/pull/1672).
+
+### Fixed
+
+- Update to work with appside mempool [#1643](https://github.com/astriaorg/astria/pull/1643).
+
+## [0.8.3] - 2024-09-06
+
+### Changed
+
+- Improved instrumentation [#1326](https://github.com/astriaorg/astria/pull/1326).
+
+## [0.8.2] - 2024-08-22
+
+### Changed
+
+- Update `bytemark` dependency based on cargo audit warning [#1350](https://github.com/astriaorg/astria/pull/1350).
+
+## [0.8.1] - 2024-07-26
+
+### Added
+
+- Add chain_id check on executor build [#1175](https://github.com/astriaorg/astria/pull/1175).
+
+## [0.8.0] - 2024-06-27
+
+### Added
+
+- Add bech32m addresses [#1124](https://github.com/astriaorg/astria/pull/1124).
+
+### Changed
+
+- Use macro to declare metric constants [#1129](https://github.com/astriaorg/astria/pull/1129).
+- Remove non-bech32m address bytes [#1186](https://github.com/astriaorg/astria/pull/1186).
+- Use full IBC ICS20 denoms instead of IDs [#1209](https://github.com/astriaorg/astria/pull/1209).
+
+## [0.7.0] - 2024-05-21
+
+### Added
+
+- Add initial set of metrics [#932](https://github.com/astriaorg/astria/pull/932).
+
+### Changed
+
+- Update `SignedTransaction` to contain `Any` for transaction [#1044](https://github.com/astriaorg/astria/pull/1044).
+- Avoid holding private key in env var [#1074](https://github.com/astriaorg/astria/pull/1074).
+
+## [0.6.0] - 2024-04-26
+
+### Added
+
+- Add a gRPC collector [#784](https://github.com/astriaorg/astria/pull/784).
+- Add graceful shutdown [#854](https://github.com/astriaorg/astria/pull/854).
+- Create wrapper types for `RollupId` and `Account` [#987](https://github.com/astriaorg/astria/pull/987).
+
+### Changed
+
+- Interact with executor through handle [#834](https://github.com/astriaorg/astria/pull/834).
+- Update to ABCI v0.38 [#831](https://github.com/astriaorg/astria/pull/831).
+- Fully split `sequencerapis` and remove [#958](https://github.com/astriaorg/astria/pull/958).
+- Require chain id in transactions [#973](https://github.com/astriaorg/astria/pull/973).
+
+### Fixed
+
+- Make snapshot testing deterministic [#865](https://github.com/astriaorg/astria/pull/865).
+- Account for fee asset id while estimating sequence action size [#990](https://github.com/astriaorg/astria/pull/990).
+- Add capacity to bundle factory [#937](https://github.com/astriaorg/astria/pull/937).
+- Use tx hash as hex again [#1014](https://github.com/astriaorg/astria/pull/1014).
+
+## [0.5.0] - 2024-03-19
+
+### Changed
+
+- Simplify emitting error fields with cause chains [#765](https://github.com/astriaorg/astria/pull/765).
+- Disambiguate chain-id [#791](https://github.com/astriaorg/astria/pull/791).
+- Migrate `v1alpha1` sequencer apis to `v1` [#817](https://github.com/astriaorg/astria/pull/817).
+- Rename `Collector` to `GethCollector` [#792](https://github.com/astriaorg/astria/pull/792).
+- Flatten module structure [#796](https://github.com/astriaorg/astria/pull/796).
+
+### Fixed
+
+- Reset timer when bundle empty [#804](https://github.com/astriaorg/astria/pull/804).
+
+## [0.4.0] - 2024-02-15
+
+### Added
+
+- Add `SignedTransaction::sha256_of_proto_encoding()` method [#687](https://github.com/astriaorg/astria/pull/687).
+- Use opentelemetry [#656](https://github.com/astriaorg/astria/pull/656).
+- Metrics setup [#739](https://github.com/astriaorg/astria/pull/739) and [#750](https://github.com/astriaorg/astria/pull/750).
+- Add pretty-printing to stdout [#736](https://github.com/astriaorg/astria/pull/736).
+- Print build info in all services [#753](https://github.com/astriaorg/astria/pull/753).
+
+### Changed
+
+- Update licenses [#706](https://github.com/astriaorg/astria/pull/706).
+- Bundle multiple rollup transactions into a single sequencer transaction [#651](https://github.com/astriaorg/astria/pull/651).
+- Move fee asset from `UnsignedTransaction` to `SequenceAction` and `TransferAction` [#719](https://github.com/astriaorg/astria/pull/719).
+- Bump rust to 1.76, cargo-chef to 0.1.63 [#744](https://github.com/astriaorg/astria/pull/744).
+- Add some information to crates update msrv [#754](https://github.com/astriaorg/astria/pull/754).
+
+### Fixed
+
+- Replace allocating display impl [#738](https://github.com/astriaorg/astria/pull/738).
+- Fix docker builds [#756](https://github.com/astriaorg/astria/pull/756).
+
+## [0.3.1] - 2024-01-10
+
+### Added
+
+- Lint debug fields in tracing events [#664](https://github.com/astriaorg/astria/pull/664).
+
+### Changed
+
+- Add proto formatting, cleanup justfile [#637](https://github.com/astriaorg/astria/pull/637).
+- Switch tagging format in CI [#639](https://github.com/astriaorg/astria/pull/639).
+- Don't deny unknown config fields [#657](https://github.com/astriaorg/astria/pull/657).
+- Define abci error codes in protobuf [#647](https://github.com/astriaorg/astria/pull/647).
+- Use display formatting instead of debug formatting in tracing events [#671](https://github.com/astriaorg/astria/pull/671).
+
+### Fixed
+
+- Amend Cargo.toml when building images [#672](https://github.com/astriaorg/astria/pull/672).
+
+## [0.3.0] - 2023-11-30
+
+### Added
+
+- Add integrity test of eth tx [#574](https://github.com/astriaorg/astria/pull/574).
+
+### Changed
+
+- Redefine sequencer blocks, celestia blobs as protobuf [#395](https://github.com/astriaorg/astria/pull/395).
+
+## [0.2.5] - 2023-11-07
+
+### Fixed
+
+- Refetch nonce on submission failure [#459](https://github.com/astriaorg/astria/pull/459).
+- Fix flaky test [#552](https://github.com/astriaorg/astria/pull/552).
+
+## [0.2.4] - 2023-10-24
+
+### Fixed
+
+- Resubscribe if rollup subscription stops [#532](https://github.com/astriaorg/astria/pull/532).
+
+## [0.2.3] - 2023-10-17
+
+### Added
+
+- Allow rollup names with dash [#514](https://github.com/astriaorg/astria/pull/514).
+
+## [0.2.2] - 2023-10-12
+
+### Added
+
+- Log collected txs [#460](https://github.com/astriaorg/astria/pull/460).
+- Report cause of failed nonce fetch [#492](https://github.com/astriaorg/astria/pull/492).
+
+### Changed
+
+- Bump penumbra, tendermint; prune workspace cargo of unused deps [#468](https://github.com/astriaorg/astria/pull/468).
+
+## 0.2.1 - 2023-09-29
+
+### Fixed
+
+- Execute docker builds on new tags [#422](https://github.com/astriaorg/astria/pull/422).
+
+## 0.2.0 - 2023-09-22
+
+### Added
+
+- Initial release.
+
+[unreleased]: https://github.com/astriaorg/astria/compare/composer-v1.0.0-rc.1...HEAD
+[1.0.0-rc.1]: https://github.com/astriaorg/astria/compare/composer-v0.8.3...composer-v1.0.0-rc.1
+[0.8.3]: https://github.com/astriaorg/astria/compare/composer-v0.8.2...composer-v0.8.3
+[0.8.2]: https://github.com/astriaorg/astria/compare/composer-v0.8.1...composer-v0.8.2
+[0.8.1]: https://github.com/astriaorg/astria/compare/composer-v0.8.0...composer-v0.8.1
+[0.8.0]: https://github.com/astriaorg/astria/compare/composer-v0.7.0...composer-v0.8.0
+[0.7.0]: https://github.com/astriaorg/astria/compare/composer-v0.6.0...composer-v0.7.0
+[0.6.0]: https://github.com/astriaorg/astria/compare/composer-v0.5.0...composer-v0.6.0
+[0.5.0]: https://github.com/astriaorg/astria/compare/composer-v0.4.0...composer-v0.5.0
+[0.4.0]: https://github.com/astriaorg/astria/compare/composer-v0.3.1...composer-v0.4.0
+[0.3.1]: https://github.com/astriaorg/astria/compare/composer-v0.3.0...composer-v0.3.1
+[0.3.0]: https://github.com/astriaorg/astria/compare/v0.2.5--composer...v0.3.0--composer
+[0.2.5]: https://github.com/astriaorg/astria/compare/v0.2.4--composer...v0.2.5--composer
+[0.2.4]: https://github.com/astriaorg/astria/compare/v0.2.3--composer...v0.2.4--composer
+[0.2.3]: https://github.com/astriaorg/astria/compare/v0.2.2--composer...v0.2.3--composer
+[0.2.2]: https://github.com/astriaorg/astria/compare/v0.2.1--composer...v0.2.2--composer

--- a/crates/astria-conductor/CHANGELOG.md
+++ b/crates/astria-conductor/CHANGELOG.md
@@ -1,0 +1,356 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0-rc.1] - 2024-10-17
+
+### Added
+
+- Add traceability to rollup deposits [#1410](https://github.com/astriaorg/astria/pull/1410).
+- Implement restart logic [#1463](https://github.com/astriaorg/astria/pull/1463).
+- Implement chain ID checks [#1482](https://github.com/astriaorg/astria/pull/1482).
+
+### Changed
+
+- Replace `once_cell` with `LazyLock` [#1576](https://github.com/astriaorg/astria/pull/1576).
+- Migrate all instances of `#[allow]` to `#[expect]` [#1561](https://github.com/astriaorg/astria/pull/1561).
+- Code freeze through github actions [#1588](https://github.com/astriaorg/astria/pull/1588).
+- Upgrade to proto `v1`s throughout [#1672](https://github.com/astriaorg/astria/pull/1672).
+
+### Fixed
+
+- Fix flaky restart test [#1575](https://github.com/astriaorg/astria/pull/1575).
+- Remove enable mint entry from example env config [#1674](https://github.com/astriaorg/astria/pull/1674).
+
+## [0.20.1] - 2024-09-06
+
+### Changed
+
+- Improve instrumentation [#1330](https://github.com/astriaorg/astria/pull/1330).
+
+## [0.20.0] - 2024-08-22
+
+### Changed
+
+- Update `bytemark` dependency based on cargo audit warning [#1350](https://github.com/astriaorg/astria/pull/1350).
+- Update with support for celestia-node v0.15.0 [#1367](https://github.com/astriaorg/astria/pull/1367).
+- Support disabled celestia auth [#1372](https://github.com/astriaorg/astria/pull/1372). 
+
+## [0.19.0] - 2024-07-26
+
+### Fixed
+
+- Don't panic during panic [#1252](https://github.com/astriaorg/astria/pull/1252).
+- Change execution API to use primitive RollupId [#1291](https://github.com/astriaorg/astria/pull/1291).
+
+## [0.18.0] - 2024-06-27
+
+### Added
+
+- Add bech32m addresses [#1124](https://github.com/astriaorg/astria/pull/1124).
+
+### Changed
+
+- Remove non-bech32m address bytes [#1186](https://github.com/astriaorg/astria/pull/1186).
+
+## [0.17.0] - 2024-06-04
+
+### Added
+
+- Rate limit sequencer cometbft requests [#1068](https://github.com/astriaorg/astria/pull/1068).
+- Add retry to execution API gRPCs [#1115](https://github.com/astriaorg/astria/pull/1115).
+- Add metrics [#1091](https://github.com/astriaorg/astria/pull/1091).
+
+### Changed
+
+- Perform signal handling in binary and test shutdown logic [#1094](https://github.com/astriaorg/astria/pull/1094).
+- Celestia base heights in commitment state [#1121](https://github.com/astriaorg/astria/pull/1121).
+- Skip outdated block metadata [#1120](https://github.com/astriaorg/astria/pull/1120).
+
+## [0.16.0] - 2024-05-21
+
+### Changed
+
+- Update `SignedTransaction` to contain `Any` for transaction [#1044](https://github.com/astriaorg/astria/pull/1044).
+
+### Fixed
+
+- Don't exit on bad Sequencer connection [#1076](https://github.com/astriaorg/astria/pull/1076).
+- Respect shutdown signals during init [#1080](https://github.com/astriaorg/astria/pull/1080).
+
+## [0.15.0] - 2024-05-09
+
+### Added
+
+- Fetch missing blocks as necessary [#1054](https://github.com/astriaorg/astria/pull/1054).
+
+### Changed
+
+- Batch multiple Sequencer blocks to save on Celestia fees [#1045](https://github.com/astriaorg/astria/pull/1045).
+
+### Fixed
+
+- Only execute firm blocks if firm and soft block numbers match [#1021](https://github.com/astriaorg/astria/pull/1021).
+- Retry blob fetch on request timeout [#1061](https://github.com/astriaorg/astria/pull/1061).
+
+## [0.14.0] - 2024-04-26
+
+### Added
+
+- Create `sequencerblockapis` `v1alpha1` [#939](https://github.com/astriaorg/astria/pull/939).
+- Add blackbox tests for conductor running in soft-only mode [#917](https://github.com/astriaorg/astria/pull/917).
+- Brotli compress data blobs [#1006](https://github.com/astriaorg/astria/pull/1006).
+
+### Changed
+
+- Update `SequencerBlockHeader` and related proto types to not use cometbft header [#830](https://github.com/astriaorg/astria/pull/830).
+- Update execution service to use sequencerblock [#954](https://github.com/astriaorg/astria/pull/954).
+- Fully split `sequencerapis` and remove [#958](https://github.com/astriaorg/astria/pull/958).
+- Fetch blocks pending finalization [#980](https://github.com/astriaorg/astria/pull/980).
+
+### Fixed
+
+- Robust Celestia blob fetch, verify, convert [#946](https://github.com/astriaorg/astria/pull/946).
+
+## [0.13.1] - 2024-04-05
+
+### Added
+
+- Add serialization to execution `v1alpha2` compliant with protobuf json mapping [#857](https://github.com/astriaorg/astria/pull/857).
+
+### Changed
+
+- Simplify builder types by config-like [#829](https://github.com/astriaorg/astria/pull/829).
+- Use cancellation tokens for shutdown [#845](https://github.com/astriaorg/astria/pull/845).
+- Generate pbjon impls for sequencer types needed to mock conductor [#905](https://github.com/astriaorg/astria/pull/905).
+- Replace hex by base64 for display formatting, emitting tracing events [#908](https://github.com/astriaorg/astria/pull/908).
+
+### Fixed
+
+- Bump otel to resolve panics in layered span access [#820](https://github.com/astriaorg/astria/pull/820).
+- Don't panic while shutting down [#846](https://github.com/astriaorg/astria/pull/846).
+- Clarify conductor log [#868](https://github.com/astriaorg/astria/pull/868).
+- Enable tls for grpc connections [#925](https://github.com/astriaorg/astria/pull/925).
+
+## [0.13.0] - 2024-03-19
+
+### Added
+
+- Provide explicit HTTP, Websocket Celestia RPC URLs [#780](https://github.com/astriaorg/astria/pull/780).
+- Report if conductor won't read more Celestia heights [#799](https://github.com/astriaorg/astria/pull/799).
+
+### Changed
+
+- Simplify emitting error fields with cause chains [#765](https://github.com/astriaorg/astria/pull/765).
+- Assert host fulfills execution API contract [#772](https://github.com/astriaorg/astria/pull/772).
+- Update increment celestia height to fetch [#801](https://github.com/astriaorg/astria/pull/801).
+- Use Celestia crates published on crates.io [#806](https://github.com/astriaorg/astria/pull/806).
+- Emit more information about blocks received from Sequencer, Celestia [#811](https://github.com/astriaorg/astria/pull/811).
+- Use Sequencer gRPC API to fetch soft bocks. [#815](https://github.com/astriaorg/astria/pull/815).
+- Migrate `v1alpha1` sequencer apis to `v1` [#817](https://github.com/astriaorg/astria/pull/817).
+
+### Removed
+
+- Remove all optimism functionality [#775](https://github.com/astriaorg/astria/pull/775).
+- Delete unused proto file [#783](https://github.com/astriaorg/astria/pull/783).
+
+### Fixed
+
+- Keep `wsclient` alive [#762](https://github.com/astriaorg/astria/pull/762).
+- Simplify mapping Celestia heights to Sequencer heights [#797](https://github.com/astriaorg/astria/pull/797).
+- Serialize rollup IDs as strings so telemetry doesn't crash [#821](https://github.com/astriaorg/astria/pull/821).
+
+## [0.12.0] - 2024-02-15
+
+### Added
+
+- Add `SignedTransaction::sha256_of_proto_encoding()` method [#687](https://github.com/astriaorg/astria/pull/687).
+- Add `ibc_sudo_address` to genesis, only allow `IbcRelay` actions from this address [#721](https://github.com/astriaorg/astria/pull/721).
+- Add firm block syncing [#691](https://github.com/astriaorg/astria/pull/691).
+- Use opentelemetry [#656](https://github.com/astriaorg/astria/pull/656).
+- Metrics setup [#739](https://github.com/astriaorg/astria/pull/739) and [#750](https://github.com/astriaorg/astria/pull/750).
+- Add `ibc_relayer_addresses` list and allow modifications via `ibc_sudo_address` [#737](https://github.com/astriaorg/astria/pull/737).
+- Add pretty-printing to stdout [#736](https://github.com/astriaorg/astria/pull/736).
+- Print build info in all services [#753](https://github.com/astriaorg/astria/pull/753).
+
+### Changed
+
+- Transfer fees to block proposer instead of burning [#690](https://github.com/astriaorg/astria/pull/690).
+- Update licenses [#706](https://github.com/astriaorg/astria/pull/706).
+- Move fee asset from `UnsignedTransaction` to `SequenceAction` and `TransferAction`  [#719](https://github.com/astriaorg/astria/pull/719).
+- Build all binaries, fix pr title ci [#728](https://github.com/astriaorg/astria/pull/728).
+- Split protos into multiple buf repos [#732](https://github.com/astriaorg/astria/pull/732).
+- Bump rust to 1.76, cargo-chef to 0.1.63 [#744](https://github.com/astriaorg/astria/pull/744).
+- Aet permitted commitment spread from rollup genesis [#743](https://github.com/astriaorg/astria/pull/743).
+
+### Fixed
+
+- Fix `FungibleTokenPacketData` decoding [#686](https://github.com/astriaorg/astria/pull/686).
+- Relax size requirements of hash buffers [#709](https://github.com/astriaorg/astria/pull/709).
+- Replace allocating display impl [#738](https://github.com/astriaorg/astria/pull/738).
+- Fix docker builds [#756](https://github.com/astriaorg/astria/pull/756).
+
+## [0.11.1] - 2024-01-10
+
+### Added
+
+- Lint debug fields in tracing events [#664](https://github.com/astriaorg/astria/pull/664).
+
+### Changed
+
+- Use methods to increment, ensure macro to compare [#619](https://github.com/astriaorg/astria/pull/619).
+- Add proto formatting, cleanup justfile [#637](https://github.com/astriaorg/astria/pull/637).
+- Bump all checkout actions in CI to v3 [#641](https://github.com/astriaorg/astria/pull/641).
+- Unify construction of cometbft blocks in tests [#640](https://github.com/astriaorg/astria/pull/640).
+- Switch tagging format in CI [#639](https://github.com/astriaorg/astria/pull/639).
+- Rename astria-proto to astria-core [#644](https://github.com/astriaorg/astria/pull/644).
+- Break up sequencer `v1alpha1` module [#646](https://github.com/astriaorg/astria/pull/646).
+- Don't deny unknown config fields [#657](https://github.com/astriaorg/astria/pull/657).
+- Define abci error codes in protobuf [#647](https://github.com/astriaorg/astria/pull/647).
+- Use display formatting instead of debug formatting in tracing events [#671](https://github.com/astriaorg/astria/pull/671).
+
+### Fixed
+
+- Add error context, simplify type conversions [#620](https://github.com/astriaorg/astria/pull/620).
+- Fail hard when executing blocks fails [#621](https://github.com/astriaorg/astria/pull/621).
+- Amend Cargo.toml when building images [#672](https://github.com/astriaorg/astria/pull/672).
+
+## [0.11.0] - 2023-11-30
+
+### Added
+
+- Don't attempt to execute finalized blocks [#617](https://github.com/astriaorg/astria/pull/617).
+
+### Changed
+
+- Make block verifier a submodule of data availability [#593](https://github.com/astriaorg/astria/pull/593).
+- Require chain_id be 32 bytes [#436](https://github.com/astriaorg/astria/pull/436).
+- Redefine sequencer blocks, celestia blobs as protobuf [#395](https://github.com/astriaorg/astria/pull/395).
+
+### Fixed
+
+- Validator height should be trailing [#613](https://github.com/astriaorg/astria/pull/613).
+
+## [0.10.0] - 2023-11-18
+
+### Added
+
+- Add an RFC 6962 compliant Merkle tree with flat memory representation [#554](https://github.com/astriaorg/astria/pull/554).
+- Implement derivation and execution of optimism `DepositTransaction`s [#535](https://github.com/astriaorg/astria/pull/535).
+
+## [0.9.0] - 2023-11-14
+
+### Changed
+
+- Implement clippy pedantic suggestions [#573](https://github.com/astriaorg/astria/pull/573).
+
+### Fixed
+
+- Use sequencer chain id for sequencer blobs [#577](https://github.com/astriaorg/astria/pull/577).
+
+## [0.8.0] - 2023-11-07
+
+### Added
+
+- Add re-sync for missed sequencer blocks [#515](https://github.com/astriaorg/astria/pull/515).
+- Add commitment grab to better set sync start height [#553](https://github.com/astriaorg/astria/pull/553).
+
+### Changed
+
+- Celestia-client: use eiger's version [#486](https://github.com/astriaorg/astria/pull/486).
+- Replace formatted error backtraces by value impl [#516](https://github.com/astriaorg/astria/pull/516).
+- `v1alpha2` integration [#528](https://github.com/astriaorg/astria/pull/528).
+- Define service configs in terms of a central crate [#537](https://github.com/astriaorg/astria/pull/537).
+- Verify current block commit in conductor; remove `last_commit` from `SequencerBlockData` [#560](https://github.com/astriaorg/astria/pull/560).
+
+### Removed
+
+- Remove signing and signature verification of data posted to DA [#538](https://github.com/astriaorg/astria/pull/538).
+- Remove disable empty block execution config setting [#556](https://github.com/astriaorg/astria/pull/556).
+
+### Fixed
+
+- Update rollup chain id in conductor example env to match composer [#505](https://github.com/astriaorg/astria/pull/505).
+- Clarify logging in executor [#508](https://github.com/astriaorg/astria/pull/508).
+- Implement `chain_ids_commitment` inclusion proof generation and verification [#548](https://github.com/astriaorg/astria/pull/548).
+- Empty blocks from da get executed [#551](https://github.com/astriaorg/astria/pull/551).
+- Dependency update for yanked `ahash` deps [#544](https://github.com/astriaorg/astria/pull/544).
+
+## [0.7.0] - 2023-10-13
+
+### Added
+
+- Add execution commit level v2 [#474](https://github.com/astriaorg/astria/pull/474).
+- Report cause of failed nonce fetch [#492](https://github.com/astriaorg/astria/pull/492).
+
+### Changed
+
+- Use fork of tendermint with backported `reqwest` client [#498](https://github.com/astriaorg/astria/pull/498).
+- Never recycle websocket clients [#499](https://github.com/astriaorg/astria/pull/499).
+- Spawn driver as task and report exit [#500](https://github.com/astriaorg/astria/pull/500).
+- Resubscribe with backoff instead of failing [#501](https://github.com/astriaorg/astria/pull/501).
+
+## [0.6.1] - 2023-10-12
+
+### Added
+
+- Log task exit [#479](https://github.com/astriaorg/astria/pull/479).
+
+### Changed
+
+- Bump penumbra, tendermint; prune workspace cargo of unused deps [#468](https://github.com/astriaorg/astria/pull/468).
+- Reconnect to sequencer websocket with backoff [#483](https://github.com/astriaorg/astria/pull/483).
+
+### Fixed
+
+- Don't panic on empty blocks [#467](https://github.com/astriaorg/astria/pull/467).
+- Fix action tree root inclusion proof verification [#469](https://github.com/astriaorg/astria/pull/469).
+
+## [0.6.0] - 2023-10-05
+
+### Changed
+
+- Add genesis sequencer block height to config and env vars [#445](https://github.com/astriaorg/astria/pull/445).
+- Refactor and implement full node sync from sequencer [#455](https://github.com/astriaorg/astria/pull/455).
+
+## [0.5.1] - 2023-09-27
+
+### Fixed
+
+- Bug fixes related to validating data and allowing empty rollup blocks.
+- Fix tendermint block to `SequencerBlockData` conversion [#424](https://github.com/astriaorg/astria/pull/424).
+- Continue to execution when block subset empty [#426](https://github.com/astriaorg/astria/pull/426).
+
+## 0.5.0 - 2023-09-22
+
+### Added
+
+- Initial release.
+
+[unreleased]: https://github.com/astriaorg/astria/compare/conductor-v1.0.0-rc.1...HEAD
+[1.0.0-rc.1]: https://github.com/astriaorg/astria/compare/conductor-v0.20.1...conductor-v1.0.0-rc.1
+[0.20.1]: https://github.com/astriaorg/astria/compare/conductor-v0.20.0...conductor-v0.20.1
+[0.20.0]: https://github.com/astriaorg/astria/compare/conductor-v0.19.0...conductor-v0.20.0
+[0.19.0]: https://github.com/astriaorg/astria/compare/conductor-v0.18.0...conductor-v0.19.0
+[0.18.0]: https://github.com/astriaorg/astria/compare/conductor-v0.17.0...conductor-v0.18.0
+[0.17.0]: https://github.com/astriaorg/astria/compare/conductor-v0.16.0...conductor-v0.17.0
+[0.16.0]: https://github.com/astriaorg/astria/compare/conductor-v0.15.0...conductor-v0.16.0
+[0.15.0]: https://github.com/astriaorg/astria/compare/conductor-v0.14.0...conductor-v0.15.0
+[0.14.0]: https://github.com/astriaorg/astria/compare/conductor-v0.13.1...conductor-v0.14.0
+[0.13.1]: https://github.com/astriaorg/astria/compare/conductor-v0.13.0...conductor-v0.13.1
+[0.13.0]: https://github.com/astriaorg/astria/compare/conductor-v0.12.0...conductor-v0.13.0
+[0.12.0]: https://github.com/astriaorg/astria/compare/conductor-v0.11.1...conductor-v0.12.0
+[0.11.1]: https://github.com/astriaorg/astria/compare/conductor-v0.11.0...conductor-v0.11.1
+[0.11.0]: https://github.com/astriaorg/astria/compare/v0.10.1--conductor...v0.11.0--conductor
+[0.10.0]: https://github.com/astriaorg/astria/compare/v0.9.0--conductor...v0.10.0--conductor
+[0.9.0]: https://github.com/astriaorg/astria/compare/v0.8.0--conductor...v0.9.0--conductor
+[0.8.0]: https://github.com/astriaorg/astria/compare/v0.7.0--conductor...v0.8.0--conductor
+[0.7.0]: https://github.com/astriaorg/astria/compare/v0.6.1--conductor...v0.7.0--conductor
+[0.6.1]: https://github.com/astriaorg/astria/compare/v0.6.0--conductor...v0.6.1--conductor
+[0.6.0]: https://github.com/astriaorg/astria/compare/v0.5.1--conductor...v0.6.0--conductor
+[0.5.1]: https://github.com/astriaorg/astria/compare/v0.5.0--conductor...v0.5.1--conductor

--- a/crates/astria-conductor/CHANGELOG.md
+++ b/crates/astria-conductor/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-rc.2] - 2024-10-23
+
+### Changed
+
+- Make native asset optional [#1703](https://github.com/astriaorg/astria/pull/1703).
+
 ## [1.0.0-rc.1] - 2024-10-17
 
 ### Added
@@ -340,7 +346,8 @@ address [#721](https://github.com/astriaorg/astria/pull/721).
 
 - Initial release.
 
-[unreleased]: https://github.com/astriaorg/astria/compare/conductor-v1.0.0-rc.1...HEAD
+[unreleased]: https://github.com/astriaorg/astria/compare/conductor-v1.0.0-rc.2...HEAD
+[1.0.0-rc.2]: https://github.com/astriaorg/astria/compare/conductor-v1.0.0-rc.1...conductor-v1.0.0-rc.2
 [1.0.0-rc.1]: https://github.com/astriaorg/astria/compare/conductor-v0.20.1...conductor-v1.0.0-rc.1
 [0.20.1]: https://github.com/astriaorg/astria/compare/conductor-v0.20.0...conductor-v0.20.1
 [0.20.0]: https://github.com/astriaorg/astria/compare/conductor-v0.19.0...conductor-v0.20.0

--- a/crates/astria-conductor/CHANGELOG.md
+++ b/crates/astria-conductor/CHANGELOG.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable no-duplicate-heading -->
+
 # Changelog
 
 All notable changes to this project will be documented in this file.
@@ -39,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update `bytemark` dependency based on cargo audit warning [#1350](https://github.com/astriaorg/astria/pull/1350).
 - Update with support for celestia-node v0.15.0 [#1367](https://github.com/astriaorg/astria/pull/1367).
-- Support disabled celestia auth [#1372](https://github.com/astriaorg/astria/pull/1372). 
+- Support disabled celestia auth [#1372](https://github.com/astriaorg/astria/pull/1372).
 
 ## [0.19.0] - 2024-07-26
 
@@ -108,7 +110,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update `SequencerBlockHeader` and related proto types to not use cometbft header [#830](https://github.com/astriaorg/astria/pull/830).
+- Update `SequencerBlockHeader` and related proto types to not use cometbft
+header [#830](https://github.com/astriaorg/astria/pull/830).
 - Update execution service to use sequencerblock [#954](https://github.com/astriaorg/astria/pull/954).
 - Fully split `sequencerapis` and remove [#958](https://github.com/astriaorg/astria/pull/958).
 - Fetch blocks pending finalization [#980](https://github.com/astriaorg/astria/pull/980).
@@ -121,7 +124,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add serialization to execution `v1alpha2` compliant with protobuf json mapping [#857](https://github.com/astriaorg/astria/pull/857).
+- Add serialization to execution `v1alpha2` compliant with protobuf json
+mapping [#857](https://github.com/astriaorg/astria/pull/857).
 
 ### Changed
 
@@ -170,11 +174,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `SignedTransaction::sha256_of_proto_encoding()` method [#687](https://github.com/astriaorg/astria/pull/687).
-- Add `ibc_sudo_address` to genesis, only allow `IbcRelay` actions from this address [#721](https://github.com/astriaorg/astria/pull/721).
+- Add `ibc_sudo_address` to genesis, only allow `IbcRelay` actions from this
+address [#721](https://github.com/astriaorg/astria/pull/721).
 - Add firm block syncing [#691](https://github.com/astriaorg/astria/pull/691).
 - Use opentelemetry [#656](https://github.com/astriaorg/astria/pull/656).
 - Metrics setup [#739](https://github.com/astriaorg/astria/pull/739) and [#750](https://github.com/astriaorg/astria/pull/750).
-- Add `ibc_relayer_addresses` list and allow modifications via `ibc_sudo_address` [#737](https://github.com/astriaorg/astria/pull/737).
+- Add `ibc_relayer_addresses` list and allow modifications via
+`ibc_sudo_address` [#737](https://github.com/astriaorg/astria/pull/737).
 - Add pretty-printing to stdout [#736](https://github.com/astriaorg/astria/pull/736).
 - Print build info in all services [#753](https://github.com/astriaorg/astria/pull/753).
 
@@ -182,7 +188,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Transfer fees to block proposer instead of burning [#690](https://github.com/astriaorg/astria/pull/690).
 - Update licenses [#706](https://github.com/astriaorg/astria/pull/706).
-- Move fee asset from `UnsignedTransaction` to `SequenceAction` and `TransferAction`  [#719](https://github.com/astriaorg/astria/pull/719).
+- Move fee asset from `UnsignedTransaction` to `SequenceAction` and
+`TransferAction` [#719](https://github.com/astriaorg/astria/pull/719).
 - Build all binaries, fix pr title ci [#728](https://github.com/astriaorg/astria/pull/728).
 - Split protos into multiple buf repos [#732](https://github.com/astriaorg/astria/pull/732).
 - Bump rust to 1.76, cargo-chef to 0.1.63 [#744](https://github.com/astriaorg/astria/pull/744).
@@ -266,7 +273,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replace formatted error backtraces by value impl [#516](https://github.com/astriaorg/astria/pull/516).
 - `v1alpha2` integration [#528](https://github.com/astriaorg/astria/pull/528).
 - Define service configs in terms of a central crate [#537](https://github.com/astriaorg/astria/pull/537).
-- Verify current block commit in conductor; remove `last_commit` from `SequencerBlockData` [#560](https://github.com/astriaorg/astria/pull/560).
+- Verify current block commit in conductor; remove `last_commit` from
+`SequencerBlockData` [#560](https://github.com/astriaorg/astria/pull/560).
 
 ### Removed
 

--- a/crates/astria-config/CHANGELOG.md
+++ b/crates/astria-config/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Added
+
+- Initial release.

--- a/crates/astria-config/CHANGELOG.md
+++ b/crates/astria-config/CHANGELOG.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable no-duplicate-heading -->
+
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/crates/astria-core/CHANGELOG.md
+++ b/crates/astria-core/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Added
+
+- Initial release.

--- a/crates/astria-core/CHANGELOG.md
+++ b/crates/astria-core/CHANGELOG.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable no-duplicate-heading -->
+
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/crates/astria-eyre/CHANGELOG.md
+++ b/crates/astria-eyre/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Added
+
+- Initial release.

--- a/crates/astria-eyre/CHANGELOG.md
+++ b/crates/astria-eyre/CHANGELOG.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable no-duplicate-heading -->
+
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/crates/astria-grpc-mock/CHANGELOG.md
+++ b/crates/astria-grpc-mock/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Added
+
+- Initial release.

--- a/crates/astria-grpc-mock/CHANGELOG.md
+++ b/crates/astria-grpc-mock/CHANGELOG.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable no-duplicate-heading -->
+
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/crates/astria-merkle/CHANGELOG.md
+++ b/crates/astria-merkle/CHANGELOG.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable no-duplicate-heading -->
+
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/crates/astria-merkle/CHANGELOG.md
+++ b/crates/astria-merkle/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+## 1.0.0-rc.1 - 2024-10-17
+
+### Added
+
+- Initial release.

--- a/crates/astria-sequencer-relayer/CHANGELOG.md
+++ b/crates/astria-sequencer-relayer/CHANGELOG.md
@@ -1,0 +1,267 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0-rc.1] - 2024-10-17
+
+### Changed
+
+- Replace `once_cell` with `LazyLock` [#1576](https://github.com/astriaorg/astria/pull/1576).
+- Migrate all instances of `#[allow]` to `#[expect]` [#1561](https://github.com/astriaorg/astria/pull/1561).
+- Code freeze through github actions [#1588](https://github.com/astriaorg/astria/pull/1588).
+- Prefer `astria.primitive.v1.RollupId` over bytes [#1661](https://github.com/astriaorg/astria/pull/1661).
+- Upgrade to proto `v1`s throughout [#1672](https://github.com/astriaorg/astria/pull/1672).
+
+## [0.16.2] - 2024-09-06
+
+### Changed
+
+- Improved Instrumentation [#1375](https://github.com/astriaorg/astria/pull/1375).
+
+## [0.16.1] - 2024-08-22
+
+### Fixed
+
+- Cargo audit warning [#1350](https://github.com/astriaorg/astria/pull/1350)
+- Change `reqwest` for `isahc` in relayer blackbox tests (ENG-699) [#1366](https://github.com/astriaorg/astria/pull/1366).
+
+## [0.16.0] - 2024-07-26
+
+### Changed
+
+- Minimize resubmissions to Celestia [#1234](https://github.com/astriaorg/astria/pull/1234).
+
+## [0.15.0] - 2024-06-27
+
+### Added
+
+- Add chain IDs for sequencer and Celestia to config env vars [#1063](https://github.com/astriaorg/astria/pull/1063).
+- Add bech32m addresses [#1124](https://github.com/astriaorg/astria/pull/1124).
+
+### Changed
+
+- Update `metric_name` macro to handle a collection of names [#1163](https://github.com/astriaorg/astria/pull/1163).
+- Add timeout to gRPCs to Celestia app [#1191](https://github.com/astriaorg/astria/pull/1191).
+- Remove non-bech32m address bytes [#1186](https://github.com/astriaorg/astria/pull/1186).
+
+### Removed
+
+- Remove functionality to restrict relaying blocks to only those proposed by a given validator [#1168](https://github.com/astriaorg/astria/pull/1168).
+
+### Fixed
+
+- Ensure tracer providers are shut down in all services [#1098](https://github.com/astriaorg/astria/pull/1098).
+- Avoid hanging while waiting for submitter task to return [#1206](https://github.com/astriaorg/astria/pull/1206).
+
+## [0.14.0] - 2024-05-21
+
+### Changed
+
+- Update `SignedTransaction` to contain `Any` for transaction [#1044](https://github.com/astriaorg/astria/pull/1044).
+- Make per submission gauges into histograms [#1060](https://github.com/astriaorg/astria/pull/1060).
+- Change compression ratio calculation [#1075](https://github.com/astriaorg/astria/pull/1075).
+
+## [0.13.0] - 2024-05-09
+
+### Added
+
+- Provide filter for rollups [#1001](https://github.com/astriaorg/astria/pull/1001).
+- Add metric recording highest sequencer block submitted [#1040](https://github.com/astriaorg/astria/pull/1040).
+
+### Changed
+
+- Reinstate black box tests [#1033](https://github.com/astriaorg/astria/pull/1033).
+- Batch multiple Sequencer blocks to save on Celestia fees [#1045](https://github.com/astriaorg/astria/pull/1045).
+
+## [0.12.0] - 2024-04-26
+
+### Added
+
+- Provide a shutdown controller [#889](https://github.com/astriaorg/astria/pull/889).
+- Brotli compress data blobs [#1006](https://github.com/astriaorg/astria/pull/1006).
+
+### Changed
+ 
+- Generate pbjon impls for sequencer types needed to mock conductor [#905](https://github.com/astriaorg/astria/pull/905).
+- Replace hex by base64 for display formatting, emitting tracing events [#908](https://github.com/astriaorg/astria/pull/908).
+- Update `SequencerBlockHeader` and related proto types to not use cometbft header [#830](https://github.com/astriaorg/astria/pull/830).
+- Update to ABCI v0.38 [#831](https://github.com/astriaorg/astria/pull/831).
+- Submit blobs directly to celestia app [#963](https://github.com/astriaorg/astria/pull/963).
+
+### Removed
+
+- Remove `SequencerBlock::try_from_cometbft` [#1005](https://github.com/astriaorg/astria/pull/1005).
+
+### Fixed
+
+- Fix shutdown not propagating on API server fail [#883](https://github.com/astriaorg/astria/pull/883).
+
+## [0.11.0] - 2024-03-19
+
+### Added
+
+- Add sequencer service proto [#701](https://github.com/astriaorg/astria/pull/701).
+- Add metrics [#771](https://github.com/astriaorg/astria/pull/771).
+- Introduce state to not submit previous sequencer blocks [#778](https://github.com/astriaorg/astria/pull/778).
+- Warn if submission tracking is inconsistent, but continue operation [#798](https://github.com/astriaorg/astria/pull/798).
+- Report information on sequencer block submitted to Celestia [#807](https://github.com/astriaorg/astria/pull/807).
+- Implement graceful shutdown [#823](https://github.com/astriaorg/astria/pull/823).
+
+### Changed
+
+- Simplify emitting error fields with cause chains [#765](https://github.com/astriaorg/astria/pull/765).
+- Retry sequencer block fetch, celestia blob submission [#769](https://github.com/astriaorg/astria/pull/769).
+- Provide address, not port, to serve API requests [#776](https://github.com/astriaorg/astria/pull/776).
+- Use Celestia crates published on crates.io [#806](https://github.com/astriaorg/astria/pull/806).
+- Make block to filtered block conversion more flexible [#794](https://github.com/astriaorg/astria/pull/794).
+- Update relayer to use sequencer API to pull blocks [#810](https://github.com/astriaorg/astria/pull/810).
+- Migrate `v1alpha1` sequencer apis to `v1` [#817](https://github.com/astriaorg/astria/pull/817).
+- Replace grab-bag constructor with config-like builder [#822](https://github.com/astriaorg/astria/pull/822).
+
+### Removed
+
+- Delete unused proto file [#783](https://github.com/astriaorg/astria/pull/783).
+
+## [0.10.0] - 2024-02-15
+
+### Added
+
+- Add `ibc_sudo_address` to genesis, only allow `IbcRelay` actions from this address [#721](https://github.com/astriaorg/astria/pull/721).
+- Use opentelemetry [#656](https://github.com/astriaorg/astria/pull/656).
+- Allow specific assets for fee payment [#730](https://github.com/astriaorg/astria/pull/730).
+- Metrics setup [#739](https://github.com/astriaorg/astria/pull/739) and [#750](https://github.com/astriaorg/astria/pull/750).
+- Add `ibc_relayer_addresses` list and allow modifications via `ibc_sudo_address` [#737](https://github.com/astriaorg/astria/pull/737).
+- Add pretty-printing to stdout [#736](https://github.com/astriaorg/astria/pull/736).
+- Set permitted commitment spread from rollup genesis [#743](https://github.com/astriaorg/astria/pull/743).
+- Implement ability to update fee assets using sudo key [#752](https://github.com/astriaorg/astria/pull/752).
+- Print build info in all services [#753](https://github.com/astriaorg/astria/pull/753).
+
+### Changed
+
+- Transfer fees to block proposer instead of burning [#690](https://github.com/astriaorg/astria/pull/690).
+- Update licenses [#706](https://github.com/astriaorg/astria/pull/706).
+- Update balance queries to return every asset owned by account [#683](https://github.com/astriaorg/astria/pull/683).
+- Use `IbcComponent` and penumbra `HostInterface`  [#700](https://github.com/astriaorg/astria/pull/700).
+- Move fee asset from `UnsignedTransaction` to `SequenceAction` and `TransferAction`  [#719](https://github.com/astriaorg/astria/pull/719).
+- Split protos into multiple buf repos [#732](https://github.com/astriaorg/astria/pull/732).
+- Add fee for `Ics20Withdrawal` action [#733](https://github.com/astriaorg/astria/pull/733).
+- Bump rust to 1.76, cargo-chef to 0.1.63 [#744](https://github.com/astriaorg/astria/pull/744).
+- Upgrade to penumbra release 0.66 [#741](https://github.com/astriaorg/astria/pull/741).
+- Move ibc-related code to its own module [#757](https://github.com/astriaorg/astria/pull/757).
+
+### Fixed
+
+- Fix `FungibleTokenPacketData` decoding [#686](https://github.com/astriaorg/astria/pull/686).
+- Relax size requirements of hash buffers [#709](https://github.com/astriaorg/astria/pull/709).
+- Build all binaries, fix pr title ci [#728](https://github.com/astriaorg/astria/pull/728).
+- Replace allocating display impl [#738](https://github.com/astriaorg/astria/pull/738).
+
+## [0.9.1] - 2024-01-10
+
+### Added
+
+- Lint debug fields in tracing events [#664](https://github.com/astriaorg/astria/pull/664).
+
+### Changed
+
+- Move protobuf specs to repository top level [#629](https://github.com/astriaorg/astria/pull/629).
+- Add proto formatting, cleanup justfile [#637](https://github.com/astriaorg/astria/pull/637).
+- Bump all checkout actions in CI to v3 [#6414](https://github.com/astriaorg/astria/pull/6414).
+- Switch tagging format in CI [#639](https://github.com/astriaorg/astria/pull/639).
+- Autocut release binaries [#643](https://github.com/astriaorg/astria/pull/643).
+- Update to use new chart structure, dusk-2 [#611](https://github.com/astriaorg/astria/pull/611).
+- Break up sequencer `v1alpha1` module [#646](https://github.com/astriaorg/astria/pull/646).
+- Don't deny unknown config fields [#657](https://github.com/astriaorg/astria/pull/657).
+- Define abci error codes in protobuf [#647](https://github.com/astriaorg/astria/pull/647).
+- Use display formatting instead of debug formatting in tracing events [#671](https://github.com/astriaorg/astria/pull/671).
+
+### Fixed
+
+- Adjust input to proto breaking change linter after refactor [#635](https://github.com/astriaorg/astria/pull/635).
+- Amend Cargo.toml when building images [#672](https://github.com/astriaorg/astria/pull/672).
+
+## [0.9.0] - 2023-11-30
+
+### Changed
+
+- Replace buf-generate by tonic_build [#581](https://github.com/astriaorg/astria/pull/581).
+- Bump all dependencies (mainly penumbra, celestia, tendermint) [#582](https://github.com/astriaorg/astria/pull/582).
+- Require `chain_id` be 32 bytes [#436](https://github.com/astriaorg/astria/pull/436).
+- Update penumbra-ibc features [#615](https://github.com/astriaorg/astria/pull/615).
+- Redefine sequencer blocks, celestia blobs as protobuf [#395](https://github.com/astriaorg/astria/pull/395).
+
+### Fixed
+
+- update `wait_for_sequencer` log to be correct [#586](https://github.com/astriaorg/astria/pull/586).
+
+
+## [0.8.0] - 2023-11-18
+
+## Added
+
+- Add an RFC 6962 compliant Merkle tree with flat memory representation [#554](https://github.com/astriaorg/astria/pull/554).
+
+### Fixed
+
+- Don't use fixed fee pricing [#590](https://github.com/astriaorg/astria/pull/590).
+
+## [0.7.0] - 2023-11-14
+
+### Changed
+
+- Implement clippy pedantic suggestions [#572](https://github.com/astriaorg/astria/pull/572).
+
+### Fixed
+
+- Use sequencer chain id for sequencer blobs [#577](https://github.com/astriaorg/astria/pull/577).
+
+## [0.6.0] - 2023-11-07
+
+### Changed
+
+- Sequencer-validation: implement std Error [#430](https://github.com/astriaorg/astria/pull/430).
+- Bump penumbra, tendermint; prune workspace cargo of unused deps [#468](https://github.com/astriaorg/astria/pull/468).
+- Use fork of tendermint with backported reqwest client [#498](https://github.com/astriaorg/astria/pull/498).
+- Celestia-client: use eiger's version [#486](https://github.com/astriaorg/astria/pull/486).
+- Define service configs in terms of a central crate [#537](https://github.com/astriaorg/astria/pull/537).
+- Remove signing and signature verification of data posted to DA [#538](https://github.com/astriaorg/astria/pull/538).
+- Verify current block commit in conductor; remove `last_commit` from `SequencerBlockData` [#560](https://github.com/astriaorg/astria/pull/560).
+
+### Fixed
+
+- Implement `chain_ids_commitment` inclusion proof generation and verification [#548](https://github.com/astriaorg/astria/pull/548).
+
+## [0.5.1] - 2023-09-27
+
+### Fixed
+
+- Fix tendermint block to `SequencerBlockData` conversion [#424](https://github.com/astriaorg/astria/pull/424).
+
+## 0.5.0 - 2023-09-22
+
+### Added
+
+- Initial release.
+
+[unreleased]: https://github.com/astriaorg/astria/compare/sequencer-relayer-v1.0.0-rc.1...HEAD
+[1.0.0-rc.1]: https://github.com/astriaorg/astria/compare/sequencer-relayer-v0.16.2...sequencer-relayer-v1.0.0-rc.1
+[0.16.2]: https://github.com/astriaorg/astria/compare/sequencer-relayer-v0.16.1...sequencer-relayer-v0.16.2
+[0.16.1]: https://github.com/astriaorg/astria/compare/sequencer-relayer-v0.16.0...sequencer-relayer-v0.16.1
+[0.16.0]: https://github.com/astriaorg/astria/compare/sequencer-relayer-v0.15.0...sequencer-relayer-v0.16.0
+[0.15.0]: https://github.com/astriaorg/astria/compare/sequencer-relayer-v0.14.0...sequencer-relayer-v0.15.0
+[0.14.0]: https://github.com/astriaorg/astria/compare/sequencer-relayer-v0.13.0...sequencer-relayer-v0.14.0
+[0.13.0]: https://github.com/astriaorg/astria/compare/sequencer-relayer-v0.12.0...sequencer-relayer-v0.13.0
+[0.12.0]: https://github.com/astriaorg/astria/compare/sequencer-relayer-v0.11.0...sequencer-relayer-v0.12.0
+[0.11.0]: https://github.com/astriaorg/astria/compare/sequencer-relayer-v0.10.0...sequencer-relayer-v0.11.0
+[0.10.0]: https://github.com/astriaorg/astria/compare/sequencer-relayer-v0.9.1...sequencer-relayer-v0.10.0
+[0.9.1]: https://github.com/astriaorg/astria/compare/sequencer-relayer-v0.9.0...sequencer-relayer-v0.9.1
+[0.9.0]: https://github.com/astriaorg/astria/compare/v0.8.0--sequencer-relayer...v0.9.0--sequencer-relayer
+[0.8.0]: https://github.com/astriaorg/astria/compare/v0.7.0--sequencer-relayer...v0.8.0--sequencer-relayer
+[0.7.0]: https://github.com/astriaorg/astria/compare/v0.6.0--sequencer-relayer...v0.7.0--sequencer-relayer
+[0.6.0]: https://github.com/astriaorg/astria/compare/v0.5.1--sequencer-relayer...v0.6.0--sequencer-relayer
+[0.5.1]: https://github.com/astriaorg/astria/compare/v0.5.0--sequencer-relayer...v0.5.1--sequencer-relayer

--- a/crates/astria-sequencer-relayer/CHANGELOG.md
+++ b/crates/astria-sequencer-relayer/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-rc.2] - 2024-10-23
+
+### Changed
+
+- Make native asset optional [#1703](https://github.com/astriaorg/astria/pull/1703).
+
 ## [1.0.0-rc.1] - 2024-10-17
 
 ### Changed
@@ -255,7 +261,8 @@ address [#721](https://github.com/astriaorg/astria/pull/721).
 
 - Initial release.
 
-[unreleased]: https://github.com/astriaorg/astria/compare/sequencer-relayer-v1.0.0-rc.1...HEAD
+[unreleased]: https://github.com/astriaorg/astria/compare/sequencer-relayer-v1.0.0-rc.2...HEAD
+[1.0.0-rc.2]: https://github.com/astriaorg/astria/compare/sequencer-relayer-v1.0.0-rc.1...sequencer-relayer-v1.0.0-rc.2
 [1.0.0-rc.1]: https://github.com/astriaorg/astria/compare/sequencer-relayer-v0.16.2...sequencer-relayer-v1.0.0-rc.1
 [0.16.2]: https://github.com/astriaorg/astria/compare/sequencer-relayer-v0.16.1...sequencer-relayer-v0.16.2
 [0.16.1]: https://github.com/astriaorg/astria/compare/sequencer-relayer-v0.16.0...sequencer-relayer-v0.16.1

--- a/crates/astria-sequencer-relayer/CHANGELOG.md
+++ b/crates/astria-sequencer-relayer/CHANGELOG.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable no-duplicate-heading -->
+
 # Changelog
 
 All notable changes to this project will be documented in this file.
@@ -51,7 +53,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- Remove functionality to restrict relaying blocks to only those proposed by a given validator [#1168](https://github.com/astriaorg/astria/pull/1168).
+- Remove functionality to restrict relaying blocks to only those proposed by a
+given validator [#1168](https://github.com/astriaorg/astria/pull/1168).
 
 ### Fixed
 
@@ -86,10 +89,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Brotli compress data blobs [#1006](https://github.com/astriaorg/astria/pull/1006).
 
 ### Changed
- 
+
 - Generate pbjon impls for sequencer types needed to mock conductor [#905](https://github.com/astriaorg/astria/pull/905).
 - Replace hex by base64 for display formatting, emitting tracing events [#908](https://github.com/astriaorg/astria/pull/908).
-- Update `SequencerBlockHeader` and related proto types to not use cometbft header [#830](https://github.com/astriaorg/astria/pull/830).
+- Update `SequencerBlockHeader` and related proto types to not use cometbft
+header [#830](https://github.com/astriaorg/astria/pull/830).
 - Update to ABCI v0.38 [#831](https://github.com/astriaorg/astria/pull/831).
 - Submit blobs directly to celestia app [#963](https://github.com/astriaorg/astria/pull/963).
 
@@ -131,11 +135,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `ibc_sudo_address` to genesis, only allow `IbcRelay` actions from this address [#721](https://github.com/astriaorg/astria/pull/721).
+- Add `ibc_sudo_address` to genesis, only allow `IbcRelay` actions from this
+address [#721](https://github.com/astriaorg/astria/pull/721).
 - Use opentelemetry [#656](https://github.com/astriaorg/astria/pull/656).
 - Allow specific assets for fee payment [#730](https://github.com/astriaorg/astria/pull/730).
 - Metrics setup [#739](https://github.com/astriaorg/astria/pull/739) and [#750](https://github.com/astriaorg/astria/pull/750).
-- Add `ibc_relayer_addresses` list and allow modifications via `ibc_sudo_address` [#737](https://github.com/astriaorg/astria/pull/737).
+- Add `ibc_relayer_addresses` list and allow modifications via
+`ibc_sudo_address` [#737](https://github.com/astriaorg/astria/pull/737).
 - Add pretty-printing to stdout [#736](https://github.com/astriaorg/astria/pull/736).
 - Set permitted commitment spread from rollup genesis [#743](https://github.com/astriaorg/astria/pull/743).
 - Implement ability to update fee assets using sudo key [#752](https://github.com/astriaorg/astria/pull/752).
@@ -147,7 +153,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update licenses [#706](https://github.com/astriaorg/astria/pull/706).
 - Update balance queries to return every asset owned by account [#683](https://github.com/astriaorg/astria/pull/683).
 - Use `IbcComponent` and penumbra `HostInterface`  [#700](https://github.com/astriaorg/astria/pull/700).
-- Move fee asset from `UnsignedTransaction` to `SequenceAction` and `TransferAction`  [#719](https://github.com/astriaorg/astria/pull/719).
+- Move fee asset from `UnsignedTransaction` to `SequenceAction` and
+`TransferAction` [#719](https://github.com/astriaorg/astria/pull/719).
 - Split protos into multiple buf repos [#732](https://github.com/astriaorg/astria/pull/732).
 - Add fee for `Ics20Withdrawal` action [#733](https://github.com/astriaorg/astria/pull/733).
 - Bump rust to 1.76, cargo-chef to 0.1.63 [#744](https://github.com/astriaorg/astria/pull/744).
@@ -199,7 +206,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - update `wait_for_sequencer` log to be correct [#586](https://github.com/astriaorg/astria/pull/586).
 
-
 ## [0.8.0] - 2023-11-18
 
 ## Added
@@ -230,7 +236,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Celestia-client: use eiger's version [#486](https://github.com/astriaorg/astria/pull/486).
 - Define service configs in terms of a central crate [#537](https://github.com/astriaorg/astria/pull/537).
 - Remove signing and signature verification of data posted to DA [#538](https://github.com/astriaorg/astria/pull/538).
-- Verify current block commit in conductor; remove `last_commit` from `SequencerBlockData` [#560](https://github.com/astriaorg/astria/pull/560).
+- Verify current block commit in conductor; remove `last_commit` from
+`SequencerBlockData` [#560](https://github.com/astriaorg/astria/pull/560).
 
 ### Fixed
 

--- a/crates/astria-sequencer/CHANGELOG.md
+++ b/crates/astria-sequencer/CHANGELOG.md
@@ -1,0 +1,424 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+[1.0.0-rc.1] - 2024-10-17
+
+### Added
+
+- Add traceability to rollup deposits [#1410](https://github.com/astriaorg/astria/pull/1410).
+- Report deposit events [#1447](https://github.com/astriaorg/astria/pull/1447).
+- Add IBC sudo change action [#1509](https://github.com/astriaorg/astria/pull/1509).
+- Transaction categories on `UnsignedTransaction` [#1512](https://github.com/astriaorg/astria/pull/1512).
+- Provide astrotrek chart [#1513](https://github.com/astriaorg/astria/pull/1513).
+
+### Changed
+
+- Change test addresses to versions with known private keys [#1487](https://github.com/astriaorg/astria/pull/1487).
+- Make mempool balance aware [#1408](https://github.com/astriaorg/astria/pull/1408).
+- Migrate from `anyhow::Result` to `eyre::Result` [#1387](https://github.com/astriaorg/astria/pull/1387).
+- Change `Deposit` byte length calculation [#1507](https://github.com/astriaorg/astria/pull/1507).
+- Put blocks and deposits to non-verified storage (ENG-812) [#1525](https://github.com/astriaorg/astria/pull/1525).
+- Replace `once_cell` with `LazyLock` [#1576](https://github.com/astriaorg/astria/pull/1576).
+- Use builder pattern for transaction container tests [#1592](https://github.com/astriaorg/astria/pull/1592).
+- Exclusively use Borsh encoding for stored data [#1492](https://github.com/astriaorg/astria/pull/1492).
+- Genesis chart template to support latest changes [#1594](https://github.com/astriaorg/astria/pull/1594).
+- Simplify boolean expressions in `transaction container` [#1595](https://github.com/astriaorg/astria/pull/1595).
+- Make empty transactions invalid  [#1609](https://github.com/astriaorg/astria/pull/1609).
+- Rewrite `check_tx` to be more efficient and fix regression [#1515](https://github.com/astriaorg/astria/pull/1515).
+- Generate `SequencerBlock` after transaction execution in proposal phase [#1562](https://github.com/astriaorg/astria/pull/1562).
+- Add limit to total amount of transactions in parked  [#1638](https://github.com/astriaorg/astria/pull/1638).
+- Remove action suffix from all action types [#1630](https://github.com/astriaorg/astria/pull/1630).
+- Update `futures-util` dependency based on cargo audit warning [#1644](https://github.com/astriaorg/astria/pull/1644).
+- Update storage keys locations and values (ENG-898) [#1616](https://github.com/astriaorg/astria/pull/1616).
+- Enforce block ordering by transaction group  [#1618](https://github.com/astriaorg/astria/pull/1618).
+- Rework all fees [#1647](https://github.com/astriaorg/astria/pull/1647).
+- Prefer `astria.primitive.v1.RollupId` over bytes [#1661](https://github.com/astriaorg/astria/pull/1661).
+- Call transactions `Transaction`, contents `TransactionBody` [#1650](https://github.com/astriaorg/astria/pull/1650).
+- Rename sequence action to rollup data submission [#1665](https://github.com/astriaorg/astria/pull/1665).
+- Upgrade to proto `v1`s throughout [#1672](https://github.com/astriaorg/astria/pull/1672).
+
+### Removed
+
+- Remove unused enable mint env [#1673](https://github.com/astriaorg/astria/pull/1673).
+
+### Fixed
+
+- Add `end_block` to `app_execute_transaction_with_every_action_snapshot` [#1455](https://github.com/astriaorg/astria/pull/1455).
+- Fix incorrect error message from `BridgeUnlock` actions [#1505](https://github.com/astriaorg/astria/pull/1505).
+- Fix and refactor ics20 logic [#1495](https://github.com/astriaorg/astria/pull/1495).
+- Install astria-eyre hook [#1552](https://github.com/astriaorg/astria/pull/1552).
+- Provide context in `check_tx` response log [#1506](https://github.com/astriaorg/astria/pull/1506).
+- Fix app hash in horcrux sentries [#1646](https://github.com/astriaorg/astria/pull/1646).
+- Allow compat prefixed addresses when receiving ics20 transfers [#1655](https://github.com/astriaorg/astria/pull/1655).
+- Remove enable mint entry from example env config [#1674](https://github.com/astriaorg/astria/pull/1674).
+
+[0.17.0] - 2024-09-06
+
+### Changed
+
+- BREAKING: Enforce withdrawals consumed [#1391](https://github.com/astriaorg/astria/pull/1391).
+- BREAKING: Permit bech32 compatible addresses [#1425](https://github.com/astriaorg/astria/pull/1425).
+- Memoize `address_bytes` of verification key [#1444](https://github.com/astriaorg/astria/pull/1444).
+
+[0.16.0] - 2024-08-22
+
+### Added
+
+- Add fee reporting [#1305](https://github.com/astriaorg/astria/pull/1305).
+
+### Changed
+
+- Update `bytemark` dependency based on cargo audit warning [#1350](https://github.com/astriaorg/astria/pull/1350).
+- BREAKING: Take funds from bridge in ics20 withdrawals [#1344](https://github.com/astriaorg/astria/pull/1344).
+- BREAKING: Require that bridge unlock address always be set [#1339](https://github.com/astriaorg/astria/pull/1339).
+- Rewrite mempool to have per-account transaction storage and maintenance  [#1323](https://github.com/astriaorg/astria/pull/1323).
+
+### Removed
+
+- Remove global state [#1317](https://github.com/astriaorg/astria/pull/1317).
+
+### Fixed
+
+- Fix abci error code [#1280](https://github.com/astriaorg/astria/pull/1280).
+- BREAKING: Fix TOCTOU issues by merging check and execution [#1332](https://github.com/astriaorg/astria/pull/1332).
+- Fix block fee collection [#1343](https://github.com/astriaorg/astria/pull/1343).
+- Bump penumbra dep to fix ibc state access bug [#1389](https://github.com/astriaorg/astria/pull/1389).
+
+[0.15.0] - 2024-07-26
+
+### Added
+
+- Implement transaction fee query [#1196](https://github.com/astriaorg/astria/pull/1196).
+- Add metrics [#1248](https://github.com/astriaorg/astria/pull/1248).
+- Add mempool benchmarks [#1238](https://github.com/astriaorg/astria/pull/1238).
+
+### Changed
+
+- Generate serde traits impls for all protocol protobufs [#1260](https://github.com/astriaorg/astria/pull/1260).
+- Define bridge memos in proto [#1285](https://github.com/astriaorg/astria/pull/1285).
+
+### Fixed
+
+- Fix prepare proposal metrics [#1211](https://github.com/astriaorg/astria/pull/1211).
+- Fix wrong metric and remove unused metric [#1240](https://github.com/astriaorg/astria/pull/1240).
+- Store native asset ibc->trace mapping in `init_chain` [#1242](https://github.com/astriaorg/astria/pull/1242).
+- Disambiguate return addresses [#1266](https://github.com/astriaorg/astria/pull/1266).
+- Improve and fix instrumentation [#1255](https://github.com/astriaorg/astria/pull/1255).
+
+[0.14.1] - 2024-07-03
+
+### Added
+
+- Implement abci query for bridge account info [#1189](https://github.com/astriaorg/astria/pull/1189).
+
+### Fixed
+
+- Update asset query path [#1141](https://github.com/astriaorg/astria/pull/1141).
+
+
+## [0.14.0] - 2024-06-27
+
+### Added
+
+- Add `allowed_fee_asset_ids` abci query and `sequencer_client` support [#1127](https://github.com/astriaorg/astria/pull/1127).
+- Implement `bridge/account_last_tx_hash` abci query [#1158](https://github.com/astriaorg/astria/pull/1158).
+- Add bech32m addresses [#1124](https://github.com/astriaorg/astria/pull/1124).
+- Implement refund to rollup logic upon ics20 transfer refund [#1161](https://github.com/astriaorg/astria/pull/1161).
+- Implement bridge sudo and withdrawer addresses [#1142](https://github.com/astriaorg/astria/pull/1142).
+- Add ttl and invalid cache to app mempool [#1138](https://github.com/astriaorg/astria/pull/1138).
+- Implement `Ics20TransferDepositMemo` format for incoming ics20 transfers to bridge accounts [#1202](https://github.com/astriaorg/astria/pull/1202).
+- Add ibc memo type snapshot tests [#1205](https://github.com/astriaorg/astria/pull/1205).
+- Allow configuring base address prefix [#1201](https://github.com/astriaorg/astria/pull/1201).
+
+### Changed
+
+- Query full denomination from asset ID [#1067](https://github.com/astriaorg/astria/pull/1067).
+- Add `clippy::arithmetic-side-effects` lint and fix resulting warnings [#1081](https://github.com/astriaorg/astria/pull/1081).
+- Use macro to declare metric constants [#1129](https://github.com/astriaorg/astria/pull/1129).
+- Bump penumbra deps [#1159](https://github.com/astriaorg/astria/pull/1159).
+- Register all metrics during startup [#1144](https://github.com/astriaorg/astria/pull/1144).
+- Parse ics20 denoms as ibc or trace prefixed variants [#1181](https://github.com/astriaorg/astria/pull/1181).
+- Remove non-bech32m address bytes [#1186](https://github.com/astriaorg/astria/pull/1186).
+- Bump penumbra deps [#1216](https://github.com/astriaorg/astria/pull/1216).
+- Use full IBC ICS20 denoms instead of IDs [#1209](https://github.com/astriaorg/astria/pull/1209).
+
+### Removed
+
+- Remove mint module [#1134](https://github.com/astriaorg/astria/pull/1134).
+
+### Fixed
+
+- Prefix removal source non-refund ics20 packet [#1162](https://github.com/astriaorg/astria/pull/1162).
+
+## [0.13.0] - 2024-05-23
+
+### Added
+
+- Implement `get_pending_nonce` for sequencer API [#1073](https://github.com/astriaorg/astria/pull/1073).
+
+### Changed
+
+- Fees go to sudo poa [#1104](https://github.com/astriaorg/astria/pull/1104).
+
+## [0.12.0] - 2024-05-21
+
+### Added
+
+- Implement basic app side mempool with nonce ordering [#1000](https://github.com/astriaorg/astria/pull/1000).
+- Add fees to genesis state [#1055](https://github.com/astriaorg/astria/pull/1055).
+- Implement bridge unlock action and derestrict transfers [#1034](https://github.com/astriaorg/astria/pull/1034).
+- Implement `FeeChangeAction` for the authority component [#1037](https://github.com/astriaorg/astria/pull/1037).
+
+### Changed
+
+- Store fees for actions in app state [#1017](https://github.com/astriaorg/astria/pull/1017).
+- Update ics20 withdrawal to have a memo field [#1056](https://github.com/astriaorg/astria/pull/1056).
+- Update `SignedTransaction` to contain `Any` for transaction [#1044](https://github.com/astriaorg/astria/pull/1044).
+
+### Fixed
+
+- Stateful check now ensures balance for total tx [#1009](https://github.com/astriaorg/astria/pull/1009).
+- Set current app hash properly when creating app [#1025](https://github.com/astriaorg/astria/pull/1025).
+- Panic sequencer instead of cometbft on erroring abci consensus requests [#1016](https://github.com/astriaorg/astria/pull/1016).
+- Fix ibc prefix conversion [#1065](https://github.com/astriaorg/astria/pull/1065).
+
+## [0.11.0] - 2024-04-26
+
+### Added
+
+- Add cargo audit to CI [#887](https://github.com/astriaorg/astria/pull/887).
+- Add unit tests for state extension trait [#890](https://github.com/astriaorg/astria/pull/890).
+- Create `sequencerblockapis` `v1alpha1` [#939](https://github.com/astriaorg/astria/pull/939).
+- Add display for deposits in `end_block` [#864](https://github.com/astriaorg/astria/pull/864).
+- Create wrapper types for `RollupId` and `Account` [#987](https://github.com/astriaorg/astria/pull/987).
+- Add initial set of metrics to sequencer [#965](https://github.com/astriaorg/astria/pull/965).
+
+### Changed
+
+- Check for sufficient balance in `check_tx` [#869](https://github.com/astriaorg/astria/pull/869).
+- Generate names for protobuf rust types [#904](https://github.com/astriaorg/astria/pull/904).
+- Replace hex by base64 for display formatting, emitting tracing events [#908](https://github.com/astriaorg/astria/pull/908).
+- Set revision number from chain id in `init_chain` [#935](https://github.com/astriaorg/astria/pull/935).
+- Update `SequencerBlockHeader` and related proto types to not use cometbft header [#830](https://github.com/astriaorg/astria/pull/830).
+- Update to ABCI v0.38 [#831](https://github.com/astriaorg/astria/pull/831).
+- Fully split `sequencerapis` and remove [#958](https://github.com/astriaorg/astria/pull/958).
+- Require chain id in transactions [#973](https://github.com/astriaorg/astria/pull/973).
+- Update justfile and testnet script [#985](https://github.com/astriaorg/astria/pull/985).
+- Bridge account only takes a single asset [#988](https://github.com/astriaorg/astria/pull/988).
+
+### Removed
+
+- No telemetry for formatting db keys [#909](https://github.com/astriaorg/astria/pull/909).
+- Remove `SequencerBlock::try_from_cometbft` [#1005](https://github.com/astriaorg/astria/pull/1005).
+
+### Fixed
+
+- Make `get_deposit_rollup_ids` not return duplicates [#916](https://github.com/astriaorg/astria/pull/916).
+- `is_proposer` check now considers proposer's address [#936](https://github.com/astriaorg/astria/pull/936).
+- Respect `max_tx_bytes` when preparing proposals [#911](https://github.com/astriaorg/astria/pull/911).
+- Fix state setup to be consistent before transaction execution [#945](https://github.com/astriaorg/astria/pull/945).
+- Don't store execution result of failed tx [#992](https://github.com/astriaorg/astria/pull/992).
+- Don't allow sudo to cause consensus failures [#999](https://github.com/astriaorg/astria/pull/999).
+
+## [0.10.1] - 2024-04-03
+
+### Added
+
+- Implement bridge deposits for incoming ICS20 transfers [#843](https://github.com/astriaorg/astria/pull/843).
+- Add serialization to execution `v1alpha2` compliant with protobuf json mapping [#857](https://github.com/astriaorg/astria/pull/857).
+- Add unit tests for state extension traits [#858](https://github.com/astriaorg/astria/pull/858), [#871](https://github.com/astriaorg/astria/pull/871), [#874](https://github.com/astriaorg/astria/pull/874), [#875](https://github.com/astriaorg/astria/pull/875), [#876](https://github.com/astriaorg/astria/pull/876) and [#878](https://github.com/astriaorg/astria/pull/878).
+
+### Changed
+
+- Use `Arc<Self>` target in generated gRPC service traits [#853](https://github.com/astriaorg/astria/pull/853).
+- Logging as human readable for account state [#898](https://github.com/astriaorg/astria/pull/898).
+
+### Fixed
+
+- Bump otel to resolve panics in layered span access [#820](https://github.com/astriaorg/astria/pull/820).
+- Fix `is_source` prefix check [#844](https://github.com/astriaorg/astria/pull/844).
+- Fix escrow channel check when receiving non-refund ics20 packet [#851](https://github.com/astriaorg/astria/pull/851).
+- Fix rollup ids commitment for deposits [#863](https://github.com/astriaorg/astria/pull/863).
+
+## [0.10.0] - 2024-03-19
+
+### Added
+
+- Add sequencer service proto [#701](https://github.com/astriaorg/astria/pull/701).
+- Implement bridge accounts and related actions [#768](https://github.com/astriaorg/astria/pull/768).
+
+### Changed
+
+- Simplify emitting error fields with cause chains [#765](https://github.com/astriaorg/astria/pull/765).
+- Update dependencies [#782](https://github.com/astriaorg/astria/pull/782).
+- Store sequencer blocks in the sequencer state [#787](https://github.com/astriaorg/astria/pull/787).
+- Include deposit data as part of rollup data [#802](https://github.com/astriaorg/astria/pull/802).
+- Bump penumbra deps [#825](https://github.com/astriaorg/astria/pull/825).
+
+### Fixed
+
+- Filtered blocks success when no data expected [#819](https://github.com/astriaorg/astria/pull/819).
+- Fix bug in `get_sequencer_block_by_hash` [#832](https://github.com/astriaorg/astria/pull/832).
+
+## [0.9.0] - 2024-02-15
+
+### Added
+
+- Add `SignedTransaction::sha256_of_proto_encoding()` method [#687](https://github.com/astriaorg/astria/pull/687).
+- Add `ibc_sudo_address` to genesis, only allow `IbcRelay` actions from this address [#721](https://github.com/astriaorg/astria/pull/721).
+- Use opentelemetry [#656](https://github.com/astriaorg/astria/pull/656).
+- Allow specific assets for fee payment [#730](https://github.com/astriaorg/astria/pull/730).
+- Metrics setup [#739](https://github.com/astriaorg/astria/pull/739) and [#750](https://github.com/astriaorg/astria/pull/750).
+- Add `ibc_relayer_addresses` list and allow modifications via `ibc_sudo_address` [#737](https://github.com/astriaorg/astria/pull/737).
+- Add pretty-printing to stdout [#736](https://github.com/astriaorg/astria/pull/736).
+- Implement ability to update fee assets using sudo key [#752](https://github.com/astriaorg/astria/pull/752).
+- Print build info in all services [#753](https://github.com/astriaorg/astria/pull/753).
+
+### Changed
+
+- Transfer fees to block proposer instead of burning [#690](https://github.com/astriaorg/astria/pull/690).
+- Update licenses [#706](https://github.com/astriaorg/astria/pull/706).
+- Update balance queries to return every asset owned by account [#683](https://github.com/astriaorg/astria/pull/683).
+- Use `IbcComponent` and penumbra `HostInterface` [#700](https://github.com/astriaorg/astria/pull/700).
+- Move fee asset from `UnsignedTransaction` to `SequenceAction` and `TransferAction` [#719](https://github.com/astriaorg/astria/pull/719).
+- Relax size requirements of hash buffers [#709](https://github.com/astriaorg/astria/pull/709).
+- Split protos into multiple buf repos [#732](https://github.com/astriaorg/astria/pull/732).
+- Add fee for `Ics20Withdrawal` action [#733](https://github.com/astriaorg/astria/pull/733).
+- Bump rust to 1.76, cargo-chef to 0.1.63 [#744](https://github.com/astriaorg/astria/pull/744).
+- Upgrade to penumbra release 0.66 [#741](https://github.com/astriaorg/astria/pull/741).
+- Move ibc-related code to its own module [#757](https://github.com/astriaorg/astria/pull/757).
+
+### Fixed
+
+- Fix `FungibleTokenPacketData` decoding [#686](https://github.com/astriaorg/astria/pull/686).
+- Replace allocating display impl [#738](https://github.com/astriaorg/astria/pull/738).
+- Fix docker builds [#756](https://github.com/astriaorg/astria/pull/756).
+
+## [0.8.0] - 2024-01-10
+
+### Added
+
+- Add proto formatting, cleanup justfile [#637](https://github.com/astriaorg/astria/pull/637).
+- Implement ICS20 withdrawals [#609](https://github.com/astriaorg/astria/pull/609).
+- Add IBC gRPC server to sequencer app [#631](https://github.com/astriaorg/astria/pull/631).
+- Lint debug fields in tracing events [#664](https://github.com/astriaorg/astria/pull/664).
+
+### Changed
+
+- Move protobuf specs to repository top level [#629](https://github.com/astriaorg/astria/pull/629).
+- Bump all checkout actions in CI to v3 [#641](https://github.com/astriaorg/astria/pull/641).
+- Unify construction of cometbft blocks in tests [#640](https://github.com/astriaorg/astria/pull/640).
+- Store mapping of IBC asset ID to full denomination trace [#614](https://github.com/astriaorg/astria/pull/614).
+- Switch tagging format in CI [#639](https://github.com/astriaorg/astria/pull/639).
+- Bump penumbra deps [#655](https://github.com/astriaorg/astria/pull/655).
+- Rename `astria-proto` to `astria-core` [#644](https://github.com/astriaorg/astria/pull/644).
+- Break up `v1alpha1` module [#646](https://github.com/astriaorg/astria/pull/646).
+- Don't deny unknown config fields [#657](https://github.com/astriaorg/astria/pull/657).
+- Call abort on ABCI server on signal [#670](https://github.com/astriaorg/astria/pull/670).
+- Define abci error codes in protobuf [#647](https://github.com/astriaorg/astria/pull/647).
+- Use display formatting instead of debug formatting in tracing events [#671](https://github.com/astriaorg/astria/pull/671).
+- Update instrumentation for all consensus & app functions [#677](https://github.com/astriaorg/astria/pull/677).
+- Add max sequencer bytes per block limit [#676](https://github.com/astriaorg/astria/pull/676).
+
+### Removed
+
+- Remove `AppHash` [#655](https://github.com/astriaorg/astria/pull/655).
+
+### Fixed
+
+- Adjust input to proto breaking change linter after refactor [#635](https://github.com/astriaorg/astria/pull/635).
+- Fix ABCI event handling [#666](https://github.com/astriaorg/astria/pull/666).
+- Clear processed tx count in `begin_block` [#659](https://github.com/astriaorg/astria/pull/659).
+- Amend Cargo.toml when building images [#672](https://github.com/astriaorg/astria/pull/672).
+- Update app state to latest committed before starting round [#673](https://github.com/astriaorg/astria/pull/673).
+- Allow blocksync to complete successfully [#675](https://github.com/astriaorg/astria/pull/675).
+
+## [0.7.0] - 2023-11-30
+
+### Added
+
+- Implement support for arbitrary assets [#568](https://github.com/astriaorg/astria/pull/568).
+- Support `IbcAction`s and implement ICS20 incoming transfer application logic [#579](https://github.com/astriaorg/astria/pull/579).
+
+### Changed
+
+- Replace `buf-generate` by `tonic_build` [#581](https://github.com/astriaorg/astria/pull/581).
+- Bump all dependencies (mainly penumbra, celestia, tendermint) [#582](https://github.com/astriaorg/astria/pull/582).
+- Enforce sequencer blob invariants [#576](https://github.com/astriaorg/astria/pull/576).
+- Require `chain_id` be 32 bytes [#436](https://github.com/astriaorg/astria/pull/436).
+- Update penumbra-ibc features [#615](https://github.com/astriaorg/astria/pull/615).
+
+### Fixed
+
+- Fix instrument logging not to log every tx [#595](https://github.com/astriaorg/astria/pull/595).
+- Cap tx size at 250kB [#601](https://github.com/astriaorg/astria/pull/601).
+
+## [0.6.0] - 2023-11-18
+
+### Added
+
+- Add an RFC-6962 compliant Merkle tree with flat memory representation [#554](https://github.com/astriaorg/astria/pull/554).
+
+## [0.5.0] - 2023-11-07
+
+### Added
+
+- Implement sudo key changes [#431](https://github.com/astriaorg/astria/pull/431).
+- Implement minting module [#435](https://github.com/astriaorg/astria/pull/435).
+
+### Changed
+
+- Remove byzantine validators in `begin_block` [#429](https://github.com/astriaorg/astria/pull/429).
+- Bump penumbra, tendermint; prune workspace cargo of unused deps [#468](https://github.com/astriaorg/astria/pull/468).
+- Bump rust to 1.72 in CI [#477](https://github.com/astriaorg/astria/pull/477).
+- Use fork of tendermint with backported `reqwest` client [#498](https://github.com/astriaorg/astria/pull/498).
+- Move transaction execution to prepare/process proposal [#480](https://github.com/astriaorg/astria/pull/480).
+
+### Fixed
+
+- Fix tests without `--all-features` [#481](https://github.com/astriaorg/astria/pull/481).
+- Fix typos [#541](https://github.com/astriaorg/astria/pull/541).
+- Implement `chain_ids_commitment` inclusion proof generation and verification [#548](https://github.com/astriaorg/astria/pull/548).
+- Fix authority component `ValidatorSet` non determinism [#557](https://github.com/astriaorg/astria/pull/557).
+- Run only `prepare_proposal` if proposer [#558](https://github.com/astriaorg/astria/pull/558).
+
+## [0.4.1] - 2023-09-27
+
+### Added
+
+- Implement basic validator set updates [#359](https://github.com/astriaorg/astria/pull/359).
+
+### Fixed
+
+- Fix mempool nonce check [#434](https://github.com/astriaorg/astria/pull/434).
+
+## 0.4.0 - 2023-09-22
+
+### Added
+
+- Initial release.
+
+[unreleased]: https://github.com/astriaorg/astria/compare/sequencer-v1.0.0-rc.1...HEAD
+[1.0.0-rc.1]: https://github.com/astriaorg/astria/compare/sequencer-v0.17.0...sequencer-v1.0.0-rc.1
+[0.17.0]: https://github.com/astriaorg/astria/compare/cli-v0.4.0...sequencer-v0.17.0
+[0.16.0]: https://github.com/astriaorg/astria/compare/sequencer-v0.15.0...sequencer-v0.16.0
+[0.15.0]: https://github.com/astriaorg/astria/compare/sequencer-v0.14.1...sequencer-v0.15.0
+[0.14.1]: https://github.com/astriaorg/astria/compare/sequencer-v0.14.0...sequencer-v0.14.1
+[0.14.0]: https://github.com/astriaorg/astria/compare/sequencer-v0.13.0...sequencer-v0.14.0
+[0.13.0]: https://github.com/astriaorg/astria/compare/sequencer-v0.12.0...sequencer-v0.13.0
+[0.12.0]: https://github.com/astriaorg/astria/compare/sequencer-v0.11.0...sequencer-v0.12.0
+[0.11.0]: https://github.com/astriaorg/astria/compare/sequencer-v0.10.1...sequencer-v0.11.0
+[0.10.1]: https://github.com/astriaorg/astria/compare/sequencer-v0.10.0...sequencer-v0.10.1
+[0.10.0]: https://github.com/astriaorg/astria/compare/sequencer-v0.9.0...sequencer-v0.10.0
+[0.9.0]: https://github.com/astriaorg/astria/compare/sequencer-v0.8.0...sequencer-v0.9.0
+[0.8.0]: https://github.com/astriaorg/astria/compare/sequencer-v0.7.0...sequencer-v0.8.0
+[0.7.0]: https://github.com/astriaorg/astria/compare/v0.6.0--sequencer...v0.7.0--sequencer
+[0.6.0]: https://github.com/astriaorg/astria/compare/v0.5.0--sequencer...v0.6.0--sequencer
+[0.5.0]: https://github.com/astriaorg/astria/compare/v0.4.1--sequencer...v0.5.0--sequencer
+[0.4.1]: https://github.com/astriaorg/astria/compare/v0.4.0--sequencer...v0.4.1--sequencer

--- a/crates/astria-sequencer/CHANGELOG.md
+++ b/crates/astria-sequencer/CHANGELOG.md
@@ -9,7 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-[1.0.0-rc.1] - 2024-10-17
+## [1.0.0-rc.2] - 2024-10-23
+
+### Changed
+
+- Make ABCI response for account balances deterministic [#1574](https://github.com/astriaorg/astria/pull/1574).
+- Move and improve transaction fee estimation [#1722](https://github.com/astriaorg/astria/pull/1722).
+- Make fees optional at genesis [#1664](https://github.com/astriaorg/astria/pull/1664).
+- Add test for rollup refund in [#1728](https://github.com/astriaorg/astria/pull/1728).
+- Make native asset optional [#1703](https://github.com/astriaorg/astria/pull/1703).
+
+### Removed
+
+- Remove unused asset storage variant [#1704](https://github.com/astriaorg/astria/pull/1704).
+
+### Fixed
+
+- Fix fee estimation [#1701](https://github.com/astriaorg/astria/pull/1701).
+
+## [1.0.0-rc.1] - 2024-10-17
 
 ### Added
 
@@ -60,7 +78,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow compat prefixed addresses when receiving ics20 transfers [#1655](https://github.com/astriaorg/astria/pull/1655).
 - Remove enable mint entry from example env config [#1674](https://github.com/astriaorg/astria/pull/1674).
 
-[0.17.0] - 2024-09-06
+## [0.17.0] - 2024-09-06
 
 ### Changed
 
@@ -68,7 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - BREAKING: Permit bech32 compatible addresses [#1425](https://github.com/astriaorg/astria/pull/1425).
 - Memoize `address_bytes` of verification key [#1444](https://github.com/astriaorg/astria/pull/1444).
 
-[0.16.0] - 2024-08-22
+## [0.16.0] - 2024-08-22
 
 ### Added
 
@@ -92,7 +110,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix block fee collection [#1343](https://github.com/astriaorg/astria/pull/1343).
 - Bump penumbra dep to fix ibc state access bug [#1389](https://github.com/astriaorg/astria/pull/1389).
 
-[0.15.0] - 2024-07-26
+## [0.15.0] - 2024-07-26
 
 ### Added
 
@@ -113,7 +131,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Disambiguate return addresses [#1266](https://github.com/astriaorg/astria/pull/1266).
 - Improve and fix instrumentation [#1255](https://github.com/astriaorg/astria/pull/1255).
 
-[0.14.1] - 2024-07-03
+## [0.14.1] - 2024-07-03
 
 ### Added
 
@@ -417,7 +435,8 @@ address [#721](https://github.com/astriaorg/astria/pull/721).
 
 - Initial release.
 
-[unreleased]: https://github.com/astriaorg/astria/compare/sequencer-v1.0.0-rc.1...HEAD
+[unreleased]: https://github.com/astriaorg/astria/compare/sequencer-v1.0.0-rc.2...HEAD
+[1.0.0-rc.2]: https://github.com/astriaorg/astria/compare/sequencer-v1.0.0-rc.1...sequencer-v1.0.0-rc.2
 [1.0.0-rc.1]: https://github.com/astriaorg/astria/compare/sequencer-v0.17.0...sequencer-v1.0.0-rc.1
 [0.17.0]: https://github.com/astriaorg/astria/compare/cli-v0.4.0...sequencer-v0.17.0
 [0.16.0]: https://github.com/astriaorg/astria/compare/sequencer-v0.15.0...sequencer-v0.16.0

--- a/crates/astria-sequencer/CHANGELOG.md
+++ b/crates/astria-sequencer/CHANGELOG.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable no-duplicate-heading -->
+
 # Changelog
 
 All notable changes to this project will be documented in this file.
@@ -121,7 +123,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update asset query path [#1141](https://github.com/astriaorg/astria/pull/1141).
 
-
 ## [0.14.0] - 2024-06-27
 
 ### Added
@@ -132,7 +133,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement refund to rollup logic upon ics20 transfer refund [#1161](https://github.com/astriaorg/astria/pull/1161).
 - Implement bridge sudo and withdrawer addresses [#1142](https://github.com/astriaorg/astria/pull/1142).
 - Add ttl and invalid cache to app mempool [#1138](https://github.com/astriaorg/astria/pull/1138).
-- Implement `Ics20TransferDepositMemo` format for incoming ics20 transfers to bridge accounts [#1202](https://github.com/astriaorg/astria/pull/1202).
+- Implement `Ics20TransferDepositMemo` format for incoming ics20 transfers to
+bridge accounts [#1202](https://github.com/astriaorg/astria/pull/1202).
 - Add ibc memo type snapshot tests [#1205](https://github.com/astriaorg/astria/pull/1205).
 - Allow configuring base address prefix [#1201](https://github.com/astriaorg/astria/pull/1201).
 
@@ -205,7 +207,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Generate names for protobuf rust types [#904](https://github.com/astriaorg/astria/pull/904).
 - Replace hex by base64 for display formatting, emitting tracing events [#908](https://github.com/astriaorg/astria/pull/908).
 - Set revision number from chain id in `init_chain` [#935](https://github.com/astriaorg/astria/pull/935).
-- Update `SequencerBlockHeader` and related proto types to not use cometbft header [#830](https://github.com/astriaorg/astria/pull/830).
+- Update `SequencerBlockHeader` and related proto types to not use cometbft
+header [#830](https://github.com/astriaorg/astria/pull/830).
 - Update to ABCI v0.38 [#831](https://github.com/astriaorg/astria/pull/831).
 - Fully split `sequencerapis` and remove [#958](https://github.com/astriaorg/astria/pull/958).
 - Require chain id in transactions [#973](https://github.com/astriaorg/astria/pull/973).
@@ -231,8 +234,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Implement bridge deposits for incoming ICS20 transfers [#843](https://github.com/astriaorg/astria/pull/843).
-- Add serialization to execution `v1alpha2` compliant with protobuf json mapping [#857](https://github.com/astriaorg/astria/pull/857).
-- Add unit tests for state extension traits [#858](https://github.com/astriaorg/astria/pull/858), [#871](https://github.com/astriaorg/astria/pull/871), [#874](https://github.com/astriaorg/astria/pull/874), [#875](https://github.com/astriaorg/astria/pull/875), [#876](https://github.com/astriaorg/astria/pull/876) and [#878](https://github.com/astriaorg/astria/pull/878).
+- Add serialization to execution `v1alpha2` compliant with protobuf json
+mapping [#857](https://github.com/astriaorg/astria/pull/857).
+- Add unit tests for state extension traits
+[#858](https://github.com/astriaorg/astria/pull/858),
+[#871](https://github.com/astriaorg/astria/pull/871),
+[#874](https://github.com/astriaorg/astria/pull/874),
+[#875](https://github.com/astriaorg/astria/pull/875),
+[#876](https://github.com/astriaorg/astria/pull/876) and
+[#878](https://github.com/astriaorg/astria/pull/878).
 
 ### Changed
 
@@ -271,11 +281,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `SignedTransaction::sha256_of_proto_encoding()` method [#687](https://github.com/astriaorg/astria/pull/687).
-- Add `ibc_sudo_address` to genesis, only allow `IbcRelay` actions from this address [#721](https://github.com/astriaorg/astria/pull/721).
+- Add `ibc_sudo_address` to genesis, only allow `IbcRelay` actions from this
+address [#721](https://github.com/astriaorg/astria/pull/721).
 - Use opentelemetry [#656](https://github.com/astriaorg/astria/pull/656).
 - Allow specific assets for fee payment [#730](https://github.com/astriaorg/astria/pull/730).
 - Metrics setup [#739](https://github.com/astriaorg/astria/pull/739) and [#750](https://github.com/astriaorg/astria/pull/750).
-- Add `ibc_relayer_addresses` list and allow modifications via `ibc_sudo_address` [#737](https://github.com/astriaorg/astria/pull/737).
+- Add `ibc_relayer_addresses` list and allow modifications via
+`ibc_sudo_address` [#737](https://github.com/astriaorg/astria/pull/737).
 - Add pretty-printing to stdout [#736](https://github.com/astriaorg/astria/pull/736).
 - Implement ability to update fee assets using sudo key [#752](https://github.com/astriaorg/astria/pull/752).
 - Print build info in all services [#753](https://github.com/astriaorg/astria/pull/753).
@@ -286,7 +298,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update licenses [#706](https://github.com/astriaorg/astria/pull/706).
 - Update balance queries to return every asset owned by account [#683](https://github.com/astriaorg/astria/pull/683).
 - Use `IbcComponent` and penumbra `HostInterface` [#700](https://github.com/astriaorg/astria/pull/700).
-- Move fee asset from `UnsignedTransaction` to `SequenceAction` and `TransferAction` [#719](https://github.com/astriaorg/astria/pull/719).
+- Move fee asset from `UnsignedTransaction` to `SequenceAction` and
+`TransferAction` [#719](https://github.com/astriaorg/astria/pull/719).
 - Relax size requirements of hash buffers [#709](https://github.com/astriaorg/astria/pull/709).
 - Split protos into multiple buf repos [#732](https://github.com/astriaorg/astria/pull/732).
 - Add fee for `Ics20Withdrawal` action [#733](https://github.com/astriaorg/astria/pull/733).

--- a/crates/astria-telemetry/CHANGELOG.md
+++ b/crates/astria-telemetry/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Added
+
+- Initial release.

--- a/crates/astria-telemetry/CHANGELOG.md
+++ b/crates/astria-telemetry/CHANGELOG.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable no-duplicate-heading -->
+
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/justfile
+++ b/justfile
@@ -77,7 +77,7 @@ _lint-toml:
 
 [no-exit-message]
 _lint-md:
-  markdownlint-cli2 "**/*.md" "#target" "#.github" "#**/*/astria-bridge-contracts/lib/**/*.md" "#**/CHANGELOG.md"
+  markdownlint-cli2
 
 [no-exit-message]
 _fmt-proto:

--- a/justfile
+++ b/justfile
@@ -77,7 +77,7 @@ _lint-toml:
 
 [no-exit-message]
 _lint-md:
-  markdownlint-cli2 "**/*.md" "#target" "#.github" "#**/*/astria-bridge-contracts/lib/**/*.md"
+  markdownlint-cli2 "**/*.md" "#target" "#.github" "#**/*/astria-bridge-contracts/lib/**/*.md" "#**/CHANGELOG.md"
 
 [no-exit-message]
 _fmt-proto:


### PR DESCRIPTION
## Summary
Provided changelogs.

## Background
Changelogs are good to have.

## Changes
- Added changelogs to all crates for which we have GH releases.  Their release notes were ported into the changelogs.
- Added changelogs to all remaining public-facing crates.  Only `astria-merkle` has been version bumped from 0.1.0, so except for this one, all of these changelogs are initialised with only an `Unreleased` section.
- Updated the PR template to remind authors to update relevant changelogs when opening PRs.
- ~Excluded the changelog files from the markdown linter, since the format is defined by [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).~
- Added a markdownlint config file to specify the globs and removed duplicated globs lists from various places.

## Testing
N/A

## Related Issues
Closes #1687.