### PR TITLE
feat(chart): add auctioneer chart and just commands

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -49,7 +49,7 @@ jobs:
       id-token: write
       packages: write
     with:
-      depot-project-id: abcdefghij # TODO: change this to the correct depot project ID
+      depot-project-id: 1kp2p2bvbr
       package-name: auctioneer
       binary-name: auctioneer
       tag: ${{ inputs.tag }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -40,22 +40,6 @@ jobs:
   run_checker:
     uses: ./.github/workflows/reusable-run-checker.yml
 
-  auctioneer:
-    needs: run_checker
-    if: needs.run_checker.outputs.run_docker == 'true' || (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'auctioneer')
-    uses: "./.github/workflows/reusable-docker-build.yml"
-    permissions:
-      contents: read
-      id-token: write
-      packages: write
-    with:
-      depot-project-id: 1kp2p2bvbr
-      package-name: auctioneer
-      binary-name: auctioneer
-      tag: ${{ inputs.tag }}
-      force: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'auctioneer' }}
-    secrets: inherit
-
   composer:
     needs: run_checker
     if: needs.run_checker.outputs.run_docker == 'true' || (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'composer')
@@ -313,7 +297,7 @@ jobs:
 
   docker:
     if: ${{ always() && !cancelled() }}
-    needs: [auctioneer, composer, conductor, sequencer, sequencer-relayer, evm-bridge-withdrawer, cli, smoke-test, smoke-cli, ibc-bridge-test, ibc-no-native-asset-test, ibc-timeout-refund]
+    needs: [composer, conductor, sequencer, sequencer-relayer, evm-bridge-withdrawer, cli, smoke-test, smoke-cli, ibc-bridge-test, ibc-no-native-asset-test, ibc-timeout-refund]
     uses: ./.github/workflows/reusable-success.yml
     with:
       success: ${{ !contains(needs.*.result, 'failure') }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -12,6 +12,7 @@ on:
         required: false
         type: choice
         options:
+          - auctioneer
           - composer
           - conductor
           - sequencer
@@ -38,6 +39,22 @@ on:
 jobs:
   run_checker:
     uses: ./.github/workflows/reusable-run-checker.yml
+
+  auctioneer:
+    needs: run_checker
+    if: needs.run_checker.outputs.run_docker == 'true' || (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'auctioneer')
+    uses: "./.github/workflows/reusable-docker-build.yml"
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    with:
+      depot-project-id: abcdefghij # TODO: change this to the correct depot project ID
+      package-name: auctioneer
+      binary-name: auctioneer
+      tag: ${{ inputs.tag }}
+      force: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'auctioneer' }}
+    secrets: inherit
 
   composer:
     needs: run_checker
@@ -296,7 +313,7 @@ jobs:
 
   docker:
     if: ${{ always() && !cancelled() }}
-    needs: [composer, conductor, sequencer, sequencer-relayer, evm-bridge-withdrawer, cli, smoke-test, smoke-cli, ibc-bridge-test, ibc-no-native-asset-test, ibc-timeout-refund]
+    needs: [auctioneer, composer, conductor, sequencer, sequencer-relayer, evm-bridge-withdrawer, cli, smoke-test, smoke-cli, ibc-bridge-test, ibc-no-native-asset-test, ibc-timeout-refund]
     uses: ./.github/workflows/reusable-success.yml
     with:
       success: ${{ !contains(needs.*.result, 'failure') }}

--- a/charts/auctioneer/Chart.yaml
+++ b/charts/auctioneer/Chart.yaml
@@ -22,3 +22,7 @@ version: 0.0.1
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "0.0.1"
+
+maintainers:
+  - name: itamarreif
+    url: astria.org

--- a/charts/auctioneer/Chart.yaml
+++ b/charts/auctioneer/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: auctioneer
+description: Astria auctioneer helm chart
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.0.1
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.0.1"

--- a/charts/auctioneer/templates/_helpers.tpl
+++ b/charts/auctioneer/templates/_helpers.tpl
@@ -16,14 +16,14 @@ auctioneer
 Common labels
 */}}
 {{- define "auctioneer.labels" -}}
