### PR TITLE
refactor(sequencer): use stream for allowed assets, fix query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,6 +811,7 @@ dependencies = [
  "ibc-proto",
  "ibc-types",
  "insta",
+ "maplit",
  "matchit",
  "paste",
  "penumbra-ibc",
@@ -5009,6 +5010,12 @@ dependencies = [
  "cc",
  "libc",
 ]
+
+[[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "matchers"

--- a/crates/astria-sequencer/Cargo.toml
+++ b/crates/astria-sequencer/Cargo.toml
@@ -78,6 +78,7 @@ config = { package = "astria-config", path = "../astria-config", features = [
 ] }
 insta = { workspace = true, features = ["json"] }
 paste = "1.0.15"
+maplit = "1.0.2"
 rand_chacha = "0.3.1"
 tokio = { workspace = true, features = ["test-util"] }
 

--- a/crates/astria-sequencer/src/accounts/state_ext.rs
+++ b/crates/astria-sequencer/src/accounts/state_ext.rs
@@ -43,13 +43,13 @@ pin_project! {
     /// A stream of IBC prefixed assets for a given account.
     pub(crate) struct AccountAssetsStream<St> {
         #[pin]
-        pub(crate) underlying: St,
+        underlying: St,
     }
 }
 
 impl<St> Stream for AccountAssetsStream<St>
 where
-    St: Stream<Item = Result<String>>,
+    St: Stream<Item = astria_eyre::anyhow::Result<String>>,
 {
     type Item = Result<asset::IbcPrefixed>;
 
@@ -58,7 +58,9 @@ where
         let key = match ready!(this.underlying.as_mut().poll_next(cx)) {
             Some(Ok(key)) => key,
             Some(Err(err)) => {
-                return Poll::Ready(Some(Err(err).wrap_err("failed reading from state")));
+                return Poll::Ready(Some(Err(
+                    anyhow_to_eyre(err).wrap_err("failed reading from state")
+                )));
             }
             None => return Poll::Ready(None),
         };
@@ -78,7 +80,7 @@ pin_project! {
     /// A stream of IBC prefixed assets and their balances for a given account.
     pub(crate) struct AccountAssetBalancesStream<St> {
         #[pin]
-        pub(crate) underlying: St,
+        underlying: St,
     }
 }
 


### PR DESCRIPTION
## Summary
Uses a stream to fetch all allowed assets.

## Background
Prior to this patch fetching all allowed assets from state was done using a future that was itself a loop over a (rocksbd) prefix key stream. This future always resulted in a vector of assets.. This patch instead replaces it by a stream, moving the decision for how to consume the items to the call site.

## Changes
- Replaces `fees::StateReadExt::get_allowed_assets` by `fees::StateReadExt::allowed_assets` and a typed stream implementation.
- Rewrites the ABCI query for allowed fee assets in terms of this stream. If reading a fee asset from state failed this query will now return an empty collection rather than an internal server error.
- Update the fee asset change action removal subcommand to check if the allowed asset stream contains at least 1 fee asset using the stream (rather than fetching all the assets).
- Updates all tests to use the stream.

## Testing
Tests were updated and still work using the new logic.