### PR TITLE
fix(charts): configurable components block times variables

### DIFF
--- a/charts/celestia-local/Chart.yaml
+++ b/charts/celestia-local/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.0
+version: 0.7.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/celestia-local/files/scripts/init-celestia-appd.sh
+++ b/charts/celestia-local/files/scripts/init-celestia-appd.sh
@@ -62,6 +62,9 @@ sed -i'.bak' 's#"null"#"kv"#g' "${home_dir}"/config/config.toml
 sed -i'.bak' 's#discard_abci_responses = true#discard_abci_responses = false#g' "${home_dir}"/config/config.toml
 # Override the VotingPeriod from 1 week to 1 minute
 sed -i'.bak' 's#"604800s"#"60s"#g' "${home_dir}"/config/genesis.json
+# Set the CommitTimeout to 5 second
+sed -i'.bak' 's#timeout_commit = "11s"#timeout_commit = "5s"#g' "${home_dir}"/config/config.toml
+
 if $fast; then
-  sed -i'.bak' 's#timeout_commit = "11s"#timeout_commit = "1s"#g' "${home_dir}"/config/config.toml
+  sed -i'.bak' 's#timeout_commit = "5s"#timeout_commit = "1s"#g' "${home_dir}"/config/config.toml
 fi

--- a/charts/celestia-local/values.yaml
+++ b/charts/celestia-local/values.yaml
@@ -16,7 +16,7 @@ storage:
       path: "/data/celestia-data"
 
 celestiaAppImage: "ghcr.io/celestiaorg/celestia-app:v2.3.1"
-celestiaNodeImage: "ghcr.io/celestiaorg/celestia-node:v0.18.3-mocha"
+celestiaNodeImage: "ghcr.io/celestiaorg/celestia-node:v0.20.4"
 
 podSecurityContext:
   runAsUser: 10001

--- a/charts/evm-rollup/Chart.yaml
+++ b/charts/evm-rollup/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/evm-rollup/templates/configmap.yaml
+++ b/charts/evm-rollup/templates/configmap.yaml
@@ -8,7 +8,7 @@ data:
   ASTRIA_CONDUCTOR_CELESTIA_NODE_HTTP_URL: "{{ .Values.config.celestia.rpc }}"
   ASTRIA_CONDUCTOR_EXPECTED_CELESTIA_CHAIN_ID: "{{ tpl .Values.config.conductor.celestiaChainId . }}"
   ASTRIA_CONDUCTOR_CELESTIA_BEARER_TOKEN: "{{ .Values.config.celestia.token }}"
-  ASTRIA_CONDUCTOR_CELESTIA_BLOCK_TIME_MS: "12000"
+  ASTRIA_CONDUCTOR_CELESTIA_BLOCK_TIME_MS: "{{ .Values.config.conductor.celestiaBlockTimeMs }}"
   ASTRIA_CONDUCTOR_EXECUTION_RPC_URL: "http://127.0.0.1:{{ .Values.ports.executionGRPC }}"
   ASTRIA_CONDUCTOR_EXECUTION_COMMIT_LEVEL: "{{ .Values.config.conductor.executionCommitLevel }}"
   ASTRIA_CONDUCTOR_SEQUENCER_GRPC_URL: "{{ tpl .Values.config.conductor.sequencerGrpc . }}"

--- a/charts/evm-rollup/values.yaml
+++ b/charts/evm-rollup/values.yaml
@@ -173,7 +173,7 @@ config:
     # rate.
     sequencerBlockTimeMs: 2000
     # The expected fastest block time possible from DA, determines polling rate.
-    celestiaBlockTimeMs: 12000
+    celestiaBlockTimeMs: 6000
     # URL path for the sequencer
     sequencerRpc: ""
     # gRPC path for the sequencer

--- a/charts/evm-rollup/values.yaml
+++ b/charts/evm-rollup/values.yaml
@@ -172,6 +172,8 @@ config:
     # The expected fastest block time possible from sequencer, determines polling
     # rate.
     sequencerBlockTimeMs: 2000
+    # The expected fastest block time possible from DA, determines polling rate.
+    celestiaBlockTimeMs: 12000
     # URL path for the sequencer
     sequencerRpc: ""
     # gRPC path for the sequencer

--- a/charts/evm-stack/Chart.lock
+++ b/charts/evm-stack/Chart.lock
@@ -20,5 +20,5 @@ dependencies:
 - name: blockscout-stack
   repository: https://blockscout.github.io/helm-charts
   version: 1.6.8
-digest: sha256:b24083a75d7242a95b7b98176e67e429c30fb33192769252f40555077034e244
-generated: "2024-11-20T11:23:34.812102+02:00"
+digest: sha256:d89234a3481aa511fb32e38b9d5799efb5848f490e67dc67e837e4eb6af670d1
+generated: "2024-12-12T18:24:37.475398+02:00"

