### PR TITLE
chore: update codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,7 @@
 * @joroshiba @SuperFluffy @noot
 
+*.snap @joroshiba
+
 specs/ @astriaorg/engineering
 justfile @astriaorg/engineering
 README.md @astriaorg/engineering
@@ -27,4 +29,4 @@ rust-toolchain @astriaorg/rust-reviewers
 .cargo/ @astriaorg/rust-reviewers
 nextest.toml @astriaorg/rust-reviewers
 rusfmt.toml @astriaorg/rust-reviewers
-crates/src/*/CHANGELOG.md @astriaorg/rust-reviewers
+crates/*/CHANGELOG.md @astriaorg/rust-reviewers


### PR DESCRIPTION
## Summary
Small updates to codeowners

## Background
Changelog entry was set incorrectly and snap files are used for breaking changes which need high level approval to be made.