### PR TITLE
chore: remove redundant bin entries from all crates' Cargo.toml

### DIFF
--- a/crates/astria-bridge-withdrawer/Cargo.toml
+++ b/crates/astria-bridge-withdrawer/Cargo.toml
@@ -8,9 +8,6 @@ readme = "README.md"
 repository = "https://github.com/astriaorg/astria"
 homepage = "https://astria.org"
 
-[[bin]]
-name = "astria-bridge-withdrawer"
-
 [dependencies]
 http = "0.2.9"
 

--- a/crates/astria-cli/Cargo.toml
+++ b/crates/astria-cli/Cargo.toml
@@ -8,9 +8,6 @@ readme = "README.md"
 repository = "https://github.com/astriaorg/astria"
 homepage = "https://astria.org"
 
-[[bin]]
-name = "astria-cli"
-
 [dependencies]
 color-eyre = "0.6"
 # v2.0.0-rc.0 - can be updated once https://github.com/ZcashFoundation/frost/issues/755 is closed

--- a/crates/astria-composer/Cargo.toml
+++ b/crates/astria-composer/Cargo.toml
@@ -8,9 +8,6 @@ readme = "README.md"
 repository = "https://github.com/astriaorg/astria"
 homepage = "https://astria.org"
 
-[[bin]]
-name = "astria-composer"
-
 [dependencies]
 astria-build-info = { path = "../astria-build-info", features = ["runtime"] }
 astria-core = { path = "../astria-core", features = [

--- a/crates/astria-conductor/Cargo.toml
+++ b/crates/astria-conductor/Cargo.toml
@@ -8,9 +8,6 @@ readme = "README.md"
 repository = "https://github.com/astriaorg/astria"
 homepage = "https://astria.org"
 
-[[bin]]
-name = "astria-conductor"
-
 [dependencies]
 astria-build-info = { path = "../astria-build-info", features = ["runtime"] }
 astria-core = { path = "../astria-core", features = [

--- a/crates/astria-sequencer-relayer/Cargo.toml
+++ b/crates/astria-sequencer-relayer/Cargo.toml
@@ -8,9 +8,6 @@ readme = "README.md"
 repository = "https://github.com/astriaorg/astria"
 homepage = "https://astria.org"
 
-[[bin]]
-name = "astria-sequencer-relayer"
-
 [dependencies]
 bech32 = "0.11.0"
 http = "0.2.9"

--- a/crates/astria-sequencer/Cargo.toml
+++ b/crates/astria-sequencer/Cargo.toml
@@ -8,9 +8,6 @@ readme = "README.md"
 repository = "https://github.com/astriaorg/astria"
 homepage = "https://astria.org"
 
-[[bin]]
-name = "astria-sequencer"
-
 [features]
 benchmark = ["divan"]
 


### PR DESCRIPTION
## Summary
Removes redundant `[[bin]]` entries in all crates' `Cargo.toml`.

## Background
Rust crates with a `main.rs` default to the name of the crate when naming it binaries. An extra entry that uses the same name is redundant and confusing.

## Changes
Remove all `[[bin]]` entries from all crates' `Cargo.toml`.

## Testing
Docker builds still run. In practice nothing has changed.