-{{ include "rollup.selectorLabels" . }}
+{{ include "auctioneer.selectorLabels" . }}
 {{- end }}
 
 {{/*
 Selector labels
 */}}
 {{- define "auctioneer.selectorLabels" -}}
-app: {{ include "rollup.appName" . }}
+app: {{ include "auctioneer.appName" . }}
 {{- end }}
 
 {{- define "auctioneer.image" -}}

--- a/charts/auctioneer/templates/_helpers.tpl
+++ b/charts/auctioneer/templates/_helpers.tpl
@@ -1,0 +1,31 @@
+{{/*
+Namepsace to deploy elements into.
+*/}}
+{{- define "auctioneer.namespace" -}}
+{{- default .Release.Namespace .Values.global.namespaceOverride | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{/*
+application name to deploy elements into.
+*/}}
+{{- define "auctioneer.appName" -}}
+auctioneer
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "auctioneer.labels" -}}
+{{ include "rollup.selectorLabels" . }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "auctioneer.selectorLabels" -}}
+app: {{ include "rollup.appName" . }}
+{{- end }}
+
+{{- define "auctioneer.image" -}}
+{{ .Values.images.auctioneer.repo }}:{{ if .Values.global.dev }}{{ .Values.images.auctioneer.devTag }}{{ else }}{{ .Values.images.auctioneer.tag }}{{ end }}
+{{- end }}

--- a/charts/auctioneer/templates/configmap.yaml
+++ b/charts/auctioneer/templates/configmap.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: auctioneer-env
+  namespace: {{ include "auctioneer.namespace" . }}
+data:
+  ASTRIA_AUCTIONEER_SEQUENCER_GRPC_ENDPOINT: "{{ .Values.config.sequencerGrpcEndpoint }}"
+  ASTRIA_AUCTIONEER_SEQUENCER_ABCI_ENDPOINT: "{{ .Values.config.sequencerAbciEndpoint }}"
+  ASTRIA_AUCTIONEER_SEQUENCER_CHAIN_ID: "{{ .Values.config.sequencerChainId }}"
+  ASTRIA_AUCTIONEER_SEQUENCER_PRIVATE_KEY_PATH: "/var/secrets/{{ .Values.config.sequencerPrivateKey.secret.filename }}"
+  ASTRIA_AUCTIONEER_FEE_ASSET_DENOMINATION: "{{ .Values.config.feeAssetDenomination }}"
+  ASTRIA_AUCTIONEER_SEQUENCER_ADDRESS_PREFIX: "{{ .Values.config.sequencerAddressPrefix }}"
+  ASTRIA_AUCTIONEER_ROLLUP_GRPC_ENDPOINT: "{{ .Values.config.rollupGrpcEndpoint }}"
+  ASTRIA_AUCTIONEER_ROLLUP_ID: "{{ .Values.config.rollupId }}"
+  ASTRIA_AUCTIONEER_LATENCY_MARGIN_MS: "{{ .Values.config.latencyMarginMs }}"
+  ASTRIA_AUCTIONEER_LOG: "astria_auctioneer={{ .Values.config.logLevel }}"
+  ASTRIA_AUCTIONEER_FORCE_STDOUT: "{{ .Values.global.useTTY }}"
+  ASTRIA_AUCTIONEER_PRETTY_PRINT: "{{ .Values.global.useTTY }}"
+  NO_COLOR: "{{ .Values.global.useTTY }}"
+  ASTRIA_AUCTIONEER_NO_METRICS: "{{ not .Values.metrics.enabled }}"
+  ASTRIA_AUCTIONEER_METRICS_HTTP_LISTENER_ADDR: "0.0.0.0:{{ .Values.ports.metrics }}"
+  ASTRIA_AUCTIONEER_NO_OTEL: "{{ not .Values.otel.enabled }}"
+  ASTRIA_AUCTIONEER_NO_METRICS: "{{ not .Values.metrics.enabled }}"
+  ASTRIA_AUCTIONEER_METRICS_HTTP_LISTENER_ADDR: "0.0.0.0:{{ .Values.ports.metrics }}"
+  OTEL_EXPORTER_OTLP_ENDPOINT: "{{ tpl .Values.otel.endpoint . }}"
+  OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: "{{ tpl .Values.otel.tracesEndpoint . }}"
+  OTEL_EXPORTER_OTLP_TRACES_TIMEOUT: "{{ tpl .Values.otel.tracesTimeout . }}"
+  OTEL_EXPORTER_OTLP_TRACES_COMPRESSION: "{{ tpl .Values.otel.tracesCompression . }}"
+  OTEL_EXPORTER_OTLP_HEADERS: "{{ tpl .Values.otel.otlpHeaders . }}"
+  OTEL_EXPORTER_OTLP_TRACE_HEADERS: "{{ tpl .Values.otel.traceHeaders . }}"
+  OTEL_SERVICE_NAME: "{{ tpl .Values.otel.serviceName . }}"
+  {{- if not .Values.global.dev }}
+  {{- else }}
+  {{- end }}
+---
+{{- if not .Values.secretProvider.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: {{ include "auctioneer.namespace" .  }}
+  name: auctioneer-private-key
+data:
+  {{ .Values.config.sequencerPrivateKey.secret.filename }}: |
+    {{ .Values.config.sequencerPrivateKey.devContent }}
+---
+{{- end }}

--- a/charts/auctioneer/templates/deployment.yaml
+++ b/charts/auctioneer/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "auctioneer.appName " . }}
+  name: {{ include "auctioneer.appName" . }}
   namespace: {{ include "auctioneer.namespace" . }}
   labels:
     {{ include "auctioneer.labels" . }}

