### PR TITLE
feat(ci): add non native asset Ibc test 

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -230,6 +230,38 @@ jobs:
           TAG=sha-$(git rev-parse --short HEAD)
           just ibc-test run $TAG
 
+  ibc-no-native-asset-test:
+    needs: [ run_checker, composer, conductor, sequencer, sequencer-relayer, evm-bridge-withdrawer, cli ]
+    if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'astriaorg/astria') && (github.event_name == 'merge_group' || needs.run_checker.outputs.run_docker == 'true')
+    runs-on: buildjet-8vcpu-ubuntu-2204
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install just
+        uses: taiki-e/install-action@just
+      - name: Install kind
+        uses: helm/kind-action@v1
+        with:
+          install_only: true
+      - name: Log in to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup IBC Bridge Test Environment
+        timeout-minutes: 8
+        run: |
+          TAG=sha-$(git rev-parse --short HEAD)
+          just deploy cluster
+          kubectl create secret generic regcred --from-file=.dockerconfigjson=$HOME/.docker/config.json --type=kubernetes.io/dockerconfigjson
+          echo -e "\n\nDeploying with astria images tagged $TAG"
+          just ibc-test deploy-without-native $TAG
+      - name: Run IBC utia as native test
+        timeout-minutes: 3
+        run: |
+          TAG=sha-$(git rev-parse --short HEAD)
+          just ibc-test run-without-native $TAG
+
   docker:
     if: ${{ always() && !cancelled() }}
     needs: [composer, conductor, sequencer, sequencer-relayer, evm-bridge-withdrawer, cli, smoke-test, smoke-cli, ibc-bridge-test]

--- a/charts/ibc-test.just
+++ b/charts/ibc-test.just
@@ -58,7 +58,7 @@ run-without-native tag=defaultTag:
   ASTRIA_CLI_IMAGE="{{cli_image}}{{ if tag != '' { replace(':#', '#', tag) } else { '' } }}"
 
   # Execute the transfer from Celestia to the Rollup
-  just ibc-test _do-compat-ibc-transfer {{defaultNamespace}} {{sequencer_sudo_address}}
+  just ibc-test _do-ibc-transfer {{defaultNamespace}} {{sequencer_sudo_address}}
 
   # Add transfer/channel-0/utia as fee-asset
   docker run --rm --network host $ASTRIA_CLI_IMAGE sequencer sudo fee-asset add --private-key {{sequencer_sudo_pkey}} --asset transfer/channel-0/utia --sequencer-url {{sequencer_rpc_url}} --sequencer.chain-id {{sequencer_chain_id}}
@@ -93,7 +93,7 @@ run tag=defaultTag:
   just init-ibc-bridge {{sequencer_tia_bridge_pkey}} transfer/channel-0/utia nria {{tag}}
 
   # Execute the transfer from Celestia to the Rollup
-  just ibc-test _do-ibc-transfer
+  just ibc-test _do-rollup-ibc-transfer
 
   # Multiplication factor is 10^-6 (utia to tia) * 10^18 (rollup factor) = 10^12
   let expected_balance="$initial_balance + {{transfer_amount}} * 10**12"
@@ -118,7 +118,7 @@ run tag=defaultTag:
   fi
 
   # Execute the transfer from Celstia to sequencer with compat address
-  just ibc-test _do-compat-ibc-transfer {{defaultNamespace}} {{compat_address}}
+  just ibc-test _do-ibc-transfer {{defaultNamespace}} {{compat_address}}
 
   # check that celestia balance updated correctly
   for i in {1..50}
@@ -248,7 +248,7 @@ transfer_fees := "26000"
 # TODO: move this to deploy.just so that defaultNamespace need not be redefined
 defaultNamespace := "astria-dev-cluster"
 [no-cd]
-_do-ibc-transfer namespace=defaultNamespace:
+_do-rollup-ibc-transfer namespace=defaultNamespace:
   echo "Performing IBC transfer..."
   kubectl exec -n {{namespace}} pods/celestia-local-0 celestia-app -- /bin/bash -c \
   'celestia-appd tx ibc-transfer transfer \
@@ -265,7 +265,7 @@ _do-ibc-transfer namespace=defaultNamespace:
     --home /home/celestia \
     --keyring-backend="{{keyring_backend}}"'
 
