### PR TITLE
chore(sequencer): init allowed assets in fees component

### DIFF
--- a/crates/astria-sequencer/src/accounts/component.rs
+++ b/crates/astria-sequencer/src/accounts/component.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use astria_core::protocol::genesis::v1::GenesisAppState;
 use astria_eyre::eyre::{
+    OptionExt as _,
     Result,
     WrapErr as _,
 };
@@ -33,7 +34,11 @@ impl Component for AccountsComponent {
             let native_asset = state
                 .get_native_asset()
                 .await
-                .wrap_err("failed to read native asset from state")?;
+                .wrap_err("failed to read native asset from state")?
+                .ok_or_eyre(
+                    "native asset does not exist in state but is required to set genesis account \
+                     balances",
+                )?;
             for account in app_state.accounts() {
                 state
                     .put_account_balance(&account.address, &native_asset, account.balance)

--- a/crates/astria-sequencer/src/accounts/state_ext.rs
+++ b/crates/astria-sequencer/src/accounts/state_ext.rs
@@ -597,7 +597,7 @@ mod tests {
         // native account should work with ibc too
         state.put_native_asset(nria()).unwrap();
 
-        let asset_0 = state.get_native_asset().await.unwrap();
+        let asset_0 = state.get_native_asset().await.unwrap().unwrap();
         let asset_1 = asset_1();
         let asset_2 = asset_2();
 

--- a/crates/astria-sequencer/src/app/mod.rs
+++ b/crates/astria-sequencer/src/app/mod.rs
@@ -111,7 +111,6 @@ use crate::{
         component::FeesComponent,
         construct_tx_fee_event,
         StateReadExt as _,
-        StateWriteExt as _,
     },
     grpc::StateWriteExt as _,
     ibc::component::IbcComponent,
@@ -304,12 +303,6 @@ impl App {
         state_tx
             .put_block_height(0)
             .wrap_err("failed to write block height to state")?;
-
-        for fee_asset in genesis_state.allowed_fee_assets() {
-            state_tx
-                .put_allowed_fee_asset(fee_asset)
-                .wrap_err("failed to write allowed fee asset to state")?;
-        }
 
         // call init_chain on all components
         FeesComponent::init_chain(&mut state_tx, &genesis_state)

--- a/crates/astria-sequencer/src/app/tests_app/mod.rs
+++ b/crates/astria-sequencer/src/app/tests_app/mod.rs
@@ -112,7 +112,7 @@ async fn app_genesis_and_init_chain() {
 
     assert_eq!(
         app.state.get_native_asset().await.unwrap(),
-        "nria".parse::<TracePrefixed>().unwrap()
+        Some("nria".parse::<TracePrefixed>().unwrap()),
     );
 }
 

--- a/crates/astria-sequencer/src/fees/component.rs
+++ b/crates/astria-sequencer/src/fees/component.rs
@@ -28,6 +28,12 @@ impl Component for FeesComponent {
     where
         S: fees::StateWriteExt + fees::StateReadExt,
     {
+        for fee_asset in app_state.allowed_fee_assets() {
+            state
+                .put_allowed_fee_asset(fee_asset)
+                .wrap_err("failed to write allowed fee asset to state")?;
+        }
+
         let transfer_fees = app_state.fees().transfer;
         if let Some(transfer_fees) = transfer_fees {
             state

--- a/crates/astria-sequencer/src/mempool/mempool_state.rs
+++ b/crates/astria-sequencer/src/mempool/mempool_state.rs
@@ -56,7 +56,7 @@ mod tests {
         // native account should work with ibc too
         state.put_native_asset(nria()).unwrap();
 
-        let asset_0 = state.get_native_asset().await.unwrap();
+        let asset_0 = state.get_native_asset().await.unwrap().unwrap();
         let asset_1: Denom = "asset_0".parse().unwrap();
         let asset_2: Denom = "asset_1".parse().unwrap();
 


### PR DESCRIPTION
## Summary
Moves the initialization of allowed assets from the overall app to the fees component.

## Background
https://github.com/astriaorg/astria/pull/1647 moved fee asset state handling to the new `fees` component. It was overlooked that writing allowed fee assets should also happen in its init chain logic.

## Changes
- Move initialization of app init state to the fees component.

## Testing
Nothing has changed in terms of how the state is represented. Tests that rely on init chain still work.

## Breaking Changelist
This is not a breaking change because the state after this change looks the same.