### PR TITLE
fix(charts): local blockscout

### DIFF
--- a/charts/evm-stack/Chart.lock
+++ b/charts/evm-stack/Chart.lock
@@ -19,6 +19,6 @@ dependencies:
   version: 15.2.4
 - name: blockscout-stack
   repository: https://blockscout.github.io/helm-charts
-  version: 1.6.2
-digest: sha256:b0f9adad7d8a55f86ebd7b2e7aeb4f5b479b5b38a6c423ff013b9a5a57446f4d
-generated: "2024-11-01T11:28:14.128143-07:00"
+  version: 1.6.8
+digest: sha256:6f78f78158a72ac9edc9c6c1d9b1d52b30e04a49fdc7c8f70ed01cf5a5c92f6a
+generated: "2024-11-04T18:43:55.201062+02:00"

--- a/charts/evm-stack/Chart.lock
+++ b/charts/evm-stack/Chart.lock
@@ -20,5 +20,5 @@ dependencies:
 - name: blockscout-stack
   repository: https://blockscout.github.io/helm-charts
   version: 1.6.8
-digest: sha256:6f78f78158a72ac9edc9c6c1d9b1d52b30e04a49fdc7c8f70ed01cf5a5c92f6a
-generated: "2024-11-04T18:43:55.201062+02:00"
+digest: sha256:d7d13d546b7c02594756cc24511f95316bd9e8664a5d336b551e22e70332a0d8
+generated: "2024-11-07T11:31:10.563322+02:00"

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -43,7 +43,7 @@ dependencies:
     condition: postgresql.enabled
   - name: blockscout-stack
     repository: "https://blockscout.github.io/helm-charts"
-    version: "1.6.2"
+    version: "1.6.8"
     condition: blockscout-stack.enabled
 
 

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
 
 dependencies:
   - name: celestia-node

--- a/charts/evm-stack/values.yaml
+++ b/charts/evm-stack/values.yaml
@@ -83,11 +83,10 @@ evm-bridge-withdrawer:
     traceHeaders: "{{ .Values.global.otel.traceHeaders }}"
 
 blockscout-stack:
+  enabled: false
   frontend:
     image:
-      tag: v1.32.0
-  enabled: false
-
+      tag: v1.35.2
 
 postgresql:
   enabled: false

--- a/dev/values/rollup/dev.yaml
+++ b/dev/values/rollup/dev.yaml
@@ -176,13 +176,14 @@ postgresql:
 blockscout-stack:
   enabled: true
   config:
-    id: 1337
-    name: Astria
-    shortname: Astria
-    currency:
-      name: RIA
-      symbol: RIA
-      decimals: 18
+    network:
+      id: 1337
+      name: Astria
+      shortname: Astria
+      currency:
+        name: RIA
+        symbol: RIA
+        decimals: 18
     testnet: true
     prometheus:
       enabled: false
@@ -212,19 +213,28 @@ blockscout-stack:
         value: "byzantium,constantinople,petersburg,istanbul,berlin,paris,shanghai,default"
       - name: DISABLE_EXCHANGE_RATES
         value: "true"
-      - name: COIN
-        value: "RIA"
 
     ingress:
       enabled: true
       hostname: explorer.astria.localdev.me
+      paths:
+        - path: /api
+          pathType: Prefix
+        - path: /socket
+          pathType: Prefix
+        - path: /sitemap.xml
+          pathType: ImplementationSpecific
+        - path: /public-metrics
+          pathType: Prefix
+        - path: /auth/auth0
+          pathType: Exact
+        - path: /auth/auth0/callback
+          pathType: Exact
+        - path: /auth/logout
+          pathType: Exact
 
   frontend:
     extraEnv:
-      - name: NEXT_PUBLIC_NETWORK_NAME
-        value: "Astria Flame"
-      - name: NEXT_PUBLIC_NETWORK_SHORT_NAME
-        value: "Flame"
       - name: NEXT_PUBLIC_NETWORK_VERIFICATION_TYPE
         value: "validation"
       - name: NEXT_PUBLIC_AD_BANNER_PROVIDER
@@ -233,12 +243,8 @@ blockscout-stack:
         value: "http"
       - name: NEXT_PUBLIC_API_WEBSOCKET_PROTOCOL
         value: "ws"
-      - name: NEXT_PUBLIC_NETWORK_CURRENCY_NAME
-        value: "Ria"
       - name: NEXT_PUBLIC_NETWORK_CURRENCY_WEI_NAME
         value: "aRia"
-      - name: NEXT_PUBLIC_NETWORK_CURRENCY_SYMBOL
-        value: "RIA"
       - name: NEXT_PUBLIC_AD_TEXT_PROVIDER
         value: "none"
     ingress:


### PR DESCRIPTION
## Summary
fixes error in local rollup deployment through the cluster
## Background
On running `just deploy-dev-rollup` helm throws an ingress pathType error. This PR fixes the error other warnings.

## Changes
- bump blockscout app version
- changes sitemap.xml pathType to `ImplementationSpecific`

## Testing
locally against the cluster with smoke tests.
