### PR TITLE
fix(sequencer): remove unnecessary unwrap

### DIFF
--- a/crates/astria-sequencer/src/fees/mod.rs
+++ b/crates/astria-sequencer/src/fees/mod.rs
@@ -336,7 +336,7 @@ async fn check_and_pay_fees<S: StateWrite, T: FeeHandler + Protobuf>(
     let total_fees = base.saturating_add(act.variable_component().saturating_mul(multiplier));
     let transaction_context = state
         .get_transaction_context()
-        .expect("transaction source must be present in state when executing an action");
+        .ok_or_eyre("transaction source must be present in state when executing an action")?;
     let from = transaction_context.address_bytes();
     let position_in_transaction = transaction_context.position_in_transaction;
 


### PR DESCRIPTION
## Summary
Removed unnecessary unwrap from fee handling.

## Background
Previously, if transaction context was missing for some reason, sequencer would panic. This is not a service stopping error and we should be handling it gracefully.

## Changes
- Removed unnecessary unwrap from fee handling.

## Testing
Passing all tests, no new ones needed.

## Changelogs
No updates required

## Related Issues
closes #1848 
