### PR TITLE
chore(cli)!: default to dusk-11

### DIFF
--- a/crates/astria-cli/CHANGELOG.md
+++ b/crates/astria-cli/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changes
+
 - Default to dusk-11 network [#1755](https://github.com/astriaorg/astria/pull/1755)
 - Change env var for sequencer chain id [#1755](https://github.com/astriaorg/astria/pull/1755)
 

--- a/crates/astria-cli/CHANGELOG.md
+++ b/crates/astria-cli/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changes
+- Default to dusk-11 network [#1755](https://github.com/astriaorg/astria/pull/1755)
+- Change env var for sequencer chain id [#1755](https://github.com/astriaorg/astria/pull/1755)
+
 ## [0.5.1] - 2024-10-23
 
 ### Added

--- a/crates/astria-cli/src/lib.rs
+++ b/crates/astria-cli/src/lib.rs
@@ -15,8 +15,8 @@ use clap::{
 };
 use color_eyre::eyre;
 
-const DEFAULT_SEQUENCER_RPC: &str = "https://rpc.sequencer.dusk-10.devnet.astria.org";
-const DEFAULT_SEQUENCER_CHAIN_ID: &str = "astria-dusk-10";
+const DEFAULT_SEQUENCER_RPC: &str = "https://rpc.sequencer.dusk-11.devnet.astria.org";
+const DEFAULT_SEQUENCER_CHAIN_ID: &str = "astria-dusk-11";
 
 /// Run commands against the Astria network.
 #[derive(Debug, Parser)]

--- a/crates/astria-cli/src/sequencer/block_height.rs
+++ b/crates/astria-cli/src/sequencer/block_height.rs
@@ -39,7 +39,7 @@ struct Get {
     /// The chain id of the sequencing chain being used
     #[arg(
         long = "sequencer.chain-id",
-        env = "ROLLUP_SEQUENCER_CHAIN_ID",
+        env = "SEQUENCER_CHAIN_ID",
         default_value = crate::DEFAULT_SEQUENCER_CHAIN_ID
     )]
     sequencer_chain_id: String,

--- a/crates/astria-cli/src/sequencer/bridge_lock.rs
+++ b/crates/astria-cli/src/sequencer/bridge_lock.rs
@@ -43,7 +43,7 @@ pub(super) struct Command {
     /// The chain id of the sequencing chain being used
     #[arg(
         long = "sequencer.chain-id",
-        env = "ROLLUP_SEQUENCER_CHAIN_ID",
+        env = "SEQUENCER_CHAIN_ID",
         default_value = crate::DEFAULT_SEQUENCER_CHAIN_ID
     )]
     sequencer_chain_id: String,

--- a/crates/astria-cli/src/sequencer/ics20_withdrawal.rs
+++ b/crates/astria-cli/src/sequencer/ics20_withdrawal.rs
@@ -76,7 +76,7 @@ pub(super) struct Command {
     /// The chain id of the sequencing chain being used
     #[arg(
          long = "sequencer.chain-id",
-         env = "ROLLUP_SEQUENCER_CHAIN_ID",
+         env = "SEQUENCER_CHAIN_ID",
          default_value = crate::DEFAULT_SEQUENCER_CHAIN_ID
      )]
     sequencer_chain_id: String,

--- a/crates/astria-cli/src/sequencer/init_bridge_account.rs
+++ b/crates/astria-cli/src/sequencer/init_bridge_account.rs
@@ -31,7 +31,7 @@ pub(super) struct Command {
     /// The chain id of the sequencing chain being used
     #[arg(
         long = "sequencer.chain-id",
-        env = "ROLLUP_SEQUENCER_CHAIN_ID",
+        env = "SEQUENCER_CHAIN_ID",
         default_value = crate::DEFAULT_SEQUENCER_CHAIN_ID
     )]
     sequencer_chain_id: String,

--- a/crates/astria-cli/src/sequencer/sudo/fee_asset.rs
+++ b/crates/astria-cli/src/sequencer/sudo/fee_asset.rs
@@ -107,7 +107,7 @@ struct ArgsInner {
     /// The chain id of the sequencing chain being used
     #[arg(
         long = "sequencer.chain-id",
-        env = "ROLLUP_SEQUENCER_CHAIN_ID",
+        env = "SEQUENCER_CHAIN_ID",
         default_value = crate::DEFAULT_SEQUENCER_CHAIN_ID
     )]
     sequencer_chain_id: String,

--- a/crates/astria-cli/src/sequencer/sudo/ibc_relayer.rs
+++ b/crates/astria-cli/src/sequencer/sudo/ibc_relayer.rs
@@ -104,7 +104,7 @@ struct ArgsInner {
     /// The chain id of the sequencing chain being used
     #[arg(
         long = "sequencer.chain-id",
-        env = "ROLLUP_SEQUENCER_CHAIN_ID",
+        env = "SEQUENCER_CHAIN_ID",
         default_value = crate::DEFAULT_SEQUENCER_CHAIN_ID
     )]
     sequencer_chain_id: String,

--- a/crates/astria-cli/src/sequencer/sudo/sudo_address_change.rs
+++ b/crates/astria-cli/src/sequencer/sudo/sudo_address_change.rs
@@ -33,7 +33,7 @@ pub(super) struct Command {
     /// The chain id of the sequencing chain being used
     #[arg(
         long = "sequencer.chain-id",
-        env = "ROLLUP_SEQUENCER_CHAIN_ID",
+        env = "SEQUENCER_CHAIN_ID",
         default_value = crate::DEFAULT_SEQUENCER_CHAIN_ID
     )]
     sequencer_chain_id: String,

--- a/crates/astria-cli/src/sequencer/sudo/validator_update.rs
+++ b/crates/astria-cli/src/sequencer/sudo/validator_update.rs
@@ -21,7 +21,7 @@ pub(super) struct Command {
     /// The chain id of the sequencing chain being used
     #[arg(
         long = "sequencer.chain-id",
-        env = "ROLLUP_SEQUENCER_CHAIN_ID",
+        env = "SEQUENCER_CHAIN_ID",
         default_value = crate::DEFAULT_SEQUENCER_CHAIN_ID
     )]
     sequencer_chain_id: String,

--- a/crates/astria-cli/src/sequencer/transfer.rs
+++ b/crates/astria-cli/src/sequencer/transfer.rs
@@ -42,7 +42,7 @@ pub(super) struct Command {
     /// The chain id of the sequencing chain being used
     #[arg(
         long = "sequencer.chain-id",
-        env = "ROLLUP_SEQUENCER_CHAIN_ID",
+        env = "SEQUENCER_CHAIN_ID",
         default_value = crate::DEFAULT_SEQUENCER_CHAIN_ID
     )]
     sequencer_chain_id: String,


### PR DESCRIPTION
## Summary
Updates the CLI to work with a production network by default

## Background
The CLI has continued to default to dusk-10 and had an old env var name that didn't make sense for chain id without rollup code inside.

## Changes
- Default chain and RPC for dusk 11

## Breaking Changelist
- Changed the env var for sequencer chain id spec on many commands from `ROLLUP_SEQUENCER_CHAIN_ID` to `SEQUENCER_CHAIN_ID`

## Testing
N/A

## Changelogs
Changelogs updated.
