### PR TITLE
fix(ci): remove unnecessary checks from ibc-tests

### DIFF
--- a/charts/ibc-test.just
+++ b/charts/ibc-test.just
@@ -146,29 +146,8 @@ run tag=defaultTag:
     exit 1
   fi
 
-  # set celestia wallet balance balance variables
-  initial_celestia_balance=$(just ibc-test get-celestia-balance)
-  expected_celestia_balance=$(echo "$initial_celestia_balance - {{transfer_amount}} - {{transfer_fees}}" | bc)
-
   # Execute the transfer from Celstia to sequencer with compat address
   just ibc-test _do-ibc-transfer {{defaultNamespace}} {{compat_address}}
-
-  # check that celestia balance updated correctly
-  for i in {1..50}
-  do
-    current_celestia_balance=$(just ibc-test get-celestia-balance)
-    echo "check $i, balance: $current_celestia_balance, expected: $expected_celestia_balance"
-    if (( $expected_celestia_balance == $current_celestia_balance )); then
-      expected_celestia_balance_found="1"
-      break
-    else
-      sleep 1
-    fi
-  done
-  if [[ -z $expected_celestia_balance_found ]]; then
-    echo "expected celestia balance was not found after withdraw; IBC transfer from Celestia to the Rollup failed"
-    exit 1
-  fi
 
   # check that sequencer balance updated correctly
   ASTRIA_CLI_IMAGE="{{cli_image}}{{ if tag != '' { replace(':#', '#', tag) } else { '' } }}"
@@ -284,29 +263,8 @@ run-timeout tag=defaultTag:
     exit 1
   fi
 
-  # set celestia wallet balance balance variables
-  initial_celestia_balance=$(just ibc-test get-celestia-balance)
-  expected_celestia_balance=$(echo "$initial_celestia_balance - {{transfer_amount}} - {{transfer_fees}}" | bc)
-
   # Execute the transfer from Celstia to sequencer with compat address
   just ibc-test _do-ibc-transfer {{defaultNamespace}} {{compat_address}}
-
-  # check that celestia balance updated correctly
-  for i in {1..50}
-  do
-    current_celestia_balance=$(just ibc-test get-celestia-balance)
-    echo "check $i, balance: $current_celestia_balance, expected: $expected_celestia_balance"
-    if (( $expected_celestia_balance == $current_celestia_balance )); then
-      expected_celestia_balance_found="1"
-      break
-    else
-      sleep 1
-    fi
-  done
-  if [[ -z $expected_celestia_balance_found ]]; then
-    echo "expected celestia balance was not found after withdraw; IBC transfer from Celestia to the Rollup failed"
-    exit 1
-  fi
 
   # check that sequencer balance updated correctly
   ASTRIA_CLI_IMAGE="{{cli_image}}{{ if tag != '' { replace(':#', '#', tag) } else { '' } }}"

--- a/charts/ibc-test.just
+++ b/charts/ibc-test.just
@@ -89,10 +89,7 @@ run-without-native tag=defaultTag:
   # Execute the transfer from Celestia to the Rollup
   just ibc-test _do-ibc-transfer {{defaultNamespace}} {{sequencer_sudo_address}}
 
-  # Add transfer/channel-0/utia as fee-asset
-  docker run --rm --network host $ASTRIA_CLI_IMAGE sequencer sudo fee-asset add --private-key {{sequencer_sudo_pkey}} --asset transfer/channel-0/utia --sequencer-url {{sequencer_rpc_url}} --sequencer.chain-id {{sequencer_chain_id}}
   # check that sequencer balance updated correctly
-
   EXPECTED_BALANCE=$(echo "1 * {{transfer_amount}}" | bc)
   for i in {1..50}
   do
@@ -109,6 +106,11 @@ run-without-native tag=defaultTag:
     echo "expected sequencer balance was not found after IBC transfer; IBC transfer with compat address failed"
     exit 1
   fi
+
+  # Add transfer/channel-0/utia as allowed fee-asset
+  docker run --rm --network host $ASTRIA_CLI_IMAGE sequencer sudo fee-asset add --private-key {{sequencer_sudo_pkey}} --asset transfer/channel-0/utia --sequencer-url {{sequencer_rpc_url}} --sequencer.chain-id {{sequencer_chain_id}}
+
+  # TODO: query allowd fee asset verifying succefull addition
 
 [no-cd]
 run tag=defaultTag:

--- a/charts/ibc-test.just
+++ b/charts/ibc-test.just
@@ -146,6 +146,10 @@ run tag=defaultTag:
     exit 1
   fi
 
+  # set celestia wallet balance balance variables
+  initial_celestia_balance=$(just ibc-test get-celestia-balance)
+  expected_celestia_balance=$(echo "$initial_celestia_balance - {{transfer_amount}} - {{transfer_fees}}" | bc)
+
   # Execute the transfer from Celstia to sequencer with compat address
   just ibc-test _do-ibc-transfer {{defaultNamespace}} {{compat_address}}
 
@@ -279,6 +283,10 @@ run-timeout tag=defaultTag:
     echo "expected balance was not found; IBC transfer from Celestia to the Rollup failed"
     exit 1
   fi
+
+  # set celestia wallet balance balance variables
+  initial_celestia_balance=$(just ibc-test get-celestia-balance)
+  expected_celestia_balance=$(echo "$initial_celestia_balance - {{transfer_amount}} - {{transfer_fees}}" | bc)
 
   # Execute the transfer from Celstia to sequencer with compat address
   just ibc-test _do-ibc-transfer {{defaultNamespace}} {{compat_address}}


### PR DESCRIPTION
## Summary
removes immediate celestia balance check after performing ibc-transfer **from** celestia 
## Background
Current ibc-tests checks celestia wallet balance immediately after permorming an ibc transfer, this is redundant as we check the bablance change on the sequencer side. In addition to currently being broken duo to outdated expected value, the test currently passes randomly, most likely duo to latency. 
## Changes
- remove celestia balance checks from ibc transfer from celestia
- moves ibc-transfer check in `run-without-native` above fee-asset change, avoiding latency issues.

## Testing
- locally tested bad behavior by adding a 1s sleep prior to the first balance check
## Changelogs
No updates required.
