### PR TITLE
fix(charts): fix hermes config

### DIFF
--- a/charts/hermes/Chart.yaml
+++ b/charts/hermes/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.1
+version: 0.5.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hermes/files/config.toml
+++ b/charts/hermes/files/config.toml
@@ -110,6 +110,15 @@ trust_threshold = '{{ $chain.trustThreshold }}'
 {{- if $chain.memoPrefix }}
 memo_prefix = '{{ $chain.memoPrefix }}'
 {{- end }}
+{{- if $chain.feeGranter }}
+fee_granter = '{{ $chain.feeGranter }}'
+{{- end }}
+{{- if $chain.compatMode }}
+compat_mode = '{{ $chain.compatMode }}'
+{{- end }}
+{{- if $chain.clearInterval }}
+clear_interval = '{{ $chain.clearInterval }}'
+{{- end }}
 
 {{- if $chain.packetFilter }}
 {{- if $chain.packetFilter.policy }}
@@ -132,14 +141,4 @@ recv = [
   {{- end }}
 {{- end }}
 {{- end }}
-{{- if $chain.feeGranter }}
-fee_granter = '{{ $chain.feeGranter }}'
-{{- end }}
-{{- if $chain.compatMode }}
-compat_mode = '{{ $chain.compatMode }}'
-{{- end }}
-{{- if $chain.clearInterval }}
-clear_interval = '{{ $chain.clearInterval }}'
-{{- end }}
-
 {{ end }}

--- a/charts/hermes/files/config.toml
+++ b/charts/hermes/files/config.toml
@@ -2,7 +2,6 @@
 log_level = '{{ .Values.global.logLevel }}'
 
 [rest]
-
 # Whether or not to enable the REST service. Default: false
 enabled = {{ .Values.rest.enabled }}
 

--- a/charts/hermes/templates/configmaps.yaml
+++ b/charts/hermes/templates/configmaps.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ include "hermes.namespace" . }}
 data:
   config.toml: |
-  {{- tpl (.Files.Get "files/config.toml") $ | nindent 4 }}
+    {{- tpl (.Files.Get "files/config.toml") $ | nindent 4 }}
 ---
 {{- if not .Values.secretProvider.enabled }}
 {{- range $chainId, $chain := .Values.chains }}

--- a/charts/hermes/templates/servicemonitor.yaml
+++ b/charts/hermes/templates/servicemonitor.yaml
@@ -2,14 +2,14 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: hermes-relayer-metrics
+  name: {{ include "hermes.fullname" . }}-metrics
   labels:
     app: {{ include "hermes.fullname" . }}
     {{- with .Values.serviceMonitor.additionalLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  jobLabel: hermes-relayer-metric
+  jobLabel: {{ include "hermes.fullname" . }}-metric
   namespaceSelector:
     matchNames:
       - {{ include "hermes.namespace" . }}


### PR DESCRIPTION
## Summary
The hermes config didn't work when path filters were used because some standard config properties were below the seperated path filter section.

## Background
Allow use of path filters on deployed hermes instances.

## Changelogs
No updates required.
