### PR TITLE
fix: update audit ignore list

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -6,4 +6,10 @@ ignore = [
   # `proc-macro-error` is Unmaintained. It is a transient dependency of borsh crates, so cannot
   # easily be replaced.
   "RUSTSEC-2024-0370",
+  # `instant` is Unmaintained. It is a transient dependency of `isahc`, `wiremock` and `ethers`, so
+  # cannot easily be replaced.
+  "RUSTSEC-2024-0384",
+  # `derivative` is Unmaintained. It is a transient dependency of many crates including several
+  # penumbra ones, so cannot easily be replaced.
+  "RUSTSEC-2024-0388",
 ]


### PR DESCRIPTION
## Summary
Ignore two new RustSec warnings.

## Background
We get two non-critical warnings when running `cargo audit`: [RUSTSEC-2024-0384](https://rustsec.org/advisories/RUSTSEC-2024-0384) and [RUSTSEC-2024-0388](https://rustsec.org/advisories/RUSTSEC-2024-0388).

<details><summary>RUSTSEC-2024-0384</summary><p>

```
Crate:     instant
Version:   0.1.13
Warning:   unmaintained
Title:     `instant` is unmaintained
Date:      2024-09-01
ID:        RUSTSEC-2024-0384
URL:       https://rustsec.org/advisories/RUSTSEC-2024-0384
Dependency tree:
instant 0.1.13
├── fastrand 1.9.0
│   └── futures-lite 1.13.0
│       ├── isahc 1.7.2
│       │   └── astria-sequencer-relayer 1.0.0
│       └── http-types 2.12.0
│           └── wiremock 0.5.22
│               ├── astria-sequencer-relayer 1.0.0
│               ├── astria-sequencer-client 0.1.0
│               │   ├── astria-sequencer-relayer 1.0.0
│               │   ├── astria-conductor 1.0.0
│               │   ├── astria-composer 1.0.0
│               │   ├── astria-cli 0.5.1
│               │   └── astria-bridge-withdrawer 1.0.1
│               ├── astria-conductor 1.0.0
│               ├── astria-composer 1.0.0
│               └── astria-bridge-withdrawer 1.0.1
├── ethers-providers 2.0.14
│   ├── ethers-middleware 2.0.14
│   │   └── ethers 2.0.14
│   │       ├── astria-test-utils 0.1.0
│   │       │   └── astria-composer 1.0.0
│   │       ├── astria-composer 1.0.0
│   │       ├── astria-cli 0.5.1
│   │       ├── astria-bridge-withdrawer 1.0.1
│   │       └── astria-bridge-contracts 0.1.0
│   │           ├── astria-cli 0.5.1
│   │           └── astria-bridge-withdrawer 1.0.1
│   ├── ethers-contract 2.0.14
│   │   ├── ethers-middleware 2.0.14
│   │   └── ethers 2.0.14
│   └── ethers 2.0.14
└── ethers-middleware 2.0.14
```
</p></details>

<details><summary>RUSTSEC-2024-0388</summary><p>

```
Crate:     derivative
Version:   2.2.0
Warning:   unmaintained
Title:     `derivative` is unmaintained; consider using an alternative
Date:      2024-06-26
ID:        RUSTSEC-2024-0388
URL:       https://rustsec.org/advisories/RUSTSEC-2024-0388
Dependency tree:
derivative 2.2.0
├── penumbra-tct 0.80.7
│   ├── penumbra-txhash 0.80.7
│   │   └── penumbra-ibc 0.80.7
│   │       ├── astria-sequencer 1.0.0
│   │       └── astria-core 0.1.0
│   │           ├── astria-sequencer-utils 0.1.0
│   │           ├── astria-sequencer-relayer 1.0.0
│   │           ├── astria-sequencer-client 0.1.0
│   │           │   ├── astria-sequencer-relayer 1.0.0
│   │           │   ├── astria-conductor 1.0.0
│   │           │   ├── astria-composer 1.0.0
│   │           │   ├── astria-cli 0.5.1
│   │           │   └── astria-bridge-withdrawer 1.0.1
│   │           ├── astria-sequencer 1.0.0
│   │           ├── astria-core 0.1.0
│   │           ├── astria-conductor 1.0.0
│   │           ├── astria-composer 1.0.0
│   │           ├── astria-cli 0.5.1
│   │           ├── astria-bridge-withdrawer 1.0.1
│   │           └── astria-bridge-contracts 0.1.0
│   │               ├── astria-cli 0.5.1
│   │               └── astria-bridge-withdrawer 1.0.1
│   ├── penumbra-sct 0.80.7
│   │   └── penumbra-ibc 0.80.7
│   └── penumbra-keys 0.80.7
│       └── penumbra-sct 0.80.7
├── penumbra-num 0.80.7
│   ├── penumbra-ibc 0.80.7
│   └── penumbra-asset 0.80.7
│       ├── penumbra-keys 0.80.7
│       └── penumbra-ibc 0.80.7
├── penumbra-keys 0.80.7
├── penumbra-asset 0.80.7
├── ark-r1cs-std 0.4.0
│   ├── poseidon377 1.2.0
│   │   ├── penumbra-tct 0.80.7
│   │   ├── penumbra-sct 0.80.7
│   │   ├── penumbra-keys 0.80.7
│   │   └── penumbra-asset 0.80.7
│   ├── poseidon-permutation 1.1.0
│   │   └── poseidon377 1.2.0
│   ├── penumbra-tct 0.80.7
│   ├── penumbra-sct 0.80.7
│   ├── penumbra-num 0.80.7
│   ├── penumbra-keys 0.80.7
│   ├── penumbra-asset 0.80.7
│   └── decaf377 0.10.1
│       ├── poseidon377 1.2.0
│       ├── poseidon-permutation 1.1.0
│       ├── poseidon-parameters 1.1.0
│       │   ├── poseidon377 1.2.0
│       │   └── poseidon-permutation 1.1.0
│       ├── penumbra-tct 0.80.7
│       ├── penumbra-sct 0.80.7
│       ├── penumbra-num 0.80.7
│       ├── penumbra-keys 0.80.7
│       ├── penumbra-asset 0.80.7
│       ├── decaf377-rdsa 0.11.0
│       │   ├── penumbra-sct 0.80.7
│       │   ├── penumbra-proto 0.80.7
│       │   │   ├── penumbra-txhash 0.80.7
│       │   │   ├── penumbra-tct 0.80.7
│       │   │   ├── penumbra-sct 0.80.7
│       │   │   ├── penumbra-num 0.80.7
│       │   │   ├── penumbra-keys 0.80.7
│       │   │   ├── penumbra-ibc 0.80.7
│       │   │   ├── penumbra-asset 0.80.7
│       │   │   ├── astria-sequencer 1.0.0
│       │   │   └── astria-core 0.1.0
│       │   ├── penumbra-num 0.80.7
│       │   ├── penumbra-keys 0.80.7
│       │   └── penumbra-asset 0.80.7
│       ├── decaf377-ka 0.80.7
│       │   └── penumbra-keys 0.80.7
│       └── decaf377-fmd 0.80.7
│           ├── penumbra-proto 0.80.7
│           ├── penumbra-num 0.80.7
│           ├── penumbra-keys 0.80.7
│           └── penumbra-asset 0.80.7
├── ark-poly 0.4.2
│   ├── ark-groth16 0.4.0
│   │   ├── poseidon377 1.2.0
│   │   ├── penumbra-num 0.80.7
│   │   └── decaf377 0.10.1
│   └── ark-ec 0.4.2
│       ├── poseidon377 1.2.0
│       ├── decaf377 0.10.1
│       ├── ark-r1cs-std 0.4.0
│       ├── ark-groth16 0.4.0
│       ├── ark-ed-on-bls12-377 0.4.0
│       │   ├── penumbra-tct 0.80.7
│       │   └── decaf377 0.10.1
│       ├── ark-crypto-primitives 0.4.0
│       │   └── ark-groth16 0.4.0
│       └── ark-bls12-377 0.4.0
│           ├── decaf377 0.10.1
│           └── ark-ed-on-bls12-377 0.4.0
├── ark-ff 0.4.2
│   ├── ruint 1.12.3
│   │   └── celestia-types 0.1.1
│   │       ├── celestia-rpc 0.1.1
│   │       │   └── astria-conductor 1.0.0
│   │       ├── astria-sequencer-relayer 1.0.0
│   │       ├── astria-core 0.1.0
│   │       └── astria-conductor 1.0.0
│   ├── poseidon377 1.2.0
│   ├── poseidon-permutation 1.1.0
│   ├── penumbra-tct 0.80.7
│   ├── penumbra-sct 0.80.7
│   ├── penumbra-num 0.80.7
│   ├── penumbra-keys 0.80.7
│   ├── penumbra-ibc 0.80.7
│   ├── penumbra-asset 0.80.7
│   ├── decaf377-rdsa 0.11.0
│   ├── decaf377-ka 0.80.7
│   ├── decaf377-fmd 0.80.7
│   ├── decaf377 0.10.1
│   ├── ark-snark 0.4.0
│   │   ├── poseidon377 1.2.0
│   │   ├── penumbra-num 0.80.7
│   │   ├── decaf377 0.10.1
│   │   └── ark-crypto-primitives 0.4.0
│   ├── ark-relations 0.4.0
│   │   ├── poseidon377 1.2.0
│   │   ├── poseidon-permutation 1.1.0
│   │   ├── penumbra-tct 0.80.7
│   │   ├── penumbra-sct 0.80.7
│   │   ├── penumbra-num 0.80.7
│   │   ├── penumbra-keys 0.80.7
│   │   ├── penumbra-asset 0.80.7
│   │   ├── decaf377 0.10.1
│   │   ├── ark-snark 0.4.0
│   │   ├── ark-r1cs-std 0.4.0
│   │   ├── ark-groth16 0.4.0
│   │   └── ark-crypto-primitives 0.4.0
│   ├── ark-r1cs-std 0.4.0
│   ├── ark-poly 0.4.2
│   ├── ark-groth16 0.4.0
│   ├── ark-ed-on-bls12-377 0.4.0
│   ├── ark-ec 0.4.2
│   ├── ark-crypto-primitives 0.4.0
│   └── ark-bls12-377 0.4.0
├── ark-ff 0.3.0
│   └── ruint 1.12.3
├── ark-ec 0.4.2
└── ark-crypto-primitives 0.4.0
```

</p></details>

Given that the RustSec report doesn't suggest any concrete problems with either crate, and how difficult it will be to move away from these dependencies, I have just ignored these warnings in CI.

## Changes
- Ignore RustSec warnings in `.cargo/audit.toml`.

## Testing
Ran `cargo audit` locally.

## Changelogs
No updates required - nothing really fixed or updated.

## Related Issues
Closes #1796.
Closes #1797.
