### PR TITLE
refactor(sequencer): remove unused asset storage variant

### DIFF
--- a/crates/astria-sequencer/src/accounts/storage/values.rs
+++ b/crates/astria-sequencer/src/accounts/storage/values.rs
@@ -11,7 +11,6 @@ pub(crate) struct Value(ValueImpl);
 enum ValueImpl {
     Balance(Balance),
     Nonce(Nonce),
-    Fee(Fee),
 }
 
 #[derive(Debug, BorshSerialize, BorshDeserialize)]
@@ -76,37 +75,5 @@ impl<'a> TryFrom<crate::storage::StoredValue<'a>> for Nonce {
             bail!("accounts stored value type mismatch: expected nonce, found {value:?}");
         };
         Ok(nonce)
-    }
-}
-
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-pub(in crate::accounts) struct Fee(u128);
-
-impl From<u128> for Fee {
-    fn from(fee: u128) -> Self {
-        Fee(fee)
-    }
-}
-
-impl From<Fee> for u128 {
-    fn from(fee: Fee) -> Self {
-        fee.0
-    }
-}
-
-impl<'a> From<Fee> for crate::storage::StoredValue<'a> {
-    fn from(fee: Fee) -> Self {
-        crate::storage::StoredValue::Accounts(Value(ValueImpl::Fee(fee)))
-    }
-}
-
-impl<'a> TryFrom<crate::storage::StoredValue<'a>> for Fee {
-    type Error = astria_eyre::eyre::Error;
-
-    fn try_from(value: crate::storage::StoredValue<'a>) -> Result<Self, Self::Error> {
-        let crate::storage::StoredValue::Accounts(Value(ValueImpl::Fee(fee))) = value else {
-            bail!("accounts stored value type mismatch: expected fee, found {value:?}");
-        };
-        Ok(fee)
     }
 }

--- a/crates/astria-sequencer/src/assets/storage/values.rs
+++ b/crates/astria-sequencer/src/assets/storage/values.rs
@@ -13,7 +13,6 @@ pub(crate) struct Value<'a>(ValueImpl<'a>);
 #[derive(Debug, BorshSerialize, BorshDeserialize)]
 enum ValueImpl<'a> {
     TracePrefixedDenom(TracePrefixedDenom<'a>),
-    Fee(Fee),
 }
 
 #[derive(Debug, BorshSerialize, BorshDeserialize)]
@@ -64,37 +63,5 @@ impl<'a> TryFrom<crate::storage::StoredValue<'a>> for TracePrefixedDenom<'a> {
             );
         };
         Ok(denom)
-    }
-}
-
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
-pub(in crate::assets) struct Fee(u128);
-
-impl From<u128> for Fee {
-    fn from(fee: u128) -> Self {
-        Fee(fee)
-    }
-}
-
-impl From<Fee> for u128 {
-    fn from(fee: Fee) -> Self {
-        fee.0
-    }
-}
-
-impl<'a> From<Fee> for crate::storage::StoredValue<'a> {
-    fn from(fee: Fee) -> Self {
-        crate::storage::StoredValue::Assets(Value(ValueImpl::Fee(fee)))
-    }
-}
-
-impl<'a> TryFrom<crate::storage::StoredValue<'a>> for Fee {
-    type Error = astria_eyre::eyre::Error;
-
-    fn try_from(value: crate::storage::StoredValue<'a>) -> Result<Self, Self::Error> {
-        let crate::storage::StoredValue::Assets(Value(ValueImpl::Fee(fee))) = value else {
-            bail!("assets stored value type mismatch: expected fee, found {value:?}");
-        };
-        Ok(fee)
     }
 }


### PR DESCRIPTION
## Summary
Removes an unused variant of the internal storage implementation of sequencer asset component.t

## Background
As part of https://github.com/astriaorg/astria/pull/1647 fees were moved from the assets to the fees component. The present variant was overlooked.

## Changes
- Remove a storage variant from the assets component.

## Testing
Not applicable. Dead code.

## Breaking Changelist
This is not a breaking change because a) the variant was never used (there was not even a theoretic way to write it after https://github.com/astriaorg/astria/pull/1647) and b) no variants existed after the variant. If they had, this change would lead to a shift in the variants, causing breakage.