### PR TITLE
chore: update `critical-section` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2134,9 +2134,9 @@ dependencies = [
 
 [[package]]
 name = "critical-section"
-version = "1.1.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f64009896348fc5af4222e9cf7d7d82a95a256c634ebcf61c53e4ea461422242"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-channel"


### PR DESCRIPTION
## Summary
Updated the version of  `critical-section`.

## Background
Running `cargo audit` yields a non-critical warning that `critical-section` v1.1.3 has been yanked.

## Changes
- Ran `cargo update -p critical-section` to increase the version to v1.2.0.

## Testing
Ran normal test suite, although I believe since this is only consumed by the threshold signing subcommands of `astria-cli` I expect unit tests don't cover this.  I manually ran the cli to create threshold keys, and sign and verify a file.
