### PR TITLE
feat(charts): faster celestia blocktime In ibc-test

### DIFF
--- a/charts/celestia-local/Chart.yaml
+++ b/charts/celestia-local/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.3
+version: 0.6.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/celestia-local/files/scripts/init-celestia-appd.sh
+++ b/charts/celestia-local/files/scripts/init-celestia-appd.sh
@@ -62,3 +62,6 @@ sed -i'.bak' 's#"null"#"kv"#g' "${home_dir}"/config/config.toml
 sed -i'.bak' 's#discard_abci_responses = true#discard_abci_responses = false#g' "${home_dir}"/config/config.toml
 # Override the VotingPeriod from 1 week to 1 minute
 sed -i'.bak' 's#"604800s"#"60s"#g' "${home_dir}"/config/genesis.json
+if $fast; then
+  sed -i'.bak' 's#timeout_commit = "11s"#timeout_commit = "1s"#g' "${home_dir}"/config/config.toml
+fi

--- a/charts/celestia-local/templates/configmap.yaml
+++ b/charts/celestia-local/templates/configmap.yaml
@@ -21,6 +21,7 @@ data:
   ibc_account_key_name: "{{ .Values.ibcAccountKeyName }}"
   dev_account_mnemonic: "{{ .Values.devAccountMnemonic }}"
   dev_account_key_name: "{{ .Values.devAccountName }}"
+  fast: "{{ .Values.fast }}"
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/charts/celestia-local/values.yaml
+++ b/charts/celestia-local/values.yaml
@@ -47,6 +47,7 @@ ibcAccountMnemonic: globe elegant people render embark whisper pumpkin local thi
 # address celestia1m0ksdjl2p5nzhqy3p47fksv52at3ln885xvl96
 devAccountName: "dev-account"
 devAccountMnemonic: enrich avocado local net will avoid dizzy truth column excuse ready lesson
+fast: false
 
 # Default service ports
 ports:

--- a/charts/ibc-test.just
+++ b/charts/ibc-test.just
@@ -9,6 +9,21 @@ delete:
   -just delete hermes-local
   -just delete rollup
 
+_base-deploy tag=defaultTag:
+  echo "Deploying ingress controller..." && just deploy-ingress-controller > /dev/null
+  just wait-for-ingress-controller > /dev/null
+  echo "Deploying local celestia instance..."
+  helm install celestia-local-chart ./celestia-local --namespace {{defaultNamespace}} --set fast=true --create-namespace  > /dev/null
+  helm dependency update ./sequencer > /dev/null
+  helm dependency update ./evm-stack > /dev/null
+  echo "Setting up single astria sequencer..." && helm install \
+    -n astria-validator-single single-sequencer-chart ./sequencer \
+    -f ../dev/values/validators/all.yml \
+    -f ../dev/values/validators/single.yml \
+    {{ if tag != '' { replace('--set images.sequencer.devTag=# --set sequencer-relayer.images.sequencerRelayer.devTag=#', '#', tag) } else { '' } }} \
+    --create-namespace > /dev/null
+  just wait-for-sequencer > /dev/null
+
 @deploy tag=defaultTag:
   echo "Deploying ingress controller..." && just deploy-ingress-controller > /dev/null
   just wait-for-ingress-controller > /dev/null
@@ -38,7 +53,8 @@ delete:
 @deploy-without-native tag=defaultTag:
   echo "Deploying ingress controller..." && just deploy-ingress-controller > /dev/null
   just wait-for-ingress-controller > /dev/null
-  echo "Deploying local celestia instance..." && just deploy celestia-local > /dev/null
+  echo "Deploying local celestia instance..."
+  helm install celestia-local-chart ./celestia-local --namespace {{defaultNamespace}} --set fast=true --create-namespace  > /dev/null
   helm dependency update ./sequencer > /dev/null
   echo "Setting up single astria sequencer..." && helm install \
     -n astria-validator-single single-sequencer-chart ./sequencer \
@@ -54,7 +70,8 @@ delete:
 @deploy-timeout tag=defaultTag:
   echo "Deploying ingress controller..." && just deploy-ingress-controller > /dev/null
   just wait-for-ingress-controller > /dev/null