--- a/charts/auctioneer/templates/deployment.yaml
+++ b/charts/auctioneer/templates/deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: auctioneer
+  namespace: {{ include "auctioneer.namespace" . }}
+  labels:
+    app: auctioneer
+spec:
+  replicas: {{ .Values.global.replicaCount }}
+  selector:
+    matchLabels:
+      app: auctioneer
+  template:
+    metadata:
+      labels:
+        app: auctioneer
+    spec:
+      containers:
+        - name: auctioneer
+          image: {{ include "auctioneer.image" . }}
+          imagePullPolicy: {{ .Values.images.auctioneer.pullPolicy }}
+          command: ["/usr/local/bin/astria-auctioneer"]
+          stdin: {{ .Values.global.useTTY }}
+          tty: {{ .Values.global.useTTY }}
+          envFrom:
+            - configMapRef:
+                name: auctioneer-env
+          volumeMounts:
+            - mountPath: "/var/secrets"
+              name: auctioneer-private-key
+          {{- if .Values.metrics.enabled }}
+          ports:
+            - containerPort: {{ .Values.ports.metrics }}
+              name: auctioneer-metrics
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | trim | nindent 12 }}
+      volumes:
+        - name: auctioneer-private-key
+          {{- if .Values.secretProvider.enabled }}
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: auctioneer-private-key
+          {{- else }}
+          configMap:
+            name: auctioneer-private-key
+              {{- end }}

--- a/charts/auctioneer/templates/deployment.yaml
+++ b/charts/auctioneer/templates/deployment.yaml
@@ -1,19 +1,19 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: auctioneer
+  name: {{ include "auctioneer.appName " . }}
   namespace: {{ include "auctioneer.namespace" . }}
   labels:
-    app: auctioneer
+    {{ include "auctioneer.labels" . }}
 spec:
   replicas: {{ .Values.global.replicaCount }}
   selector:
     matchLabels:
-      app: auctioneer
+      {{ include "auctioneer.labels" . }}
   template:
     metadata:
       labels:
-        app: auctioneer
+        {{ include "auctioneer.labels" . }}
     spec:
       containers:
         - name: auctioneer

