### PR TITLE
fix(sequencer)!: ensure deposits use trace-prefixed assets

### DIFF
--- a/crates/astria-sequencer/CHANGELOG.md
+++ b/crates/astria-sequencer/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Ensure all deposit assets are trace prefixed [#1807](https://github.com/astriaorg/astria/pull/1807).
+
 ## [1.0.0] - 2024-10-25
 
 ### Changed


### PR DESCRIPTION
## Summary
Ensures deposits created within bridge lock actions use only trace-prefixed assets.

## Background
Currently, deposits created within a bridge lock action include whichever asset is used in the action, which can be either IBC- or trace-prefixed. This poses a problem, since our EVM has no concept of IBC-prefixed assets, and we shouldn't expect others using our network to, either. One solution discussed was to enforce all `BridgeLock` actions to use trace prefixed assets, but this would be a consensus breaking change. This aims to remedy the bug whilst making no breaking changes.

## Changes
- Map any IBC-prefixed assets included in a `BridgeLock` action to trace-prefixed when constructing the `Deposit`.

## Testing
- Added unit test to ensure an IBC-prefixed asset included in a bridge lock action is correctly mapped to a trace-prefixed asset in the corresponding deposit.
- Tested that change would be non-breaking by syncing a full node to mainnet

## Changelogs
Changelog updated.

## Breaking Changes
Technically, this change is breaking, since any sequencer version prior to this which received a `BridgeLock` action containing an IBC-prefixed asset would emit a `Deposit` with an IBC-prefixed asset, while any sequencer version after would only emit deposits with trace-prefixed assets. However, owing to the fact that no such cases have happened yet on mainnet, this change would not be practically breaking so long as no `BridgeLock` actions containing IBC-prefixed denoms have been submitted by the time this patch is pushed out. This is actively being tested by a full-node running this PR against mainnet.

## Steps to sync this PR to Mainnet on your local machine

Ensure you have docker installed + running

### Download and build Sequencer
```bash
git clone https://github.com/astriaorg/astria.git
cd astria
git checkout ENG-1004/trace_prefixed_deposits
cargo build -p astria-sequencer --release
just docker-build astria-sequencer
```

### Helm install
```bash
helm repo add astria https://astriaorg.github.io/charts/
```
Download this file and put in the `astria` repo: https://github.com/astriaorg/networks/blob/main/astria/full-node-values.yaml

Make these edits to `full-node-values.yaml`, replacing "your_moniker" with your chosen moniker:

```yaml
namespace: "astria-node"
moniker: `<your_moniker>`
images:
     sequencer:
          tag: local
cometbft:
     secrets:
          nodeKey:
               devContent:
                    priv_key:
                         value: 1yh4XrMHn75sSW5cOhGDTVgv5BbqXlhrLduxHcE2t1osbwKQzo7xlvSK1vh5CVDvHESPYK/56uTKXM/1ifqHbw==
     privValidatorKey:
          devContent:
               address: 8C17BBDC7C350C83C550163458FC9B7A5B54A64E
               pub_key:
                    value: 4v1RdMiKkWgBBTTP26iRSLOEkAY99gMVfZijm6OCzjs=
               priv_key:
                    value: WxsUPI2QASIwK+XV547R8xzL66a5oBR2G8h53t0Gcl7i/VF0yIqRaAEFNM/bqJFIs4SQBj32AxV9mKObo4LOOw==
sequencer:
     metrics:
          enabled: false
     otel:
          enabled: false
storage:
     local: true
     entities:
          sequencerSharedStorage:
               storageClassName: <your_moniker>-sequencer-shared-storage-local
```

From the `astria` repo:
```bash
just deploy cluster
just deploy ingress-controller
just wait-for-ingress-controller
just load-image sequencer
helm install astria-full-node astria/sequencer --version 1.0.0-rc.4 \
  --namespace astria-node --create-namespace -f full-node-values.yaml
```

After this you should be able to go into k9s and see both the sequencer and CometBFT running

## Related Issues
closes #1806
