### PR TITLE
chore(bridge-withdrawer): accumulating counter instead of guage for settled value

### DIFF
--- a/crates/astria-bridge-withdrawer/CHANGELOG.md
+++ b/crates/astria-bridge-withdrawer/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New `accumed_settled_value` metric which tracks total settled since startup
+
+
+### Removed
+
+- `batch_total_settled_value` which as a guage was not useful for tracking total settled value
+
 ## [1.0.1] - 2024-11-01
 
 ### Fixed

--- a/crates/astria-bridge-withdrawer/CHANGELOG.md
+++ b/crates/astria-bridge-withdrawer/CHANGELOG.md
@@ -11,12 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- New `accumed_settled_value` metric which tracks total settled since startup
+- New `accumulateded_settled_value` metric which tracks total settled since startup [#1814](https://github.com/astriaorg/astria/pull/1814)
 
 
 ### Removed
 
-- `batch_total_settled_value` which as a guage was not useful for tracking total settled value
+- `batch_total_settled_value` which as a guage was not useful for tracking total settled value [#1814](https://github.com/astriaorg/astria/pull/1814)
 
 ## [1.0.1] - 2024-11-01
 

--- a/crates/astria-bridge-withdrawer/src/bridge_withdrawer/submitter/mod.rs
+++ b/crates/astria-bridge-withdrawer/src/bridge_withdrawer/submitter/mod.rs
@@ -144,8 +144,6 @@ impl Submitter {
         } = self;
 
         if actions.is_empty() {
-            metrics.set_batch_total_settled_value(0);
-
             return Ok(());
         }
 
@@ -212,7 +210,7 @@ impl Submitter {
                 batch.value = total_value,
                 "withdraw batch successfully executed."
             );
-            metrics.set_batch_total_settled_value(total_value);
+            metrics.increment_accumulated_settled_value(total_value);
             state.set_last_rollup_height_submitted(rollup_height);
             state.set_last_sequencer_height(tx_response.height.value());
             state.set_last_sequencer_tx_hash(tx_response.hash);

--- a/crates/astria-bridge-withdrawer/src/metrics.rs
+++ b/crates/astria-bridge-withdrawer/src/metrics.rs
@@ -18,7 +18,7 @@ pub struct Metrics {
     nonce_fetch_latency: Histogram,
     sequencer_submission_failure_count: Counter,
     sequencer_submission_latency: Histogram,
-    batch_total_settled_value: Gauge,
+    accumulated_settled_value: Gauge,
 }
 
 impl Metrics {
@@ -46,8 +46,8 @@ impl Metrics {
         self.sequencer_submission_failure_count.increment(1);
     }
 
-    pub(crate) fn set_batch_total_settled_value(&self, value: u128) {
-        self.batch_total_settled_value.set(value);
+    pub(crate) fn increment_accumulated_settled_value(&self, value: u128) {
+        self.accumulated_settled_value.increment(value);
     }
 }
 
@@ -97,10 +97,10 @@ impl metrics::Metrics for Metrics {
             )?
             .register()?;
 
-        let batch_total_settled_value = builder
+        let accumulated_settled_value = builder
             .new_gauge_factory(
-                BATCH_TOTAL_SETTLED_VALUE,
-                "Total value of withdrawals settled in a given sequencer block",
+                ACCUMULATED_SETTLED_VALUE,
+                "Total value of withdrawals settled over time from batches",
             )?
             .register()?;
 
@@ -111,7 +111,7 @@ impl metrics::Metrics for Metrics {
             nonce_fetch_latency,
             sequencer_submission_failure_count,
             sequencer_submission_latency,
-            batch_total_settled_value,
+            accumulated_settled_value,
         })
     }
 }
@@ -123,13 +123,13 @@ metric_names!(const METRICS_NAMES:
     CURRENT_NONCE,
     SEQUENCER_SUBMISSION_FAILURE_COUNT,
     SEQUENCER_SUBMISSION_LATENCY,
-    BATCH_TOTAL_SETTLED_VALUE,
+    ACCUMULATED_SETTLED_VALUE,
 );
 
 #[cfg(test)]
 mod tests {
     use super::{
-        BATCH_TOTAL_SETTLED_VALUE,
+        ACCUMULATED_SETTLED_VALUE,
         CURRENT_NONCE,
         NONCE_FETCH_COUNT,
         NONCE_FETCH_FAILURE_COUNT,
@@ -157,6 +157,6 @@ mod tests {
             "sequencer_submission_failure_count",
         );
         assert_const(SEQUENCER_SUBMISSION_LATENCY, "sequencer_submission_latency");
-        assert_const(BATCH_TOTAL_SETTLED_VALUE, "batch_total_settled_value");
+        assert_const(ACCUMULATED_SETTLED_VALUE, "accumulated_settled_value");
     }
 }


### PR DESCRIPTION
## Summary
Replaces the guage metric `batch_total_settled_value` with the counter metric `accumulated_settled_value`

## Background
The guage metric was not useful because we were not capturing the guage at each packet time, it was most likely going to always be zero. Instead replace with a counter which we can run a rate on to see the total amount of flow out. Because this is strictly increasing we aren't subject to different outputs with different scraping intervals. 

## Changes
- remove `batch_total_settled_value` and replace with `accumulated_settled_value`

## Testing
How are these changes tested?

## Changelogs
Changelogs updated

## Metrics
- Remove `batch_total_settled_value`
- Added `accumulated_settled_value` metric

## Breaking Changelist
This is technically speaking a breaking change on the metric interface, however the existing metric never worked, so I wouldn't consider truly breaking. 
