### PR TITLE
fix: avoid redirect operator in justfile docker commands

### DIFF
--- a/justfile
+++ b/justfile
@@ -14,11 +14,11 @@ default_repo_name := 'ghcr.io/astriaorg'
 
 # Builds docker image for the crate. Defaults to 'local' tag.
 docker-build crate tag=default_docker_tag repo_name=default_repo_name:
-  docker buildx build --load --build-arg TARGETBINARY={{crate}} -f containerfiles/Dockerfile -t {{repo_name}}/$(sed 's/^[^-]*-//' <<< {{crate}}):{{tag}} .
+  docker buildx build --load --build-arg TARGETBINARY={{crate}} -f containerfiles/Dockerfile -t {{repo_name}}/$(echo {{crate}} | sed 's/^[^-]*-//'):{{tag}} .
 
 docker-build-and-load crate tag=default_docker_tag repo_name=default_repo_name:
   @just docker-build {{crate}} {{tag}} {{repo_name}}
-  @just load-image $(sed 's/^[^-]*-//' <<< {{crate}}) {{tag}} {{repo_name}}
+  @just load-image $(echo {{crate}} | sed 's/^[^-]*-//') {{tag}} {{repo_name}}
 
 # Installs the astria rust cli from local codebase
 install-cli:


### PR DESCRIPTION
## Summary
This replaces `sed '...' <<< text` with `echo text | sed '...'` in the main justfile.

## Background
On Ubuntu, the default shell doesn't recognise the redirect operator `<<<`, hence the `just` commands `docker-build` and `docker-build-and-load` both fail on Ubuntu.

## Changes
- Replaced usage of `<<<` by piping `echo` output.

## Testing
Ran the commands on Ubuntu and macOS.

## Changelogs
No updates required.
