### PR TITLE
fix: hermes service monitor 

### DIFF
--- a/charts/hermes/templates/servicemonitor.yaml
+++ b/charts/hermes/templates/servicemonitor.yaml
@@ -2,14 +2,14 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: hermes-relayer-metrics
+  name: {{ include "hermes.fullname" . }}-metrics
   labels:
     app: {{ include "hermes.fullname" . }}
     {{- with .Values.serviceMonitor.additionalLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  jobLabel: hermes-relayer-metric
+  jobLabel: {{ include "hermes.fullname" . }}-metric
   namespaceSelector:
     matchNames:
       - {{ include "hermes.namespace" . }}


### PR DESCRIPTION
## Summary
makes hermes chart service monitor name based on chart name or override value instead of constant value
## Background
While deploying multiple hermes instances on the same namespace there is an issue where the serviceMonitor name is identical for all instances, making the resource to be shared across apps
## Changes
- serviceMonitor name now configurable

## Metrics
- fixes service monitor template which allows monitoring
