### PR TITLE
chore(sequencer): remove unnecessary result return

### DIFF
--- a/crates/astria-sequencer/src/fees/mod.rs
+++ b/crates/astria-sequencer/src/fees/mod.rs
@@ -347,9 +347,7 @@ async fn check_and_pay_fees<S: StateWrite, T: FeeHandler + Protobuf>(
             .wrap_err("failed to check allowed fee assets in state")?,
         "invalid fee asset",
     );
-    state
-        .add_fee_to_block_fees::<_, T>(fee_asset, total_fees, position_in_transaction)
-        .wrap_err("failed to add to block fees")?;
+    state.add_fee_to_block_fees::<_, T>(fee_asset, total_fees, position_in_transaction);
     state
         .decrease_balance(&from, fee_asset, total_fees)
         .await

--- a/crates/astria-sequencer/src/fees/state_ext.rs
+++ b/crates/astria-sequencer/src/fees/state_ext.rs
@@ -383,8 +383,7 @@ pub(crate) trait StateWriteExt: StateWrite {
         asset: &'a TAsset,
         amount: u128,
         position_in_transaction: u64,
-    ) -> Result<()>
-    where
+    ) where
         TAsset: Sync + std::fmt::Display,
         asset::IbcPrefixed: From<&'a TAsset>,
     {
@@ -409,7 +408,6 @@ pub(crate) trait StateWriteExt: StateWrite {
         };
 
         self.object_put(keys::BLOCK, new_fees);
-        Ok(())
     }
 
     #[instrument(skip_all)]
@@ -622,9 +620,7 @@ mod tests {
         // can write
         let asset = asset_0();
         let amount = 100u128;
-        state
-            .add_fee_to_block_fees::<_, Transfer>(&asset, amount, 0)
-            .unwrap();
+        state.add_fee_to_block_fees::<_, Transfer>(&asset, amount, 0);
 
         // holds expected
         let fee_balances_updated = state.get_block_fees();
@@ -652,12 +648,8 @@ mod tests {
         let amount_first = 100u128;
         let amount_second = 200u128;
 
-        state
-            .add_fee_to_block_fees::<_, Transfer>(&asset_first, amount_first, 0)
-            .unwrap();
-        state
-            .add_fee_to_block_fees::<_, Transfer>(&asset_second, amount_second, 1)
-            .unwrap();
+        state.add_fee_to_block_fees::<_, Transfer>(&asset_first, amount_first, 0);
+        state.add_fee_to_block_fees::<_, Transfer>(&asset_second, amount_second, 1);
         // holds expected
         let fee_balances = HashSet::<_>::from_iter(state.get_block_fees());
         assert_eq!(


### PR DESCRIPTION
## Summary
Removed an unnecessary return of a `Result` from the `fees` state extension trait.

## Background
The method is infallible.

## Changes
- Removed the return type from `add_fee_to_block_fees()`

## Testing
Passing all tests.

## Changelogs
No updates required

## Related Issues
closes #1845
