### PR TITLE
fix(docker): correct local docker-build tag naming

### DIFF
--- a/justfile
+++ b/justfile
@@ -14,11 +14,11 @@ default_repo_name := 'ghcr.io/astriaorg'
 
 # Builds docker image for the crate. Defaults to 'local' tag.
 docker-build crate tag=default_docker_tag repo_name=default_repo_name:
-  docker buildx build --load --build-arg TARGETBINARY={{crate}} -f containerfiles/Dockerfile -t {{repo_name}}/{{crate}}:{{tag}} .
+  docker buildx build --load --build-arg TARGETBINARY={{crate}} -f containerfiles/Dockerfile -t {{repo_name}}/$(sed 's/^[^-]*-//' <<< {{crate}}):{{tag}} .
 
 docker-build-and-load crate tag=default_docker_tag repo_name=default_repo_name:
   @just docker-build {{crate}} {{tag}} {{repo_name}}
-  @just load-image {{crate}} {{tag}} {{repo_name}}
+  @just load-image $(sed 's/^[^-]*-//' <<< {{crate}}) {{tag}} {{repo_name}}
 
 # Installs the astria rust cli from local codebase
 install-cli:


### PR DESCRIPTION
## Summary
This pull request addresses an issue with the naming conventions used in the local Docker build process.

## Background
The build tags were previously not adhering to the expected naming scheme, leading to confusion and potential conflicts during chart deployment with local images using just commands.
## Changes
Updated the Docker build script to ensure tags are generated according to the standard chart naming convention.

## Testing
locally running and deploying the chart both using
-` just docker-build-and-load astria-sequencer`
- `docker-build astria-sequencer` && `just load-inage sequencer`

## Related Issues
closes #1743 