-_do-compat-ibc-transfer namespace=defaultNamespace toAddress="":
+_do-ibc-transfer namespace=defaultNamespace toAddress="":
   echo "Performing IBC transfer with compat address..."
   kubectl exec -n {{namespace}} pods/celestia-local-0 celestia-app -- /bin/bash -c \
   'celestia-appd tx ibc-transfer transfer \

--- a/charts/ibc-test.just
+++ b/charts/ibc-test.just
@@ -34,6 +34,53 @@ delete:
   just deploy hermes-local > /dev/null
   kubectl wait -n astria-dev-cluster deployment hermes-local-chart --for=condition=Available=True --timeout=480s
 
+@deploy-without-native tag=defaultTag:
+  echo "Deploying ingress controller..." && just deploy-ingress-controller > /dev/null
+  just wait-for-ingress-controller > /dev/null
+  echo "Deploying local celestia instance..." && just deploy celestia-local > /dev/null
+  helm dependency update ./sequencer > /dev/null
+  echo "Setting up single astria sequencer..." && helm install \
+    -n astria-validator-single single-sequencer-chart ./sequencer \
+    -f ../dev/values/validators/all-without-native.yml \
+    -f ../dev/values/validators/single.yml \
+    {{ if tag != '' { replace('--set images.sequencer.devTag=# --set sequencer-relayer.images.sequencerRelayer.devTag=#', '#', tag) } else { '' } }} \
+    --create-namespace > /dev/null
+  just wait-for-sequencer > /dev/null
+  echo "Deploying Hermes"
+  just deploy hermes-local > /dev/null
+  kubectl wait -n astria-dev-cluster deployment hermes-local-chart --for=condition=Available=True --timeout=480s
+
+[no-cd]
+run-without-native tag=defaultTag:
+  #!/usr/bin/env bash
+  set -e
+
+  ASTRIA_CLI_IMAGE="{{cli_image}}{{ if tag != '' { replace(':#', '#', tag) } else { '' } }}"
+
+  # Execute the transfer from Celestia to the Rollup
+  just ibc-test _do-compat-ibc-transfer {{defaultNamespace}} {{sequencer_sudo_address}}
+
+  # Add transfer/channel-0/utia as fee-asset
+  docker run --rm --network host $ASTRIA_CLI_IMAGE sequencer sudo fee-asset add --private-key {{sequencer_sudo_pkey}} --asset transfer/channel-0/utia --sequencer-url {{sequencer_rpc_url}} --sequencer.chain-id {{sequencer_chain_id}}
+  # check that sequencer balance updated correctly
+  
+  EXPECTED_BALANCE=$(echo "1 * {{transfer_amount}}" | bc)
+  for i in {1..50}
+  do
+    BALANCE=$(docker run --rm --network host $ASTRIA_CLI_IMAGE sequencer account balance {{sequencer_sudo_address}} --sequencer-url {{sequencer_rpc_url}}  | awk '/transfer\/channel-0\/utia/{print $(NF-1)}')
+    echo "check $i, balance: $BALANCE, Expected: $EXPECTED_BALANCE"
+    if [ "$BALANCE" == "$EXPECTED_BALANCE" ]; then
+      expected_sequencer_balance_found="1"
+      break
+    else
+      sleep 1
+    fi
+  done
+  if [[ -z $expected_sequencer_balance_found ]]; then
+    echo "expected sequencer balance was not found after IBC transfer; IBC transfer with compat address failed"
+    exit 1
+  fi
+
 [no-cd]
 run tag=defaultTag:
   #!/usr/bin/env bash
@@ -71,7 +118,7 @@ run tag=defaultTag:
   fi
 
   # Execute the transfer from Celstia to sequencer with compat address
-  just ibc-test _do-compat-ibc-transfer
+  just ibc-test _do-compat-ibc-transfer {{defaultNamespace}} {{compat_address}}
 
   # check that celestia balance updated correctly
   for i in {1..50}
