### PR TITLE
feat(cli): add ibc sudo address change command

### DIFF
--- a/crates/astria-cli/src/sequencer/sudo/ibc_sudo_address_change.rs
+++ b/crates/astria-cli/src/sequencer/sudo/ibc_sudo_address_change.rs
@@ -1,0 +1,63 @@
+use astria_core::{
+    primitive::v1::Address,
+    protocol::transaction::v1::{
+        action::IbcSudoChange,
+        Action,
+    },
+};
+use color_eyre::eyre::{
+    self,
+    WrapErr as _,
+};
+
+use crate::utils::submit_transaction;
+
+#[derive(Debug, clap::Args)]
+pub(super) struct Command {
+    /// The bech32m prefix that will be used for constructing addresses using the private key
+    #[arg(long, default_value = "astria")]
+    prefix: String,
+    // TODO: https://github.com/astriaorg/astria/issues/594
+    // Don't use a plain text private, prefer wrapper like from
+    // the secrecy crate with specialized `Debug` and `Drop` implementations
+    // that overwrite the key on drop and don't reveal it when printing.
+    #[arg(long, env = "SEQUENCER_PRIVATE_KEY")]
+    private_key: String,
+    /// The url of the Sequencer node
+    #[arg(
+        long,
+        env = "SEQUENCER_URL",
+        default_value = crate::DEFAULT_SEQUENCER_RPC
+    )]
+    sequencer_url: String,
+    /// The chain id of the sequencing chain being used
+    #[arg(
+        long = "sequencer.chain-id",
+        env = "ROLLUP_SEQUENCER_CHAIN_ID",
+        default_value = crate::DEFAULT_SEQUENCER_CHAIN_ID
+    )]
+    sequencer_chain_id: String,
+    /// The new address to take over sudo privileges
+    #[arg(long)]
+    address: Address,
+}
+
+impl Command {
+    pub(super) async fn run(self) -> eyre::Result<()> {
+        let res = submit_transaction(
+            self.sequencer_url.as_str(),
+            self.sequencer_chain_id.clone(),
+            &self.prefix,
+            self.private_key.as_str(),
+            Action::IbcSudoChange(IbcSudoChange {
+                new_address: self.address,
+            }),
+        )
+        .await
+        .wrap_err("failed to submit SudoAddressChange transaction")?;
+
+        println!("SudoAddressChange completed!");
+        println!("Included in block: {}", res.height);
+        Ok(())
+    }
+}

--- a/crates/astria-cli/src/sequencer/sudo/ibc_sudo_change.rs
+++ b/crates/astria-cli/src/sequencer/sudo/ibc_sudo_change.rs
@@ -54,9 +54,9 @@ impl Command {
             }),
         )
         .await
-        .wrap_err("failed to submit SudoAddressChange transaction")?;
+        .wrap_err("failed to submit IbcSudoChange transaction")?;
 
-        println!("SudoAddressChange completed!");
+        println!("IbcSudoChange completed!");
         println!("Included in block: {}", res.height);
         Ok(())
     }

--- a/crates/astria-cli/src/sequencer/sudo/mod.rs
+++ b/crates/astria-cli/src/sequencer/sudo/mod.rs
@@ -2,7 +2,7 @@ use color_eyre::eyre;
 
 mod fee_asset;
 mod ibc_relayer;
-mod ibc_sudo_address_change;
+mod ibc_sudo_change;
 mod sudo_address_change;
 mod validator_update;
 
@@ -32,5 +32,5 @@ enum SubCommand {
     FeeAsset(fee_asset::Command),
     SudoAddressChange(sudo_address_change::Command),
     ValidatorUpdate(validator_update::Command),
-    IbcSudoAddressChange(ibc_sudo_address_change::Command),
+    IbcSudoAddressChange(ibc_sudo_change::Command),
 }

--- a/crates/astria-cli/src/sequencer/sudo/mod.rs
+++ b/crates/astria-cli/src/sequencer/sudo/mod.rs
@@ -2,6 +2,7 @@ use color_eyre::eyre;
 
 mod fee_asset;
 mod ibc_relayer;
+mod ibc_sudo_address_change;
 mod sudo_address_change;
 mod validator_update;
 
@@ -18,6 +19,9 @@ impl Command {
             SubCommand::FeeAsset(fee_asset) => fee_asset.run().await,
             SubCommand::SudoAddressChange(sudo_address_change) => sudo_address_change.run().await,
             SubCommand::ValidatorUpdate(validator_update) => validator_update.run().await,
+            SubCommand::IbcSudoAddressChange(ibc_sudo_address_change) => {
+                ibc_sudo_address_change.run().await
+            }
         }
     }
 }
@@ -28,4 +32,5 @@ enum SubCommand {
     FeeAsset(fee_asset::Command),
     SudoAddressChange(sudo_address_change::Command),
     ValidatorUpdate(validator_update::Command),
+    IbcSudoAddressChange(ibc_sudo_address_change::Command),
 }


### PR DESCRIPTION
## Summary
adds ibc sudo address change command
## Background
Cli currently does not support the `IbcSudoChange` action

## Changes
- added `IbcSudoChange` command to the cli as sudo command

## Testing
tested manually against dusk-11 network

## Related Issues
part of #1474 