### PR TITLE
chore(sequencer-relayer): add metrics for recording Celestia fees

### DIFF
--- a/crates/astria-bridge-withdrawer/src/metrics.rs
+++ b/crates/astria-bridge-withdrawer/src/metrics.rs
@@ -46,18 +46,8 @@ impl Metrics {
         self.sequencer_submission_failure_count.increment(1);
     }
 
-    #[expect(
-        clippy::cast_precision_loss,
-        reason = "metric with potential loss of precision, logging when it occurs"
-    )]
     pub(crate) fn set_batch_total_settled_value(&self, value: u128) {
-        if value > u128::from(u32::MAX) {
-            tracing::warn!(
-                "{BATCH_TOTAL_SETTLED_VALUE} set with {value} which exceeds u32::MAX, precision \
-                 loss in metric"
-            );
-        }
-        self.batch_total_settled_value.set(value as f64);
+        self.batch_total_settled_value.set(value);
     }
 }
 

--- a/crates/astria-telemetry/Cargo.toml
+++ b/crates/astria-telemetry/Cargo.toml
@@ -32,15 +32,13 @@ serde_json = { workspace = true, optional = true }
 serde_with = { version = "3.7.0", optional = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+tracing = { workspace = true }
 tracing-opentelemetry = "0.23.0"
 tracing-subscriber = { version = "0.3.17", features = [
   "fmt",
   "env-filter",
   "json",
 ] }
-
-[dev-dependencies]
-tracing = { workspace = true }
 
 [features]
 display = [

--- a/crates/astria-telemetry/src/metrics/into_f64.rs
+++ b/crates/astria-telemetry/src/metrics/into_f64.rs
@@ -1,3 +1,9 @@
+use tracing::warn;
+
+/// This is 2^53; the upper bound for guaranteed absence of precision loss when casting from an
+/// integer to `f64`.
+const PRECISION_LOSS_THRESHOLD: f64 = 9_007_199_254_740_992.0;
+
 /// A trait to safely convert to `f64`.
 pub trait IntoF64 {
     /// Converts `self` to `f64`.
@@ -64,6 +70,38 @@ impl IntoF64 for usize {
         reason = "precision loss is unlikely (values too small) but also unimportant in metrics"
     )]
     fn into_f64(self) -> f64 {
-        self as f64
+        let value = self as f64;
+        if value > PRECISION_LOSS_THRESHOLD {
+            warn!("possible precision loss when casting {self}_usize to `f64`");
+        }
+        value
+    }
+}
+
+impl IntoF64 for u64 {
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "precision loss is unlikely (values too small) but also unimportant in metrics"
+    )]
+    fn into_f64(self) -> f64 {
+        let value = self as f64;
+        if value > PRECISION_LOSS_THRESHOLD {
+            warn!("possible precision loss when casting {self}_u64 to `f64`");
+        }
+        value
+    }
+}
+
+impl IntoF64 for u128 {
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "precision loss is unlikely (values too small) but also unimportant in metrics"
+    )]
+    fn into_f64(self) -> f64 {
+        let value = self as f64;
+        if value > PRECISION_LOSS_THRESHOLD {
+            warn!("possible precision loss when casting {self}_u128 to `f64`");
+        }
+        value
     }
 }


### PR DESCRIPTION
## Summary
This adds three new gauges to the relayer metrics to record the Celestia fees incurred in the latest submission: total fees, cost per uncompressed byte and cost per compressed byte.

## Background
The new metrics could provide useful information.

## Changes
- Added three new metrics.
- Provided `IntoF64` for `u64` (for one of the new metrics) and for `u128` (for a recently-added bridge-withdrawer metric)
- Added warnings to `IntoF64` impls which have the potential for precision loss

## Testing
Tests for metrics are generally still pending.  Checked the new metrics were being populated in a relayer on a local testnet.

Example output:

```
# HELP astria_sequencer_relayer_celestia_fees_total_utia The total Celestia fees in utia for the latest successful submission
# TYPE astria_sequencer_relayer_celestia_fees_total_utia gauge
astria_sequencer_relayer_celestia_fees_total_utia{service="astria-sequencer-relayer"} 186

# HELP astria_sequencer_relayer_celestia_fees_utia_per_uncompressed_blob_byte The Celestia fees in utia per uncompressed blob byte for the latest successful submission
# TYPE astria_sequencer_relayer_celestia_fees_utia_per_uncompressed_blob_byte gauge
astria_sequencer_relayer_celestia_fees_utia_per_uncompressed_blob_byte{service="astria-sequencer-relayer"} 0.07080319756376094

# HELP astria_sequencer_relayer_celestia_fees_utia_per_compressed_blob_byte The Celestia fees in utia per compressed blob byte for the latest successful submission
# TYPE astria_sequencer_relayer_celestia_fees_utia_per_compressed_blob_byte gauge
astria_sequencer_relayer_celestia_fees_utia_per_compressed_blob_byte{service="astria-sequencer-relayer"} 0.12836438923395446
```

## Metrics
New metrics:
- `astria_sequencer_relayer_celestia_fees_total_utia`
- `astria_sequencer_relayer_celestia_fees_utia_per_uncompressed_blob_byte`
- `astria_sequencer_relayer_celestia_fees_utia_per_compressed_blob_byte`

## Related Issues
Closes #1734.