--- a/charts/evm-stack/Chart.lock
+++ b/charts/evm-stack/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.4.0
 - name: evm-rollup
   repository: file://../evm-rollup
-  version: 1.0.0
+  version: 1.0.1
 - name: composer
   repository: file://../composer
   version: 1.0.0
@@ -20,5 +20,5 @@ dependencies:
 - name: blockscout-stack
   repository: https://blockscout.github.io/helm-charts
   version: 1.6.8
-digest: sha256:037f984f43d4eb0616c27f8a36a359680d4d745f4687a4ca54f7d77fb5119d99
-generated: "2024-12-11T11:48:47.334728-08:00"
+digest: sha256:b24083a75d7242a95b7b98176e67e429c30fb33192769252f40555077034e244
+generated: "2024-11-20T11:23:34.812102+02:00"

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.4
+version: 1.0.5
 
 dependencies:
   - name: celestia-node

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -23,7 +23,7 @@ dependencies:
     repository: "file://../celestia-node"
     condition: celestia-node.enabled
   - name: evm-rollup
-    version: 1.0.0
+    version: 1.0.1
     repository: "file://../evm-rollup"
   - name: composer
     version: 1.0.0
@@ -45,7 +45,6 @@ dependencies:
     repository: "https://blockscout.github.io/helm-charts"
     version: "1.6.8"
     condition: blockscout-stack.enabled
-
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sequencer-relayer/Chart.yaml
+++ b/charts/sequencer-relayer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sequencer-relayer/templates/configmaps.yaml
+++ b/charts/sequencer-relayer/templates/configmaps.yaml
@@ -6,7 +6,7 @@ metadata:
 data:
   ASTRIA_SEQUENCER_RELAYER_LOG: "astria_sequencer_relayer=debug"
   ASTRIA_SEQUENCER_RELAYER_SUBMISSION_STATE_PATH: "{{ include "sequencer-relayer.storage.submissionStatePath" . }}"
-  ASTRIA_SEQUENCER_RELAYER_BLOCK_TIME: "1000"
+  ASTRIA_SEQUENCER_RELAYER_BLOCK_TIME: "{{ .Values.config.relayer.blockTimeMs }}"
   ASTRIA_SEQUENCER_RELAYER_COMETBFT_ENDPOINT: "{{ .Values.config.relayer.cometbftRpc }}"
   ASTRIA_SEQUENCER_RELAYER_SEQUENCER_GRPC_ENDPOINT: "{{ .Values.config.relayer.sequencerGrpc }}"
   ASTRIA_SEQUENCER_RELAYER_CELESTIA_APP_GRPC_ENDPOINT: "{{ .Values.config.relayer.celestiaAppGrpc }}"

--- a/charts/sequencer-relayer/values.yaml
+++ b/charts/sequencer-relayer/values.yaml
@@ -25,6 +25,7 @@ config:
     cometbftRpc: ""
     sequencerGrpc: ""
     onlyIncludeRollups: ""
+    blockTimeMs: "1000"
 
     metrics:
       enabled: false

--- a/charts/sequencer/Chart.lock
+++ b/charts/sequencer/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: sequencer-relayer
   repository: file://../sequencer-relayer
-  version: 1.0.0
-digest: sha256:6f65d48d295fde2acca7ea368fa319add42cd33eff18ddb9768eef09ea97bf57
-generated: "2024-10-27T10:01:12.181193-07:00"
+  version: 1.0.1
+digest: sha256:3b3ce65ff473606fcc86027653cadd212ba45ac8b39d5806d713b48f695ad235
+generated: "2024-11-20T11:24:11.85775+02:00"

--- a/charts/sequencer/Chart.yaml
+++ b/charts/sequencer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -24,7 +24,7 @@ appVersion: "1.0.0"
 
 dependencies:
   - name: sequencer-relayer
-    version: "1.0.0"
+    version: "1.0.1"
     repository: "file://../sequencer-relayer"
     condition: sequencer-relayer.enabled
 


### PR DESCRIPTION
## Summary
Configurable block time environment variables for conductor and sequencer-relayer components
## Background
Currently, `ASTRIA_CONDUCTOR_CELESTIA_BLOCK_TIME_MS` and `ASTRIA_SEQUENCER_RELAYER_BLOCK_TIME` environment  variables are hard coded in the charts, the variables determines polling frequency and thus should be easily configurable. 

## Changes
- configurable blocktime variables for conductor and sequencer relayer components.

## Testing
locally templating the chart with new default values.
## Changelogs
No updates required