--- a/charts/auctioneer/templates/prometheusrule.yaml
+++ b/charts/auctioneer/templates/prometheusrule.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.alerting.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "auctioneer.appName" . }}-alerting
+{{- if .Values.alerting.prometheusRule.namespace }}
+  namespace: {{ .Values.alerting.prometheusRule.namespace | quote }}
+{{- end }}
+  labels:
+    {{- include "auctioneer.labels" . | nindent 4 }}
+  {{- if .Values.alerting.prometheusRule.additionalLabels }}
+    {{- toYaml .Values.alerting.prometheusRule.additionalLabels | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.alerting.prometheusRule.rules }}
+  groups:
+  - name: {{ template "auctioneer.appName" . }}
+    rules: {{- toYaml .Values.alerting.prometheusRule.rules | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/auctioneer/templates/secretproviderclass.yaml
+++ b/charts/auctioneer/templates/secretproviderclass.yaml
@@ -1,0 +1,13 @@
+---
+{{- if .Values.secretProvider.enabled }}
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: auctioneer-private-key
+spec:
+  provider: {{ .Values.secretProvider.provider }}
+  parameters:
+    {{- $_ := set $ "key" .Values.config.privateKey.secret }}
+    {{- tpl $.Values.secretProvider.parametersTemplate $ | nindent 4 }}
+---
+{{- end }}

--- a/charts/auctioneer/templates/service.yaml
+++ b/charts/auctioneer/templates/service.yaml
@@ -2,15 +2,15 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: auctioneer-metrics
+  name: {{ include "auctioneer.appName" . }}-metrics
   namespace: {{ include "auctioneer.namespace" . }}
   labels:
-    app: auctioneer
+    {{ include "auctioneer.labels" . }}
 spec:
   selector:
-    app: auctioneer
+    {{ include "auctioneer.selectorLabels" . }}
   ports:
-    - name: auctioneer-metrics
+    - name: metrics
       port: {{ .Values.ports.metrics }}
       targetPort: auctioneer-metrics
 {{- end }}

--- a/charts/auctioneer/templates/service.yaml
+++ b/charts/auctioneer/templates/service.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.metrics.enabled }}
+kind: Service
+apiVersion: v1
+metadata:
+  name: auctioneer-metrics
+  namespace: {{ include "auctioneer.namespace" . }}
+  labels:
+    app: auctioneer
+spec:
+  selector:
+    app: auctioneer
+  ports:
+    - name: auctioneer-metrics
+      port: {{ .Values.ports.metrics }}
+      targetPort: auctioneer-metrics
+{{- end }}

