### PR TITLE
fix(sequencer): provide unit tests and fixes for vote extensions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,7 +814,6 @@ dependencies = [
  "ibc-types",
  "indexmap 2.4.0",
  "insta",
- "is_sorted",
  "itertools 0.12.1",
  "maplit",
  "matchit",
@@ -4549,12 +4548,6 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "is_sorted"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357376465c37db3372ef6a00585d336ed3d0f11d4345eef77ebcb05865392b21"
 
 [[package]]
 name = "is_terminal_polyfill"

--- a/crates/astria-core/src/connect/types.rs
+++ b/crates/astria-core/src/connect/types.rs
@@ -189,7 +189,7 @@ pub mod v2 {
         ParseQuote { source: ParseQuoteError },
     }
 
-    #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
     pub struct CurrencyPair {
         base: Base,
         quote: Quote,
@@ -335,7 +335,7 @@ pub mod v2 {
         }
     }
 
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
     pub struct CurrencyPairId(u64);
 
     impl std::fmt::Display for CurrencyPairId {

--- a/crates/astria-sequencer/Cargo.toml
+++ b/crates/astria-sequencer/Cargo.toml
@@ -38,8 +38,6 @@ cnidarium = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.8
   "metrics",
 ] }
 ibc-proto = { version = "0.41.0", features = ["server"] }
-# `is_sorted_by` is available in rust 1.82.0, but we haven't updated our msrv yet
-is_sorted = "0.1.1"
 matchit = "0.7.2"
 tower = "0.4"
 tower-abci = "0.12.0"

--- a/crates/astria-sequencer/src/app/mod.rs
+++ b/crates/astria-sequencer/src/app/mod.rs
@@ -66,7 +66,10 @@ use sha2::{
     Digest as _,
     Sha256,
 };
-use telemetry::display::json;
+use telemetry::display::{
+    base64,
+    json,
+};
 use tendermint::{
     abci::{
         self,
@@ -541,7 +544,11 @@ impl App {
     /// Generates a commitment to the `sequence::Actions` in the block's transactions
     /// and ensures it matches the commitment created by the proposer, which
     /// should be the first transaction in the block.
-    #[instrument(name = "App::process_proposal", skip_all)]
+    #[instrument(
+        name = "App::process_proposal",
+        skip_all,
+        fields(proposer=%base64(&process_proposal.proposer_address.as_bytes())))
+    ]
     pub(crate) async fn process_proposal(
         &mut self,
         process_proposal: abci::request::ProcessProposal,


### PR DESCRIPTION
## Summary
Increase test coverage of the `app::vote_extensions` module and fixes issues discovered while implementing these tests.

## Background
This was work spun out of previous PRs to this feature branch to allow parallelizing efforts to complete the feature.

## Changes
- Provided comprehensive unit test coverage of the `app::vote_extensions` module.
- Fixed a handful of issues uncovered.

## Testing
These are tests.

## Changelogs
No updates required - the changelogs will be updated right before the feature merges to `main`.
