### PR TITLE
feat(sequencer)!: add mempool info service

### DIFF
--- a/charts/sequencer/Chart.yaml
+++ b/charts/sequencer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/sequencer/templates/configmaps.yaml
+++ b/charts/sequencer/templates/configmaps.yaml
@@ -75,5 +75,7 @@ data:
   OTEL_SERVICE_NAME: "{{ tpl .Values.sequencer.otel.serviceName . }}"
   {{- if not .Values.global.dev }}
   {{- else }}
+  ASTRIA_SEQUENCER_MEMPOOL_GRPC_ADDR: "127.0.0.1:{{ .Values.ports.sequencerMempoolGrpc }}"
+  ASTRIA_SEQUENCER_NO_MEMPOOL_GRPC: "{{ .Values.sequencer.mempool.grpc.disabled }}"
   {{- end }}
 ---

--- a/charts/sequencer/values.yaml
+++ b/charts/sequencer/values.yaml
@@ -108,6 +108,8 @@ sequencer:
   mempool:
     parked:
       maxTxCount: 200
+    grpc:
+      disabled: false
   metrics:
     enabled: false
   otel:
@@ -274,6 +276,7 @@ ports:
   sequencerGrpc: 8080
   relayerRpc: 2450
   sequencerMetrics: 9000
+  sequencerMempoolGrpc: 26661
 
 # ServiceMonitor configuration
 serviceMonitor:

--- a/crates/astria-core/src/generated/astria.sequencerblock.v1.rs
+++ b/crates/astria-core/src/generated/astria.sequencerblock.v1.rs
@@ -387,6 +387,63 @@ impl ::prost::Name for GetPendingNonceResponse {
         ::prost::alloc::format!("astria.sequencerblock.v1.{}", Self::NAME)
     }
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DumpMempoolRequest {
+    /// The submitting address needs to be the sudo address, since we don't want this info
+    /// to be publicly available.
+    #[prost(message, optional, tag = "1")]
+    pub sudo_address: ::core::option::Option<super::super::primitive::v1::Address>,
+}
+impl ::prost::Name for DumpMempoolRequest {
+    const NAME: &'static str = "DumpMempoolRequest";
+    const PACKAGE: &'static str = "astria.sequencerblock.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.sequencerblock.v1.{}", Self::NAME)
+    }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Mempool {
+    #[prost(message, repeated, tag = "1")]
+    pub pending: ::prost::alloc::vec::Vec<AccountTransactions>,
+    #[prost(message, repeated, tag = "2")]
+    pub parked: ::prost::alloc::vec::Vec<AccountTransactions>,
+    #[prost(message, repeated, tag = "3")]
+    pub comet_bft_removal_cache: ::prost::alloc::vec::Vec<
+        super::super::primitive::v1::TransactionId,
+    >,
+    #[prost(message, repeated, tag = "4")]
+    pub contained_txs: ::prost::alloc::vec::Vec<
+        super::super::primitive::v1::TransactionId,
+    >,
+}
+impl ::prost::Name for Mempool {
+    const NAME: &'static str = "Mempool";
+    const PACKAGE: &'static str = "astria.sequencerblock.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.sequencerblock.v1.{}", Self::NAME)
+    }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AccountTransactions {
+    /// The account address.
+    #[prost(message, optional, tag = "1")]
+    pub account: ::core::option::Option<super::super::primitive::v1::Address>,
+    /// The transactions associated with the account.
+    #[prost(message, repeated, tag = "2")]
+    pub transactions: ::prost::alloc::vec::Vec<
+        super::super::protocol::transaction::v1::Transaction,
+    >,
+}
+impl ::prost::Name for AccountTransactions {
+    const NAME: &'static str = "AccountTransactions";
+    const PACKAGE: &'static str = "astria.sequencerblock.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.sequencerblock.v1.{}", Self::NAME)
+    }
+}
 /// Generated client implementations.
 #[cfg(feature = "client")]
 pub mod sequencer_service_client {
@@ -560,6 +617,122 @@ pub mod sequencer_service_client {
                     GrpcMethod::new(
                         "astria.sequencerblock.v1.SequencerService",
                         "GetPendingNonce",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+    }
+}
+/// Generated client implementations.
+#[cfg(feature = "client")]
+pub mod admin_mempool_service_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
+    #[derive(Debug, Clone)]
+    pub struct AdminMempoolServiceClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl AdminMempoolServiceClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> AdminMempoolServiceClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> AdminMempoolServiceClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
+        {
+            AdminMempoolServiceClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with the given encoding.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
+            self
+        }
+        /// Enable decompressing responses.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
+        /// Dumps the mempool.
+        pub async fn dump_mempool(
+            &mut self,
+            request: impl tonic::IntoRequest<super::DumpMempoolRequest>,
+        ) -> std::result::Result<tonic::Response<super::Mempool>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/astria.sequencerblock.v1.AdminMempoolService/DumpMempool",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "astria.sequencerblock.v1.AdminMempoolService",
+                        "DumpMempool",
                     ),
                 );
             self.inner.unary(req, path, codec).await
@@ -862,5 +1035,187 @@ pub mod sequencer_service_server {
     }
     impl<T: SequencerService> tonic::server::NamedService for SequencerServiceServer<T> {
         const NAME: &'static str = "astria.sequencerblock.v1.SequencerService";
+    }
+}
+/// Generated server implementations.
+#[cfg(feature = "server")]
+pub mod admin_mempool_service_server {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    /// Generated trait containing gRPC methods that should be implemented for use with AdminMempoolServiceServer.
+    #[async_trait]
+    pub trait AdminMempoolService: Send + Sync + 'static {
+        /// Dumps the mempool.
+        async fn dump_mempool(
+            self: std::sync::Arc<Self>,
+            request: tonic::Request<super::DumpMempoolRequest>,
+        ) -> std::result::Result<tonic::Response<super::Mempool>, tonic::Status>;
+    }
+    #[derive(Debug)]
+    pub struct AdminMempoolServiceServer<T: AdminMempoolService> {
+        inner: _Inner<T>,
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
+    }
+    struct _Inner<T>(Arc<T>);
+    impl<T: AdminMempoolService> AdminMempoolServiceServer<T> {
+        pub fn new(inner: T) -> Self {
+            Self::from_arc(Arc::new(inner))
+        }
+        pub fn from_arc(inner: Arc<T>) -> Self {
+            let inner = _Inner(inner);
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
+            }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
+        where
+            F: tonic::service::Interceptor,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
+    }
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for AdminMempoolServiceServer<T>
+    where
+        T: AdminMempoolService,
+        B: Body + Send + 'static,
+        B::Error: Into<StdError> + Send + 'static,
+    {
+        type Response = http::Response<tonic::body::BoxBody>;
+        type Error = std::convert::Infallible;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<std::result::Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
+            let inner = self.inner.clone();
+            match req.uri().path() {
+                "/astria.sequencerblock.v1.AdminMempoolService/DumpMempool" => {
+                    #[allow(non_camel_case_types)]
+                    struct DumpMempoolSvc<T: AdminMempoolService>(pub Arc<T>);
+                    impl<
+                        T: AdminMempoolService,
+                    > tonic::server::UnaryService<super::DumpMempoolRequest>
+                    for DumpMempoolSvc<T> {
+                        type Response = super::Mempool;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::DumpMempoolRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as AdminMempoolService>::dump_mempool(inner, request)
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = DumpMempoolSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
+            }
+        }
+    }
+    impl<T: AdminMempoolService> Clone for AdminMempoolServiceServer<T> {
+        fn clone(&self) -> Self {
+            let inner = self.inner.clone();
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
+            }
+        }
+    }
+    impl<T: AdminMempoolService> Clone for _Inner<T> {
+        fn clone(&self) -> Self {
+            Self(Arc::clone(&self.0))
+        }
+    }
+    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.0)
+        }
+    }
+    impl<T: AdminMempoolService> tonic::server::NamedService
+    for AdminMempoolServiceServer<T> {
+        const NAME: &'static str = "astria.sequencerblock.v1.AdminMempoolService";
     }
 }