--- a/charts/auctioneer/templates/servicemonitor.yaml
+++ b/charts/auctioneer/templates/servicemonitor.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: auctioneer-metrics
+  labels:
+    {{- with .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  jobLabel: auctioneer-metrics
+  namespaceSelector:
+    matchNames:
+      - {{ include "auctioneer.namespace" . }}
+  selector:
+    matchLabels:
+      app: auctioneer
+  endpoints:
+    - port: auctioneer-metrics
+      path: /
+      {{- with .Values.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.scrapeTimeout  }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+{{- end }}

--- a/charts/auctioneer/values.yaml
+++ b/charts/auctioneer/values.yaml
@@ -1,0 +1,95 @@
+global:
+  namespaceOverride: ""
+  replicaCount: 1
+  # Whether to use tty readable logging for astria services, when false use json.
+  useTTY: false
+  dev: true
+
+images:
+  auctioneer:
+    repo: ghcr.io/astriaorg/astria-auctioneer
+    pullPolicy: IfNotPresent
+    tag: 1.0.0-rc.1
+    devTag: local
+
+config:
+  sequencerGrpcEndpoint: ""
+  sequencerAbciEndpoint: ""
+  sequencerChainId: ""
+  sequencerPrivateKey:
+    devContent: ""
+    secret:
+      filename: "key.hex"
+      resourceName: "projects/$PROJECT_ID/secrets/sequencerPrivateKey/versions/latest"
+  feeAssetDenomination: ""
+  sequencerAddressPrefix: astria
+  rollupGrpcEndpoint: ""
+  rollupId: ""
+  latencyMarginMs: ""
+  logLevel: "info"
+
+otel:
+  enabled: false
+  serviceName: "auctioneer"
+  endpoint: ""
+  tracesEndpoint: ""
+  tracesCompression: "gzip"
+  tracesTimeout: "10"
+  otlpHeaders: ""
+  traceHeaders: ""
+
+metrics:
+  enabled: false
+
+serviceMonitor:
+  # set to enable port svc and service monitor
+  enabled: false
+  port: 6060
+  additionalLabels:
+    release: kube-prometheus-stack
+
+alerting:
+  enabled: false
+  interval: ""
+  additionalLabels:
+    release: kube-prometheus-stack
+  annotations: {}
+  # scrapeTimeout: 10s
+  # path: /metrics
+  prometheusRule:
+    enabled: true
+    additionalLabels:
+      release: kube-prometheus-stack
+    namespace: monitoring
+    rules:
+    - alert: Auctioneer_Node_Down
+      expr: up{container="auctioneer"} == 0  # Insert your query Expression
+      for: 1m  # Rough number but should be enough to init warn
+      labels:
+        severity: warning
+      annotations:
+        summary: Auctioneer is Down (instance {{ $labels.instance }})
+        description: "auctioneer node '{{ $labels.namespace }}' has disappeared from Prometheus target discovery.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+
+# When deploying in a production environment should use a secret provider
+# This is configured for use with GCP, need to set own resource names
+# and keys
+secretProvider:
+  enabled: false
+  provider: gcp
+  parametersTemplate: |-
+    secrets: |
+      - resourceName: {{ .key.resourceName }}
+        fileName: "{{ .key.filename }}"
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 100Mi
+  limits:
+    cpu: 1000m
+    memory: 1Gi
+
+# Default service ports
+ports:
+  metrics: 6060

--- a/charts/auctioneer/values.yaml
+++ b/charts/auctioneer/values.yaml
@@ -3,14 +3,14 @@ global:
   replicaCount: 1
   # Whether to use tty readable logging for astria services, when false use json.
   useTTY: false
-  dev: true
+  dev: false
 
 images:
   auctioneer:
     repo: ghcr.io/astriaorg/astria-auctioneer
     pullPolicy: IfNotPresent
-    tag: 1.0.0-rc.1
-    devTag: local
+    tag: 0.0.1
+    devTag: 0.0.1
 
 config:
   sequencerGrpcEndpoint: ""

--- a/charts/deploy.just
+++ b/charts/deploy.just
@@ -145,9 +145,6 @@ deploy-auctioneer:
 delete-auctioneer:
   @just delete chart auctioneer astria-dev-cluster
 
-wait-for-auctioneer:
-  kubectl wait -n astria-dev-cluster deployment auctioneer --for=condition=Available=True --timeout=600s
-
 deploy-bridge-withdrawer:
   helm install evm-bridge-withdrawer-chart ./charts/evm-bridge-withdrawer \
     --namespace astria-dev-cluster \

--- a/charts/deploy.just
+++ b/charts/deploy.just
@@ -97,7 +97,7 @@ deploy-astrotrek:
     -n astria-dev-cluster \
 
 delete-astrotrek:
-  @just delete chart astrotrek 
+  @just delete chart astrotrek
 
 deploy-hermes-local:
   helm install hermes-local-chart ./charts/hermes \
@@ -135,6 +135,18 @@ delete-dev-rollup rollupName=defaultRollupName:
 
 wait-for-dev-rollup rollupName=defaultRollupName:
   kubectl rollout status --watch statefulset/{{rollupName}}-geth -n astria-dev-cluster --timeout=600s
+
+deploy-auctioneer:
+  helm dependency update charts/auctioneer > /dev/null
+  helm install auctioneer-chart ./charts/auctioneer \
+      --namespace astria-dev-cluster \
+      -f dev/values/auctioneer/values.yaml
+
+delete-auctioneer:
+  @just delete chart auctioneer astria-dev-cluster
+
+wait-for-auctioneer:
+  kubectl wait -n astria-dev-cluster deployment auctioneer --for=condition=Available=True --timeout=600s
 
 deploy-bridge-withdrawer:
   helm install evm-bridge-withdrawer-chart ./charts/evm-bridge-withdrawer \

--- a/charts/evm-rollup/Chart.yaml
+++ b/charts/evm-rollup/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/evm-rollup/templates/service.yaml
+++ b/charts/evm-rollup/templates/service.yaml
@@ -13,9 +13,9 @@ spec:
     - name: ws-rpc-svc
       port: {{ .Values.ports.wsRPC }}
       targetPort: ws-rpc
-      # TODO: fix this to match bharath's work in the geth repo
-    - name: bundle-grpc-svc
-    port: {{ .Values.ports.bundleGRPC }}
+    - name: execution-grpc-svc
+    # TODO: this service should be served over UDS
+      port: {{ .Values.ports.executionGRPC }}
       targetPort: bundle-grpc
 ---
 {{- if .Values.metrics.enabled }}

--- a/charts/evm-rollup/templates/service.yaml
+++ b/charts/evm-rollup/templates/service.yaml
@@ -13,6 +13,10 @@ spec:
     - name: ws-rpc-svc
       port: {{ .Values.ports.wsRPC }}
       targetPort: ws-rpc
+      # TODO: fix this to match bharath's work in the geth repo
+    - name: bundle-grpc-svc
+    port: {{ .Values.ports.bundleGRPC }}
+      targetPort: bundle-grpc
 ---
 {{- if .Values.metrics.enabled }}
 kind: Service

--- a/dev/values/auctioneer/values.yaml
+++ b/dev/values/auctioneer/values.yaml
@@ -14,7 +14,7 @@ config:
   feeAssetDenomination: "nria"
   sequencerAddressPrefix: astria
   rollupGrpcEndpoint: "http://astria-evm-service.astria-dev-cluster.svc.cluster.local:50051"
-  rollupId: "astriachain"
+  rollupId: "astria"
   latencyMarginMs: 1000
   logLevel: "debug"
 

--- a/dev/values/auctioneer/values.yaml
+++ b/dev/values/auctioneer/values.yaml
@@ -1,0 +1,28 @@
+global:
+  namespaceOverride: ""
+  replicaCount: 1
+  # Whether to use tty readable logging for astria services, when false use json.
+  useTTY: true
+  dev: true
+
+config:
+  sequencerGrpcEndpoint: "http://node0-sequencer-grpc-service.astria-dev-cluster.svc.cluster.local:8080"
+  sequencerAbciEndpoint: "http://node0-sequencer-rpc-service.astria-dev-cluster.svc.cluster.local:26657"
+  sequencerChainId: "sequencer-test-chain-0"
+  sequencerPrivateKey:
+    devContent: "b8da3289343cb92a235af079d74bae435f16272df38b9ab3ab468e62c632e2f8"
+  feeAssetDenomination: "nria"
+  sequencerAddressPrefix: astria
+  rollupGrpcEndpoint: "http://astria-evm-service.astria-dev-cluster.svc.cluster.local:50051"
+  rollupId: "astriachain"
+  latencyMarginMs: 1000
+  logLevel: "debug"
+
+otel:
+  enabled: false
+
+metrics:
+  enabled: false
+
+serviceMonitor:
+  enabled: false

--- a/dev/values/validators/all.yml
+++ b/dev/values/validators/all.yml
@@ -36,6 +36,9 @@ genesis:
     # address of the bridge account. needs funds to sign bridge init tx
     - address: astria1d7zjjljc0dsmxa545xkpwxym86g8uvvwhtezcr
       balance: "69000000"
+    # address of the auctioneer account. needs funds to submit auction results.
+    - address: astria1l5hg09ak99cfua5gu33j2m2se8eunv8nazyxtr
+      balance: "69000420"
 
 resources:
   cometbft:


### PR DESCRIPTION
## Summary
Adds a Helm chart for deploying the Auctioneer.

## Background
[PR #1556](https://github.com/astriaorg/astria/pull/1556) adds the auctioneer binary. This binary has clients to both rollup  and sequencer nodes.

## Changes
- Add the `charts/auctioneer` directory for the auctioneer binary
- Add commands to `charts/deploy.just` for deploying/deleting the auctioneer chart in our k8s cluster
- Add `dev/auctioneer/values.yaml` for dev values for the auctioneer.
- Add the auctioneer's dev wallet to the genesis allocations in `dev/validators/all.yaml` so that the auctioneer has a balance while testing against the dev cluster.
- Expose the bundle grpc service from the rollup chart so that the auctioneer can talk to it from within the cluster

## Testing
How are these changes tested?

## Breaking Changelist
- Bulleted list of breaking changes, any notes on migration. Delete section if none.

## Related Issues
Link any issues that are related, prefer full github links.

closes https://github.com/astriaorg/astria/issues/1766