-  echo "Deploying local celestia instance..." && just deploy celestia-local > /dev/null
+  echo "Deploying local celestia instance..." > /dev/null
+  helm install celestia-local-chart ./celestia-local --namespace {{defaultNamespace}} --set fast=true --create-namespace  > /dev/null
   helm dependency update ./sequencer > /dev/null
   helm dependency update ./evm-stack > /dev/null
   echo "Setting up single astria sequencer..." && helm install \
@@ -374,8 +391,8 @@ run-timeout tag=defaultTag:
   # There are some acknowledgements flying back and forth which make creating a height
   # that is a timeout without being stale with a client update a challenge without
   # waiting for acknowledgements to settle. This is a hack.
-  echo "Waiting for 30 seconds to allow for acknowledgements to settle..."
-  sleep 30
+  echo "Waiting for 5 seconds to allow for acknowledgements to settle..."
+  sleep 15
 
   # Grabbing the current celestia block height and resetting the timeout height of the withdrawal
   # to one lower to force an immediate timeout which should create a refund event.

--- a/charts/ibc-test.just
+++ b/charts/ibc-test.just
@@ -12,7 +12,8 @@ delete:
 @deploy tag=defaultTag:
   echo "Deploying ingress controller..." && just deploy-ingress-controller > /dev/null
   just wait-for-ingress-controller > /dev/null
-  echo "Deploying local celestia instance..." && just deploy celestia-local > /dev/null
+  echo "Deploying local celestia instance..."
+  helm install celestia-local-chart ./celestia-local --namespace {{defaultNamespace}} --set fast=true --create-namespace  > /dev/null
   helm dependency update ./sequencer > /dev/null
   helm dependency update ./evm-stack > /dev/null
   echo "Setting up single astria sequencer..." && helm install \

--- a/charts/ibc-test.just
+++ b/charts/ibc-test.just
@@ -9,21 +9,6 @@ delete:
   -just delete hermes-local
   -just delete rollup
 
-_base-deploy tag=defaultTag:
-  echo "Deploying ingress controller..." && just deploy-ingress-controller > /dev/null
-  just wait-for-ingress-controller > /dev/null
-  echo "Deploying local celestia instance..."
-  helm install celestia-local-chart ./celestia-local --namespace {{defaultNamespace}} --set fast=true --create-namespace  > /dev/null
-  helm dependency update ./sequencer > /dev/null
-  helm dependency update ./evm-stack > /dev/null
-  echo "Setting up single astria sequencer..." && helm install \
-    -n astria-validator-single single-sequencer-chart ./sequencer \
-    -f ../dev/values/validators/all.yml \
-    -f ../dev/values/validators/single.yml \
-    {{ if tag != '' { replace('--set images.sequencer.devTag=# --set sequencer-relayer.images.sequencerRelayer.devTag=#', '#', tag) } else { '' } }} \
-    --create-namespace > /dev/null
-  just wait-for-sequencer > /dev/null
-
 @deploy tag=defaultTag:
   echo "Deploying ingress controller..." && just deploy-ingress-controller > /dev/null
   just wait-for-ingress-controller > /dev/null
@@ -392,7 +377,7 @@ run-timeout tag=defaultTag:
   # that is a timeout without being stale with a client update a challenge without
   # waiting for acknowledgements to settle. This is a hack.
   echo "Waiting for 5 seconds to allow for acknowledgements to settle..."
-  sleep 15
+  sleep 5
 
   # Grabbing the current celestia block height and resetting the timeout height of the withdrawal
   # to one lower to force an immediate timeout which should create a refund event.

--- a/charts/ibc-test.just
+++ b/charts/ibc-test.just
@@ -394,7 +394,8 @@ run-timeout tag=defaultTag:
   docker volume remove cli-test-withdrawals
 
   # Validate that the Celestia balance timed out
-  for i in {1..30}
+  echo "Checking for 10 seconds to ensure that Celestia balance does not update"
+  for i in {1..10}
   do
     current_celestia_balance=$(just ibc-test get-celestia-balance)
     echo "check $i, balance: $current_celestia_balance, if failure balance: $expected_celestia_balance"


### PR DESCRIPTION
## Summary
adds a configurable value to set celestia timeout_commit to `1s` speeding bridge-tests
## Background
setting up hermes channels in CI bridge-test is slow, speeding up celestia blocktime will help reduce setup time.
## Changes
added a `fast` flag to `celestia-local`, when set to true will configure celestia with a block time of `1s`. Configured `ibc-test` in CI to use the new flag.

## Testing
against a local cluster

