### PR TITLE
fix(core): replace todo by implementation

### DIFF
--- a/crates/astria-core/src/protocol/transaction/v1/mod.rs
+++ b/crates/astria-core/src/protocol/transaction/v1/mod.rs
@@ -306,8 +306,33 @@ impl Protobuf for TransactionBody {
             .map_err(TransactionBodyError::group)
     }
 
+    fn into_raw(self) -> raw::TransactionBody {
+        let Self {
+            actions,
+            params,
+        } = self;
+        let actions = actions
+            .into_actions()
+            .into_iter()
+            .map(Action::into_raw)
+            .collect();
+        raw::TransactionBody {
+            actions,
+            params: Some(params.into_raw()),
+        }
+    }
+
     fn to_raw(&self) -> Self::Raw {
-        todo!()
+        let Self {
+            actions,
+            params,
+        } = self;
+        let actions = actions.actions().iter().map(Action::to_raw).collect();
+        let params = params.clone().into_raw();
+        raw::TransactionBody {
+            actions,
+            params: Some(params),
+        }
     }
 }
 
@@ -350,41 +375,12 @@ impl TransactionBody {
         }
     }
 
-    pub fn into_raw(self) -> raw::TransactionBody {
-        let Self {
-            actions,
-            params,
-        } = self;
-        let actions = actions
-            .into_actions()
-            .into_iter()
-            .map(Action::into_raw)
-            .collect();
-        raw::TransactionBody {
-            actions,
-            params: Some(params.into_raw()),
-        }
-    }
-
     #[must_use]
     pub fn into_any(self) -> pbjson_types::Any {
         let raw = self.into_raw();
         pbjson_types::Any {
             type_url: raw::TransactionBody::type_url(),
             value: raw.encode_to_vec().into(),
-        }
-    }
-
-    pub fn to_raw(&self) -> raw::TransactionBody {
-        let Self {
-            actions,
-            params,
-        } = self;
-        let actions = actions.actions().iter().map(Action::to_raw).collect();
-        let params = params.clone().into_raw();
-        raw::TransactionBody {
-            actions,
-            params: Some(params),
         }
     }
 


### PR DESCRIPTION
## Summary
Actually implements the `Protobuf::to_raw` trait method on the `TransactionBody` domain type.

## Background
`<TranasctionBody as Protobuf>::to_raw` was not implemented, and instead contained a `todo!()` macro. If called, this would panic at runtime which is a problem.

At the time of writing this was not a problem in the codbase because the method was not called. But it's very bad style to have that as part of a public API.

## Changes
- Replace the inherent methods `TransctionBody::to_raw` and `TransactionBody::into_raw` by the `Protobuf for TransactionBody` impl, fixing the bad `todo!()` in its `Protobuf::to_raw` trait method.