@@ -166,8 +213,11 @@ run tag=defaultTag:
 
 bridge_address := "astria1d7zjjljc0dsmxa545xkpwxym86g8uvvwhtezcr"
 sequencer_address := "astria1cewd7alwml4fhx3w3lxq3vgf20cqe0qm650fac"
+sequencer_sudo_pkey := "2bd806c97f0e00af1a1fc3328fa763a9269723c8db8fac4f93af71db186d6e90"
+sequencer_sudo_address := "astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm"
 compat_address := "astriacompat1cewd7alwml4fhx3w3lxq3vgf20cqe0qmdzxmvn"
 celestia_dev_account_address := "celestia1m0ksdjl2p5nzhqy3p47fksv52at3ln885xvl96"
+sequencer_chain_id := "sequencer-test-chain-0"
 celestia_chain_id := "celestia-local-0"
 celestia_node_url := "http://rpc.app.celestia.localdev.me:80"
 sequencer_tia_bridge_pkey := "6015fbe1c365d3c5ef92dc891db8c5bb26ad454bec2db4762b96e9f8b2430285"
@@ -215,13 +265,13 @@ _do-ibc-transfer namespace=defaultNamespace:
     --home /home/celestia \
     --keyring-backend="{{keyring_backend}}"'
 
-_do-compat-ibc-transfer namespace=defaultNamespace:
+_do-compat-ibc-transfer namespace=defaultNamespace toAddress="":
   echo "Performing IBC transfer with compat address..."
   kubectl exec -n {{namespace}} pods/celestia-local-0 celestia-app -- /bin/bash -c \
   'celestia-appd tx ibc-transfer transfer \
     transfer \
     channel-0 \
-    {{compat_address}} \
+    {{toAddress}} \
     "{{transfer_amount}}utia" \
     --chain-id="{{celestia_chain_id}}" \
     --from="{{celestia_dev_account_address}}" \

--- a/charts/sequencer/Chart.yaml
+++ b/charts/sequencer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0-rc.2
+version: 1.0.0-rc.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/sequencer/values.yaml
+++ b/charts/sequencer/values.yaml
@@ -34,7 +34,6 @@ genesis:
     base: "astria"
     ibcCompat: "astriacompat"
   authoritySudoAddress: ""
-  nativeAssetBaseDenomination: nria
   allowedFeeAssets: []
     # - nria
   ibc:

--- a/dev/values/validators/all-without-native.yml
+++ b/dev/values/validators/all-without-native.yml
@@ -1,0 +1,41 @@
+global:
+  dev: true
+
+genesis:
+  chainId: 'sequencer-test-chain-0'
+  genesisTime: '2023-09-22T17:22:35.092832Z'
+  addressPrefixes:
+    base: "astria"
+  authoritySudoAddress: astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm
+  allowedFeeAssets:
+    - nria
+  ibc:
+    enabled: true
+    inboundEnabled: true
+    outboundEnabled: true
+    sudoAddress: astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm
+    relayerAddresses:
+      - astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm
+      - astria1xnlvg0rle2u6auane79t4p27g8hxnj36ja960z
+  # Note large balances must be strings support templating with the u128 size
+  # account balances
+  genesisAccounts: []
+
+resources:
+  cometbft:
+    requests:
+      cpu: 1000m
+      memory: 500Mi
+    limits:
+      cpu: 1000m
+      memory: 500Mi
+  sequencer:
+    requests:
+      cpu: 1000m
+      memory: 500Mi
+    limits:
+      cpu: 1000m
+      memory: 500Mi
+
+storage:
+  enabled: false

--- a/dev/values/validators/all-without-native.yml
+++ b/dev/values/validators/all-without-native.yml
@@ -7,8 +7,6 @@ genesis:
   addressPrefixes:
     base: "astria"
   authoritySudoAddress: astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm
-  allowedFeeAssets:
-    - nria
   ibc:
     enabled: true
     inboundEnabled: true


### PR DESCRIPTION
## Summary
This PR adds an ibc-test to CI, Testing the functionality of sequencer network initialized without a native aset.

## Changes
- adds smoke test for non native asset case

## Testing
locally against a cluster, running the new ibc-test just commands

