### PR TITLE
fix(bridge-withdrawer)!: correctly identify rollup return address in ics20 withdrawal actions

### DIFF
--- a/crates/astria-bridge-contracts/src/lib.rs
+++ b/crates/astria-bridge-contracts/src/lib.rs
@@ -422,7 +422,7 @@ where
         let memo = memo_to_json(&memos::v1::Ics20WithdrawalFromRollup {
             memo: event.memo.clone(),
             rollup_block_number,
-            rollup_return_address: event.sender.to_string(),
+            rollup_return_address: event.sender.encode_hex(),
             rollup_withdrawal_event_id,
         })
         .map_err(GetWithdrawalActionsError::encode_memo)?;

--- a/crates/astria-bridge-withdrawer/tests/blackbox/helpers/test_bridge_withdrawer.rs
+++ b/crates/astria-bridge-withdrawer/tests/blackbox/helpers/test_bridge_withdrawer.rs
@@ -514,7 +514,7 @@ pub fn make_erc20_ics20_withdrawal_action(receipt: &TransactionReceipt) -> Actio
         amount: 1_000_000u128,
         memo: serde_json::to_string(&Ics20WithdrawalFromRollup {
             memo: "nootwashere".to_string(),
-            rollup_return_address: receipt.from.to_string(),
+            rollup_return_address: receipt.from.encode_hex(),
             rollup_block_number: receipt.block_number.unwrap().as_u64(),
             rollup_withdrawal_event_id: format!("{rollup_transaction_hash}.{event_index}"),
         })

--- a/crates/astria-bridge-withdrawer/tests/blackbox/helpers/test_bridge_withdrawer.rs
+++ b/crates/astria-bridge-withdrawer/tests/blackbox/helpers/test_bridge_withdrawer.rs
@@ -463,7 +463,7 @@ pub fn make_native_ics20_withdrawal_action(receipt: &TransactionReceipt) -> Acti
         amount: 1_000_000u128,
         memo: serde_json::to_string(&Ics20WithdrawalFromRollup {
             memo: "nootwashere".to_string(),
-            rollup_return_address: receipt.from.to_string(),
+            rollup_return_address: receipt.from.encode_hex(),
             rollup_block_number: receipt.block_number.unwrap().as_u64(),
             rollup_withdrawal_event_id: format!("{rollup_transaction_hash}.{event_index}"),
         })


### PR DESCRIPTION
## Summary
Use the full hex encoded sender of the smart contract event as the rollup return address in the ics20 withdrawal event memo.

## Background
Before this patch, the `astria.protocol.memos::v1::Ics20WithdrawalFromRollup` memo used the abbreviated form of the ethers contract event sender, making it impossible to return funds if necessary. Specifically, the field was set as `rollupReturnAddress":"0xc59a…2d94"`

After this patch, the full address is used, making it possible to identify the sender.

## Changes
- change the event conversion logic to use `AbiEncode::encode_hex()` instead of `H160::to_string()`
- update the black box test mock to also do this

## Breaking Changelist
- This is a breaking change because two differerent versions of bridge-withdrawer will produce different sequencer transactions.

## Related Issues
Original issue where this was first encountered but not fixed: #1427 
