### PR TITLE
fix(sequencer)!: enforce trace-prefixed assets in bridge lock actions

### DIFF
--- a/crates/astria-cli/src/sequencer/bridge_lock.rs
+++ b/crates/astria-cli/src/sequencer/bridge_lock.rs
@@ -10,6 +10,7 @@ use astria_core::{
 };
 use color_eyre::eyre::{
     self,
+    OptionExt as _,
     WrapErr as _,
 };
 
@@ -64,7 +65,11 @@ impl Command {
             self.private_key.as_str(),
             Action::BridgeLock(BridgeLock {
                 to: self.to_address,
-                asset: self.asset.clone(),
+                asset: self
+                    .asset
+                    .as_trace_prefixed()
+                    .ok_or_eyre("asset should be trace prefixed")?
+                    .clone(),
                 amount: self.amount,
                 fee_asset: self.fee_asset.clone(),
                 destination_chain_address: self.destination_chain_address.clone(),

--- a/crates/astria-core/CHANGELOG.md
+++ b/crates/astria-core/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added method `TracePrefixed::leading_channel` to read the left-most channel of
   a trace prefixed ICS20 asset [#1768](https://github.com/astriaorg/astria/pull/1768)
 
+### Changed
+
+- Changed field `asset` of `BridgeLock` to be `asset::TracePrefixed` [#1781](https://github.com/astriaorg/astria/pull/1781).
+
 ### Removed
 
 - Removed method `TracePrefixed::last_channel` [#1768](https://github.com/astriaorg/astria/pull/1768)

--- a/crates/astria-core/src/protocol/transaction/v1/action/group/tests.rs
+++ b/crates/astria-core/src/protocol/transaction/v1/action/group/tests.rs
@@ -56,7 +56,7 @@ fn try_from_list_of_actions_bundleable_general() {
         Action::BridgeLock(BridgeLock {
             to: address,
             amount: 100,
-            asset: asset.clone(),
+            asset: asset.as_trace_prefixed().unwrap().clone(),
             fee_asset: asset.clone(),
             destination_chain_address: String::new(),
         }),

--- a/crates/astria-core/src/protocol/transaction/v1/action/mod.rs
+++ b/crates/astria-core/src/protocol/transaction/v1/action/mod.rs
@@ -1513,7 +1513,7 @@ pub struct BridgeLock {
     pub to: Address,
     pub amount: u128,
     // asset to be transferred.
-    pub asset: asset::Denom,
+    pub asset: asset::TracePrefixed,
     // asset to use for fee payment.
     pub fee_asset: asset::Denom,
     // the address on the destination chain to send the transfer to.
@@ -1613,7 +1613,7 @@ impl BridgeLockError {
     }
 
     #[must_use]
-    fn invalid_asset(err: asset::ParseDenomError) -> Self {
+    fn invalid_asset(err: asset::denom::ParseTracePrefixedError) -> Self {
         Self(BridgeLockErrorKind::InvalidAsset(err))
     }
 
@@ -1632,7 +1632,7 @@ enum BridgeLockErrorKind {
     #[error("the `amount` field was not set")]
     MissingAmount,
     #[error("the `asset` field was invalid")]
-    InvalidAsset(#[source] asset::ParseDenomError),
+    InvalidAsset(#[source] asset::denom::ParseTracePrefixedError),
     #[error("the `fee_asset` field was invalid")]
     InvalidFeeAsset(#[source] asset::ParseDenomError),
 }

--- a/crates/astria-sequencer/src/app/tests_app/mod.rs
+++ b/crates/astria-sequencer/src/app/tests_app/mod.rs
@@ -347,7 +347,7 @@ async fn app_create_sequencer_block_with_sequenced_data_and_deposits() {
     let lock_action = BridgeLock {
         to: bridge_address,
         amount,
-        asset: nria().into(),
+        asset: nria(),
         fee_asset: nria().into(),
         destination_chain_address: "nootwashere".to_string(),
     };
@@ -439,7 +439,7 @@ async fn app_execution_results_match_proposal_vs_after_proposal() {
     let lock_action = BridgeLock {
         to: bridge_address,
         amount,
-        asset: nria().into(),
+        asset: nria(),
         fee_asset: nria().into(),
         destination_chain_address: "nootwashere".to_string(),
     };

--- a/crates/astria-sequencer/src/app/tests_breaking_changes.rs
+++ b/crates/astria-sequencer/src/app/tests_breaking_changes.rs
@@ -108,7 +108,7 @@ async fn app_finalize_block_snapshot() {
     let lock_action = BridgeLock {
         to: bridge_address,
         amount,
-        asset: nria().into(),
+        asset: nria(),
         fee_asset: nria().into(),
         destination_chain_address: "nootwashere".to_string(),
     };
@@ -303,7 +303,7 @@ async fn app_execute_transaction_with_every_action_snapshot() {
             BridgeLock {
                 to: bridge_address,
                 amount: 100,
-                asset: nria().into(),
+                asset: nria(),
                 fee_asset: nria().into(),
                 destination_chain_address: "nootwashere".to_string(),
             }

--- a/crates/astria-sequencer/src/app/tests_execute_transaction.rs
+++ b/crates/astria-sequencer/src/app/tests_execute_transaction.rs
@@ -736,7 +736,7 @@ async fn app_execute_transaction_bridge_lock_action_ok() {
     let action = BridgeLock {
         to: bridge_address,
         amount,
-        asset: nria().into(),
+        asset: nria(),
         fee_asset: nria().into(),
         destination_chain_address: "nootwashere".to_string(),
     };
@@ -797,7 +797,7 @@ async fn app_execute_transaction_bridge_lock_action_invalid_for_eoa() {
     let action = BridgeLock {
         to: bridge_address,
         amount,
-        asset: nria().into(),
+        asset: nria(),
         fee_asset: nria().into(),
         destination_chain_address: "nootwashere".to_string(),
     };
@@ -1034,7 +1034,7 @@ async fn app_execute_transaction_bridge_lock_unlock_action_ok() {
     let action = BridgeLock {
         to: bridge_address,
         amount,
-        asset: nria().into(),
+        asset: nria(),
         fee_asset: nria().into(),
         destination_chain_address: "nootwashere".to_string(),
     };
@@ -1106,7 +1106,7 @@ async fn app_execute_transaction_action_index_correctly_increments() {
     let action = BridgeLock {
         to: bridge_address,
         amount,
-        asset: nria().into(),
+        asset: nria(),
         fee_asset: nria().into(),
         destination_chain_address: "nootwashere".to_string(),
     };
@@ -1155,7 +1155,7 @@ async fn transaction_execution_records_deposit_event() {
     let action = BridgeLock {
         to: bob_address,
         amount: 1,
-        asset: nria().into(),
+        asset: nria(),
         fee_asset: nria().into(),
         destination_chain_address: "test_chain_address".to_string(),
     };

--- a/crates/astria-sequencer/src/bridge/bridge_lock_action.rs
+++ b/crates/astria-sequencer/src/bridge/bridge_lock_action.rs
@@ -72,7 +72,7 @@ impl ActionHandler for BridgeLock {
             bridge_address: self.to,
             rollup_id,
             amount: self.amount,
-            asset: self.asset.clone(),
+            asset: self.asset.clone().into(),
             destination_chain_address: self.destination_chain_address.clone(),
             source_transaction_id,
             source_action_index,
@@ -81,7 +81,7 @@ impl ActionHandler for BridgeLock {
 
         let transfer_action = Transfer {
             to: self.to,
-            asset: self.asset.clone(),
+            asset: self.asset.clone().into(),
             amount: self.amount,
             fee_asset: self.fee_asset.clone(),
         };

--- a/crates/astria-sequencer/src/fees/mod.rs
+++ b/crates/astria-sequencer/src/fees/mod.rs
@@ -112,7 +112,7 @@ impl FeeHandler for BridgeLock {
 
     #[instrument(skip_all)]
     fn variable_component(&self) -> u128 {
-        base_deposit_fee(&self.asset, &self.destination_chain_address)
+        base_deposit_fee(&self.asset.clone().into(), &self.destination_chain_address)
     }
 }
 

--- a/crates/astria-sequencer/src/fees/tests.rs
+++ b/crates/astria-sequencer/src/fees/tests.rs
@@ -233,7 +233,7 @@ async fn ensure_correct_block_fees_bridge_lock() {
         BridgeLock {
             to: bridge_address,
             amount: 1,
-            asset: nria().into(),
+            asset: nria(),
             fee_asset: nria().into(),
             destination_chain_address: rollup_id.to_string(),
         }
@@ -353,7 +353,7 @@ async fn bridge_lock_fee_calculation_works_as_expected() {
     let asset = test_asset();
     let bridge_lock = BridgeLock {
         to: bridge_address,
-        asset: asset.clone(),
+        asset: asset.as_trace_prefixed().unwrap().clone(),
         amount: 100,
         fee_asset: asset.clone(),
         destination_chain_address: "someaddress".to_string(),


### PR DESCRIPTION
## Summary
Changed `BridgeLock` to only support trace-prefixed assets.

## Background
Previously, the bridge lock action supported both IBC and trace prefixed assets. If someone submitted a `BridgeLock` action with an `asset::IbcPrefixed` asset, the deposit would then contain the IBC-prefixed asset, and the EVM would fail since it only checks for trace prefixed assets.

## Changes
- Changed `asset` field of `BridgeLock` to type `asset::TracePrefixed`.

## Testing
Passing all tests.

## Changelogs
Changelog updated.

## Breaking Changelist
- Technically breaking, but should not be network breaking as long as no `BridgeLock` actions with IBC-prefixed assets have been submitted.
