### PR TITLE
feat(sequencer): allow querying fee components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -794,6 +794,7 @@ dependencies = [
 name = "astria-sequencer"
 version = "1.0.0-rc.2"
 dependencies = [
+ "assert-json-diff",
  "astria-build-info",
  "astria-config",
  "astria-core",

--- a/crates/astria-sequencer/Cargo.toml
+++ b/crates/astria-sequencer/Cargo.toml
@@ -81,6 +81,7 @@ paste = "1.0.15"
 maplit = "1.0.2"
 rand_chacha = "0.3.1"
 tokio = { workspace = true, features = ["test-util"] }
+assert-json-diff = "2.0.2"
 
 [build-dependencies]
 astria-build-info = { path = "../astria-build-info", features = ["build"] }

--- a/crates/astria-sequencer/src/fees/query.rs
+++ b/crates/astria-sequencer/src/fees/query.rs
@@ -42,6 +42,7 @@ use tendermint::abci::{
     Code,
 };
 use tokio::{
+    join,
     sync::OnceCell,
     try_join,
 };
@@ -129,6 +130,44 @@ pub(crate) async fn allowed_fee_assets_request(
         code: tendermint::abci::Code::Ok,
         key: request.path.into_bytes().into(),
         value: payload,
+        height,
+        ..response::Query::default()
+    }
+}
+
+pub(crate) async fn components(
+    storage: Storage,
+    request: request::Query,
+    _params: Vec<(String, String)>,
+) -> response::Query {
+    let snapshot = storage.latest_snapshot();
+
+    let height = async {
+        snapshot
+            .get_block_height()
+            .await
+            .wrap_err("failed getting block height")
+    };
+    let fee_components = get_all_fee_components(&snapshot).map(Ok);
+    let (height, fee_components) = match try_join!(height, fee_components) {
+        Ok(vals) => vals,
+        Err(err) => {
+            return response::Query {
+                code: Code::Err(AbciErrorCode::INTERNAL_ERROR.value()),
+                info: AbciErrorCode::INTERNAL_ERROR.info(),
+                log: format!("{err:#}"),
+                ..response::Query::default()
+            };
+        }
+    };
+
+    let height = tendermint::block::Height::try_from(height).expect("height must fit into an i64");
+    response::Query {
+        code: tendermint::abci::Code::Ok,
+        key: request.path.into_bytes().into(),
+        value: serde_json::to_vec(&fee_components)
+            .expect("object does not contain keys that don't map to json keys")
+            .into(),
         height,
         ..response::Query::default()
     }
@@ -458,3 +497,138 @@ fn preprocess_fees_request(request: &request::Query) -> Result<TransactionBody, 
 
     Ok(tx)
 }
+
+#[derive(serde::Serialize)]
+struct AllFeeComponents {
+    transfer_fees: FetchResult,
+    rollup_data_submission_fees: FetchResult,
+    ics20_withdrawal_fees: FetchResult,
+    init_bridge_account_fees: FetchResult,
+    bridge_lock_fees: FetchResult,
+    bridge_unlock_fees: FetchResult,
+    bridge_sudo_change_fees: FetchResult,
+    ibc_relay_fees: FetchResult,
+    validator_update_fees: FetchResult,
+    fee_asset_change_fees: FetchResult,
+    fee_change_fees: FetchResult,
+    ibc_relayer_change_fees: FetchResult,
+    sudo_address_change_fees: FetchResult,
+    ibc_sudo_change_fees: FetchResult,
+}
+
+#[derive(serde::Serialize)]
+#[serde(untagged)]
+enum FetchResult {
+    Err(String),
+    Missing(&'static str),
+    Component(FeeComponent),
+}
+
+impl<T> From<eyre::Result<Option<T>>> for FetchResult
+where
+    FeeComponent: From<T>,
+{
+    fn from(value: eyre::Result<Option<T>>) -> Self {
+        match value {
+            Ok(Some(val)) => Self::Component(val.into()),
+            Ok(None) => Self::Missing("not set"),
+            Err(err) => Self::Err(err.to_string()),
+        }
+    }
+}
+
+async fn get_all_fee_components<S: StateRead>(state: &S) -> AllFeeComponents {
+    let (
+        transfer_fees,
+        rollup_data_submission_fees,
+        ics20_withdrawal_fees,
+        init_bridge_account_fees,
+        bridge_lock_fees,
+        bridge_unlock_fees,
+        bridge_sudo_change_fees,
+        ibc_relay_fees,
+        validator_update_fees,
+        fee_asset_change_fees,
+        fee_change_fees,
+        ibc_relayer_change_fees,
+        sudo_address_change_fees,
+        ibc_sudo_change_fees,
+    ) = join!(
+        state.get_transfer_fees().map(fetch_to_response),
+        state
+            .get_rollup_data_submission_fees()
+            .map(fetch_to_response),
+        state.get_ics20_withdrawal_fees().map(fetch_to_response),
+        state.get_init_bridge_account_fees().map(fetch_to_response),
+        state.get_bridge_lock_fees().map(fetch_to_response),
+        state.get_bridge_unlock_fees().map(fetch_to_response),
+        state.get_bridge_sudo_change_fees().map(fetch_to_response),
+        state.get_ibc_relay_fees().map(fetch_to_response),
+        state.get_validator_update_fees().map(fetch_to_response),
+        state.get_fee_asset_change_fees().map(fetch_to_response),
+        state.get_fee_change_fees().map(fetch_to_response),
+        state.get_ibc_relayer_change_fees().map(fetch_to_response),
+        state.get_sudo_address_change_fees().map(fetch_to_response),
+        state.get_ibc_sudo_change_fees().map(fetch_to_response),
+    );
+    AllFeeComponents {
+        transfer_fees,
+        rollup_data_submission_fees,
+        ics20_withdrawal_fees,
+        init_bridge_account_fees,
+        bridge_lock_fees,
+        bridge_unlock_fees,
+        bridge_sudo_change_fees,
+        ibc_relay_fees,
+        validator_update_fees,
+        fee_asset_change_fees,
+        fee_change_fees,
+        ibc_relayer_change_fees,
+        sudo_address_change_fees,
+        ibc_sudo_change_fees,
+    }
+}
+
+fn fetch_to_response<T>(value: eyre::Result<Option<T>>) -> FetchResult
+where
+    FeeComponent: From<T>,
+{
+    value.into()
+}
+
+#[derive(serde::Serialize)]
+struct FeeComponent {
+    base: u128,
+    multiplier: u128,
+}
+
+macro_rules! impl_from_domain_fee_component {
+    ( $($dt:ty ),* $(,)?) => {
+        $(
+            impl From<$dt> for FeeComponent {
+                fn from(val: $dt) -> Self {
+                    Self {
+                        base: val.base,
+                        multiplier: val.multiplier,
+                    }
+                }
+            }
+        )*
+    }
+}
+impl_from_domain_fee_component!(
+    astria_core::protocol::fees::v1::BridgeLockFeeComponents,
+    astria_core::protocol::fees::v1::BridgeSudoChangeFeeComponents,
+    astria_core::protocol::fees::v1::BridgeUnlockFeeComponents,
+    astria_core::protocol::fees::v1::FeeAssetChangeFeeComponents,
+    astria_core::protocol::fees::v1::FeeChangeFeeComponents,
+    astria_core::protocol::fees::v1::IbcRelayFeeComponents,
+    astria_core::protocol::fees::v1::IbcRelayerChangeFeeComponents,
+    astria_core::protocol::fees::v1::IbcSudoChangeFeeComponents,
+    astria_core::protocol::fees::v1::Ics20WithdrawalFeeComponents,
+    astria_core::protocol::fees::v1::InitBridgeAccountFeeComponents,
+    astria_core::protocol::fees::v1::RollupDataSubmissionFeeComponents,
+    astria_core::protocol::fees::v1::SudoAddressChangeFeeComponents,
+    astria_core::protocol::fees::v1::TransferFeeComponents,
+    astria_core::protocol::fees::v1::ValidatorUpdateFeeComponents,
+);

--- a/crates/astria-sequencer/src/service/info/mod.rs
+++ b/crates/astria-sequencer/src/service/info/mod.rs
@@ -45,48 +45,37 @@ pub(crate) struct Info {
     query_router: abci_query_router::Router,
 }
 
+const ACCOUNT_BALANCE: &str = "accounts/balance/:account";
+const ACCOUNT_NONCE: &str = "accounts/nonce/:account";
+const ASSET_DENOM: &str = "asset/denom/:id";
+const FEE_ALLOWED_ASSETS: &str = "asset/allowed_fee_assets";
+
+const BRIDGE_ACCOUNT_LAST_TX_ID: &str = "bridge/account_last_tx_hash/:address";
+const BRIDGE_ACCOUNT_INFO: &str = "bridge/account_info/:address";
+
+const TRANSACTION_FEE: &str = "transaction/fee";
+
 impl Info {
     pub(crate) fn new(storage: Storage) -> Result<Self> {
         let mut query_router = abci_query_router::Router::new();
-        query_router
-            .insert(
-                "accounts/balance/:account",
-                crate::accounts::query::balance_request,
-            )
-            .wrap_err("invalid path: `accounts/balance/:account`")?;
-        query_router
-            .insert(
-                "accounts/nonce/:account",
-                crate::accounts::query::nonce_request,
-            )
-            .wrap_err("invalid path: `accounts/nonce/:account`")?;
-        query_router
-            .insert("asset/denom/:id", crate::assets::query::denom_request)
-            .wrap_err("invalid path: `asset/denom/:id`")?;
-        query_router
-            .insert(
-                "asset/allowed_fee_assets",
-                crate::fees::query::allowed_fee_assets_request,
-            )
-            .wrap_err("invalid path: `asset/allowed_fee_asset_ids`")?;
-        query_router
-            .insert(
-                "bridge/account_last_tx_hash/:address",
-                crate::bridge::query::bridge_account_last_tx_hash_request,
-            )
-            .wrap_err("invalid path: `bridge/account_last_tx_hash/:address`")?;
-        query_router
-            .insert(
-                "transaction/fee",
-                crate::fees::query::transaction_fee_request,
-            )
-            .wrap_err("invalid path: `transaction/fee`")?;
-        query_router
-            .insert(
-                "bridge/account_info/:address",
-                crate::bridge::query::bridge_account_info_request,
-            )
-            .wrap_err("invalid path: `bridge/account_info/:address`")?;
+
+        // NOTE: Skipping error context because `InsertError` contains all required information.
+        query_router.insert(ACCOUNT_BALANCE, crate::accounts::query::balance_request)?;
+        query_router.insert(ACCOUNT_NONCE, crate::accounts::query::nonce_request)?;
+        query_router.insert(ASSET_DENOM, crate::assets::query::denom_request)?;
+        query_router.insert(
+            FEE_ALLOWED_ASSETS,
+            crate::fees::query::allowed_fee_assets_request,
+        )?;
+        query_router.insert(
+            BRIDGE_ACCOUNT_LAST_TX_ID,
+            crate::bridge::query::bridge_account_last_tx_hash_request,
+        )?;
+        query_router.insert(
+            BRIDGE_ACCOUNT_INFO,
+            crate::bridge::query::bridge_account_info_request,
+        )?;
+        query_router.insert(TRANSACTION_FEE, crate::fees::query::transaction_fee_request)?;
         Ok(Self {
             storage,
             query_router,
@@ -366,7 +355,7 @@ mod tests {
             InfoResponse::Query(query) => query,
             other => panic!("expected InfoResponse::Query, got {other:?}"),
         };
-        assert!(query_response.code.is_ok());
+        assert!(query_response.code.is_ok(), "{query_response:?}");
 
         let allowed_fee_assets_resp = raw::AllowedFeeAssetsResponse::decode(query_response.value)
             .unwrap()


### PR DESCRIPTION
## Summary
Returns a all fee components at the latest height when sending an ABCI info request containing the path `"fees/components"`.

## Background
Right now information on the sequencer state is very limited. This patch allows getting a bit more info out of it.

## Changes
- Adds a handler for the path `"fees/components"` into the ABCI info service running inside sequencer.
- The handler returns a JSON object containing the values for each component. Each component can return one of the 3 states shown below:

```
{
    "transaction_fees": {
        base: 1,
        multiplier: 2,
    },
    "rollup_data_submission_fees": "not set",
    "ibc_relay_fees": "<some error message",
}
```

## Testing
Provided an error for sending a high level ABCI info request to the `Info` service.