### PR TITLE
feat(cli): allowed fee-assets query

### DIFF
--- a/crates/astria-cli/CHANGELOG.md
+++ b/crates/astria-cli/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `fee-assets` subcommand to `sequencer` CLI [#1816](https://github.com/astriaorg/astria/pull/1816).
+
 ### Fixed
 
 - Fixed ICS20 withdrawal source when using channel with more than one

--- a/crates/astria-cli/src/sequencer/fee_assets.rs
+++ b/crates/astria-cli/src/sequencer/fee_assets.rs
@@ -50,7 +50,7 @@ impl Get {
 
         println!("Allowed fee assets:");
         for asset in res.fee_assets {
-            println!("    {}", asset);
+            println!("    {asset}");
         }
 
         Ok(())

--- a/crates/astria-cli/src/sequencer/fee_assets.rs
+++ b/crates/astria-cli/src/sequencer/fee_assets.rs
@@ -1,0 +1,58 @@
+use astria_sequencer_client::{
+    HttpClient,
+    SequencerClientExt as _,
+};
+use clap::Subcommand;
+use color_eyre::eyre::{
+    self,
+    WrapErr as _,
+};
+
+#[derive(Debug, clap::Args)]
+pub(super) struct Command {
+    #[command(subcommand)]
+    command: SubCommand,
+}
+
+impl Command {
+    pub(super) async fn run(self) -> eyre::Result<()> {
+        let SubCommand::Get(get) = self.command;
+        get.run().await
+    }
+}
+
+#[derive(Debug, Subcommand)]
+enum SubCommand {
+    /// Get the balance of a Sequencer account
+    Get(Get),
+}
+
+#[derive(clap::Args, Debug)]
+struct Get {
+    /// The url of the Sequencer node
+    #[arg(
+        long,
+        env = "SEQUENCER_URL",
+        default_value = crate::DEFAULT_SEQUENCER_RPC
+    )]
+    sequencer_url: String,
+}
+
+impl Get {
+    async fn run(self) -> eyre::Result<()> {
+        let sequencer_client = HttpClient::new(self.sequencer_url.as_str())
+            .wrap_err("failed constructing http sequencer client")?;
+
+        let res = sequencer_client
+            .get_allowed_fee_assets()
+            .await
+            .wrap_err("failed to get fee assets")?;
+
+        println!("Allowed fee assets:");
+        for asset in res.fee_assets {
+            println!("    {}", asset);
+        }
+
+        Ok(())
+    }
+}

--- a/crates/astria-cli/src/sequencer/mod.rs
+++ b/crates/astria-cli/src/sequencer/mod.rs
@@ -8,6 +8,7 @@ mod block_height;
 mod bridge_account;
 mod bridge_lock;
 mod bridge_sudo_change;
+mod fee_assets;
 mod ics20_withdrawal;
 mod init_bridge_account;
 mod sign;
@@ -39,6 +40,7 @@ impl Command {
             SubCommand::Sign(sign) => sign.run(),
             SubCommand::BridgeSudoChange(bridge_sudo_change) => bridge_sudo_change.run().await,
             SubCommand::BridgeAccount(bridge_account) => bridge_account.run().await,
+            SubCommand::FeeAssets(fee_assets) => fee_assets.run().await,
         }
     }
 }
@@ -80,4 +82,6 @@ enum SubCommand {
     BridgeSudoChange(bridge_sudo_change::Command),
     /// Commands for interacting with the bridge account
     BridgeAccount(bridge_account::Command),
+    /// Command for interacting with allowed fee assets
+    FeeAssets(fee_assets::Command),
 }


### PR DESCRIPTION
## Summary
Adds `astria-cli sequencer fee-assets get` query command, getting all allowed fee-assets
## Background
The astria CLI should have a query command for all abci query paths, the PR is part of an effort to accomplish this. It also enables more robust smoke-tests.
## Changes
- Adds allowed fee assets query subcommand.

## Testing
Manually runs the command against local, Dawn and mainnet.

## Changelogs
Changelogs updated.

## Related Issues
Link any issues that are related, prefer full GitHub links.

closes #1815 
