### PR TITLE
fix(charts): genesis template

### DIFF
--- a/charts/sequencer/Chart.yaml
+++ b/charts/sequencer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0-rc.3
+version: 1.0.0-rc.4
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/sequencer/files/cometbft/config/genesis.json
+++ b/charts/sequencer/files/cometbft/config/genesis.json
@@ -5,62 +5,88 @@
     "native_asset_base_denomination": "{{ .Values.genesis.nativeAssetBaseDenomination }}",
     {{- end }}
     "fees": {
-      "bridge_lock": {
-        "base": {{ include "sequencer.toUint128Proto" .Values.genesis.fees.bridgeLock.base }},
-        "multiplier": {{ include "sequencer.toUint128Proto" .Values.genesis.fees.bridgeLock.multiplier }}
-      },
-      "bridge_sudo_change": {
-        "base": {{ include "sequencer.toUint128Proto" .Values.genesis.fees.bridgeSudoChange.base }},
-        "multiplier": {{ include "sequencer.toUint128Proto" .Values.genesis.fees.bridgeSudoChange.multiplier }}
-      },
-      "bridge_unlock": {
-        "base": {{ include "sequencer.toUint128Proto" .Values.genesis.fees.bridgeUnlock.base }},
-        "multiplier": {{ include "sequencer.toUint128Proto" .Values.genesis.fees.bridgeUnlock.multiplier }}
-      },
-      "fee_asset_change": {
-        "base": {{ include "sequencer.toUint128Proto" .Values.genesis.fees.feeAssetChange.base }},
-        "multiplier": {{ include "sequencer.toUint128Proto" .Values.genesis.fees.feeAssetChange.multiplier }}
-      },
       "fee_change": {
         "base": {{ include "sequencer.toUint128Proto" .Values.genesis.fees.feeChange.base }},
         "multiplier": {{ include "sequencer.toUint128Proto" .Values.genesis.fees.feeChange.multiplier }}
       },
+      {{- if .Values.genesis.fees.bridgeLock }}
+      "bridge_lock": {
+        "base": {{ include "sequencer.toUint128Proto" .Values.genesis.fees.bridgeLock.base }},
+        "multiplier": {{ include "sequencer.toUint128Proto" .Values.genesis.fees.bridgeLock.multiplier }}
+      },
+      {{- end }}
+      {{- if .Values.genesis.fees.bridgeSudoChange }}
+      "bridge_sudo_change": {
+        "base": {{ include "sequencer.toUint128Proto" .Values.genesis.fees.bridgeSudoChange.base }},
+        "multiplier": {{ include "sequencer.toUint128Proto" .Values.genesis.fees.bridgeSudoChange.multiplier }}
+      },
+      {{- end }}
+      {{- if .Values.genesis.fees.bridgeUnlock }}
+      "bridge_unlock": {
+        "base": {{ include "sequencer.toUint128Proto" .Values.genesis.fees.bridgeUnlock.base }},
+        "multiplier": {{ include "sequencer.toUint128Proto" .Values.genesis.fees.bridgeUnlock.multiplier }}
+      },
+      {{- end }}
+      {{- if .Values.genesis.fees.feeAssetChange }}
+      "fee_asset_change": {
+        "base": {{ include "sequencer.toUint128Proto" .Values.genesis.fees.feeAssetChange.base }},
+        "multiplier": {{ include "sequencer.toUint128Proto" .Values.genesis.fees.feeAssetChange.multiplier }}
+      },
+      {{- end }}
+      {{- if .Values.genesis.fees.ibcRelay }}
       "ibc_relay": {
         "base": {{ include "sequencer.toUint128Proto" .Values.genesis.fees.ibcRelay.base }},
         "multiplier": {{ include "sequencer.toUint128Proto" .Values.genesis.fees.ibcRelay.multiplier }}
       },
+      {{- end }}
+      {{- if .Values.genesis.fees.ibcRelayerChange }}
       "ibc_relayer_change": {
         "base": {{ include "sequencer.toUint128Proto" .Values.genesis.fees.ibcRelayerChange.base }},
         "multiplier": {{ include "sequencer.toUint128Proto" .Values.genesis.fees.ibcRelayerChange.multiplier }}
       },
+      {{- end }}
+      {{- if .Values.genesis.fees.ibcSudoChange }}
       "ibc_sudo_change": {
         "base": {{ include "sequencer.toUint128Proto" .Values.genesis.fees.ibcSudoChange.base }},
         "multiplier": {{ include "sequencer.toUint128Proto" .Values.genesis.fees.ibcSudoChange.multiplier }}
       },
+      {{- end }}
+      {{- if .Values.genesis.fees.ics20Withdrawal }}
       "ics20_withdrawal": {
         "base": {{ include "sequencer.toUint128Proto" .Values.genesis.fees.ics20Withdrawal.base }},
         "multiplier": {{ include "sequencer.toUint128Proto" .Values.genesis.fees.ics20Withdrawal.multiplier }}
       },
+      {{- end }}
+      {{- if .Values.genesis.fees.initBridgeAccount }}
       "init_bridge_account": {
         "base": {{ include "sequencer.toUint128Proto" .Values.genesis.fees.initBridgeAccount.base }},
         "multiplier": {{ include "sequencer.toUint128Proto" .Values.genesis.fees.initBridgeAccount.multiplier }}
       },
+      {{- end }}
+      {{- if .Values.genesis.fees.rollupDataSubmission }}
       "rollup_data_submission": {
         "base": {{ include "sequencer.toUint128Proto" .Values.genesis.fees.rollupDataSubmission.base }},
         "multiplier": {{ include "sequencer.toUint128Proto" .Values.genesis.fees.rollupDataSubmission.multiplier }}
       },
+      {{- end }}
+      {{- if .Values.genesis.fees.sudoAddressChange }}
       "sudo_address_change": {
         "base": {{ include "sequencer.toUint128Proto" .Values.genesis.fees.sudoAddressChange.base }},
         "multiplier": {{ include "sequencer.toUint128Proto" .Values.genesis.fees.sudoAddressChange.multiplier }}
       },
+      {{- end }}
+      {{- if .Values.genesis.fees.transfer }}
       "transfer": {
         "base": {{ include "sequencer.toUint128Proto" .Values.genesis.fees.transfer.base }},
         "multiplier": {{ include "sequencer.toUint128Proto" .Values.genesis.fees.transfer.multiplier }}
       },
+      {{- end }}
+      {{- if .Values.genesis.fees.validatorUpdate }}
       "validator_update": {
         "base": {{ include "sequencer.toUint128Proto" .Values.genesis.fees.validatorUpdate.base }},
         "multiplier": {{ include "sequencer.toUint128Proto" .Values.genesis.fees.validatorUpdate.multiplier }}
       }
+      {{- end }}
     },
     "allowed_fee_assets": [
       {{- range $index, $value := .Values.genesis.allowedFeeAssets }}

--- a/charts/sequencer/files/cometbft/config/genesis.json
+++ b/charts/sequencer/files/cometbft/config/genesis.json
@@ -1,7 +1,9 @@
 {
   "app_hash": "",
   "app_state": {
+    {{- if .Values.genesis.nativeAssetBaseDenomination }}
     "native_asset_base_denomination": "{{ .Values.genesis.nativeAssetBaseDenomination }}",
+    {{- end }}
     "fees": {
       "bridge_lock": {
         "base": {{ include "sequencer.toUint128Proto" .Values.genesis.fees.bridgeLock.base }},

--- a/charts/sequencer/values.yaml
+++ b/charts/sequencer/values.yaml
@@ -55,6 +55,9 @@ genesis:
     maxBytes: "1048576"
 
   fees:
+    feeChange:
+      base: "0"
+      multiplier: "0"
     bridgeLock:
       base: "0"
       multiplier: "1"
@@ -65,9 +68,6 @@ genesis:
       base: "0"
       multiplier: "0"
     feeAssetChange:
-      base: "0"
-      multiplier: "0"
-    feeChange:
       base: "0"
       multiplier: "0"
     ibcRelay:


### PR DESCRIPTION
## Summary
changes genesis to allow configuring each fee component, also make `nativeAssetBaseDenomination ` an optional field
## Background
Fees can now be added after genesis, meaning we no longer have to define them all in it. 
Also in case `nativeAssetBaseDenomination` is unset, it will not be used when initiating the state and thus should not appear in `genesis.json.
## Changes
- added an if statement to remove the field in case it is nil
- can now set / unset all fees except `feeChange` in genesis

## Testing
locally with helm template command 
