### PR TITLE
feat(bridge-withdrawer): add ics20 withdrawal timeout duration option to withdrawer

### DIFF
--- a/charts/evm-bridge-withdrawer/Chart.yaml
+++ b/charts/evm-bridge-withdrawer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0-rc.2
+version: 1.0.0-rc.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/evm-bridge-withdrawer/templates/configmaps.yaml
+++ b/charts/evm-bridge-withdrawer/templates/configmaps.yaml
@@ -34,6 +34,7 @@ data:
   {{- if not .Values.global.dev }}
   {{- else }}
   ASTRIA_BRIDGE_WITHDRAWER_USE_COMPAT_ADDRESS: "{{ .Values.config.useCompatAddress }}"
+  ASTRIA_BRIDGE_WITHDRAWER_ICS20_WITHDRAWAL_TIMEOUT_DURATION: "{{ .Values.config.ics20WithdrawalTimeoutDuration }}"
   {{- end }}
 ---
 {{- if not .Values.secretProvider.enabled }}

--- a/charts/evm-bridge-withdrawer/values.yaml
+++ b/charts/evm-bridge-withdrawer/values.yaml
@@ -21,6 +21,7 @@ config:
   sequencerChainId: ""
   sequencerAddressPrefix: "astria"
   sequencerBridgeAddress: ""
+  ics20WithdrawalTimeoutDuration: "300"
   useCompatAddress: "false"
   feeAssetDenom: ""
   minExpectedFeeAssetBalance: "1000000"

--- a/charts/evm-stack/Chart.lock
+++ b/charts/evm-stack/Chart.lock
@@ -13,12 +13,12 @@ dependencies:
   version: 0.1.2
 - name: evm-bridge-withdrawer
   repository: file://../evm-bridge-withdrawer
-  version: 1.0.0-rc.2
+  version: 1.0.0-rc.3
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 15.2.4
 - name: blockscout-stack
   repository: https://blockscout.github.io/helm-charts
   version: 1.6.2
-digest: sha256:bbb5436bef71e57402482f74e2d2deabec5e4d957845bcb743b710ca49e2dc78
-generated: "2024-10-22T10:51:25.483623794-04:00"
+digest: sha256:420ca23dfb51268f78881086b018d875c72047a61bf1a82613cc4a92729f6580
+generated: "2024-10-22T19:25:34.641345415-04:00"

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -34,7 +34,7 @@ dependencies:
     repository: "file://../evm-faucet"
     condition: evm-faucet.enabled
   - name: evm-bridge-withdrawer
-    version: 1.0.0-rc.2
+    version: 1.0.0-rc.3
     repository: "file://../evm-bridge-withdrawer"
     condition: evm-bridge-withdrawer.enabled
   - name: postgresql

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.2
+version: 0.7.3
 
 dependencies:
   - name: celestia-node

--- a/crates/astria-bridge-withdrawer/local.env.example
+++ b/crates/astria-bridge-withdrawer/local.env.example
@@ -48,6 +48,9 @@ ASTRIA_BRIDGE_WITHDRAWER_ROLLUP_ASSET_DENOMINATION="nria"
 # Should match the bridge address in the geth rollup's bridge configuration for that asset.
 ASTRIA_BRIDGE_WITHDRAWER_SEQUENCER_BRIDGE_ADDRESS=""
 
+# The timeout duration for `Ics20Withdrawal`s in seconds.
+ASTRIA_BRIDGE_WITHDRAWER_ICS20_WITHDRAWAL_TIMEOUT_DURATION=300
+
 # Whether to use compat addresses for `Ics20Withdrawal`s.
 ASTRIA_BRIDGE_WITHDRAWER_USE_COMPAT_ADDRESS=false
 

--- a/crates/astria-bridge-withdrawer/src/bridge_withdrawer/ethereum/watcher.rs
+++ b/crates/astria-bridge-withdrawer/src/bridge_withdrawer/ethereum/watcher.rs
@@ -61,6 +61,7 @@ pub(crate) struct Builder {
     pub(crate) state: Arc<State>,
     pub(crate) rollup_asset_denom: asset::TracePrefixed,
     pub(crate) bridge_address: Address,
+    pub(crate) timeout_duration: Duration,
     pub(crate) use_compat_address: bool,
     pub(crate) submitter_handle: submitter::Handle,
 }
