### PR TITLE
refactor: make extended commit info third injected tx

### DIFF
--- a/crates/astria-core/src/protocol/test_utils.rs
+++ b/crates/astria-core/src/protocol/test_utils.rs
@@ -18,7 +18,10 @@ use crate::{
     },
     protocol::transaction::v1::TransactionBody,
     sequencerblock::v1::{
-        block::Deposit,
+        block::{
+            Deposit,
+            SequencerBlockBuilder,
+        },
         SequencerBlock,
     },
     Protobuf as _,
@@ -170,16 +173,17 @@ impl ConfigureSequencerBlock {
         data.extend(txs.into_iter().map(|tx| tx.into_raw().encode_to_vec()));
         let data = data.into_iter().map(Bytes::from).collect();
 
-        SequencerBlock::try_from_block_info_and_data(
+        SequencerBlockBuilder {
             block_hash,
-            chain_id.try_into().unwrap(),
-            height.into(),
-            Time::from_unix_timestamp(unix_timestamp.secs, unix_timestamp.nanos).unwrap(),
+            chain_id: chain_id.try_into().unwrap(),
+            height: height.into(),
+            time: Time::from_unix_timestamp(unix_timestamp.secs, unix_timestamp.nanos).unwrap(),
             proposer_address,
             data,
-            deposits_map,
+            deposits: deposits_map,
             with_extended_commit_info,
-        )
+        }
+        .try_build()
         .unwrap()
     }
 }

--- a/crates/astria-core/src/protocol/test_utils.rs
+++ b/crates/astria-core/src/protocol/test_utils.rs
@@ -60,6 +60,7 @@ impl ConfigureSequencerBlock {
     #[must_use]
     #[expect(
         clippy::missing_panics_doc,
+        clippy::too_many_lines,
         reason = "This should only be used in tests, so everything here is unwrapped"
     )]
     pub fn make(self) -> SequencerBlock {
@@ -156,9 +157,9 @@ impl ConfigureSequencerBlock {
         )
         .root();
         let mut data = vec![
-            extended_commit_info_bytes,
             rollup_transactions_tree.root().to_vec(),
             rollup_ids_root.to_vec(),
+            extended_commit_info_bytes,
         ];
         data.extend(txs.into_iter().map(|tx| tx.into_raw().encode_to_vec()));
         let data = data.into_iter().map(Bytes::from).collect();
@@ -170,6 +171,7 @@ impl ConfigureSequencerBlock {
             proposer_address,
             data,
             deposits_map,
+            true,
         )
         .unwrap()
     }

