### PR TITLE
refactor(sequencer): provide storage and snapshot types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -180,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.86"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 
 [[package]]
 name = "ark-bls12-377"
@@ -795,6 +796,7 @@ dependencies = [
 name = "astria-sequencer"
 version = "1.0.0"
 dependencies = [
+ "anyhow",
  "astria-build-info",
  "astria-config",
  "astria-core",
@@ -820,16 +822,19 @@ dependencies = [
  "penumbra-tower-trace",
  "pin-project-lite",
  "prost",
+ "quick_cache",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "regex",
  "serde",
  "serde_json",
  "sha2 0.10.8",
+ "tempfile",
  "tendermint",
  "tendermint-proto",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tonic 0.10.2",
  "tower",
  "tower-abci",
@@ -6412,6 +6417,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d6da84cc204722a989e01ba2f6e1e276e190f22263d0cb6ce8526fcdb0d2e1f"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "quick_cache"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d7c94f8935a9df96bb6380e8592c70edf497a643f94bd23b2f76b399385dbf4"
+dependencies = [
+ "ahash",
+ "equivalent",
+ "hashbrown 0.14.5",
+ "parking_lot",
 ]
 
 [[package]]

--- a/crates/astria-sequencer/CHANGELOG.md
+++ b/crates/astria-sequencer/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Provide and use new `Storage` struct, wrapping `cnidarium::Storage` [#1801](https://github.com/astriaorg/astria/pull/1801).
+- Provide and use new `Snapshot` struct, wrapping `cnidarium::Snapshot` and
+holding a cache of recently-read values [#1801](https://github.com/astriaorg/astria/pull/1801).
+
 ## [1.0.0] - 2024-10-25
 
 ### Changed

--- a/crates/astria-sequencer/Cargo.toml
+++ b/crates/astria-sequencer/Cargo.toml
@@ -32,12 +32,14 @@ telemetry = { package = "astria-telemetry", path = "../astria-telemetry", featur
   "display",
 ] }
 
+anyhow = "1.0.89"
 borsh = { version = "1.5.1", features = ["bytes", "derive"] }
 cnidarium = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.80.7", features = [
   "metrics",
 ] }
 ibc-proto = { version = "0.41.0", features = ["server"] }
 matchit = "0.7.2"
+quick_cache = "0.6.9"
 tower = "0.4"
 tower-abci = "0.12.0"
 tower-actor = "0.1.0"
@@ -60,10 +62,12 @@ regex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
+tempfile = { workspace = true, optional = true }
 tendermint-proto = { workspace = true }
 tendermint = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt", "tracing"] }
+tokio-stream = { workspace = true }
 tonic = { workspace = true }
 tracing = { workspace = true }
 
@@ -80,6 +84,7 @@ insta = { workspace = true, features = ["json"] }
 paste = "1.0.15"
 maplit = "1.0.2"
 rand_chacha = "0.3.1"
+tempfile = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 
 [build-dependencies]

--- a/crates/astria-sequencer/src/accounts/query.rs
+++ b/crates/astria-sequencer/src/accounts/query.rs
@@ -13,11 +13,7 @@ use astria_eyre::eyre::{
     Result,
     WrapErr as _,
 };
-use cnidarium::{
-    Snapshot,
-    StateRead,
-    Storage,
-};
+use cnidarium::StateRead;
 use futures::TryStreamExt as _;
 use prost::Message as _;
 use tendermint::{
@@ -34,6 +30,10 @@ use crate::{
     accounts::StateReadExt as _,
     app::StateReadExt as _,
     assets::StateReadExt as _,
+    storage::{
+        Snapshot,
+        Storage,
+    },
 };
 
 async fn ibc_to_trace<S: StateRead>(

--- a/crates/astria-sequencer/src/accounts/state_ext.rs
+++ b/crates/astria-sequencer/src/accounts/state_ext.rs
@@ -273,7 +273,6 @@ impl<T: StateWrite> StateWriteExt for T {}
 
 #[cfg(test)]
 mod tests {
-    use cnidarium::StateDelta;
     use futures::TryStreamExt as _;
 
     use super::*;
@@ -286,6 +285,7 @@ mod tests {
             astria_address,
             nria,
         },
+        storage::Storage,
     };
 
     fn asset_0() -> asset::Denom {
@@ -302,9 +302,8 @@ mod tests {
 
     #[tokio::test]
     async fn get_account_nonce_uninitialized_returns_zero() {
-        let storage = cnidarium::TempStorage::new().await.unwrap();
-        let snapshot = storage.latest_snapshot();
-        let state = StateDelta::new(snapshot);
+        let storage = Storage::new_temp().await;
+        let state_delta = storage.new_delta_of_latest_snapshot();
 
         // create needed variables
         let address = astria_address(&[42u8; 20]);
@@ -312,7 +311,7 @@ mod tests {
 
         // uninitialized accounts return zero
         assert_eq!(
-            state
+            state_delta
                 .get_account_nonce(&address)
                 .await
                 .expect("getting a non-initialized account's nonce should not fail"),
@@ -323,20 +322,19 @@ mod tests {
 
     #[tokio::test]
     async fn get_account_nonce_get_nonce_simple() {
-        let storage = cnidarium::TempStorage::new().await.unwrap();
-        let snapshot = storage.latest_snapshot();
-        let mut state = StateDelta::new(snapshot);
+        let storage = Storage::new_temp().await;
+        let mut state_delta = storage.new_delta_of_latest_snapshot();
 
         // create needed variables
         let address = astria_address(&[42u8; 20]);
         let nonce_expected = 0u32;
 
         // can write new
-        state
+        state_delta
             .put_account_nonce(&address, nonce_expected)
             .expect("putting an account nonce should not fail");
         assert_eq!(
-            state
+            state_delta
                 .get_account_nonce(&address)
                 .await
                 .expect("a nonce was written and must exist inside the database"),
@@ -346,11 +344,11 @@ mod tests {
 
         // can rewrite with new value
         let nonce_expected = 1u32;
-        state
+        state_delta
             .put_account_nonce(&address, nonce_expected)
             .expect("putting an account nonce should not fail");
         assert_eq!(
-            state
+            state_delta
                 .get_account_nonce(&address)
                 .await
                 .expect("a new nonce was written and must exist inside the database"),
@@ -361,20 +359,19 @@ mod tests {
 
     #[tokio::test]
     async fn get_account_nonce_get_nonce_complex() {
-        let storage = cnidarium::TempStorage::new().await.unwrap();
-        let snapshot = storage.latest_snapshot();
-        let mut state = StateDelta::new(snapshot);
+        let storage = Storage::new_temp().await;
+        let mut state_delta = storage.new_delta_of_latest_snapshot();
 
         // create needed variables
         let address = astria_address(&[42u8; 20]);
         let nonce_expected = 2u32;
 
         // can write new
-        state
+        state_delta
             .put_account_nonce(&address, nonce_expected)
             .expect("putting an account nonce should not fail");
         assert_eq!(
-            state
+            state_delta
                 .get_account_nonce(&address)
                 .await
                 .expect("a nonce was written and must exist inside the database"),
@@ -386,11 +383,11 @@ mod tests {
         let address_1 = astria_address(&[41u8; 20]);
         let nonce_expected_1 = 3u32;
 
-        state
+        state_delta
             .put_account_nonce(&address_1, nonce_expected_1)
             .expect("putting an account nonce should not fail");
         assert_eq!(
-            state
+            state_delta
                 .get_account_nonce(&address_1)
                 .await
                 .expect("a new nonce was written and must exist inside the database"),
@@ -398,7 +395,7 @@ mod tests {
             "additional account's nonce was not what was expected"
         );
         assert_eq!(
-            state
+            state_delta
                 .get_account_nonce(&address)
                 .await
                 .expect("a new nonce was written and must exist inside the database"),
@@ -409,9 +406,8 @@ mod tests {
 
     #[tokio::test]
     async fn get_account_balance_uninitialized_returns_zero() {
-        let storage = cnidarium::TempStorage::new().await.unwrap();
-        let snapshot = storage.latest_snapshot();
-        let state = StateDelta::new(snapshot);
+        let storage = Storage::new_temp().await;
+        let state_delta = storage.new_delta_of_latest_snapshot();
 
         // create needed variables
         let address = astria_address(&[42u8; 20]);
@@ -420,7 +416,7 @@ mod tests {
 
         // non-initialized accounts return zero
         assert_eq!(
-            state
+            state_delta
                 .get_account_balance(&address, &asset)
                 .await
                 .expect("getting a non-initialized asset balance should not fail"),
@@ -431,22 +427,21 @@ mod tests {
 
     #[tokio::test]
     async fn get_account_balance_simple() {
-        let storage = cnidarium::TempStorage::new().await.unwrap();
-        let snapshot = storage.latest_snapshot();
-        let mut state = StateDelta::new(snapshot);
+        let storage = Storage::new_temp().await;
+        let mut state_delta = storage.new_delta_of_latest_snapshot();
 
         // create needed variables
         let address = astria_address(&[42u8; 20]);
         let asset = asset_0();
         let mut amount_expected = 1u128;
 
-        state
+        state_delta
             .put_account_balance(&address, &asset, amount_expected)
             .expect("putting an account balance should not fail");
 
         // can initialize
         assert_eq!(
-            state
+            state_delta
                 .get_account_balance(&address, &asset)
                 .await
                 .expect("getting an asset balance should not fail"),
@@ -457,12 +452,12 @@ mod tests {
         // can update balance
         amount_expected = 2u128;
 
-        state
+        state_delta
             .put_account_balance(&address, &asset, amount_expected)
             .expect("putting an asset balance for an account should not fail");
 
         assert_eq!(
-            state
+            state_delta
                 .get_account_balance(&address, &asset)
                 .await
                 .expect("getting an asset balance should not fail"),
@@ -473,22 +468,21 @@ mod tests {
 
     #[tokio::test]
     async fn get_account_balance_multiple_accounts() {
-        let storage = cnidarium::TempStorage::new().await.unwrap();
-        let snapshot = storage.latest_snapshot();
-        let mut state = StateDelta::new(snapshot);
+        let storage = Storage::new_temp().await;
+        let mut state_delta = storage.new_delta_of_latest_snapshot();
 
         // create needed variables
         let address = astria_address(&[42u8; 20]);
         let asset = asset_0();
         let amount_expected = 1u128;
 
-        state
+        state_delta
             .put_account_balance(&address, &asset, amount_expected)
             .expect("putting an account balance should not fail");
 
         // able to write to account's storage
         assert_eq!(
-            state
+            state_delta
                 .get_account_balance(&address, &asset)
                 .await
                 .expect("getting an asset balance should not fail"),
@@ -501,11 +495,11 @@ mod tests {
         let address_1 = astria_address(&[41u8; 20]);
         let amount_expected_1 = 2u128;
 
-        state
+        state_delta
             .put_account_balance(&address_1, &asset, amount_expected_1)
             .expect("putting an account balance should not fail");
         assert_eq!(
-            state
+            state_delta
                 .get_account_balance(&address_1, &asset)
                 .await
                 .expect("getting an asset balance should not fail"),
@@ -514,7 +508,7 @@ mod tests {
              account update"
         );
         assert_eq!(
-            state
+            state_delta
                 .get_account_balance(&address, &asset)
                 .await
                 .expect("getting an asset balance should not fail"),
@@ -526,9 +520,8 @@ mod tests {
 
     #[tokio::test]
     async fn get_account_balance_multiple_assets() {
-        let storage = cnidarium::TempStorage::new().await.unwrap();
-        let snapshot = storage.latest_snapshot();
-        let mut state = StateDelta::new(snapshot);
+        let storage = Storage::new_temp().await;
+        let mut state_delta = storage.new_delta_of_latest_snapshot();
 
         // create needed variables
         let address = astria_address(&[42u8; 20]);
@@ -537,16 +530,16 @@ mod tests {
         let amount_expected_0 = 1u128;
         let amount_expected_1 = 2u128;
 
-        state
+        state_delta
             .put_account_balance(&address, &asset_0, amount_expected_0)
             .expect("putting an account balance should not fail");
-        state
+        state_delta
             .put_account_balance(&address, &asset_1, amount_expected_1)
             .expect("putting an account balance should not fail");
 
         // wrote correct balances
         assert_eq!(
-            state
+            state_delta
                 .get_account_balance(&address, &asset_0)
                 .await
                 .expect("getting an asset balance should not fail"),
@@ -554,7 +547,7 @@ mod tests {
             "returned balance for an asset did not match expected"
         );
         assert_eq!(
-            state
+            state_delta
                 .get_account_balance(&address, &asset_1)
                 .await
                 .expect("getting an asset balance should not fail"),
@@ -565,15 +558,14 @@ mod tests {
 
     #[tokio::test]
     async fn account_asset_balances_uninitialized_ok() {
-        let storage = cnidarium::TempStorage::new().await.unwrap();
-        let snapshot = storage.latest_snapshot();
-        let state = StateDelta::new(snapshot);
+        let storage = Storage::new_temp().await;
+        let state_delta = storage.new_delta_of_latest_snapshot();
 
         // create needed variables
         let address = astria_address(&[42u8; 20]);
 
         // see that call was ok
-        let stream = state.account_asset_balances(&address);
+        let stream = state_delta.account_asset_balances(&address);
 
         // Collect the stream into a vector
         let balances: Vec<_> = stream
@@ -590,25 +582,24 @@ mod tests {
 
     #[tokio::test]
     async fn account_asset_balances() {
-        let storage = cnidarium::TempStorage::new().await.unwrap();
-        let snapshot = storage.latest_snapshot();
-        let mut state = StateDelta::new(snapshot);
+        let storage = Storage::new_temp().await;
+        let mut state_delta = storage.new_delta_of_latest_snapshot();
 
         // native account should work with ibc too
-        state.put_native_asset(nria()).unwrap();
+        state_delta.put_native_asset(nria()).unwrap();
 
-        let asset_0 = state.get_native_asset().await.unwrap().unwrap();
+        let asset_0 = state_delta.get_native_asset().await.unwrap().unwrap();
         let asset_1 = asset_1();
         let asset_2 = asset_2();
 
         // also need to add assets to the ibc state
-        state
+        state_delta
             .put_ibc_asset(asset_0.clone())
             .expect("should be able to call other trait method on state object");
-        state
+        state_delta
             .put_ibc_asset(asset_1.clone().unwrap_trace_prefixed())
             .expect("should be able to call other trait method on state object");
-        state
+        state_delta
             .put_ibc_asset(asset_2.clone().unwrap_trace_prefixed())
             .expect("should be able to call other trait method on state object");
 
@@ -619,17 +610,17 @@ mod tests {
         let amount_expected_2 = 3u128;
 
         // add balances to the account
-        state
+        state_delta
             .put_account_balance(&address, &asset_0, amount_expected_0)
             .expect("putting an account balance should not fail");
-        state
+        state_delta
             .put_account_balance(&address, &asset_1, amount_expected_1)
             .expect("putting an account balance should not fail");
-        state
+        state_delta
             .put_account_balance(&address, &asset_2, amount_expected_2)
             .expect("putting an account balance should not fail");
 
-        let mut balances = state
+        let mut balances = state_delta
             .account_asset_balances(&address)
             .try_collect::<Vec<_>>()
             .await
@@ -656,23 +647,22 @@ mod tests {
 
     #[tokio::test]
     async fn increase_balance_from_uninitialized() {
-        let storage = cnidarium::TempStorage::new().await.unwrap();
-        let snapshot = storage.latest_snapshot();
-        let mut state = StateDelta::new(snapshot);
+        let storage = Storage::new_temp().await;
+        let mut state_delta = storage.new_delta_of_latest_snapshot();
 
         // create needed variables
         let address = astria_address(&[42u8; 20]);
         let asset = asset_0();
         let amount_increase = 2u128;
 
-        state
+        state_delta
             .increase_balance(&address, &asset, amount_increase)
             .await
             .expect("increasing account balance for uninitialized account should be ok");
 
         // correct balance was set
         assert_eq!(
-            state
+            state_delta
                 .get_account_balance(&address, &asset)
                 .await
                 .expect("getting an asset balance should not fail"),
@@ -680,13 +670,13 @@ mod tests {
             "returned balance for an asset balance did not match expected"
         );
 
-        state
+        state_delta
             .increase_balance(&address, &asset, amount_increase)
             .await
             .expect("increasing account balance for initialized account should be ok");
 
         assert_eq!(
-            state
+            state_delta
                 .get_account_balance(&address, &asset)
                 .await
                 .expect("getting an asset balance should not fail"),
@@ -697,23 +687,22 @@ mod tests {
 
     #[tokio::test]
     async fn decrease_balance_enough_funds() {
-        let storage = cnidarium::TempStorage::new().await.unwrap();
-        let snapshot = storage.latest_snapshot();
-        let mut state = StateDelta::new(snapshot);
+        let storage = Storage::new_temp().await;
+        let mut state_delta = storage.new_delta_of_latest_snapshot();
 
         // create needed variables
         let address = astria_address(&[42u8; 20]);
         let asset = asset_0();
         let amount_increase = 2u128;
 
-        state
+        state_delta
             .increase_balance(&address, &asset, amount_increase)
             .await
             .expect("increasing account balance for uninitialized account should be ok");
 
         // correct balance was set
         assert_eq!(
-            state
+            state_delta
                 .get_account_balance(&address, &asset)
                 .await
                 .expect("getting an asset balance should not fail"),
@@ -722,13 +711,13 @@ mod tests {
         );
 
         // decrease balance
-        state
+        state_delta
             .decrease_balance(&address, &asset, amount_increase)
             .await
             .expect("decreasing account balance for initialized account should be ok");
 
         assert_eq!(
-            state
+            state_delta
                 .get_account_balance(&address, &asset)
                 .await
                 .expect("getting an asset balance should not fail"),
@@ -739,9 +728,8 @@ mod tests {
 
     #[tokio::test]
     async fn decrease_balance_not_enough_funds() {
-        let storage = cnidarium::TempStorage::new().await.unwrap();
-        let snapshot = storage.latest_snapshot();
-        let mut state = StateDelta::new(snapshot);
+        let storage = Storage::new_temp().await;
+        let mut state_delta = storage.new_delta_of_latest_snapshot();
 
         // create needed variables
         let address = astria_address(&[42u8; 20]);
@@ -749,13 +737,13 @@ mod tests {
         let amount_increase = 2u128;
 
         // give initial balance
-        state
+        state_delta
             .increase_balance(&address, &asset, amount_increase)
             .await
             .expect("increasing account balance for uninitialized account should be ok");
 
         // decrease balance
-        let _ = state
+        let _ = state_delta
             .decrease_balance(&address, &asset, amount_increase + 1)
             .await
             .expect_err("should not be able to subtract larger balance than what existed");

--- a/crates/astria-sequencer/src/address/state_ext.rs
+++ b/crates/astria-sequencer/src/address/state_ext.rs
@@ -109,32 +109,29 @@ impl<T: StateWrite> StateWriteExt for T {}
 
 #[cfg(test)]
 mod tests {
-    use cnidarium::StateDelta;
-
     use super::*;
+    use crate::storage::Storage;
 
     #[tokio::test]
     async fn put_and_get_base_prefix() {
-        let storage = cnidarium::TempStorage::new().await.unwrap();
-        let snapshot = storage.latest_snapshot();
-        let mut state = StateDelta::new(snapshot);
+        let storage = Storage::new_temp().await;
+        let mut state_delta = storage.new_delta_of_latest_snapshot();
 
-        state.put_base_prefix("astria".to_string()).unwrap();
-        assert_eq!("astria", &state.get_base_prefix().await.unwrap());
+        state_delta.put_base_prefix("astria".to_string()).unwrap();
+        assert_eq!("astria", &state_delta.get_base_prefix().await.unwrap());
     }
 
     #[tokio::test]
     async fn put_and_get_ibc_compat_prefix() {
-        let storage = cnidarium::TempStorage::new().await.unwrap();
-        let snapshot = storage.latest_snapshot();
-        let mut state = StateDelta::new(snapshot);
+        let storage = Storage::new_temp().await;
+        let mut state_delta = storage.new_delta_of_latest_snapshot();
 
-        state
+        state_delta
             .put_ibc_compat_prefix("astriacompat".to_string())
             .unwrap();
         assert_eq!(
             "astriacompat",
-            &state.get_ibc_compat_prefix().await.unwrap()
+            &state_delta.get_ibc_compat_prefix().await.unwrap()
         );
     }
 }

--- a/crates/astria-sequencer/src/app/benchmarks.rs
+++ b/crates/astria-sequencer/src/app/benchmarks.rs
@@ -12,7 +12,6 @@ use astria_core::{
     },
     Protobuf,
 };
-use cnidarium::Storage;
 
 use crate::{
     app::{
@@ -29,6 +28,7 @@ use crate::{
         SIGNER_COUNT,
     },
     proposal::block_size_constraints::BlockSizeConstraints,
+    storage::Storage,
 };
 
 /// The max time for any benchmark.

--- a/crates/astria-sequencer/src/app/tests_app/mempool.rs
+++ b/crates/astria-sequencer/src/app/tests_app/mempool.rs
@@ -368,7 +368,7 @@ async fn maintenance_recosting_promotes() {
 
     // see transfer went through
     assert_eq!(
-        app.state
+        app.state_delta
             .get_account_balance(&astria_address_from_hex_string(CAROL_ADDRESS), &nria())
             .await
             .unwrap(),
@@ -561,7 +561,7 @@ async fn maintenance_funds_added_promotes() {
     app.commit(storage.clone()).await;
     // see transfer went through
     assert_eq!(
-        app.state
+        app.state_delta
             .get_account_balance(&astria_address_from_hex_string(BOB_ADDRESS), &nria())
             .await
             .unwrap(),

--- a/crates/astria-sequencer/src/app/tests_block_ordering.rs
+++ b/crates/astria-sequencer/src/app/tests_block_ordering.rs
@@ -208,7 +208,7 @@ async fn app_prepare_proposal_account_block_misordering_ok() {
         "expected to contain first transaction"
     );
 
-    app.mempool.run_maintenance(&app.state, false).await;
+    app.mempool.run_maintenance(&app.state_delta, false).await;
     assert_eq!(
         app.mempool.len().await,
         1,
@@ -240,6 +240,6 @@ async fn app_prepare_proposal_account_block_misordering_ok() {
         "expected to contain second transaction"
     );
 
-    app.mempool.run_maintenance(&app.state, false).await;
+    app.mempool.run_maintenance(&app.state_delta, false).await;
     assert_eq!(app.mempool.len().await, 0, "mempool should be empty");
 }

--- a/crates/astria-sequencer/src/app/tests_breaking_changes.rs
+++ b/crates/astria-sequencer/src/app/tests_breaking_changes.rs
@@ -90,14 +90,14 @@ async fn app_finalize_block_snapshot() {
     let rollup_id = RollupId::from_unhashed_bytes(b"testchainid");
     let starting_index_of_action = 0;
 
-    let mut state_tx = StateDelta::new(app.state.clone());
-    state_tx
+    let mut delta_delta = StateDelta::new(app.state_delta.clone());
+    delta_delta
         .put_bridge_account_rollup_id(&bridge_address, rollup_id)
         .unwrap();
-    state_tx
+    delta_delta
         .put_bridge_account_ibc_asset(&bridge_address, nria())
         .unwrap();
-    app.apply(state_tx);
+    app.apply(delta_delta);
 
     // the state changes must be committed, as `finalize_block` will execute the
     // changes on the latest snapshot, not the app's `StateDelta`.
@@ -345,7 +345,7 @@ async fn app_execute_transaction_with_every_action_snapshot() {
     let signed_tx = Arc::new(tx_bridge.sign(&bridge));
     app.execute_transaction(signed_tx).await.unwrap();
 
-    let sudo_address = app.state.get_sudo_address().await.unwrap();
+    let sudo_address = app.state_delta.get_sudo_address().await.unwrap();
     app.end_block(1, &sudo_address).await.unwrap();
 
     app.prepare_commit(storage.clone()).await.unwrap();

--- a/crates/astria-sequencer/src/assets/query.rs
+++ b/crates/astria-sequencer/src/assets/query.rs
@@ -3,7 +3,6 @@ use astria_core::{
     protocol::abci::AbciErrorCode,
 };
 use astria_eyre::eyre::WrapErr as _;
-use cnidarium::Storage;
 use hex::FromHex as _;
 use prost::Message as _;
 use tendermint::abci::{
@@ -15,6 +14,7 @@ use tendermint::abci::{
 use crate::{
     app::StateReadExt as _,
     assets::StateReadExt as _,
+    storage::Storage,
 };
 
 // Retrieve the full asset denomination given the asset ID.

--- a/crates/astria-sequencer/src/assets/storage/values.rs
+++ b/crates/astria-sequencer/src/assets/storage/values.rs
@@ -7,15 +7,15 @@ use borsh::{
     BorshSerialize,
 };
 
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
+#[derive(Clone, Debug, BorshSerialize, BorshDeserialize)]
 pub(crate) struct Value<'a>(ValueImpl<'a>);
 
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
+#[derive(Clone, Debug, BorshSerialize, BorshDeserialize)]
 enum ValueImpl<'a> {
     TracePrefixedDenom(TracePrefixedDenom<'a>),
 }
 
-#[derive(Debug, BorshSerialize, BorshDeserialize)]
+#[derive(Clone, Debug, BorshSerialize, BorshDeserialize)]
 pub(in crate::assets) struct TracePrefixedDenom<'a> {
     trace: Vec<(Cow<'a, str>, Cow<'a, str>)>,
     base_denom: Cow<'a, str>,

--- a/crates/astria-sequencer/src/bridge/state_ext.rs
+++ b/crates/astria-sequencer/src/bridge/state_ext.rs
@@ -330,10 +330,11 @@ impl<T: StateWrite> StateWriteExt for T {}
 
 #[cfg(test)]
 mod tests {
-    use cnidarium::StateDelta;
-
     use super::*;
-    use crate::benchmark_and_test_utils::astria_address;
+    use crate::{
+        benchmark_and_test_utils::astria_address,
+        storage::Storage,
+    };
 
     fn asset_0() -> asset::Denom {
         "asset_0".parse().unwrap()
@@ -345,17 +346,20 @@ mod tests {
 
     #[tokio::test]
     async fn get_bridge_account_rollup_id_uninitialized_ok() {
-        let storage = cnidarium::TempStorage::new().await.unwrap();
-        let snapshot = storage.latest_snapshot();
-        let state = StateDelta::new(snapshot);
+        let storage = Storage::new_temp().await;
+        let state_delta = storage.new_delta_of_latest_snapshot();
 
         let address = astria_address(&[42u8; 20]);
 
         // uninitialized ok
         assert_eq!(
-            state.get_bridge_account_rollup_id(&address).await.expect(
-                "call to get bridge account rollup id should not fail for uninitialized addresses"
-            ),
+            state_delta
+                .get_bridge_account_rollup_id(&address)
+                .await
+                .expect(
+                    "call to get bridge account rollup id should not fail for uninitialized \
+                     addresses"
+                ),
             Option::None,
             "stored rollup id for bridge not what was expected"
         );
@@ -363,19 +367,18 @@ mod tests {
 
     #[tokio::test]
     async fn put_bridge_account_rollup_id() {
-        let storage = cnidarium::TempStorage::new().await.unwrap();
-        let snapshot = storage.latest_snapshot();
-        let mut state = StateDelta::new(snapshot);
+        let storage = Storage::new_temp().await;
+        let mut state_delta = storage.new_delta_of_latest_snapshot();
 
         let mut rollup_id = RollupId::new([1u8; 32]);
         let address = astria_address(&[42u8; 20]);
 
         // can write new
-        state
+        state_delta
             .put_bridge_account_rollup_id(&address, rollup_id)
             .unwrap();
         assert_eq!(
-            state
+            state_delta
                 .get_bridge_account_rollup_id(&address)
                 .await
                 .expect("a rollup ID was written and must exist inside the database")
@@ -386,11 +389,11 @@ mod tests {
 
         // can rewrite with new value
         rollup_id = RollupId::new([2u8; 32]);
-        state
+        state_delta
             .put_bridge_account_rollup_id(&address, rollup_id)
             .unwrap();
         assert_eq!(
-            state
+            state_delta
                 .get_bridge_account_rollup_id(&address)
                 .await
                 .expect("a rollup ID was written and must exist inside the database")
@@ -402,11 +405,11 @@ mod tests {
         // can write additional account and both valid
         let rollup_id_1 = RollupId::new([2u8; 32]);
         let address_1 = astria_address(&[41u8; 20]);
-        state
+        state_delta
             .put_bridge_account_rollup_id(&address_1, rollup_id_1)
             .unwrap();
         assert_eq!(
-            state
+            state_delta
                 .get_bridge_account_rollup_id(&address_1)
                 .await
                 .expect("a rollup ID was written and must exist inside the database")
@@ -416,7 +419,7 @@ mod tests {
         );
 
         assert_eq!(
-            state
+            state_delta
                 .get_bridge_account_rollup_id(&address)
                 .await
                 .expect("a rollup ID was written and must exist inside the database")
@@ -428,12 +431,11 @@ mod tests {
 
     #[tokio::test]
     async fn get_bridge_account_asset_id_none_should_fail() {
-        let storage = cnidarium::TempStorage::new().await.unwrap();
-        let snapshot = storage.latest_snapshot();
-        let state = StateDelta::new(snapshot);
+        let storage = Storage::new_temp().await;
+        let state_delta = storage.new_delta_of_latest_snapshot();
 
         let address = astria_address(&[42u8; 20]);
-        let _ = state
+        let _ = state_delta
             .get_bridge_account_ibc_asset(&address)
             .await
             .expect_err("call to get bridge account asset ids should fail if no assets");
@@ -441,18 +443,17 @@ mod tests {
 
     #[tokio::test]
     async fn put_bridge_account_ibc_assets() {
-        let storage = cnidarium::TempStorage::new().await.unwrap();
-        let snapshot = storage.latest_snapshot();
-        let mut state = StateDelta::new(snapshot);
+        let storage = Storage::new_temp().await;
+        let mut state_delta = storage.new_delta_of_latest_snapshot();
 
         let address = astria_address(&[42u8; 20]);
         let mut asset = asset_0();
 
         // can write
-        state
+        state_delta
             .put_bridge_account_ibc_asset(&address, asset.clone())
             .expect("storing bridge account asset should not fail");
-        let mut result = state
+        let mut result = state_delta
             .get_bridge_account_ibc_asset(&address)
             .await
             .expect("bridge asset id was written and must exist inside the database");
@@ -464,10 +465,10 @@ mod tests {
 
         // can update
         asset = "asset_2".parse::<asset::Denom>().unwrap();
-        state
+        state_delta
             .put_bridge_account_ibc_asset(&address, &asset)
             .expect("storing bridge account assets should not fail");
-        result = state
+        result = state_delta
             .get_bridge_account_ibc_asset(&address)
             .await
             .expect("bridge asset id was written and must exist inside the database");
@@ -480,18 +481,18 @@ mod tests {
         // writing to other account also ok
         let address_1 = astria_address(&[41u8; 20]);
         let asset_1 = asset_1();
-        state
+        state_delta
             .put_bridge_account_ibc_asset(&address_1, &asset_1)
             .expect("storing bridge account assets should not fail");
         assert_eq!(
-            state
+            state_delta
                 .get_bridge_account_ibc_asset(&address_1)
                 .await
                 .expect("bridge asset id was written and must exist inside the database"),
             asset_1.into(),
             "second bridge account asset not what was expected"
         );
-        result = state
+        result = state_delta
             .get_bridge_account_ibc_asset(&address)
             .await
             .expect("original bridge asset id was written and must exist inside the database");
@@ -505,16 +506,15 @@ mod tests {
 
     #[tokio::test]
     async fn bridge_account_sudo_address_round_trip() {
-        let storage = cnidarium::TempStorage::new().await.unwrap();
-        let snapshot = storage.latest_snapshot();
-        let mut state = StateDelta::new(snapshot);
+        let storage = Storage::new_temp().await;
+        let mut state_delta = storage.new_delta_of_latest_snapshot();
 
         let bridge_address = [1; 20];
         let sudo_address = [2; 20];
-        state
+        state_delta
             .put_bridge_account_sudo_address(&bridge_address, sudo_address)
             .unwrap();
-        let retrieved_sudo_address = state
+        let retrieved_sudo_address = state_delta
             .get_bridge_account_sudo_address(&bridge_address)
             .await
             .unwrap();
@@ -523,16 +523,15 @@ mod tests {
 
     #[tokio::test]
     async fn bridge_account_withdrawer_address_round_trip() {
-        let storage = cnidarium::TempStorage::new().await.unwrap();
-        let snapshot = storage.latest_snapshot();
-        let mut state = StateDelta::new(snapshot);
+        let storage = Storage::new_temp().await;
+        let mut state_delta = storage.new_delta_of_latest_snapshot();
 
         let bridge_address = [1; 20];
         let withdrawer_address = [2; 20];
-        state
+        state_delta
             .put_bridge_account_withdrawer_address(&bridge_address, withdrawer_address)
             .unwrap();
-        let retrieved_withdrawer_address = state
+        let retrieved_withdrawer_address = state_delta
             .get_bridge_account_withdrawer_address(&bridge_address)
             .await
             .unwrap();
@@ -541,16 +540,15 @@ mod tests {
 
     #[tokio::test]
     async fn get_deposits_empty_ok() {
-        let storage = cnidarium::TempStorage::new().await.unwrap();
-        let snapshot = storage.latest_snapshot();
-        let state = StateDelta::new(snapshot);
+        let storage = Storage::new_temp().await;
+        let state_delta = storage.new_delta_of_latest_snapshot();
 
         let block_hash = [32; 32];
         let rollup_id = RollupId::new([2u8; 32]);
 
         // no events ok
         assert_eq!(
-            state
+            state_delta
                 .get_deposits(&block_hash, &rollup_id)
                 .await
                 .expect("call for rollup id with no deposit events should not fail"),
@@ -561,9 +559,8 @@ mod tests {
 
     #[tokio::test]
     async fn get_deposits() {
-        let storage = cnidarium::TempStorage::new().await.unwrap();
-        let snapshot = storage.latest_snapshot();
-        let mut state = StateDelta::new(snapshot);
+        let storage = Storage::new_temp().await;
+        let mut state_delta = storage.new_delta_of_latest_snapshot();
 
         let block_hash = [32; 32];
         let rollup_id_1 = RollupId::new([1u8; 32]);
@@ -587,11 +584,11 @@ mod tests {
         all_deposits.insert(rollup_id_1, rollup_1_deposits.clone());
 
         // can write
-        state
+        state_delta
             .put_deposits(&block_hash, all_deposits.clone())
             .unwrap();
         assert_eq!(
-            state
+            state_delta
                 .get_deposits(&block_hash, &rollup_id_1)
                 .await
                 .expect("deposit info was written to the database and must exist"),
@@ -607,11 +604,11 @@ mod tests {
         };
         rollup_1_deposits.push(deposit.clone());
         all_deposits.insert(rollup_id_1, rollup_1_deposits.clone());
-        state
+        state_delta
             .put_deposits(&block_hash, all_deposits.clone())
             .unwrap();
         assert_eq!(
-            state
+            state_delta
                 .get_deposits(&block_hash, &rollup_id_1)
                 .await
                 .expect("deposit info was written to the database and must exist"),
@@ -628,9 +625,9 @@ mod tests {
         };
         let rollup_2_deposits = vec![deposit.clone()];
         all_deposits.insert(rollup_id_2, rollup_2_deposits.clone());
-        state.put_deposits(&block_hash, all_deposits).unwrap();
+        state_delta.put_deposits(&block_hash, all_deposits).unwrap();
         assert_eq!(
-            state
+            state_delta
                 .get_deposits(&block_hash, &rollup_id_2)
                 .await
                 .expect("deposit info was written to the database and must exist"),
@@ -639,7 +636,7 @@ mod tests {
         );
         // verify original still ok
         assert_eq!(
-            state
+            state_delta
                 .get_deposits(&block_hash, &rollup_id_1)
                 .await
                 .expect("deposit info was written to the database and must exist"),
@@ -650,16 +647,15 @@ mod tests {
 
     #[tokio::test]
     async fn last_transaction_id_for_bridge_account_round_trip() {
-        let storage = cnidarium::TempStorage::new().await.unwrap();
-        let snapshot = storage.latest_snapshot();
-        let mut state = StateDelta::new(snapshot);
+        let storage = Storage::new_temp().await;
+        let mut state_delta = storage.new_delta_of_latest_snapshot();
 
         let bridge_address = [1; 20];
         let tx_hash = TransactionId::new([2; 32]);
-        state
+        state_delta
             .put_last_transaction_id_for_bridge_account(&bridge_address, tx_hash)
             .unwrap();
-        let retrieved_tx_hash = state
+        let retrieved_tx_hash = state_delta
             .get_last_transaction_id_for_bridge_account(&bridge_address)
             .await
             .unwrap();

--- a/crates/astria-sequencer/src/fees/query.rs
+++ b/crates/astria-sequencer/src/fees/query.rs
@@ -24,10 +24,7 @@ use astria_eyre::eyre::{
     OptionExt as _,
     WrapErr as _,
 };
-use cnidarium::{
-    StateRead,
-    Storage,
-};
+use cnidarium::StateRead;
 use futures::{
     FutureExt as _,
     StreamExt as _,
@@ -57,6 +54,7 @@ use super::{
 use crate::{
     app::StateReadExt as _,
     assets::StateReadExt as _,
+    storage::Storage,
 };
 
 async fn find_trace_prefixed_or_return_ibc<S: StateRead>(

--- a/crates/astria-sequencer/src/service/consensus.rs
+++ b/crates/astria-sequencer/src/service/consensus.rs
@@ -4,7 +4,6 @@ use astria_eyre::eyre::{
     Result,
     WrapErr as _,
 };
-use cnidarium::Storage;
 use tendermint::v0_38::abci::{
     request,
     response,
@@ -20,7 +19,10 @@ use tracing::{
     Instrument,
 };
 
-use crate::app::App;
+use crate::{
+    app::App,
+    storage::Storage,
+};
 
 pub(crate) struct Consensus {
     queue: mpsc::Receiver<Message<ConsensusRequest, ConsensusResponse, tower::BoxError>>,
@@ -468,7 +470,7 @@ mod tests {
         .try_into()
         .unwrap();
 
-        let storage = cnidarium::TempStorage::new().await.unwrap();
+        let storage = Storage::new_temp().await;
         let snapshot = storage.latest_snapshot();
         let metrics = Box::leak(Box::new(Metrics::noop_metrics(&()).unwrap()));
         let mempool = Mempool::new(metrics, 100);

--- a/crates/astria-sequencer/src/service/info/abci_query_router.rs
+++ b/crates/astria-sequencer/src/service/info/abci_query_router.rs
@@ -38,7 +38,6 @@ use std::{
     pin::Pin,
 };
 
-use cnidarium::Storage;
 use matchit::{
     InsertError,
     Match,
@@ -48,6 +47,8 @@ use tendermint::abci::{
     request,
     response,
 };
+
+use crate::storage::Storage;
 
 /// `Router` is a wrapper around [`matchit::Router`] to route abci queries
 /// to handlers.

--- a/crates/astria-sequencer/src/service/mempool/mod.rs
+++ b/crates/astria-sequencer/src/service/mempool/mod.rs
@@ -20,10 +20,7 @@ use astria_core::{
 };
 use astria_eyre::eyre::WrapErr as _;
 use bytes::Bytes;
-use cnidarium::{
-    StateRead,
-    Storage,
-};
+use cnidarium::StateRead;
 use futures::{
     Future,
     FutureExt,
@@ -59,6 +56,7 @@ use crate::{
         RemovalReason,
     },
     metrics::Metrics,
+    storage::Storage,
     transaction,
 };
 

--- a/crates/astria-sequencer/src/service/mempool/tests.rs
+++ b/crates/astria-sequencer/src/service/mempool/tests.rs
@@ -21,12 +21,13 @@ use crate::{
         Mempool,
         RemovalReason,
     },
+    storage::Storage,
 };
 
 #[tokio::test]
 async fn future_nonces_are_accepted() {
     // The mempool should allow future nonces.
-    let storage = cnidarium::TempStorage::new().await.unwrap();
+    let storage = Storage::new_temp().await;
     let snapshot = storage.latest_snapshot();
 
     let metrics = Box::leak(Box::new(Metrics::noop_metrics(&()).unwrap()));
@@ -56,7 +57,7 @@ async fn future_nonces_are_accepted() {
 #[tokio::test]
 async fn rechecks_pass() {
     // The mempool should not fail rechecks of transactions.
-    let storage = cnidarium::TempStorage::new().await.unwrap();
+    let storage = Storage::new_temp().await;
     let snapshot = storage.latest_snapshot();
 
     let metrics = Box::leak(Box::new(Metrics::noop_metrics(&()).unwrap()));
@@ -94,7 +95,7 @@ async fn can_reinsert_after_recheck_fail() {
     // The mempool should be able to re-insert a transaction after a recheck fails due to the
     // transaction being removed from the appside mempool. This is to allow users to re-insert
     // if they wish to do so.
-    let storage = cnidarium::TempStorage::new().await.unwrap();
+    let storage = Storage::new_temp().await;
     let snapshot = storage.latest_snapshot();
 
     let metrics = Box::leak(Box::new(Metrics::noop_metrics(&()).unwrap()));
@@ -142,7 +143,7 @@ async fn recheck_adds_non_tracked_tx() {
     // The mempool should be able to insert a transaction on recheck if it isn't in the mempool.
     // This could happen in the case of a sequencer restart as the cometbft mempool persists but
     // the appside one does not.
-    let storage = cnidarium::TempStorage::new().await.unwrap();
+    let storage = Storage::new_temp().await;
     let snapshot = storage.latest_snapshot();
 
     let metrics = Box::leak(Box::new(Metrics::noop_metrics(&()).unwrap()));

--- a/crates/astria-sequencer/src/storage/mod.rs
+++ b/crates/astria-sequencer/src/storage/mod.rs
@@ -1,4 +1,337 @@
+use std::{
+    fmt::{
+        self,
+        Debug,
+        Formatter,
+    },
+    path::PathBuf,
+    sync::{
+        Arc,
+        Mutex,
+    },
+};
+
+use astria_eyre::{
+    anyhow_to_eyre,
+    eyre,
+};
+use cnidarium::{
+    RootHash,
+    StagedWriteBatch,
+    StateDelta,
+};
+
+pub(crate) use self::{
+    snapshot::Snapshot,
+    stored_value::StoredValue,
+};
+use crate::Metrics;
+
 pub(crate) mod keys;
+mod snapshot;
 mod stored_value;
 
-pub(crate) use stored_value::StoredValue;
+#[derive(Clone)]
+pub(crate) struct Storage {
+    inner: cnidarium::Storage,
+    latest_snapshot: Arc<Mutex<Snapshot>>,
+    metrics: &'static Metrics,
+    #[cfg(any(test, feature = "benchmark"))]
+    _temp_dir: Option<Arc<tempfile::TempDir>>,
+}
+
+impl Storage {
+    pub(crate) async fn load(
+        path: PathBuf,
+        prefixes: Vec<String>,
+        metrics: &'static Metrics,
+    ) -> astria_eyre::Result<Self> {
+        let inner = cnidarium::Storage::load(path, prefixes)
+            .await
+            .map_err(anyhow_to_eyre)?;
+        let latest_snapshot = Arc::new(Mutex::new(Snapshot::new(inner.latest_snapshot(), metrics)));
+        Ok(Self {
+            inner,
+            latest_snapshot,
+            metrics,
+            #[cfg(any(test, feature = "benchmark"))]
+            _temp_dir: None,
+        })
+    }
+
+    #[cfg(any(test, feature = "benchmark"))]
+    pub(crate) async fn new_temp() -> Self {
+        use telemetry::Metrics as _;
+
+        let temp_dir = tempfile::tempdir().unwrap_or_else(|error| {
+            panic!("failed to create temp dir when constructing storage instance: {error}")
+        });
+        let db_path = temp_dir.path().join("storage.db");
+        let inner = cnidarium::Storage::init(db_path.clone(), vec![])
+            .await
+            .unwrap_or_else(|error| {
+                panic!(
+                    "failed to initialize storage at `{}`: {error:#}",
+                    db_path.display()
+                )
+            });
+        let metrics = Box::leak(Box::new(Metrics::noop_metrics(&()).unwrap()));
+        let latest_snapshot = Arc::new(Mutex::new(Snapshot::new(inner.latest_snapshot(), metrics)));
+
+        Self {
+            inner,
+            latest_snapshot,
+            metrics,
+            _temp_dir: Some(Arc::new(temp_dir)),
+        }
+    }
+
+    /// Returns the latest version (block height) of the tree recorded by `Storage`.
+    ///
+    /// If the tree is empty and has not been initialized, returns `u64::MAX`.
+    pub(crate) fn latest_version(&self) -> u64 {
+        self.inner.latest_version()
+    }
+
+    /// Returns a new `Snapshot` on top of the latest version of the tree.
+    pub(crate) fn latest_snapshot(&self) -> Snapshot {
+        self.latest_snapshot.lock().unwrap().clone()
+    }
+
+    /// Returns the `Snapshot` corresponding to the given version.
+    pub(crate) fn snapshot(&self, version: u64) -> Option<Snapshot> {
+        Some(Snapshot::new(self.inner.snapshot(version)?, self.metrics))
+    }
+
+    /// Returns a new `Delta` on top of the latest version of the tree.
+    pub(crate) fn new_delta_of_latest_snapshot(&self) -> StateDelta<Snapshot> {
+        self.latest_snapshot().new_delta()
+    }
+
+    /// Returns a clone of the wrapped `cnidarium::Storage`.
+    pub(crate) fn inner(&self) -> cnidarium::Storage {
+        self.inner.clone()
+    }
+
+    /// Prepares a commit for the provided `SnapshotDelta`, returning a `StagedWriteBatch`.
+    ///
+    /// The batch can be committed to the database using the [`Storage::commit_batch`] method.
+    pub(crate) async fn prepare_commit(
+        &self,
+        delta: StateDelta<Snapshot>,
+    ) -> eyre::Result<StagedWriteBatch> {
+        let (snapshot, changes) = delta.flatten();
+        let cnidarium_snapshot = snapshot.into_inner();
+        let mut cnidarium_delta = StateDelta::new(cnidarium_snapshot);
+        changes.apply_to(&mut cnidarium_delta);
+        self.inner
+            .prepare_commit(cnidarium_delta)
+            .await
+            .map_err(anyhow_to_eyre)
+    }
+
+    /// Commits the provided `SnapshotDelta` to persistent storage as the latest version of the
+    /// chain state.
+    #[cfg(test)]
+    pub(crate) async fn commit(&self, delta: StateDelta<Snapshot>) -> eyre::Result<RootHash> {
+        let batch = self.prepare_commit(delta).await?;
+        self.commit_batch(batch)
+    }
+
+    /// Commits the supplied `StagedWriteBatch` to persistent storage.
+    pub(crate) fn commit_batch(&self, batch: StagedWriteBatch) -> eyre::Result<RootHash> {
+        let root_hash = self.inner.commit_batch(batch).map_err(anyhow_to_eyre)?;
+        let mut ls = self.latest_snapshot.lock().unwrap();
+        *ls = Snapshot::new(self.inner.latest_snapshot(), self.metrics);
+        Ok(root_hash)
+    }
+
+    /// Shuts down the database and the dispatcher task, and waits for all resources to be
+    /// reclaimed.
+    ///
+    /// # Panics
+    ///
+    /// Panics if there is more than one clone remaining of the `cnidarium::Inner` storage `Arc`.
+    pub(crate) async fn release(self) {
+        self.inner.release().await;
+    }
+}
+
+impl Debug for Storage {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        self.inner.fmt(f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cnidarium::{
+        StateRead as _,
+        StateWrite as _,
+    };
+    use telemetry::Metrics as _;
+
+    use super::*;
+
+    const V_KEY: &str = "verifiable key";
+    const NV_KEY: &[u8] = b"non-verifiable key";
+    const VALUES: [[u8; 1]; 4] = [[1], [2], [3], [4]];
+
+    #[test]
+    fn should_prepare_and_commit_batch() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("storage_test");
+        let metrics = Box::leak(Box::new(Metrics::noop_metrics(&()).unwrap()));
+
+        // Run the tests on the first storage instance.
+        //
+        // NOTE: `cnidarium::Storage::load` panics if we try to open it more than once from the same
+        // thread, even if the first instance is dropped. We use two separate tokio runtimes to
+        // avoid this.
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(async {
+                let storage = Storage::load(db_path.clone(), vec![], metrics)
+                    .await
+                    .unwrap();
+
+                // Check there's no previous snapshots available.
+                assert!(storage.snapshot(0).is_none());
+
+                // Write data to the verifiable and non-verifiable stores.
+                let mut state_delta = storage.new_delta_of_latest_snapshot();
+                state_delta.put_raw(V_KEY.to_string(), VALUES[0].to_vec());
+                state_delta.nonverifiable_put_raw(NV_KEY.to_vec(), VALUES[1].to_vec());
+
+                // Commit the data.
+                let batch = storage.prepare_commit(state_delta).await.unwrap();
+                storage.commit_batch(batch).unwrap();
+
+                // Check the data is available in a new latest snapshot, and a snapshot at v0
+                // (the only version currently available).
+                let snapshot_0 = storage.snapshot(0).unwrap();
+                assert_eq!(
+                    Some(VALUES[0].to_vec()),
+                    snapshot_0.get_raw(V_KEY).await.unwrap()
+                );
+                assert_eq!(
+                    Some(VALUES[1].to_vec()),
+                    snapshot_0.nonverifiable_get_raw(NV_KEY).await.unwrap()
+                );
+
+                let snapshot_latest = storage.latest_snapshot();
+                assert_eq!(
+                    Some(VALUES[0].to_vec()),
+                    snapshot_latest.get_raw(V_KEY).await.unwrap()
+                );
+                assert_eq!(
+                    Some(VALUES[1].to_vec()),
+                    snapshot_latest.nonverifiable_get_raw(NV_KEY).await.unwrap()
+                );
+
+                // Check there's no snapshot v1.
+                assert!(storage.snapshot(1).is_none());
+
+                // Shut down the original storage instance.
+                storage.release().await;
+            });
+
+        // Open a new storage instance using the same DB file and run follow-up tests.
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(async {
+                let storage = Storage::load(db_path.clone(), vec![], metrics)
+                    .await
+                    .unwrap();
+
+                // Check the data is available in snapshot v0 (the only snapshot available now).
+                let snapshot_0 = storage.snapshot(0).unwrap();
+                assert_eq!(
+                    Some(VALUES[0].to_vec()),
+                    snapshot_0.get_raw(V_KEY).await.unwrap()
+                );
+                assert_eq!(
+                    Some(VALUES[1].to_vec()),
+                    snapshot_0.nonverifiable_get_raw(NV_KEY).await.unwrap()
+                );
+
+                // Overwrite the values and commit these changes.
+                let mut state_delta = storage.new_delta_of_latest_snapshot();
+                state_delta.put_raw(V_KEY.to_string(), VALUES[2].to_vec());
+                state_delta.nonverifiable_put_raw(NV_KEY.to_vec(), VALUES[3].to_vec());
+                let batch = storage.prepare_commit(state_delta).await.unwrap();
+                storage.commit_batch(batch).unwrap();
+
+                // Check the data has the original values in snapshot v0, but the new values in
+                // the latest snapshot (v1).
+                let snapshot_0 = storage.snapshot(0).unwrap();
+                assert_eq!(
+                    Some(VALUES[0].to_vec()),
+                    snapshot_0.get_raw(V_KEY).await.unwrap()
+                );
+                assert_eq!(
+                    Some(VALUES[1].to_vec()),
+                    snapshot_0.nonverifiable_get_raw(NV_KEY).await.unwrap()
+                );
+
+                let snapshot_latest = storage.latest_snapshot();
+                assert_eq!(
+                    Some(VALUES[2].to_vec()),
+                    snapshot_latest.get_raw(V_KEY).await.unwrap()
+                );
+                assert_eq!(
+                    Some(VALUES[3].to_vec()),
+                    snapshot_latest.nonverifiable_get_raw(NV_KEY).await.unwrap()
+                );
+
+                // Check snapshot v1 exists, and there's no snapshot v2.
+                assert!(storage.snapshot(1).is_some());
+                assert!(storage.snapshot(2).is_none());
+            });
+    }
+
+    #[tokio::test]
+    async fn should_not_commit_invalid_batch() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("storage_test");
+        let metrics = Box::leak(Box::new(Metrics::noop_metrics(&()).unwrap()));
+        let storage = Storage::load(db_path.clone(), vec![], metrics)
+            .await
+            .unwrap();
+
+        // Write and commit data twice.
+        let mut state_delta = storage.new_delta_of_latest_snapshot();
+        state_delta.put_raw(V_KEY.to_string(), VALUES[0].to_vec());
+        storage.commit(state_delta).await.unwrap();
+
+        state_delta = storage.new_delta_of_latest_snapshot();
+        state_delta.nonverifiable_put_raw(NV_KEY.to_vec(), VALUES[1].to_vec());
+        storage.commit(state_delta).await.unwrap();
+
+        // Assert we have two snapshot versions available.
+        assert!(storage.snapshot(0).is_some());
+        assert!(storage.snapshot(1).is_some());
+        assert!(storage.snapshot(2).is_none());
+
+        // Create a new state delta from snapshot v0 and try to commit it - should fail.
+        state_delta = storage.snapshot(0).unwrap().new_delta();
+        match storage.prepare_commit(state_delta).await {
+            Ok(_) => panic!("should fail to prepare commit for an existing snapshot version"),
+            Err(error) => {
+                assert!(error.to_string().contains(
+                    "trying to prepare a commit for a delta forked from version 0, but the latest \
+                     version is 1"
+                ));
+            }
+        }
+
+        // Assert we still have two snapshot versions available.
+        assert!(storage.snapshot(0).is_some());
+        assert!(storage.snapshot(1).is_some());
+        assert!(storage.snapshot(2).is_none());
+    }
+}

--- a/crates/astria-sequencer/src/storage/snapshot.rs
+++ b/crates/astria-sequencer/src/storage/snapshot.rs
@@ -1,0 +1,488 @@
+use std::{
+    any::{
+        Any,
+        TypeId,
+    },
+    fmt::{
+        self,
+        Debug,
+        Formatter,
+    },
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{
+        Context,
+        Poll,
+    },
+};
+
+use anyhow::Context as _;
+use astria_eyre::anyhow_to_eyre;
+use async_trait::async_trait;
+use bytes::Bytes;
+use cnidarium::{
+    RootHash,
+    StateDelta,
+    StateRead,
+};
+use futures::TryStreamExt;
+use pin_project_lite::pin_project;
+use quick_cache::sync::Cache as QuickCache;
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
+
+use crate::Metrics;
+
+/// An in-memory cache of objects that belong in the verifiable store.
+///
+/// A `None` value represents an item not present in the on-disk storage.
+type VerifiableCache = Arc<QuickCache<String, Option<Bytes>>>;
+/// An in-memory cache of objects that belong in the non-verifiable store.
+///
+/// A `None` value represents an item not present in the on-disk storage.
+type NonVerifiableCache = Arc<QuickCache<Vec<u8>, Option<Bytes>>>;
+
+#[derive(Clone)]
+pub(crate) struct Snapshot {
+    inner: cnidarium::Snapshot,
+    verifiable_cache: VerifiableCache,
+    non_verifiable_cache: NonVerifiableCache,
+    metrics: &'static Metrics,
+}
+
+impl Snapshot {
+    pub(super) fn new(inner: cnidarium::Snapshot, metrics: &'static Metrics) -> Self {
+        Self {
+            inner,
+            verifiable_cache: Arc::new(QuickCache::new(10_000)),
+            non_verifiable_cache: Arc::new(QuickCache::new(1_000)),
+            metrics,
+        }
+    }
+
+    pub(super) fn into_inner(self) -> cnidarium::Snapshot {
+        self.inner
+    }
+
+    pub(crate) fn new_delta(&self) -> StateDelta<Snapshot> {
+        StateDelta::new(self.clone())
+    }
+
+    pub(crate) async fn root_hash(&self) -> astria_eyre::Result<RootHash> {
+        self.inner.root_hash().await.map_err(anyhow_to_eyre)
+    }
+}
+
+impl Debug for Snapshot {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        self.inner.fmt(f)
+    }
+}
+
+#[async_trait]
+impl StateRead for Snapshot {
+    type GetRawFut = SnapshotFuture;
+    type NonconsensusPrefixRawStream = ReceiverStream<anyhow::Result<(Vec<u8>, Vec<u8>)>>;
+    type NonconsensusRangeRawStream = ReceiverStream<anyhow::Result<(Vec<u8>, Vec<u8>)>>;
+    type PrefixKeysStream = ReceiverStream<anyhow::Result<String>>;
+    type PrefixRawStream = ReceiverStream<anyhow::Result<(String, Vec<u8>)>>;
+
+    fn get_raw(&self, key: &str) -> Self::GetRawFut {
+        get_raw(
+            key.to_owned(),
+            self.inner.clone(),
+            self.verifiable_cache.clone(),
+            self.metrics,
+        )
+    }
+
+    fn nonverifiable_get_raw(&self, key: &[u8]) -> Self::GetRawFut {
+        non_verifiable_get_raw(
+            key.to_owned(),
+            self.inner.clone(),
+            self.non_verifiable_cache.clone(),
+            self.metrics,
+        )
+    }
+
+    fn object_get<T: Any + Send + Sync + Clone>(&self, _key: &str) -> Option<T> {
+        // No ephemeral object cache in read-only `Snapshot`.
+        None
+    }
+
+    fn object_type(&self, _key: &str) -> Option<TypeId> {
+        // No ephemeral object cache in read-only `Snapshot`.
+        None
+    }
+
+    fn prefix_raw(&self, prefix: &str) -> Self::PrefixRawStream {
+        let (tx_prefix_item, rx_prefix_query) = mpsc::channel(10);
+        let inner_snapshot = self.inner.clone();
+        let cache = self.verifiable_cache.clone();
+        let metrics = self.metrics;
+        tokio::spawn(inner_snapshot.prefix_keys(prefix).try_for_each(move |key| {
+            let inner_snapshot = inner_snapshot.clone();
+            let cache = cache.clone();
+            let tx_prefix_item = tx_prefix_item.clone();
+            async move {
+                let value = get_raw(key.clone(), inner_snapshot, cache, metrics)
+                    .await?
+                    .with_context(|| "should never be `None` value for streamed key")?;
+                let permit = tx_prefix_item
+                    .reserve()
+                    .await
+                    .with_context(|| "failed to reserve space on the sending channel")?;
+                permit.send(Ok((key, value)));
+                Ok(())
+            }
+        }));
+        ReceiverStream::new(rx_prefix_query)
+    }
+
+    fn prefix_keys(&self, prefix: &str) -> Self::PrefixKeysStream {
+        self.inner.prefix_keys(prefix)
+    }
+
+    /// NOTE: The cache is unusable here.
+    fn nonverifiable_prefix_raw(&self, prefix: &[u8]) -> Self::NonconsensusPrefixRawStream {
+        self.inner.nonverifiable_prefix_raw(prefix)
+    }
+
+    /// NOTE: The cache is unusable here.
+    fn nonverifiable_range_raw(
+        &self,
+        prefix: Option<&[u8]>,
+        range: impl std::ops::RangeBounds<Vec<u8>>,
+    ) -> anyhow::Result<Self::NonconsensusRangeRawStream> {
+        self.inner.nonverifiable_range_raw(prefix, range)
+    }
+}
+
+pin_project! {
+    pub struct SnapshotFuture {
+        #[pin]
+        inner: tokio::task::JoinHandle<anyhow::Result<Option<Vec<u8>>>>
+    }
+}
+
+impl SnapshotFuture {
+    fn new<F>(future: F) -> Self
+    where
+        F: Future<Output = anyhow::Result<Option<Vec<u8>>>> + Send + 'static,
+    {
+        Self {
+            inner: tokio::task::spawn(future),
+        }
+    }
+}
+
+impl Future for SnapshotFuture {
+    type Output = anyhow::Result<Option<Vec<u8>>>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        match this.inner.poll(cx) {
+            Poll::Ready(result) => {
+                Poll::Ready(result.expect("unrecoverable join error from tokio task"))
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+async fn get<S, K>(state: &S, key: K) -> anyhow::Result<Option<Vec<u8>>>
+where
+    S: StateRead + ?Sized,
+    K: AsRef<str>,
+{
+    let key = key.as_ref();
+    state
+        .get_raw(key)
+        .await
+        .with_context(|| format!("failed to get raw value under key `{key}`"))
+}
+
+async fn non_verifiable_get<S, K>(state: &S, key: K) -> anyhow::Result<Option<Vec<u8>>>
+where
+    S: StateRead,
+    K: AsRef<[u8]>,
+{
+    let key = key.as_ref();
+    state.nonverifiable_get_raw(key).await.with_context(|| {
+        format!(
+            "failed to get nonverifiable raw value under key `{}`",
+            display_non_verifiable_key(key)
+        )
+    })
+}
+
+fn get_raw(
+    key: String,
+    inner_snapshot: cnidarium::Snapshot,
+    cache: VerifiableCache,
+    metrics: &'static Metrics,
+) -> SnapshotFuture {
+    SnapshotFuture::new(async move {
+        let maybe_value = match cache.get_value_or_guard_async(&key).await {
+            Ok(value) => {
+                metrics.increment_verifiable_cache_hit();
+                value
+            }
+            Err(guard) => {
+                metrics.increment_verifiable_cache_miss();
+                let value = get(&inner_snapshot, &key).await?.map(Bytes::from);
+                let _ = guard.insert(value.clone());
+                value
+            }
+        };
+        metrics.record_verifiable_cache_item_total(cache.len());
+        Ok(maybe_value.map(Vec::from))
+    })
+}
+
+fn non_verifiable_get_raw(
+    key: Vec<u8>,
+    inner_snapshot: cnidarium::Snapshot,
+    cache: NonVerifiableCache,
+    metrics: &'static Metrics,
+) -> SnapshotFuture {
+    SnapshotFuture::new(async move {
+        let maybe_value = match cache.get_value_or_guard_async(&key).await {
+            Ok(value) => {
+                metrics.increment_non_verifiable_cache_hit();
+                value
+            }
+            Err(guard) => {
+                metrics.increment_non_verifiable_cache_miss();
+                let value = non_verifiable_get(&inner_snapshot, &key)
+                    .await?
+                    .map(Bytes::from);
+                let _ = guard.insert(value.clone());
+                value
+            }
+        };
+        metrics.record_non_verifiable_cache_item_total(cache.len());
+        Ok(maybe_value.map(Vec::from))
+    })
+}
+
+/// Provides a `String` version of the given key for display (logging) purposes, parsed from UTF-8
+/// if possible, falling back to base64 encoding.
+fn display_non_verifiable_key(key: &[u8]) -> String {
+    String::from_utf8(key.to_vec()).unwrap_or_else(|_| telemetry::display::base64(key).to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use cnidarium::StateWrite as _;
+    use tempfile::TempDir;
+
+    use super::{
+        super::Storage,
+        *,
+    };
+
+    const V_KEY: &str = "verifiable key";
+    const NV_KEY: &[u8] = b"non-verifiable key";
+    const VALUES: [[u8; 1]; 4] = [[1], [2], [3], [4]];
+
+    struct Fixture {
+        storage: Storage,
+        _temp_dir: TempDir,
+    }
+
+    impl Fixture {
+        async fn new() -> Self {
+            let (metrics, _) = telemetry::metrics::ConfigBuilder::new()
+                .set_global_recorder(false)
+                .build(&())
+                .unwrap();
+            let metrics = Box::leak(Box::new(metrics));
+            let temp_dir = tempfile::tempdir().unwrap();
+            let db_path = temp_dir.path().join("storage_test");
+            let storage = Storage::load(db_path.clone(), vec![], metrics)
+                .await
+                .unwrap();
+            Self {
+                storage,
+                _temp_dir: temp_dir,
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn get_raw_should_succeed() {
+        #[track_caller]
+        fn assert_in_cache(snapshot: &Snapshot, value: &[u8]) {
+            let Some(serialized_value) = snapshot.verifiable_cache.get(V_KEY).unwrap() else {
+                panic!("should have value in cache");
+            };
+            assert_eq!(value.to_vec(), serialized_value);
+        }
+
+        let Fixture {
+            storage,
+            _temp_dir,
+        } = Fixture::new().await;
+
+        // `get_raw` should return `None` for non-existent value.
+        let snapshot = storage.latest_snapshot();
+        assert!(snapshot.get_raw(V_KEY).await.unwrap().is_none());
+
+        // Write and commit data.
+        let mut state_delta = storage.new_delta_of_latest_snapshot();
+        state_delta.put_raw(V_KEY.to_string(), VALUES[0].to_vec());
+        storage.commit(state_delta).await.unwrap();
+
+        // `get_raw` on the latest snapshot should return the correct value and cache it.
+        let snapshot = storage.latest_snapshot();
+        assert!(snapshot.verifiable_cache.is_empty());
+        assert_eq!(
+            Some(VALUES[0].to_vec()),
+            snapshot.get_raw(V_KEY).await.unwrap()
+        );
+        assert_eq!(1, snapshot.verifiable_cache.len());
+        assert_in_cache(&snapshot, &VALUES[0]);
+
+        // Write and commit different data under the same key.
+        let mut state_delta = storage.new_delta_of_latest_snapshot();
+        state_delta.put_raw(V_KEY.to_string(), VALUES[1].to_vec());
+        storage.commit(state_delta).await.unwrap();
+
+        // `get_raw` on a v0 snapshot should return the original value, and on the latest snapshot
+        // should return the updated value. Both caches should be updated.
+        let snapshot = storage.snapshot(0).unwrap();
+        assert!(snapshot.verifiable_cache.is_empty());
+        assert_eq!(
+            Some(VALUES[0].to_vec()),
+            snapshot.get_raw(V_KEY).await.unwrap()
+        );
+        assert_eq!(1, snapshot.verifiable_cache.len());
+        assert_in_cache(&snapshot, &VALUES[0]);
+
+        let snapshot = storage.latest_snapshot();
+        assert!(snapshot.verifiable_cache.is_empty());
+        assert_eq!(
+            Some(VALUES[1].to_vec()),
+            snapshot.get_raw(V_KEY).await.unwrap()
+        );
+        assert_eq!(1, snapshot.verifiable_cache.len());
+        assert_in_cache(&snapshot, &VALUES[1]);
+
+        // Check a clone of the latest snapshot has clone of the populated cache.
+        assert_eq!(1, storage.latest_snapshot().verifiable_cache.len());
+        assert_in_cache(&storage.latest_snapshot(), &VALUES[1]);
+    }
+
+    #[tokio::test]
+    async fn nonverifiable_get_raw_should_succeed() {
+        #[track_caller]
+        fn assert_in_cache(snapshot: &Snapshot, value: &[u8]) {
+            let Some(serialized_value) = snapshot.non_verifiable_cache.get(NV_KEY).unwrap() else {
+                panic!("should have value in cache");
+            };
+            assert_eq!(value.to_vec(), serialized_value);
+        }
+
+        let Fixture {
+            storage,
+            _temp_dir,
+        } = Fixture::new().await;
+
+        // `nonverifiable_get_raw` should return `None` for non-existent value.
+        let snapshot = storage.latest_snapshot();
+        assert!(
+            snapshot
+                .nonverifiable_get_raw(NV_KEY)
+                .await
+                .unwrap()
+                .is_none()
+        );
+
+        // Write and commit data.
+        let mut state_delta = storage.new_delta_of_latest_snapshot();
+        state_delta.nonverifiable_put_raw(NV_KEY.to_vec(), VALUES[0].to_vec());
+        storage.commit(state_delta).await.unwrap();
+
+        // `nonverifiable_get_raw` on the latest snapshot should return the correct value and cache
+        // it.
+        let snapshot = storage.latest_snapshot();
+        assert!(snapshot.non_verifiable_cache.is_empty());
+        assert_eq!(
+            Some(VALUES[0].to_vec()),
+            snapshot.nonverifiable_get_raw(NV_KEY).await.unwrap()
+        );
+        assert_eq!(1, snapshot.non_verifiable_cache.len());
+        assert_in_cache(&snapshot, &VALUES[0]);
+
+        // Write and commit different data under the same key.
+        let mut state_delta = storage.new_delta_of_latest_snapshot();
+        state_delta.nonverifiable_put_raw(NV_KEY.to_vec(), VALUES[1].to_vec());
+        storage.commit(state_delta).await.unwrap();
+
+        // `nonverifiable_get_raw` on a v0 snapshot should return the original value, and on the
+        // latest snapshot should return the updated value. Both caches should be updated.
+        let snapshot = storage.snapshot(0).unwrap();
+        assert!(snapshot.non_verifiable_cache.is_empty());
+        assert_eq!(
+            Some(VALUES[0].to_vec()),
+            snapshot.nonverifiable_get_raw(NV_KEY).await.unwrap()
+        );
+        assert_eq!(1, snapshot.non_verifiable_cache.len());
+        assert_in_cache(&snapshot, &VALUES[0]);
+
+        let snapshot = storage.latest_snapshot();
+        assert!(snapshot.non_verifiable_cache.is_empty());
+        assert_eq!(
+            Some(VALUES[1].to_vec()),
+            snapshot.nonverifiable_get_raw(NV_KEY).await.unwrap()
+        );
+        assert_eq!(1, snapshot.non_verifiable_cache.len());
+        assert_in_cache(&snapshot, &VALUES[1]);
+
+        // Check a clone of the latest snapshot has clone of the populated cache.
+        assert_eq!(1, storage.latest_snapshot().non_verifiable_cache.len());
+        assert_in_cache(&storage.latest_snapshot(), &VALUES[1]);
+    }
+
+    #[tokio::test]
+    async fn prefix_raw_should_succeed() {
+        let Fixture {
+            storage,
+            _temp_dir,
+        } = Fixture::new().await;
+
+        // `prefix_raw` should return an empty stream for a non-existent prefix.
+        let snapshot = storage.latest_snapshot();
+        let map: BTreeMap<_, _> = snapshot.prefix_raw(V_KEY).try_collect().await.unwrap();
+        assert!(map.is_empty());
+
+        // Write and commit four entries under a common prefix.
+        let mut state_delta = storage.new_delta_of_latest_snapshot();
+        let kv_iter = VALUES
+            .iter()
+            .enumerate()
+            .map(|(index, value)| (format!("common {index}"), value.to_vec()));
+        for (key, value) in kv_iter.clone() {
+            state_delta.put_raw(key, value);
+        }
+        storage.commit(state_delta).await.unwrap();
+
+        // Get a new snapshot, and populate its inner cache with two of the stored values by getting
+        // them.
+        let snapshot = storage.latest_snapshot();
+        assert!(snapshot.verifiable_cache.is_empty());
+        assert!(snapshot.get_raw("common 0").await.unwrap().is_some());
+        assert!(snapshot.get_raw("common 2").await.unwrap().is_some());
+        assert_eq!(2, snapshot.verifiable_cache.len());
+
+        // `prefix_raw` should return all the key value pairs and populate the cache.
+        let actual: BTreeMap<_, _> = snapshot.prefix_raw("com").try_collect().await.unwrap();
+        let expected: BTreeMap<_, _> = kv_iter.collect();
+        assert_eq!(expected, actual);
+        assert_eq!(4, snapshot.verifiable_cache.len());
+    }
+}


### PR DESCRIPTION
## Summary
This adds new storage types to sequencer and replaces bare usage of cnidarium equivalent types.

## Background
We want to become less coupled to the raw `cnidarium` APIs, and we also want to provide a cache of recently-read values.

## Changes
- Provided new `storage::Storage` type, wrapping the `cnidarium::Storage` type.
- Provided new `storage::Snapshot` type, wrapping the `cnidarium::Snapshot` type and including a cache of fetched values.
- When the sequencer main loop has finished, we now await the server handle and then call `storage.release().await;` which should probably have been the case before this PR.
- Applied consistent naming to variables of type `StateDelta<Snapshot>` and `StateDelta<StateDelta<Snapshot>>`.

## Testing
Added unit tests for the new types covering the non-trivial methods (many new methods simply call directly through to the equivalent inner method and don't need independent unit tests).

## Changelogs
Changelogs updated.

## Metrics
- Added `astria_sequencer_verifiable_cache_hit` counter
- Added `astria_sequencer_verifiable_cache_miss` counter
- Added `astria_sequencer_verifiable_cache_item_total` histogram
- Added `astria_sequencer_non_verifiable_cache_hit` counter
- Added `astria_sequencer_non_verifiable_cache_miss` counter
- Added `astria_sequencer_non_verifiable_cache_item_total` histogram

## Related Issues
Closes #1435.