@@ -75,6 +76,7 @@ impl Builder {
             state,
             rollup_asset_denom,
             bridge_address,
+            timeout_duration,
             use_compat_address,
             submitter_handle,
         } = self;
@@ -87,6 +89,7 @@ impl Builder {
             ethereum_rpc_endpoint: ethereum_rpc_endpoint.to_string(),
             rollup_asset_denom,
             bridge_address,
+            timeout_duration,
             use_compat_address,
             state,
             shutdown_token: shutdown_token.clone(),
@@ -105,6 +108,7 @@ pub(crate) struct Watcher {
     ethereum_rpc_endpoint: String,
     rollup_asset_denom: asset::TracePrefixed,
     bridge_address: Address,
+    timeout_duration: Duration,
     use_compat_address: bool,
     state: Arc<State>,
 }
@@ -149,6 +153,7 @@ impl Watcher {
             ethereum_rpc_endpoint,
             rollup_asset_denom,
             bridge_address,
+            timeout_duration,
             use_compat_address,
             state,
         } = self;
@@ -225,6 +230,7 @@ impl Watcher {
             .bridge_address(bridge_address)
             .sequencer_asset_to_withdraw(rollup_asset_denom.clone().into())
             .set_ics20_asset_to_withdraw(ics20_asset_to_withdraw)
+            .timeout_duration(timeout_duration)
             .use_compat_address(use_compat_address)
             .try_build()
             .await

--- a/crates/astria-bridge-withdrawer/src/bridge_withdrawer/mod.rs
+++ b/crates/astria-bridge-withdrawer/src/bridge_withdrawer/mod.rs
@@ -85,6 +85,7 @@ impl BridgeWithdrawer {
             rollup_asset_denomination,
             sequencer_bridge_address,
             sequencer_grpc_endpoint,
+            ics20_withdrawal_timeout_duration,
             use_compat_address,
             ..
         } = cfg;
@@ -141,6 +142,7 @@ impl BridgeWithdrawer {
             rollup_asset_denom: rollup_asset_denomination,
             bridge_address: sequencer_bridge_address,
             use_compat_address,
+            timeout_duration: Duration::from_secs(ics20_withdrawal_timeout_duration),
             submitter_handle,
         }
         .build()

--- a/crates/astria-bridge-withdrawer/src/config.rs
+++ b/crates/astria-bridge-withdrawer/src/config.rs
@@ -26,6 +26,8 @@ pub struct Config {
     pub rollup_asset_denomination: asset::denom::TracePrefixed,
     // The bridge address corresponding to the bridged rollup asset on the sequencer.
     pub sequencer_bridge_address: String,
+    // The timeout duration for `Ics20Withdrawal`s in seconds.
+    pub ics20_withdrawal_timeout_duration: u64,
     // Whether to use compat addresses for `Ics20Withdrawal`s.
     pub use_compat_address: bool,
     // The address of the AstriaWithdrawer contract on the evm rollup.

--- a/crates/astria-bridge-withdrawer/tests/blackbox/helpers/test_bridge_withdrawer.rs
+++ b/crates/astria-bridge-withdrawer/tests/blackbox/helpers/test_bridge_withdrawer.rs
@@ -275,6 +275,7 @@ impl TestBridgeWithdrawerConfig {
             fee_asset_denomination: asset_denom.clone(),
             rollup_asset_denomination: asset_denom.as_trace_prefixed().unwrap().clone(),
             sequencer_bridge_address: default_bridge_address().to_string(),
+            ics20_withdrawal_timeout_duration: 300,
             use_compat_address: false,
             ethereum_contract_address: ethereum.contract_address(),
             ethereum_rpc_endpoint: ethereum.ws_endpoint(),


### PR DESCRIPTION
## Summary
add ics20 withdrawal timeout duration option to withdrawer.

## Background
potentially useful for testing the timeout path of ics20 transfers.

## Changes
- add ics20 withdrawal timeout duration option to withdrawer

## Testing
existing unit tests; can't really test this fully without an actual ibc connection/smoke test setup