--- a/crates/astria-core/src/sequencerblock/v1/block.rs
+++ b/crates/astria-core/src/sequencerblock/v1/block.rs
@@ -1029,7 +1029,7 @@ fn take_initial_elements_from_data(
         .map_err(|_| {
             SequencerBlockError::incorrect_rollup_transactions_root_length(data_iter.len())
         })?;
-    let rollup_transactions_proof = tree.construct_proof(1).expect(
+    let rollup_transactions_proof = tree.construct_proof(0).expect(
         "the leaf must exist in the tree as `rollup_transactions_root` was created from the same \
          index in `data` used to construct the tree",
     );
@@ -1040,7 +1040,7 @@ fn take_initial_elements_from_data(
         .as_ref()
         .try_into()
         .map_err(|_| SequencerBlockError::incorrect_rollup_ids_root_length(data_iter.len()))?;
-    let rollup_ids_proof = tree.construct_proof(2).expect(
+    let rollup_ids_proof = tree.construct_proof(1).expect(
         "the leaf must exist in the tree as `rollup_ids_root` was created from the same index in \
          `data` used to construct the tree",
     );

--- a/crates/astria-core/src/sequencerblock/v1/block.rs
+++ b/crates/astria-core/src/sequencerblock/v1/block.rs
@@ -595,6 +595,148 @@ pub struct SequencerBlockParts {
     pub rollup_ids_proof: merkle::Proof,
 }
 
+pub struct SequencerBlockBuilder {
+    pub block_hash: [u8; 32],
+    pub chain_id: tendermint::chain::Id,
+    pub height: tendermint::block::Height,
+    pub time: Time,
+    pub proposer_address: account::Id,
+    pub data: Vec<Bytes>,
+    pub deposits: HashMap<RollupId, Vec<Deposit>>,
+    pub with_extended_commit_info: bool,
+}
+
+impl SequencerBlockBuilder {
+    /// Attempts to build a [`SequencerBlock`] from the provided data.
+    ///
+    /// # Errors
+    ///
+    /// - if the first transaction in the data is not the 32-byte rollup transactions root.
+    /// - if the second transaction in the data is not the 32-byte rollup IDs root.
+    /// - if `with_extended_commit_info` is set to `true` and the third transaction in the data is
+    ///   not the extended commit info.
+    /// - if any transaction in the data cannot be decoded.
+    /// - if the rollup transactions root does not match the reconstructed root.
+    /// - if the rollup IDs root does not match the reconstructed root.
+    ///
+    /// # Panics
+    ///
+    /// - if a rollup data merkle proof cannot be constructed.
+    pub fn try_build(self) -> Result<SequencerBlock, SequencerBlockError> {
+        use prost::Message as _;
+
+        let SequencerBlockBuilder {
+            block_hash,
+            chain_id,
+            height,
+            time,
+            proposer_address,
+            data,
+            deposits,
+            with_extended_commit_info,
+        } = self;
+
+        let InitialDataElements {
+            data_root_hash,
+            // This iterator over `data` has been advanced to skip the injected transactions while
+            // retrieving the initial elements. The next element to be yielded will be
+            // the first of the actual user-submitted txs.
+            data_iter,
+            // TODO: this needs to go into the block header
+            _extended_commit_info,
+            rollup_transactions_root,
+            rollup_transactions_proof,
+            rollup_ids_root,
+            rollup_ids_proof,
+        } = take_initial_elements_from_data(data, with_extended_commit_info)?;
+
+        let mut rollup_datas = IndexMap::new();
+        for elem in data_iter {
+            let raw_tx = crate::generated::protocol::transaction::v1::Transaction::decode(&*elem)
+                .map_err(SequencerBlockError::transaction_protobuf_decode)?;
+            let tx = Transaction::try_from_raw(raw_tx)
+                .map_err(SequencerBlockError::raw_signed_transaction_conversion)?;
+            for action in tx.into_unsigned().into_actions() {
+                // XXX: The fee asset is dropped. We should explain why that's ok.
+                if let action::Action::RollupDataSubmission(action::RollupDataSubmission {
+                    rollup_id,
+                    data,
+                    fee_asset: _,
+                }) = action
+                {
+                    let elem = rollup_datas.entry(rollup_id).or_insert(vec![]);
+                    let data = RollupData::SequencedData(data)
+                        .into_raw()
+                        .encode_to_vec()
+                        .into();
+                    elem.push(data);
+                }
+            }
+        }
+        for (id, deposits) in deposits {
+            rollup_datas
+                .entry(id)
+                .or_default()
+                .extend(deposits.into_iter().map(|deposit| {
+                    RollupData::Deposit(Box::new(deposit))
+                        .into_raw()
+                        .encode_to_vec()
+                        .into()
+                }));
+        }
+
+        // XXX: The rollup data must be sorted by its keys before constructing the merkle tree.
+        // Since it's constructed from non-deterministically ordered sources, there is otherwise no
+        // guarantee that the same data will give the root.
+        rollup_datas.sort_unstable_keys();
+
+        // ensure the rollup IDs commitment matches the one calculated from the rollup data
+        if rollup_ids_root != merkle::Tree::from_leaves(rollup_datas.keys()).root() {
+            return Err(SequencerBlockError::rollup_ids_root_does_not_match_reconstructed());
+        }
+
+        let rollup_transaction_tree = derive_merkle_tree_from_rollup_txs(&rollup_datas);
+        if rollup_transactions_root != rollup_transaction_tree.root() {
+            return Err(
+                SequencerBlockError::rollup_transactions_root_does_not_match_reconstructed(),
+            );
+        }
+
+        let mut rollup_transactions = IndexMap::new();
+        for (i, (rollup_id, data)) in rollup_datas.into_iter().enumerate() {
+            // NOTE: This should never error as the tree was derived with the same `rollup_datas`
+            // just above.
+            let proof = rollup_transaction_tree
+                .construct_proof(i)
+                .expect("the proof must exist because the tree was derived with the same leaf");
+            rollup_transactions.insert(
+                rollup_id,
+                RollupTransactions {
+                    rollup_id,
+                    transactions: data, // TODO: rename this field?
+                    proof,
+                },
+            );
+        }
+        rollup_transactions.sort_unstable_keys();
+
+        Ok(SequencerBlock {
+            block_hash,
+            header: SequencerBlockHeader {
+                chain_id,
+                height,
+                time,
+                rollup_transactions_root,
+                data_hash: data_root_hash,
+                proposer_address,
+            },
+            rollup_transactions,
+            rollup_transactions_proof,
+            rollup_ids_proof,
+        })
+    }
+}
+
 /// `SequencerBlock` is constructed from a tendermint/cometbft block by
 /// converting its opaque `data` bytes into sequencer specific types.
 #[derive(Clone, Debug, PartialEq)]
@@ -762,130 +904,6 @@ impl SequencerBlock {
     #[must_use]
     pub fn split_for_celestia(self) -> (SubmittedMetadata, Vec<SubmittedRollupData>) {
         celestia::PreparedBlock::from_sequencer_block(self).into_parts()
-    }
-
-    /// Converts from relevant header fields and the block data.
-    ///
-    /// # Errors
-    /// TODO(https://github.com/astriaorg/astria/issues/612)
-    ///
-    /// # Panics
-    ///
-    /// - if a rollup data merkle proof cannot be constructed.
-    #[expect(
-        clippy::too_many_arguments,
-        reason = "all arguments are required to make a block"
-    )]
-    pub fn try_from_block_info_and_data(
-        block_hash: [u8; 32],
-        chain_id: tendermint::chain::Id,
-        height: tendermint::block::Height,
-        time: Time,
-        proposer_address: account::Id,
-        data: Vec<Bytes>,
-        deposits: HashMap<RollupId, Vec<Deposit>>,
-        with_extended_commit_info: bool,
-    ) -> Result<Self, SequencerBlockError> {
-        use prost::Message as _;
-
-        let InitialDataElements {
-            data_root_hash,
-            // This iterator over `data` has been advanced to skip the injected transactions while
-            // retrieving the initial elements. The next element to be yielded will be
-            // the first of the actual user-submitted txs.
-            data_iter,
-            // TODO: this needs to go into the block header
-            _extended_commit_info,
-            rollup_transactions_root,
-            rollup_transactions_proof,
-            rollup_ids_root,
-            rollup_ids_proof,
-        } = take_initial_elements_from_data(data, with_extended_commit_info)?;
-
-        let mut rollup_datas = IndexMap::new();
-        for elem in data_iter {
-            let raw_tx = crate::generated::protocol::transaction::v1::Transaction::decode(&*elem)
-                .map_err(SequencerBlockError::transaction_protobuf_decode)?;
-            let tx = Transaction::try_from_raw(raw_tx)
-                .map_err(SequencerBlockError::raw_signed_transaction_conversion)?;
-            for action in tx.into_unsigned().into_actions() {
-                // XXX: The fee asset is dropped. We should explain why that's ok.
-                if let action::Action::RollupDataSubmission(action::RollupDataSubmission {
-                    rollup_id,
-                    data,
-                    fee_asset: _,
-                }) = action
-                {
-                    let elem = rollup_datas.entry(rollup_id).or_insert(vec![]);
-                    let data = RollupData::SequencedData(data)
-                        .into_raw()
-                        .encode_to_vec()
-                        .into();
-                    elem.push(data);
-                }
-            }
-        }
-        for (id, deposits) in deposits {
-            rollup_datas
-                .entry(id)
-                .or_default()
-                .extend(deposits.into_iter().map(|deposit| {
-                    RollupData::Deposit(Box::new(deposit))
-                        .into_raw()
-                        .encode_to_vec()
-                        .into()
-                }));
-        }
-
-        // XXX: The rollup data must be sorted by its keys before constructing the merkle tree.
-        // Since it's constructed from non-deterministically ordered sources, there is otherwise no
-        // guarantee that the same data will give the root.
-        rollup_datas.sort_unstable_keys();
-
-        // ensure the rollup IDs commitment matches the one calculated from the rollup data
-        if rollup_ids_root != merkle::Tree::from_leaves(rollup_datas.keys()).root() {
-            return Err(SequencerBlockError::rollup_ids_root_does_not_match_reconstructed());
-        }
-
-        let rollup_transaction_tree = derive_merkle_tree_from_rollup_txs(&rollup_datas);
-        if rollup_transactions_root != rollup_transaction_tree.root() {
-            return Err(
-                SequencerBlockError::rollup_transactions_root_does_not_match_reconstructed(),
-            );
-        }
-
-        let mut rollup_transactions = IndexMap::new();
-        for (i, (rollup_id, data)) in rollup_datas.into_iter().enumerate() {
-            // NOTE: This should never error as the tree was derived with the same `rollup_datas`
-            // just above.
-            let proof = rollup_transaction_tree
-                .construct_proof(i)
-                .expect("the proof must exist because the tree was derived with the same leaf");
-            rollup_transactions.insert(
-                rollup_id,
-                RollupTransactions {
-                    rollup_id,
-                    transactions: data, // TODO: rename this field?
-                    proof,
-                },
-            );
-        }
-        rollup_transactions.sort_unstable_keys();
-
-        Ok(Self {
-            block_hash,
-            header: SequencerBlockHeader {
-                chain_id,
-                height,
-                time,
-                rollup_transactions_root,
-                data_hash: data_root_hash,
-                proposer_address,
-            },
-            rollup_transactions,
-            rollup_transactions_proof,
-            rollup_ids_proof,
-        })
     }
 
     /// Converts from the raw decoded protobuf representation of this type.

--- a/crates/astria-core/src/sequencerblock/v1/block.rs
+++ b/crates/astria-core/src/sequencerblock/v1/block.rs
@@ -809,7 +809,7 @@ impl SequencerBlock {
             let tx = Transaction::try_from_raw(raw_tx)
                 .map_err(SequencerBlockError::raw_signed_transaction_conversion)?;
             for action in tx.into_unsigned().into_actions() {
-                // XXX: The fee asset is dropped. We shjould explain why that's ok.
+                // XXX: The fee asset is dropped. We should explain why that's ok.
                 if let action::Action::RollupDataSubmission(action::RollupDataSubmission {
                     rollup_id,
                     data,

--- a/crates/astria-sequencer/src/app/mod.rs
+++ b/crates/astria-sequencer/src/app/mod.rs
@@ -37,7 +37,7 @@ use astria_core::{
             Transaction,
         },
     },
-    sequencerblock::v1::block::SequencerBlock,
+    sequencerblock::v1::block::SequencerBlockBuilder,
     Protobuf as _,
 };
 use astria_eyre::{
@@ -1126,16 +1126,17 @@ impl App {
             .extend(std::iter::repeat(ExecTxResult::default()).take(injected_txs_count));
         finalize_block_tx_results.extend(tx_results);
 
-        let sequencer_block = SequencerBlock::try_from_block_info_and_data(
+        let sequencer_block = SequencerBlockBuilder {
             block_hash,
             chain_id,
             height,
             time,
             proposer_address,
-            txs,
-            deposits_in_this_block,
-            vote_extensions_enabled,
-        )
+            data: txs,
+            deposits: deposits_in_this_block,
+            with_extended_commit_info: vote_extensions_enabled,
+        }
+        .try_build()
         .wrap_err("failed to convert block info and data to SequencerBlock")?;
         state_tx
             .put_sequencer_block(sequencer_block)

--- a/crates/astria-sequencer/src/app/test_utils.rs
+++ b/crates/astria-sequencer/src/app/test_utils.rs
@@ -197,13 +197,10 @@ pub(crate) fn transactions_with_extended_commit_info_and_commitments(
     }
     .into();
     let commitments = generate_rollup_datas_commitment(txs, deposits.unwrap_or_default());
-    let txs_with_commit_info: Vec<Bytes> =
-        std::iter::once(extended_commit_info.encode_to_vec().into())
-            .chain(
-                commitments
-                    .into_iter()
-                    .chain(txs.iter().map(|tx| tx.to_raw().encode_to_vec().into())),
-            )
-            .collect();
+    let txs_with_commit_info: Vec<Bytes> = commitments
+        .into_iter()
+        .chain(std::iter::once(extended_commit_info.encode_to_vec().into()))
+        .chain(txs.iter().map(|tx| tx.to_raw().encode_to_vec().into()))
+        .collect();
     txs_with_commit_info
 }


### PR DESCRIPTION
## Summary
make extended commit info third injected tx, and update `SequencerBlock::try_from_block_info_and_data` to handle whether the extended commit info is in the block or not.

## Background
 it makes more sense to append to the existing list of injected txs which are the two commitments at the start of the block. 

## Changes
- make extended commit info the third injected tx instead of the first
- update `SequencerBlock::try_from_block_info_and_data` to handle whether the extended commit info is in the block or not
- cleanup of related unit tests

## Testing
unit tests

## Breaking Changelist
- unbreaks `SequencerBlock::try_from_block_info_and_data`
