### PR TITLE
fix(bridge-withdrawer): also set metric when value 0

### DIFF
--- a/crates/astria-bridge-withdrawer/CHANGELOG.md
+++ b/crates/astria-bridge-withdrawer/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix metric `set_batch_total_settled_value` to set to zero when no transactions are settled
+
 ## [1.0.0] - 2024-10-25
 
 ### Changed

--- a/crates/astria-bridge-withdrawer/CHANGELOG.md
+++ b/crates/astria-bridge-withdrawer/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix metric `set_batch_total_settled_value` to set to zero when no transactions are settled
+- Set `batch_total_settled_value` metric to 0 when no withdrawals are settled [#1778](https://github.com/astriaorg/astria/pull/1768)
 
 ## [1.0.0] - 2024-10-25
 

--- a/crates/astria-bridge-withdrawer/src/bridge_withdrawer/ethereum/watcher.rs
+++ b/crates/astria-bridge-withdrawer/src/bridge_withdrawer/ethereum/watcher.rs
@@ -380,17 +380,16 @@ async fn get_and_forward_block_events(
     if actions.is_empty() {
         info!(
             "no withdrawal actions found for block `{block_hash}` at rollup height \
-             `{rollup_height}; skipping"
+             `{rollup_height}"
         );
-    } else {
-        submitter_handle
-            .send_batch(Batch {
-                actions,
-                rollup_height,
-            })
-            .await
-            .wrap_err("failed to send batched events; receiver dropped?")?;
     }
+    submitter_handle
+        .send_batch(Batch {
+            actions,
+            rollup_height,
+        })
+        .await
+        .wrap_err("failed to send batched events; receiver dropped?")?;
 
     Ok(())
 }

--- a/crates/astria-bridge-withdrawer/src/bridge_withdrawer/submitter/mod.rs
+++ b/crates/astria-bridge-withdrawer/src/bridge_withdrawer/submitter/mod.rs
@@ -142,6 +142,13 @@ impl Submitter {
             metrics,
             ..
         } = self;
+
+        if actions.is_empty() {
+            metrics.set_batch_total_settled_value(0);
+
+            return Ok(());
+        }
+
         // get nonce and make unsigned transaction
         let nonce = get_pending_nonce(
             sequencer_grpc_client.clone(),


### PR DESCRIPTION
## Summary
The metric `batch_total_settled_value` was not being set to zero when blocks where empty, resulting in maintaining previous value and resetting incorrectly when no txs processed.

## Changes
- Updated metric to be set to 0 when block is empty

## Changelogs
Changelogs updated.

## Metrics
- `batch_total_settled_value` improved

