### PR TITLE
fix(charts): template evm-bridge-withdrawer objects names

### DIFF
--- a/charts/deploy.just
+++ b/charts/deploy.just
@@ -145,7 +145,7 @@ delete-bridge-withdrawer:
   @just delete chart evm-bridge-withdrawer astria-dev-cluster
 
 wait-for-bridge-withdrawer:
-  kubectl wait -n astria-dev-cluster deployment evm-bridge-withdrawer --for=condition=Available=True --timeout=600s
+  kubectl wait -n astria-dev-cluster deployment evm-bridge-withdrawer-local --for=condition=Available=True --timeout=600s
 
 defaultHypAgentConfig         := ""
 defaultHypRelayerPrivateKey   := ""

--- a/charts/evm-bridge-withdrawer/Chart.yaml
+++ b/charts/evm-bridge-withdrawer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0-rc.2
+version: 1.0.0-rc.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/evm-bridge-withdrawer/templates/_helpers.tpl
+++ b/charts/evm-bridge-withdrawer/templates/_helpers.tpl
@@ -13,7 +13,7 @@ Namepsace to deploy elements into.
 application name to deploy elements into.
 */}}
 {{- define "evm-bridge-withdrawer.appName" -}}
-evm-bridge-withdrawer
+evm-bridge-withdrawer-{{ .Values.global.serviceName }}
 {{- end }}
 
 {{/*

--- a/charts/evm-bridge-withdrawer/templates/configmaps.yaml
+++ b/charts/evm-bridge-withdrawer/templates/configmaps.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: evm-bridge-withdrawer-env
+  name: {{ include "evm-bridge-withdrawer.appName" . }}-env
   namespace: {{ include "evm-bridge-withdrawer.namespace" . }}
 data:
   ASTRIA_BRIDGE_WITHDRAWER_LOG: "astria_bridge_withdrawer=debug"
@@ -40,7 +40,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: evm-bridge-withdrawer-private-key
+  name: {{ include "evm-bridge-withdrawer.appName" . }}-private-key
   namespace: {{ include "evm-bridge-withdrawer.namespace" . }}
 data:
   {{ .Values.config.sequencerPrivateKey.secret.filename }}: |

--- a/charts/evm-bridge-withdrawer/templates/deployment.yaml
+++ b/charts/evm-bridge-withdrawer/templates/deployment.yaml
@@ -1,21 +1,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: evm-bridge-withdrawer
+  name: {{ include "evm-bridge-withdrawer.appName" . }}
   labels:
-    app: evm-bridge-withdrawer
+    {{ include "evm-bridge-withdrawer.selectorLabels" . }}
   namespace: {{ include "evm-bridge-withdrawer.namespace" . }}
 spec:
   replicas: {{ .Values.global.replicaCount }}
   selector:
     matchLabels:
-      app: evm-bridge-withdrawer
+      {{ include "evm-bridge-withdrawer.selectorLabels" . }}
   template:
     metadata:
       annotations:
       name: astria-sequencer
       labels:
-        app: evm-bridge-withdrawer
+        {{ include "evm-bridge-withdrawer.selectorLabels" . }}
     spec:
       containers:
         - name: evm-bridge-withdrawer
@@ -26,7 +26,7 @@ spec:
           tty: {{ .Values.global.useTTY }}
           envFrom:
             - configMapRef:
-                name: evm-bridge-withdrawer-env
+                name: {{ include "evm-bridge-withdrawer.appName" . }}-env
           volumeMounts:
             - mountPath: /secret/sequencerPrivateKey/
               name: sequencer-private-key-volume
@@ -53,8 +53,8 @@ spec:
             driver: secrets-store.csi.k8s.io
             readOnly: true
             volumeAttributes:
-              secretProviderClass: evm-bridge-withdrawer-key
+              secretProviderClass: {{ include "evm-bridge-withdrawer.appName" . }}-key
           {{- else }}
           configMap:
-            name: evm-bridge-withdrawer-private-key
+            name: {{ include "evm-bridge-withdrawer.appName" . }}-private-key
           {{- end }}

--- a/charts/evm-bridge-withdrawer/templates/prometheusrule.yaml
+++ b/charts/evm-bridge-withdrawer/templates/prometheusrule.yaml
@@ -2,7 +2,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: evm-bridge-withdrawer-alerting
+  name: {{ include "evm-bridge-withdrawer.appName" . }}-alerting
 {{- if .Values.alerting.prometheusRule.namespace }}
   namespace: {{ .Values.alerting.prometheusRule.namespace | quote }}
 {{- end }}

--- a/charts/evm-bridge-withdrawer/templates/secretproviderclass.yaml
+++ b/charts/evm-bridge-withdrawer/templates/secretproviderclass.yaml
@@ -3,7 +3,7 @@
 apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
-  name: evm-bridge-withdrawer-key
+  name: {{ include "evm-bridge-withdrawer.appName" . }}-key
 spec:
   provider: gcp
   parameters:

--- a/charts/evm-bridge-withdrawer/templates/service.yaml
+++ b/charts/evm-bridge-withdrawer/templates/service.yaml
@@ -2,7 +2,7 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: evm-bridge-withdrawer-metrics
+  name: {{ include "evm-bridge-withdrawer.appName" . }}-metrics
   namespace: {{ include "evm-bridge-withdrawer.namespace" . }}
   labels:
     {{- include "evm-bridge-withdrawer.labels" . | nindent 4 }}

--- a/charts/evm-bridge-withdrawer/templates/servicemonitor.yaml
+++ b/charts/evm-bridge-withdrawer/templates/servicemonitor.yaml
@@ -2,20 +2,20 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: evm-bridge-withdrawer-metrics
+  name: {{ include "evm-bridge-withdrawer.appName" . }}-metrics
   labels:
     app: evm-bridge-withdrawer
     {{- with .Values.serviceMonitor.additionalLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  jobLabel: evm-bridge-withdrawer-metric
+  jobLabel: {{ include "evm-bridge-withdrawer.appName" . }}-metric
   namespaceSelector:
     matchNames:
       - {{ include "evm-bridge-withdrawer.namespace" . }}
   selector:
     matchLabels:
-      app: evm-bridge-withdrawer
+    {{- include "evm-bridge-withdrawer.labels" . | nindent 4 }}
   endpoints:
     - port: metrics
       path: /

--- a/charts/evm-bridge-withdrawer/templates/servicemonitor.yaml
+++ b/charts/evm-bridge-withdrawer/templates/servicemonitor.yaml
@@ -15,7 +15,7 @@ spec:
       - {{ include "evm-bridge-withdrawer.namespace" . }}
   selector:
     matchLabels:
-    {{- include "evm-bridge-withdrawer.labels" . | nindent 4 }}
+      {{ include "evm-bridge-withdrawer.selectorLabels" . }}
   endpoints:
     - port: metrics
       path: /

--- a/charts/evm-bridge-withdrawer/values.yaml
+++ b/charts/evm-bridge-withdrawer/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 global:
   namespaceOverride: ""
-  serviceName: ""
+  serviceName: "local"
   replicaCount: 1
   useTTY: true
   dev: false

--- a/charts/evm-bridge-withdrawer/values.yaml
+++ b/charts/evm-bridge-withdrawer/values.yaml
@@ -3,6 +3,7 @@
 # Declare variables to be passed into your templates.
 global:
   namespaceOverride: ""
+  serviceName: ""
   replicaCount: 1
   useTTY: true
   dev: false

--- a/charts/evm-stack/Chart.lock
+++ b/charts/evm-stack/Chart.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 0.1.2
 - name: evm-bridge-withdrawer
   repository: file://../evm-bridge-withdrawer
-  version: 1.0.0-rc.2
+  version: 1.0.0-rc.3
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 15.2.4

--- a/charts/evm-stack/Chart.lock
+++ b/charts/evm-stack/Chart.lock
@@ -20,5 +20,5 @@ dependencies:
 - name: blockscout-stack
   repository: https://blockscout.github.io/helm-charts
   version: 1.6.2
-digest: sha256:cbef2e78861e88ca4396d44dc1d96a7b27c32c691896ed16097a1081d63c6d91
-generated: "2024-10-24T14:29:08.887894+03:00"
+digest: sha256:117d452966a5efe4e5809c8f21b4966a29a616b333cef566b20ec259c0268a0d
+generated: "2024-10-24T20:13:17.502491+03:00"

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.3
+version: 0.7.4
 
 dependencies:
   - name: celestia-node

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -34,7 +34,7 @@ dependencies:
     repository: "file://../evm-faucet"
     condition: evm-faucet.enabled
   - name: evm-bridge-withdrawer
-    version: 1.0.0-rc.2
+    version: 1.0.0-rc.3
     repository: "file://../evm-bridge-withdrawer"
     condition: evm-bridge-withdrawer.enabled
   - name: postgresql


### PR DESCRIPTION
## Summary
Templates `evm-bridge-withdrawer` objects names.
## Background
The `evm-bridge-withdrawer` chart has hard coded name for objects in it, causing resource sharing conflicts for same namespace deployments. With this PR, objects will now be configurable with a `serviceName` variable to avoid resource sharing.
## Changes
- adds new serviceName configarble value
- templated all objects names with `serviceName`
- small fixes to labels

## Testing
Changes were initially done to support multiple bridge-withdrawer on devnet and testnet. Thus, changes were tested against `dusk-11` & `dawn-1 ` as well as local testing.