--- a/crates/astria-core/src/generated/astria.sequencerblock.v1.rs
+++ b/crates/astria-core/src/generated/astria.sequencerblock.v1.rs
@@ -389,9 +389,9 @@ impl ::prost::Name for GetPendingNonceResponse {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MempoolInfoRequest {}
-impl ::prost::Name for MempoolInfoRequest {
-    const NAME: &'static str = "MempoolInfoRequest";
+pub struct DumpMempoolRequest {}
+impl ::prost::Name for DumpMempoolRequest {
+    const NAME: &'static str = "DumpMempoolRequest";
     const PACKAGE: &'static str = "astria.sequencerblock.v1";
     fn full_name() -> ::prost::alloc::string::String {
         ::prost::alloc::format!("astria.sequencerblock.v1.{}", Self::NAME)
@@ -399,7 +399,7 @@ impl ::prost::Name for MempoolInfoRequest {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MempoolInfoResponse {
+pub struct DumpMempoolResponse {
     #[prost(message, repeated, tag = "1")]
     pub pending: ::prost::alloc::vec::Vec<AccountTransactions>,
     #[prost(message, repeated, tag = "2")]
@@ -413,8 +413,8 @@ pub struct MempoolInfoResponse {
         super::super::primitive::v1::TransactionId,
     >,
 }
-impl ::prost::Name for MempoolInfoResponse {
-    const NAME: &'static str = "MempoolInfoResponse";
+impl ::prost::Name for DumpMempoolResponse {
+    const NAME: &'static str = "DumpMempoolResponse";
     const PACKAGE: &'static str = "astria.sequencerblock.v1";
     fn full_name() -> ::prost::alloc::string::String {
         ::prost::alloc::format!("astria.sequencerblock.v1.{}", Self::NAME)
@@ -707,9 +707,9 @@ pub mod mempool_info_service_client {
         /// Dumps the mempool.
         pub async fn dump_mempool(
             &mut self,
-            request: impl tonic::IntoRequest<super::MempoolInfoRequest>,
+            request: impl tonic::IntoRequest<super::DumpMempoolRequest>,
         ) -> std::result::Result<
-            tonic::Response<super::MempoolInfoResponse>,
+            tonic::Response<super::DumpMempoolResponse>,
             tonic::Status,
         > {
             self.inner
@@ -1046,9 +1046,9 @@ pub mod mempool_info_service_server {
         /// Dumps the mempool.
         async fn dump_mempool(
             self: std::sync::Arc<Self>,
-            request: tonic::Request<super::MempoolInfoRequest>,
+            request: tonic::Request<super::DumpMempoolRequest>,
         ) -> std::result::Result<
-            tonic::Response<super::MempoolInfoResponse>,
+            tonic::Response<super::DumpMempoolResponse>,
             tonic::Status,
         >;
     }
@@ -1136,16 +1136,16 @@ pub mod mempool_info_service_server {
                     struct DumpMempoolSvc<T: MempoolInfoService>(pub Arc<T>);
                     impl<
                         T: MempoolInfoService,
-                    > tonic::server::UnaryService<super::MempoolInfoRequest>
+                    > tonic::server::UnaryService<super::DumpMempoolRequest>
                     for DumpMempoolSvc<T> {
-                        type Response = super::MempoolInfoResponse;
+                        type Response = super::DumpMempoolResponse;
                         type Future = BoxFuture<
                             tonic::Response<Self::Response>,
                             tonic::Status,
                         >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::MempoolInfoRequest>,
+                            request: tonic::Request<super::DumpMempoolRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {

--- a/crates/astria-core/src/generated/astria.sequencerblock.v1.rs
+++ b/crates/astria-core/src/generated/astria.sequencerblock.v1.rs
@@ -389,14 +389,9 @@ impl ::prost::Name for GetPendingNonceResponse {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct DumpMempoolRequest {
-    /// The submitting address needs to be the sudo address, since we don't want this info
-    /// to be publicly available.
-    #[prost(message, optional, tag = "1")]
-    pub sudo_address: ::core::option::Option<super::super::primitive::v1::Address>,
-}
-impl ::prost::Name for DumpMempoolRequest {
-    const NAME: &'static str = "DumpMempoolRequest";
+pub struct MempoolInfoRequest {}
+impl ::prost::Name for MempoolInfoRequest {
+    const NAME: &'static str = "MempoolInfoRequest";
     const PACKAGE: &'static str = "astria.sequencerblock.v1";
     fn full_name() -> ::prost::alloc::string::String {
         ::prost::alloc::format!("astria.sequencerblock.v1.{}", Self::NAME)
@@ -404,7 +399,7 @@ impl ::prost::Name for DumpMempoolRequest {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct Mempool {
+pub struct MempoolInfoResponse {
     #[prost(message, repeated, tag = "1")]
     pub pending: ::prost::alloc::vec::Vec<AccountTransactions>,
     #[prost(message, repeated, tag = "2")]
@@ -418,8 +413,8 @@ pub struct Mempool {
         super::super::primitive::v1::TransactionId,
     >,
 }
-impl ::prost::Name for Mempool {
-    const NAME: &'static str = "Mempool";
+impl ::prost::Name for MempoolInfoResponse {
+    const NAME: &'static str = "MempoolInfoResponse";
     const PACKAGE: &'static str = "astria.sequencerblock.v1";
     fn full_name() -> ::prost::alloc::string::String {
         ::prost::alloc::format!("astria.sequencerblock.v1.{}", Self::NAME)
@@ -625,15 +620,15 @@ pub mod sequencer_service_client {
 }
 /// Generated client implementations.
 #[cfg(feature = "client")]
-pub mod admin_mempool_service_client {
+pub mod mempool_info_service_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
     use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
-    pub struct AdminMempoolServiceClient<T> {
+    pub struct MempoolInfoServiceClient<T> {
         inner: tonic::client::Grpc<T>,
     }
-    impl AdminMempoolServiceClient<tonic::transport::Channel> {
+    impl MempoolInfoServiceClient<tonic::transport::Channel> {
         /// Attempt to create a new client by connecting to a given endpoint.
         pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
         where
@@ -644,7 +639,7 @@ pub mod admin_mempool_service_client {
             Ok(Self::new(conn))
         }
     }
-    impl<T> AdminMempoolServiceClient<T>
+    impl<T> MempoolInfoServiceClient<T>
     where
         T: tonic::client::GrpcService<tonic::body::BoxBody>,
         T::Error: Into<StdError>,
@@ -662,7 +657,7 @@ pub mod admin_mempool_service_client {
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
-        ) -> AdminMempoolServiceClient<InterceptedService<T, F>>
+        ) -> MempoolInfoServiceClient<InterceptedService<T, F>>
         where
             F: tonic::service::Interceptor,
             T::ResponseBody: Default,
@@ -676,7 +671,7 @@ pub mod admin_mempool_service_client {
                 http::Request<tonic::body::BoxBody>,
             >>::Error: Into<StdError> + Send + Sync,
         {
-            AdminMempoolServiceClient::new(InterceptedService::new(inner, interceptor))
+            MempoolInfoServiceClient::new(InterceptedService::new(inner, interceptor))
         }
         /// Compress requests with the given encoding.
         ///
@@ -712,8 +707,11 @@ pub mod admin_mempool_service_client {
         /// Dumps the mempool.
         pub async fn dump_mempool(
             &mut self,
-            request: impl tonic::IntoRequest<super::DumpMempoolRequest>,
-        ) -> std::result::Result<tonic::Response<super::Mempool>, tonic::Status> {
+            request: impl tonic::IntoRequest<super::MempoolInfoRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::MempoolInfoResponse>,
+            tonic::Status,
+        > {
             self.inner
                 .ready()
                 .await
@@ -725,13 +723,13 @@ pub mod admin_mempool_service_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
-                "/astria.sequencerblock.v1.AdminMempoolService/DumpMempool",
+                "/astria.sequencerblock.v1.MempoolInfoService/DumpMempool",
             );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(
                     GrpcMethod::new(
-                        "astria.sequencerblock.v1.AdminMempoolService",
+                        "astria.sequencerblock.v1.MempoolInfoService",
                         "DumpMempool",
                     ),
                 );
@@ -1039,20 +1037,23 @@ pub mod sequencer_service_server {
 }
 /// Generated server implementations.
 #[cfg(feature = "server")]
-pub mod admin_mempool_service_server {
+pub mod mempool_info_service_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    /// Generated trait containing gRPC methods that should be implemented for use with AdminMempoolServiceServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with MempoolInfoServiceServer.
     #[async_trait]
-    pub trait AdminMempoolService: Send + Sync + 'static {
+    pub trait MempoolInfoService: Send + Sync + 'static {
         /// Dumps the mempool.
         async fn dump_mempool(
             self: std::sync::Arc<Self>,
-            request: tonic::Request<super::DumpMempoolRequest>,
-        ) -> std::result::Result<tonic::Response<super::Mempool>, tonic::Status>;
+            request: tonic::Request<super::MempoolInfoRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::MempoolInfoResponse>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
-    pub struct AdminMempoolServiceServer<T: AdminMempoolService> {
+    pub struct MempoolInfoServiceServer<T: MempoolInfoService> {
         inner: _Inner<T>,
         accept_compression_encodings: EnabledCompressionEncodings,
         send_compression_encodings: EnabledCompressionEncodings,
@@ -1060,7 +1061,7 @@ pub mod admin_mempool_service_server {
         max_encoding_message_size: Option<usize>,
     }
     struct _Inner<T>(Arc<T>);
-    impl<T: AdminMempoolService> AdminMempoolServiceServer<T> {
+    impl<T: MempoolInfoService> MempoolInfoServiceServer<T> {
         pub fn new(inner: T) -> Self {
             Self::from_arc(Arc::new(inner))
         }
@@ -1112,9 +1113,9 @@ pub mod admin_mempool_service_server {
             self
         }
     }
-    impl<T, B> tonic::codegen::Service<http::Request<B>> for AdminMempoolServiceServer<T>
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for MempoolInfoServiceServer<T>
     where
-        T: AdminMempoolService,
+        T: MempoolInfoService,
         B: Body + Send + 'static,
         B::Error: Into<StdError> + Send + 'static,
     {
@@ -1130,25 +1131,25 @@ pub mod admin_mempool_service_server {
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
             let inner = self.inner.clone();
             match req.uri().path() {
-                "/astria.sequencerblock.v1.AdminMempoolService/DumpMempool" => {
+                "/astria.sequencerblock.v1.MempoolInfoService/DumpMempool" => {
                     #[allow(non_camel_case_types)]
-                    struct DumpMempoolSvc<T: AdminMempoolService>(pub Arc<T>);
+                    struct DumpMempoolSvc<T: MempoolInfoService>(pub Arc<T>);
                     impl<
-                        T: AdminMempoolService,
-                    > tonic::server::UnaryService<super::DumpMempoolRequest>
+                        T: MempoolInfoService,
+                    > tonic::server::UnaryService<super::MempoolInfoRequest>
                     for DumpMempoolSvc<T> {
-                        type Response = super::Mempool;
+                        type Response = super::MempoolInfoResponse;
                         type Future = BoxFuture<
                             tonic::Response<Self::Response>,
                             tonic::Status,
                         >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::DumpMempoolRequest>,
+                            request: tonic::Request<super::MempoolInfoRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as AdminMempoolService>::dump_mempool(inner, request)
+                                <T as MempoolInfoService>::dump_mempool(inner, request)
                                     .await
                             };
                             Box::pin(fut)
@@ -1192,7 +1193,7 @@ pub mod admin_mempool_service_server {
             }
         }
     }
-    impl<T: AdminMempoolService> Clone for AdminMempoolServiceServer<T> {
+    impl<T: MempoolInfoService> Clone for MempoolInfoServiceServer<T> {
         fn clone(&self) -> Self {
             let inner = self.inner.clone();
             Self {
@@ -1204,7 +1205,7 @@ pub mod admin_mempool_service_server {
             }
         }
     }
-    impl<T: AdminMempoolService> Clone for _Inner<T> {
+    impl<T: MempoolInfoService> Clone for _Inner<T> {
         fn clone(&self) -> Self {
             Self(Arc::clone(&self.0))
         }
@@ -1214,8 +1215,8 @@ pub mod admin_mempool_service_server {
             write!(f, "{:?}", self.0)
         }
     }
-    impl<T: AdminMempoolService> tonic::server::NamedService
-    for AdminMempoolServiceServer<T> {
-        const NAME: &'static str = "astria.sequencerblock.v1.AdminMempoolService";
+    impl<T: MempoolInfoService> tonic::server::NamedService
+    for MempoolInfoServiceServer<T> {
+        const NAME: &'static str = "astria.sequencerblock.v1.MempoolInfoService";
     }
 }

--- a/crates/astria-core/src/generated/astria.sequencerblock.v1.serde.rs
+++ b/crates/astria-core/src/generated/astria.sequencerblock.v1.serde.rs
@@ -307,98 +307,6 @@ impl<'de> serde::Deserialize<'de> for Deposit {
         deserializer.deserialize_struct("astria.sequencerblock.v1.Deposit", FIELDS, GeneratedVisitor)
     }
 }
-impl serde::Serialize for DumpMempoolRequest {
-    #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        use serde::ser::SerializeStruct;
-        let mut len = 0;
-        if self.sudo_address.is_some() {
-            len += 1;
-        }
-        let mut struct_ser = serializer.serialize_struct("astria.sequencerblock.v1.DumpMempoolRequest", len)?;
-        if let Some(v) = self.sudo_address.as_ref() {
-            struct_ser.serialize_field("sudoAddress", v)?;
-        }
-        struct_ser.end()
-    }
-}
-impl<'de> serde::Deserialize<'de> for DumpMempoolRequest {
-    #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        const FIELDS: &[&str] = &[
-            "sudo_address",
-            "sudoAddress",
-        ];
-
-        #[allow(clippy::enum_variant_names)]
-        enum GeneratedField {
-            SudoAddress,
-        }
-        impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
-            where
-                D: serde::Deserializer<'de>,
-            {
-                struct GeneratedVisitor;
-
-                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
-                    type Value = GeneratedField;
-
-                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                        write!(formatter, "expected one of: {:?}", &FIELDS)
-                    }
-
-                    #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
-                    where
-                        E: serde::de::Error,
-                    {
-                        match value {
-                            "sudoAddress" | "sudo_address" => Ok(GeneratedField::SudoAddress),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
-                        }
-                    }
-                }
-                deserializer.deserialize_identifier(GeneratedVisitor)
-            }
-        }
-        struct GeneratedVisitor;
-        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
-            type Value = DumpMempoolRequest;
-
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                formatter.write_str("struct astria.sequencerblock.v1.DumpMempoolRequest")
-            }
-
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<DumpMempoolRequest, V::Error>
-                where
-                    V: serde::de::MapAccess<'de>,
-            {
-                let mut sudo_address__ = None;
-                while let Some(k) = map_.next_key()? {
-                    match k {
-                        GeneratedField::SudoAddress => {
-                            if sudo_address__.is_some() {
-                                return Err(serde::de::Error::duplicate_field("sudoAddress"));
-                            }
-                            sudo_address__ = map_.next_value()?;
-                        }
-                    }
-                }
-                Ok(DumpMempoolRequest {
-                    sudo_address: sudo_address__,
-                })
-            }
-        }
-        deserializer.deserialize_struct("astria.sequencerblock.v1.DumpMempoolRequest", FIELDS, GeneratedVisitor)
-    }
-}
 impl serde::Serialize for FilteredSequencerBlock {
     #[allow(deprecated)]
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
@@ -973,7 +881,78 @@ impl<'de> serde::Deserialize<'de> for GetSequencerBlockRequest {
         deserializer.deserialize_struct("astria.sequencerblock.v1.GetSequencerBlockRequest", FIELDS, GeneratedVisitor)
     }
 }
-impl serde::Serialize for Mempool {
+impl serde::Serialize for MempoolInfoRequest {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let len = 0;
+        let struct_ser = serializer.serialize_struct("astria.sequencerblock.v1.MempoolInfoRequest", len)?;
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for MempoolInfoRequest {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                            Err(serde::de::Error::unknown_field(value, FIELDS))
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = MempoolInfoRequest;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.sequencerblock.v1.MempoolInfoRequest")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MempoolInfoRequest, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                while map_.next_key::<GeneratedField>()?.is_some() {
+                    let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                }
+                Ok(MempoolInfoRequest {
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.sequencerblock.v1.MempoolInfoRequest", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for MempoolInfoResponse {
     #[allow(deprecated)]
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where
@@ -993,7 +972,7 @@ impl serde::Serialize for Mempool {
         if !self.contained_txs.is_empty() {
             len += 1;
         }
-        let mut struct_ser = serializer.serialize_struct("astria.sequencerblock.v1.Mempool", len)?;
+        let mut struct_ser = serializer.serialize_struct("astria.sequencerblock.v1.MempoolInfoResponse", len)?;
         if !self.pending.is_empty() {
             struct_ser.serialize_field("pending", &self.pending)?;
         }
@@ -1009,7 +988,7 @@ impl serde::Serialize for Mempool {
         struct_ser.end()
     }
 }
-impl<'de> serde::Deserialize<'de> for Mempool {
+impl<'de> serde::Deserialize<'de> for MempoolInfoResponse {
     #[allow(deprecated)]
     fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
     where
@@ -1064,13 +1043,13 @@ impl<'de> serde::Deserialize<'de> for Mempool {
         }
         struct GeneratedVisitor;
         impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
-            type Value = Mempool;
+            type Value = MempoolInfoResponse;
 
             fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                formatter.write_str("struct astria.sequencerblock.v1.Mempool")
+                formatter.write_str("struct astria.sequencerblock.v1.MempoolInfoResponse")
             }
 
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Mempool, V::Error>
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MempoolInfoResponse, V::Error>
                 where
                     V: serde::de::MapAccess<'de>,
             {
@@ -1106,7 +1085,7 @@ impl<'de> serde::Deserialize<'de> for Mempool {
                         }
                     }
                 }
-                Ok(Mempool {
+                Ok(MempoolInfoResponse {
                     pending: pending__.unwrap_or_default(),
                     parked: parked__.unwrap_or_default(),
                     comet_bft_removal_cache: comet_bft_removal_cache__.unwrap_or_default(),
@@ -1114,7 +1093,7 @@ impl<'de> serde::Deserialize<'de> for Mempool {
                 })
             }
         }
-        deserializer.deserialize_struct("astria.sequencerblock.v1.Mempool", FIELDS, GeneratedVisitor)
+        deserializer.deserialize_struct("astria.sequencerblock.v1.MempoolInfoResponse", FIELDS, GeneratedVisitor)
     }
 }
 impl serde::Serialize for RollupData {

--- a/crates/astria-core/src/generated/astria.sequencerblock.v1.serde.rs
+++ b/crates/astria-core/src/generated/astria.sequencerblock.v1.serde.rs
@@ -307,6 +307,221 @@ impl<'de> serde::Deserialize<'de> for Deposit {
         deserializer.deserialize_struct("astria.sequencerblock.v1.Deposit", FIELDS, GeneratedVisitor)
     }
 }
+impl serde::Serialize for DumpMempoolRequest {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let len = 0;
+        let struct_ser = serializer.serialize_struct("astria.sequencerblock.v1.DumpMempoolRequest", len)?;
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for DumpMempoolRequest {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                            Err(serde::de::Error::unknown_field(value, FIELDS))
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = DumpMempoolRequest;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.sequencerblock.v1.DumpMempoolRequest")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<DumpMempoolRequest, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                while map_.next_key::<GeneratedField>()?.is_some() {
+                    let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                }
+                Ok(DumpMempoolRequest {
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.sequencerblock.v1.DumpMempoolRequest", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for DumpMempoolResponse {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.pending.is_empty() {
+            len += 1;
+        }
+        if !self.parked.is_empty() {
+            len += 1;
+        }
+        if !self.comet_bft_removal_cache.is_empty() {
+            len += 1;
+        }
+        if !self.contained_txs.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.sequencerblock.v1.DumpMempoolResponse", len)?;
+        if !self.pending.is_empty() {
+            struct_ser.serialize_field("pending", &self.pending)?;
+        }
+        if !self.parked.is_empty() {
+            struct_ser.serialize_field("parked", &self.parked)?;
+        }
+        if !self.comet_bft_removal_cache.is_empty() {
+            struct_ser.serialize_field("cometBftRemovalCache", &self.comet_bft_removal_cache)?;
+        }
+        if !self.contained_txs.is_empty() {
+            struct_ser.serialize_field("containedTxs", &self.contained_txs)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for DumpMempoolResponse {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "pending",
+            "parked",
+            "comet_bft_removal_cache",
+            "cometBftRemovalCache",
+            "contained_txs",
+            "containedTxs",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Pending,
+            Parked,
+            CometBftRemovalCache,
+            ContainedTxs,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "pending" => Ok(GeneratedField::Pending),
+                            "parked" => Ok(GeneratedField::Parked),
+                            "cometBftRemovalCache" | "comet_bft_removal_cache" => Ok(GeneratedField::CometBftRemovalCache),
+                            "containedTxs" | "contained_txs" => Ok(GeneratedField::ContainedTxs),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = DumpMempoolResponse;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.sequencerblock.v1.DumpMempoolResponse")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<DumpMempoolResponse, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut pending__ = None;
+                let mut parked__ = None;
+                let mut comet_bft_removal_cache__ = None;
+                let mut contained_txs__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Pending => {
+                            if pending__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("pending"));
+                            }
+                            pending__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Parked => {
+                            if parked__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("parked"));
+                            }
+                            parked__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::CometBftRemovalCache => {
+                            if comet_bft_removal_cache__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("cometBftRemovalCache"));
+                            }
+                            comet_bft_removal_cache__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::ContainedTxs => {
+                            if contained_txs__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("containedTxs"));
+                            }
+                            contained_txs__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(DumpMempoolResponse {
+                    pending: pending__.unwrap_or_default(),
+                    parked: parked__.unwrap_or_default(),
+                    comet_bft_removal_cache: comet_bft_removal_cache__.unwrap_or_default(),
+                    contained_txs: contained_txs__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.sequencerblock.v1.DumpMempoolResponse", FIELDS, GeneratedVisitor)
+    }
+}
 impl serde::Serialize for FilteredSequencerBlock {
     #[allow(deprecated)]
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
@@ -879,221 +1094,6 @@ impl<'de> serde::Deserialize<'de> for GetSequencerBlockRequest {
             }
         }
         deserializer.deserialize_struct("astria.sequencerblock.v1.GetSequencerBlockRequest", FIELDS, GeneratedVisitor)
-    }
-}
-impl serde::Serialize for MempoolInfoRequest {
-    #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        use serde::ser::SerializeStruct;
-        let len = 0;
-        let struct_ser = serializer.serialize_struct("astria.sequencerblock.v1.MempoolInfoRequest", len)?;
-        struct_ser.end()
-    }
-}
-impl<'de> serde::Deserialize<'de> for MempoolInfoRequest {
-    #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        const FIELDS: &[&str] = &[
-        ];
-
-        #[allow(clippy::enum_variant_names)]
-        enum GeneratedField {
-        }
-        impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
-            where
-                D: serde::Deserializer<'de>,
-            {
-                struct GeneratedVisitor;
-
-                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
-                    type Value = GeneratedField;
-
-                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                        write!(formatter, "expected one of: {:?}", &FIELDS)
-                    }
-
-                    #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
-                    where
-                        E: serde::de::Error,
-                    {
-                            Err(serde::de::Error::unknown_field(value, FIELDS))
-                    }
-                }
-                deserializer.deserialize_identifier(GeneratedVisitor)
-            }
-        }
-        struct GeneratedVisitor;
-        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
-            type Value = MempoolInfoRequest;
-
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                formatter.write_str("struct astria.sequencerblock.v1.MempoolInfoRequest")
-            }
-
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MempoolInfoRequest, V::Error>
-                where
-                    V: serde::de::MapAccess<'de>,
-            {
-                while map_.next_key::<GeneratedField>()?.is_some() {
-                    let _ = map_.next_value::<serde::de::IgnoredAny>()?;
-                }
-                Ok(MempoolInfoRequest {
-                })
-            }
-        }
-        deserializer.deserialize_struct("astria.sequencerblock.v1.MempoolInfoRequest", FIELDS, GeneratedVisitor)
-    }
-}
-impl serde::Serialize for MempoolInfoResponse {
-    #[allow(deprecated)]
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        use serde::ser::SerializeStruct;
-        let mut len = 0;
-        if !self.pending.is_empty() {
-            len += 1;
-        }
-        if !self.parked.is_empty() {
-            len += 1;
-        }
-        if !self.comet_bft_removal_cache.is_empty() {
-            len += 1;
-        }
-        if !self.contained_txs.is_empty() {
-            len += 1;
-        }
-        let mut struct_ser = serializer.serialize_struct("astria.sequencerblock.v1.MempoolInfoResponse", len)?;
-        if !self.pending.is_empty() {
-            struct_ser.serialize_field("pending", &self.pending)?;
-        }
-        if !self.parked.is_empty() {
-            struct_ser.serialize_field("parked", &self.parked)?;
-        }
-        if !self.comet_bft_removal_cache.is_empty() {
-            struct_ser.serialize_field("cometBftRemovalCache", &self.comet_bft_removal_cache)?;
-        }
-        if !self.contained_txs.is_empty() {
-            struct_ser.serialize_field("containedTxs", &self.contained_txs)?;
-        }
-        struct_ser.end()
-    }
-}
-impl<'de> serde::Deserialize<'de> for MempoolInfoResponse {
-    #[allow(deprecated)]
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        const FIELDS: &[&str] = &[
-            "pending",
-            "parked",
-            "comet_bft_removal_cache",
-            "cometBftRemovalCache",
-            "contained_txs",
-            "containedTxs",
-        ];
-
-        #[allow(clippy::enum_variant_names)]
-        enum GeneratedField {
-            Pending,
-            Parked,
-            CometBftRemovalCache,
-            ContainedTxs,
-        }
-        impl<'de> serde::Deserialize<'de> for GeneratedField {
-            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
-            where
-                D: serde::Deserializer<'de>,
-            {
-                struct GeneratedVisitor;
-
-                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
-                    type Value = GeneratedField;
-
-                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                        write!(formatter, "expected one of: {:?}", &FIELDS)
-                    }
-
-                    #[allow(unused_variables)]
-                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
-                    where
-                        E: serde::de::Error,
-                    {
-                        match value {
-                            "pending" => Ok(GeneratedField::Pending),
-                            "parked" => Ok(GeneratedField::Parked),
-                            "cometBftRemovalCache" | "comet_bft_removal_cache" => Ok(GeneratedField::CometBftRemovalCache),
-                            "containedTxs" | "contained_txs" => Ok(GeneratedField::ContainedTxs),
-                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
-                        }
-                    }
-                }
-                deserializer.deserialize_identifier(GeneratedVisitor)
-            }
-        }
-        struct GeneratedVisitor;
-        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
-            type Value = MempoolInfoResponse;
-
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                formatter.write_str("struct astria.sequencerblock.v1.MempoolInfoResponse")
-            }
-
-            fn visit_map<V>(self, mut map_: V) -> std::result::Result<MempoolInfoResponse, V::Error>
-                where
-                    V: serde::de::MapAccess<'de>,
-            {
-                let mut pending__ = None;
-                let mut parked__ = None;
-                let mut comet_bft_removal_cache__ = None;
-                let mut contained_txs__ = None;
-                while let Some(k) = map_.next_key()? {
-                    match k {
-                        GeneratedField::Pending => {
-                            if pending__.is_some() {
-                                return Err(serde::de::Error::duplicate_field("pending"));
-                            }
-                            pending__ = Some(map_.next_value()?);
-                        }
-                        GeneratedField::Parked => {
-                            if parked__.is_some() {
-                                return Err(serde::de::Error::duplicate_field("parked"));
-                            }
-                            parked__ = Some(map_.next_value()?);
-                        }
-                        GeneratedField::CometBftRemovalCache => {
-                            if comet_bft_removal_cache__.is_some() {
-                                return Err(serde::de::Error::duplicate_field("cometBftRemovalCache"));
-                            }
-                            comet_bft_removal_cache__ = Some(map_.next_value()?);
-                        }
-                        GeneratedField::ContainedTxs => {
-                            if contained_txs__.is_some() {
-                                return Err(serde::de::Error::duplicate_field("containedTxs"));
-                            }
-                            contained_txs__ = Some(map_.next_value()?);
-                        }
-                    }
-                }
-                Ok(MempoolInfoResponse {
-                    pending: pending__.unwrap_or_default(),
-                    parked: parked__.unwrap_or_default(),
-                    comet_bft_removal_cache: comet_bft_removal_cache__.unwrap_or_default(),
-                    contained_txs: contained_txs__.unwrap_or_default(),
-                })
-            }
-        }
-        deserializer.deserialize_struct("astria.sequencerblock.v1.MempoolInfoResponse", FIELDS, GeneratedVisitor)
     }
 }
 impl serde::Serialize for RollupData {

--- a/crates/astria-core/src/generated/astria.sequencerblock.v1.serde.rs
+++ b/crates/astria-core/src/generated/astria.sequencerblock.v1.serde.rs
@@ -1,3 +1,111 @@
+impl serde::Serialize for AccountTransactions {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.account.is_some() {
+            len += 1;
+        }
+        if !self.transactions.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.sequencerblock.v1.AccountTransactions", len)?;
+        if let Some(v) = self.account.as_ref() {
+            struct_ser.serialize_field("account", v)?;
+        }
+        if !self.transactions.is_empty() {
+            struct_ser.serialize_field("transactions", &self.transactions)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for AccountTransactions {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "account",
+            "transactions",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Account,
+            Transactions,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "account" => Ok(GeneratedField::Account),
+                            "transactions" => Ok(GeneratedField::Transactions),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = AccountTransactions;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.sequencerblock.v1.AccountTransactions")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<AccountTransactions, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut account__ = None;
+                let mut transactions__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Account => {
+                            if account__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("account"));
+                            }
+                            account__ = map_.next_value()?;
+                        }
+                        GeneratedField::Transactions => {
+                            if transactions__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("transactions"));
+                            }
+                            transactions__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(AccountTransactions {
+                    account: account__,
+                    transactions: transactions__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.sequencerblock.v1.AccountTransactions", FIELDS, GeneratedVisitor)
+    }
+}
 impl serde::Serialize for Deposit {
     #[allow(deprecated)]
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
@@ -197,6 +305,98 @@ impl<'de> serde::Deserialize<'de> for Deposit {
             }
         }
         deserializer.deserialize_struct("astria.sequencerblock.v1.Deposit", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for DumpMempoolRequest {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.sudo_address.is_some() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.sequencerblock.v1.DumpMempoolRequest", len)?;
+        if let Some(v) = self.sudo_address.as_ref() {
+            struct_ser.serialize_field("sudoAddress", v)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for DumpMempoolRequest {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "sudo_address",
+            "sudoAddress",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            SudoAddress,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "sudoAddress" | "sudo_address" => Ok(GeneratedField::SudoAddress),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = DumpMempoolRequest;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.sequencerblock.v1.DumpMempoolRequest")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<DumpMempoolRequest, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut sudo_address__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::SudoAddress => {
+                            if sudo_address__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("sudoAddress"));
+                            }
+                            sudo_address__ = map_.next_value()?;
+                        }
+                    }
+                }
+                Ok(DumpMempoolRequest {
+                    sudo_address: sudo_address__,
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.sequencerblock.v1.DumpMempoolRequest", FIELDS, GeneratedVisitor)
     }
 }
 impl serde::Serialize for FilteredSequencerBlock {
@@ -771,6 +971,150 @@ impl<'de> serde::Deserialize<'de> for GetSequencerBlockRequest {
             }
         }
         deserializer.deserialize_struct("astria.sequencerblock.v1.GetSequencerBlockRequest", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for Mempool {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.pending.is_empty() {
+            len += 1;
+        }
+        if !self.parked.is_empty() {
+            len += 1;
+        }
+        if !self.comet_bft_removal_cache.is_empty() {
+            len += 1;
+        }
+        if !self.contained_txs.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.sequencerblock.v1.Mempool", len)?;
+        if !self.pending.is_empty() {
+            struct_ser.serialize_field("pending", &self.pending)?;
+        }
+        if !self.parked.is_empty() {
+            struct_ser.serialize_field("parked", &self.parked)?;
+        }
+        if !self.comet_bft_removal_cache.is_empty() {
+            struct_ser.serialize_field("cometBftRemovalCache", &self.comet_bft_removal_cache)?;
+        }
+        if !self.contained_txs.is_empty() {
+            struct_ser.serialize_field("containedTxs", &self.contained_txs)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for Mempool {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "pending",
+            "parked",
+            "comet_bft_removal_cache",
+            "cometBftRemovalCache",
+            "contained_txs",
+            "containedTxs",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Pending,
+            Parked,
+            CometBftRemovalCache,
+            ContainedTxs,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "pending" => Ok(GeneratedField::Pending),
+                            "parked" => Ok(GeneratedField::Parked),
+                            "cometBftRemovalCache" | "comet_bft_removal_cache" => Ok(GeneratedField::CometBftRemovalCache),
+                            "containedTxs" | "contained_txs" => Ok(GeneratedField::ContainedTxs),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = Mempool;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.sequencerblock.v1.Mempool")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Mempool, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut pending__ = None;
+                let mut parked__ = None;
+                let mut comet_bft_removal_cache__ = None;
+                let mut contained_txs__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Pending => {
+                            if pending__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("pending"));
+                            }
+                            pending__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Parked => {
+                            if parked__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("parked"));
+                            }
+                            parked__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::CometBftRemovalCache => {
+                            if comet_bft_removal_cache__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("cometBftRemovalCache"));
+                            }
+                            comet_bft_removal_cache__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::ContainedTxs => {
+                            if contained_txs__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("containedTxs"));
+                            }
+                            contained_txs__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(Mempool {
+                    pending: pending__.unwrap_or_default(),
+                    parked: parked__.unwrap_or_default(),
+                    comet_bft_removal_cache: comet_bft_removal_cache__.unwrap_or_default(),
+                    contained_txs: contained_txs__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.sequencerblock.v1.Mempool", FIELDS, GeneratedVisitor)
     }
 }
 impl serde::Serialize for RollupData {

--- a/crates/astria-sequencer/CHANGELOG.md
+++ b/crates/astria-sequencer/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added local admin gRPC server [#1783](https://github.com/astriaorg/astria/pull/1783).
+
 ## [1.0.0] - 2024-10-25
 
 ### Changed

--- a/crates/astria-sequencer/CHANGELOG.md
+++ b/crates/astria-sequencer/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added local admin gRPC server [#1783](https://github.com/astriaorg/astria/pull/1783).
+- Added mempool info service gRPC server [#1783](https://github.com/astriaorg/astria/pull/1783).
 
 ## [1.0.0] - 2024-10-25
 

--- a/crates/astria-sequencer/Cargo.toml
+++ b/crates/astria-sequencer/Cargo.toml
@@ -10,6 +10,7 @@ homepage = "https://astria.org"
 
 [features]
 benchmark = ["divan"]
+client = ["astria-core/client"]
 
 [dependencies]
 astria-core = { path = "../astria-core", features = [

--- a/crates/astria-sequencer/local.env.example
+++ b/crates/astria-sequencer/local.env.example
@@ -14,6 +14,11 @@ ASTRIA_SEQUENCER_GRPC_ADDR="127.0.0.1:8080"
 # Log level for the sequencer
 ASTRIA_SEQUENCER_LOG="astria_sequencer=info"
 
+# The gRPC endpoint for the mempool info service
+ASTRIA_SEQUENCER_MEMPOOL_GRPC_ADDR="127.0.0.1:8080"
+# Set to true to disable the mempool info service
+ASTRIA_SEQUENCER_NO_MEMPOOL_GRPC=false
+
 # If true disables writing to the opentelemetry OTLP endpoint.
 ASTRIA_SEQUENCER_NO_OTEL=false
 

--- a/crates/astria-sequencer/src/config.rs
+++ b/crates/astria-sequencer/src/config.rs
@@ -20,6 +20,10 @@ pub struct Config {
     pub log: String,
     /// The gRPC endpoint
     pub grpc_addr: String,
+    /// The gRPC endpoint for the mempool info service
+    pub mempool_grpc_addr: String,
+    /// Set to true to disable the mempool info service
+    pub no_mempool_grpc: bool,
     /// Forces writing trace data to stdout no matter if connected to a tty or not.
     pub force_stdout: bool,
     /// Disables writing trace data to an opentelemetry endpoint.

--- a/crates/astria-sequencer/src/mempool/admin_grpc.rs
+++ b/crates/astria-sequencer/src/mempool/admin_grpc.rs
@@ -1,0 +1,135 @@
+use std::sync::Arc;
+
+use astria_core::{
+    generated::sequencerblock::v1::{
+        admin_mempool_service_server::AdminMempoolService,
+        AccountTransactions,
+        DumpMempoolRequest,
+        Mempool as MempoolDump,
+    },
+    primitive::v1::{
+        Address,
+        TransactionId,
+    },
+    Protobuf,
+};
+use cnidarium::Storage;
+use tonic::{
+    Code,
+    Request,
+    Response,
+    Status,
+};
+
+use super::{
+    transactions_container::{
+        TransactionsContainer as _,
+        TransactionsForAccount,
+    },
+    Mempool,
+};
+use crate::authority::StateReadExt;
+
+pub(crate) struct AdminGrpcServer {
+    storage: Storage,
+    mempool: Mempool,
+}
+
+impl AdminGrpcServer {
+    pub(crate) fn new(storage: Storage, mempool: Mempool) -> Self {
+        Self {
+            storage,
+            mempool,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl AdminMempoolService for AdminGrpcServer {
+    async fn dump_mempool(
+        self: Arc<Self>,
+        request: Request<DumpMempoolRequest>,
+    ) -> Result<Response<MempoolDump>, Status> {
+        let state_sudo_address = self
+            .storage
+            .latest_snapshot()
+            .get_sudo_address()
+            .await
+            .map_err(|err| {
+                Status::new(
+                    Code::Internal,
+                    format!("failed to get sudo address from state: {err:?}"),
+                )
+            })?;
+        let req_sudo_address =
+            Address::try_from_raw(&request.get_ref().sudo_address.clone().ok_or(Status::new(
+                Code::InvalidArgument,
+                "request sudo address is required",
+            ))?)
+            .map_err(|err| {
+                Status::new(
+                    Code::Internal,
+                    format!("failed to convert sudo address to domain type: {err:?}"),
+                )
+            })?;
+        if state_sudo_address != *req_sudo_address.as_bytes() {
+            return Err(Status::new(
+                Code::PermissionDenied,
+                "sudo address does not match the one in the state",
+            ));
+        }
+
+        let mempool_read_pending = self.mempool.pending.read().await;
+        let pending = mempool_read_pending
+            .txs()
+            .iter()
+            .map(|(address, txs)| AccountTransactions {
+                account: Some(Address::unchecked_from_parts(*address, "astria").into_raw()),
+                transactions: txs
+                    .txs()
+                    .iter()
+                    .map(|(_, tx)| tx.signed_tx().to_raw())
+                    .collect(),
+            })
+            .collect();
+
+        let mempool_read_parked = self.mempool.pending.read().await;
+        let parked = mempool_read_parked
+            .txs()
+            .iter()
+            .map(|(address, txs)| AccountTransactions {
+                account: Some(Address::unchecked_from_parts(*address, "astria").into_raw()),
+                transactions: txs
+                    .txs()
+                    .iter()
+                    .map(|(_, tx)| tx.signed_tx().to_raw())
+                    .collect(),
+            })
+            .collect();
+
+        let comet_bft_removal_cache = self
+            .mempool
+            .comet_bft_removal_cache
+            .read()
+            .await
+            .cache
+            .keys()
+            .map(|slice| TransactionId::new(*slice).into_raw())
+            .collect();
+        let contained_txs = self
+            .mempool
+            .contained_txs
+            .read()
+            .await
+            .iter()
+            .map(|slice| TransactionId::new(*slice).into_raw())
+            .collect();
+
+        Ok(Response::new(MempoolDump {
+            pending,
+            parked,
+            comet_bft_removal_cache,
+            contained_txs,
+        }))
+    }
+}

--- a/crates/astria-sequencer/src/mempool/admin_grpc.rs
+++ b/crates/astria-sequencer/src/mempool/admin_grpc.rs
@@ -1,8 +1,14 @@
-use std::sync::Arc;
+use std::{
+    net::SocketAddr,
+    sync::Arc,
+};
 
 use astria_core::{
     generated::sequencerblock::v1::{
-        admin_mempool_service_server::AdminMempoolService,
+        admin_mempool_service_server::{
+            AdminMempoolService,
+            AdminMempoolServiceServer,
+        },
         AccountTransactions,
         DumpMempoolRequest,
         Mempool as MempoolDump,
@@ -14,11 +20,19 @@ use astria_core::{
     Protobuf,
 };
 use cnidarium::Storage;
+use tokio::{
+    sync::oneshot,
+    task::JoinHandle,
+};
 use tonic::{
     Code,
     Request,
     Response,
     Status,
+};
+use tracing::{
+    info,
+    instrument,
 };
 
 use super::{
@@ -93,7 +107,7 @@ impl AdminMempoolService for AdminGrpcServer {
             })
             .collect();
 
-        let mempool_read_parked = self.mempool.pending.read().await;
+        let mempool_read_parked = self.mempool.parked.read().await;
         let parked = mempool_read_parked
             .txs()
             .iter()
@@ -131,5 +145,180 @@ impl AdminMempoolService for AdminGrpcServer {
             comet_bft_removal_cache,
             contained_txs,
         }))
+    }
+}
+
+#[instrument(skip_all)]
+pub(crate) fn start_local_admin_grpc_server(
+    storage: &cnidarium::Storage,
+    mempool: Mempool,
+    shutdown_rx: oneshot::Receiver<()>,
+) -> JoinHandle<Result<(), tonic::transport::Error>> {
+    use futures::TryFutureExt as _;
+    use penumbra_tower_trace::remote_addr;
+
+    let grpc_addr = "127.0.0.1:8080"
+        .parse::<SocketAddr>()
+        .expect("local host should parse to socket address");
+    let admin_api = AdminGrpcServer::new(storage.clone(), mempool);
+
+    let grpc_server = tonic::transport::Server::builder()
+        .trace_fn(|req| {
+            if let Some(remote_addr) = remote_addr(req) {
+                let addr = remote_addr.to_string();
+                tracing::error_span!("admin_grpc", addr)
+            } else {
+                tracing::error_span!("admin_grpc")
+            }
+        })
+        .accept_http1(true)
+        .add_service(AdminMempoolServiceServer::new(admin_api));
+
+    info!(grpc_addr = grpc_addr.to_string(), "starting grpc server");
+    tokio::task::spawn(
+        grpc_server.serve_with_shutdown(grpc_addr, shutdown_rx.unwrap_or_else(|_| ())),
+    )
+}
+
+#[cfg(all(test, feature = "client"))]
+mod tests {
+    use astria_core::{
+        generated::sequencerblock::v1::{
+            admin_mempool_service_client::AdminMempoolServiceClient,
+            DumpMempoolRequest,
+            Mempool as MempoolDump,
+        },
+        primitive::v1::{
+            Address,
+            TransactionId,
+        },
+        Protobuf as _,
+    };
+    use cnidarium::StateDelta;
+    use telemetry::Metrics as _;
+
+    use crate::{
+        app::{
+            benchmark_and_test_utils::{
+                mock_balances,
+                mock_tx_cost,
+            },
+            test_utils::MockTxBuilder,
+        },
+        authority::StateWriteExt as _,
+        benchmark_and_test_utils::astria_address,
+        mempool::{
+            admin_grpc::{
+                start_local_admin_grpc_server,
+                TransactionsForAccount as _,
+            },
+            transactions_container::TransactionsContainer as _,
+            Mempool,
+        },
+        Metrics,
+    };
+
+    // Run with `cargo test -p astria-sequencer --features client`
+    #[tokio::test]
+    async fn test_admin_grpc_service() {
+        let metrics = Box::leak(Box::new(Metrics::noop_metrics(&()).unwrap()));
+        let mempool = Mempool::new(metrics, 100);
+        let storage = cnidarium::TempStorage::new().await.unwrap();
+        let snapshot = storage.latest_snapshot();
+        let mut state = StateDelta::new(snapshot);
+        let sudo_address = astria_address(&[1; 20]);
+        state.put_sudo_address(sudo_address).unwrap();
+        storage.commit(state).await.unwrap();
+
+        let initial_balances = mock_balances(1, 0);
+        let tx_cost = mock_tx_cost(1, 0, 0);
+        let tx1 = MockTxBuilder::new().nonce(1).build();
+        let tx2 = MockTxBuilder::new().nonce(2).build();
+        let tx3 = MockTxBuilder::new().nonce(3).build();
+        let tx4 = MockTxBuilder::new().nonce(4).build();
+
+        mempool
+            .insert(tx1.clone(), 1, initial_balances.clone(), tx_cost.clone())
+            .await
+            .unwrap();
+        mempool
+            .insert(tx2.clone(), 1, initial_balances.clone(), tx_cost.clone())
+            .await
+            .unwrap();
+        mempool
+            .insert(tx3.clone(), 1, initial_balances.clone(), tx_cost.clone())
+            .await
+            .unwrap();
+        mempool
+            .insert(tx4.clone(), 1, initial_balances.clone(), tx_cost.clone())
+            .await
+            .unwrap();
+
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+        let admin_grpc_handle =
+            start_local_admin_grpc_server(&storage, mempool.clone(), shutdown_rx);
+
+        // Wait for the server to start
+        tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+
+        let mut client = AdminMempoolServiceClient::connect("http://127.0.0.1:8080")
+            .await
+            .unwrap();
+
+        let request = DumpMempoolRequest {
+            sudo_address: Some(sudo_address.into_raw()),
+        };
+        let MempoolDump {
+            pending,
+            parked,
+            comet_bft_removal_cache,
+            contained_txs,
+        } = client.dump_mempool(request).await.unwrap().into_inner();
+
+        pending
+            .iter()
+            .zip(mempool.pending.read().await.txs().iter())
+            .for_each(|(a, b)| {
+                assert_eq!(
+                    a.account.clone().unwrap(),
+                    Address::unchecked_from_parts(*b.0, "astria").into_raw()
+                );
+                a.transactions
+                    .iter()
+                    .zip(b.1.txs().iter())
+                    .for_each(|(l, r)| {
+                        assert_eq!(l, &r.1.signed_tx().to_raw());
+                    });
+            });
+        parked
+            .iter()
+            .zip(mempool.parked.read().await.txs().iter())
+            .for_each(|(a, b)| {
+                assert_eq!(
+                    a.account.clone().unwrap(),
+                    Address::unchecked_from_parts(*b.0, "astria").into_raw()
+                );
+                a.transactions
+                    .iter()
+                    .zip(b.1.txs().iter())
+                    .for_each(|(l, r)| {
+                        assert_eq!(l, &r.1.signed_tx().to_raw());
+                    });
+            });
+        comet_bft_removal_cache
+            .iter()
+            .zip(mempool.comet_bft_removal_cache.read().await.cache.keys())
+            .for_each(|(a, b)| {
+                assert_eq!(TransactionId::try_from_raw_ref(a).unwrap().get(), *b);
+            });
+        contained_txs
+            .iter()
+            .zip(mempool.contained_txs.read().await.iter())
+            .for_each(|(a, b)| {
+                assert_eq!(TransactionId::try_from_raw_ref(a).unwrap().get(), *b);
+            });
+
+        shutdown_tx.send(()).unwrap();
+        admin_grpc_handle.await.unwrap().unwrap();
     }
 }

--- a/crates/astria-sequencer/src/mempool/mempool_grpc.rs
+++ b/crates/astria-sequencer/src/mempool/mempool_grpc.rs
@@ -10,8 +10,8 @@ use astria_core::{
             MempoolInfoServiceServer,
         },
         AccountTransactions,
-        MempoolInfoRequest,
-        MempoolInfoResponse,
+        DumpMempoolRequest,
+        DumpMempoolResponse,
     },
     primitive::v1::{
         Address,
@@ -57,8 +57,8 @@ impl MempoolGrpcServer {
 impl MempoolInfoService for MempoolGrpcServer {
     async fn dump_mempool(
         self: Arc<Self>,
-        _request: Request<MempoolInfoRequest>,
-    ) -> Result<Response<MempoolInfoResponse>, Status> {
+        _request: Request<DumpMempoolRequest>,
+    ) -> Result<Response<DumpMempoolResponse>, Status> {
         let mempool_read_pending = self.mempool.pending.read().await;
         let pending = mempool_read_pending
             .txs()
@@ -105,7 +105,7 @@ impl MempoolInfoService for MempoolGrpcServer {
             .map(|slice| TransactionId::new(*slice).into_raw())
             .collect();
 
-        Ok(Response::new(MempoolInfoResponse {
+        Ok(Response::new(DumpMempoolResponse {
             pending,
             parked,
             comet_bft_removal_cache,
@@ -148,8 +148,8 @@ mod tests {
     use astria_core::{
         generated::sequencerblock::v1::{
             mempool_info_service_client::MempoolInfoServiceClient,
-            MempoolInfoRequest,
-            MempoolInfoResponse,
+            DumpMempoolRequest,
+            DumpMempoolResponse,
         },
         primitive::v1::{
             Address,
@@ -223,8 +223,8 @@ mod tests {
             .await
             .unwrap();
 
-        let request = MempoolInfoRequest {};
-        let MempoolInfoResponse {
+        let request = DumpMempoolRequest {};
+        let DumpMempoolResponse {
             pending,
             parked,
             comet_bft_removal_cache,

--- a/crates/astria-sequencer/src/mempool/mod.rs
+++ b/crates/astria-sequencer/src/mempool/mod.rs
@@ -1,6 +1,6 @@
-pub(crate) mod admin_grpc;
 #[cfg(feature = "benchmark")]
 mod benchmarks;
+pub(crate) mod mempool_grpc;
 mod mempool_state;
 mod transactions_container;
 

--- a/crates/astria-sequencer/src/mempool/mod.rs
+++ b/crates/astria-sequencer/src/mempool/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod admin_grpc;
 #[cfg(feature = "benchmark")]
 mod benchmarks;
 mod mempool_state;

--- a/crates/astria-sequencer/src/mempool/transactions_container.rs
+++ b/crates/astria-sequencer/src/mempool/transactions_container.rs
@@ -98,6 +98,10 @@ impl TimemarkedTransaction {
         now.saturating_duration_since(self.time_first_seen) > ttl
     }
 
+    pub(super) fn signed_tx(&self) -> &Arc<Transaction> {
+        &self.signed_tx
+    }
+
     pub(super) fn nonce(&self) -> u32 {
         self.signed_tx.nonce()
     }

--- a/proto/sequencerblockapis/astria/sequencerblock/v1/service.proto
+++ b/proto/sequencerblockapis/astria/sequencerblock/v1/service.proto
@@ -30,8 +30,7 @@ message GetPendingNonceResponse {
   uint32 inner = 1;
 }
 
-message MempoolInfoRequest {
-}
+message MempoolInfoRequest {}
 
 message MempoolInfoResponse {
   repeated AccountTransactions pending = 1;

--- a/proto/sequencerblockapis/astria/sequencerblock/v1/service.proto
+++ b/proto/sequencerblockapis/astria/sequencerblock/v1/service.proto
@@ -30,9 +30,9 @@ message GetPendingNonceResponse {
   uint32 inner = 1;
 }
 
-message MempoolInfoRequest {}
+message DumpMempoolRequest {}
 
-message MempoolInfoResponse {
+message DumpMempoolResponse {
   repeated AccountTransactions pending = 1;
   repeated AccountTransactions parked = 2;
   repeated astria.primitive.v1.TransactionId comet_bft_removal_cache = 3;
@@ -69,7 +69,7 @@ service SequencerService {
 
 service MempoolInfoService {
   // Dumps the mempool.
-  rpc DumpMempool(MempoolInfoRequest) returns (MempoolInfoResponse) {
+  rpc DumpMempool(DumpMempoolRequest) returns (DumpMempoolResponse) {
     option (google.api.http) = {get: "/v1/admin/mempool"};
   }
 }

--- a/proto/sequencerblockapis/astria/sequencerblock/v1/service.proto
+++ b/proto/sequencerblockapis/astria/sequencerblock/v1/service.proto
@@ -30,13 +30,10 @@ message GetPendingNonceResponse {
   uint32 inner = 1;
 }
 
-message DumpMempoolRequest {
-  // The submitting address needs to be the sudo address, since we don't want this info
-  // to be publicly available.
-  astria.primitive.v1.Address sudo_address = 1 [(google.api.field_behavior) = REQUIRED];
+message MempoolInfoRequest {
 }
 
-message Mempool {
+message MempoolInfoResponse {
   repeated AccountTransactions pending = 1;
   repeated AccountTransactions parked = 2;
   repeated astria.primitive.v1.TransactionId comet_bft_removal_cache = 3;
@@ -71,9 +68,9 @@ service SequencerService {
   }
 }
 
-service AdminMempoolService {
+service MempoolInfoService {
   // Dumps the mempool.
-  rpc DumpMempool(DumpMempoolRequest) returns (Mempool) {
+  rpc DumpMempool(MempoolInfoRequest) returns (MempoolInfoResponse) {
     option (google.api.http) = {get: "/v1/admin/mempool"};
   }
 }

--- a/proto/sequencerblockapis/astria/sequencerblock/v1/service.proto
+++ b/proto/sequencerblockapis/astria/sequencerblock/v1/service.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package astria.sequencerblock.v1;
 
 import "astria/primitive/v1/types.proto";
+import "astria/protocol/transaction/v1/transaction.proto";
 import "astria/sequencerblock/v1/block.proto";
 import "google/api/annotations.proto";
 import "google/api/field_behavior.proto";
@@ -29,6 +30,26 @@ message GetPendingNonceResponse {
   uint32 inner = 1;
 }
 
+message DumpMempoolRequest {
+  // The submitting address needs to be the sudo address, since we don't want this info
+  // to be publicly available.
+  astria.primitive.v1.Address sudo_address = 1 [(google.api.field_behavior) = REQUIRED];
+}
+
+message Mempool {
+  repeated AccountTransactions pending = 1;
+  repeated AccountTransactions parked = 2;
+  repeated astria.primitive.v1.TransactionId comet_bft_removal_cache = 3;
+  repeated astria.primitive.v1.TransactionId contained_txs = 4;
+}
+
+message AccountTransactions {
+  // The account address.
+  astria.primitive.v1.Address account = 1;
+  // The transactions associated with the account.
+  repeated astria.protocol.transaction.v1.Transaction transactions = 2;
+}
+
 service SequencerService {
   // Given a block height, returns the sequencer block at that height.
   rpc GetSequencerBlock(GetSequencerBlockRequest) returns (SequencerBlock) {
@@ -47,5 +68,12 @@ service SequencerService {
   // Returns the pending nonce for the given account.
   rpc GetPendingNonce(GetPendingNonceRequest) returns (GetPendingNonceResponse) {
     option (google.api.http) = {get: "/v1/sequencer/pendingnonce/{account}"};
+  }
+}
+
+service AdminMempoolService {
+  // Dumps the mempool.
+  rpc DumpMempool(DumpMempoolRequest) returns (Mempool) {
+    option (google.api.http) = {get: "/v1/admin/mempool"};
   }
 }


### PR DESCRIPTION
## Summary
Added mempool dump gRPC on a new gRPC server.

## Background
This was briefly mentioned as something that would be nice to have for observability of the mempool.

## Changes
- Added mempool info gRPC service in proto, along with associated types.
- Added mempool info gRPC server to sequence.
- Added mempool dump RPC to admin gRPC server, which returns a simplified copy of the mempool.
- Added new env variables for mempool info gRPC address as well as disabling the service.

## Testing
Added new unit test under "client" feature.

## Breaking Changes
Non-consensus breaking, changed sequencer config.

## Changelogs
Changelog updated.