### PR TITLE
fix(sequencer): bump penumbra dep to commit with ibc height fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1872,8 +1872,8 @@ dependencies = [
 
 [[package]]
 name = "cnidarium"
-version = "0.80.7"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.7#35f9f2f64a652b6055a39ff227e504636436cb7e"
+version = "0.80.9"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=ac7abacc9bb09503d6fd6a396bc0b6850079084e#ac7abacc9bb09503d6fd6a396bc0b6850079084e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1901,8 +1901,8 @@ dependencies = [
 
 [[package]]
 name = "cnidarium-component"
-version = "0.80.7"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.7#35f9f2f64a652b6055a39ff227e504636436cb7e"
+version = "0.80.9"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=ac7abacc9bb09503d6fd6a396bc0b6850079084e#ac7abacc9bb09503d6fd6a396bc0b6850079084e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2446,8 +2446,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-fmd"
-version = "0.80.7"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.7#35f9f2f64a652b6055a39ff227e504636436cb7e"
+version = "0.80.9"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=ac7abacc9bb09503d6fd6a396bc0b6850079084e#ac7abacc9bb09503d6fd6a396bc0b6850079084e"
 dependencies = [
  "ark-ff 0.4.2",
  "ark-serialize 0.4.2",
@@ -2460,8 +2460,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-ka"
-version = "0.80.7"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.7#35f9f2f64a652b6055a39ff227e504636436cb7e"
+version = "0.80.9"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=ac7abacc9bb09503d6fd6a396bc0b6850079084e#ac7abacc9bb09503d6fd6a396bc0b6850079084e"
 dependencies = [
  "ark-ff 0.4.2",
  "decaf377",
@@ -3247,8 +3247,9 @@ dependencies = [
 
 [[package]]
 name = "f4jumble"
-version = "0.0.0"
-source = "git+https://github.com/zcash/librustzcash?rev=2425a0869098e3b0588ccd73c42716bcf418612c#2425a0869098e3b0588ccd73c42716bcf418612c"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a83e8d7fd0c526af4aad893b7c9fe41e2699ed8a776a6c74aecdeafe05afc75"
 dependencies = [
  "blake2b_simd 1.0.2",
 ]
@@ -5749,8 +5750,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-asset"
-version = "0.80.7"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.7#35f9f2f64a652b6055a39ff227e504636436cb7e"
+version = "0.80.9"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=ac7abacc9bb09503d6fd6a396bc0b6850079084e#ac7abacc9bb09503d6fd6a396bc0b6850079084e"
 dependencies = [
  "anyhow",
  "ark-ff 0.4.2",
@@ -5788,8 +5789,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-ibc"
-version = "0.80.7"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.7#35f9f2f64a652b6055a39ff227e504636436cb7e"
+version = "0.80.9"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=ac7abacc9bb09503d6fd6a396bc0b6850079084e#ac7abacc9bb09503d6fd6a396bc0b6850079084e"
 dependencies = [
  "anyhow",
  "ark-ff 0.4.2",
@@ -5825,8 +5826,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-keys"
-version = "0.80.7"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.7#35f9f2f64a652b6055a39ff227e504636436cb7e"
+version = "0.80.9"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=ac7abacc9bb09503d6fd6a396bc0b6850079084e#ac7abacc9bb09503d6fd6a396bc0b6850079084e"
 dependencies = [
  "aes",
  "anyhow",
@@ -5869,8 +5870,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-num"
-version = "0.80.7"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.7#35f9f2f64a652b6055a39ff227e504636436cb7e"
+version = "0.80.9"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=ac7abacc9bb09503d6fd6a396bc0b6850079084e#ac7abacc9bb09503d6fd6a396bc0b6850079084e"
 dependencies = [
  "anyhow",
  "ark-ff 0.4.2",
@@ -5905,8 +5906,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-proto"
-version = "0.80.7"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.7#35f9f2f64a652b6055a39ff227e504636436cb7e"
+version = "0.80.9"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=ac7abacc9bb09503d6fd6a396bc0b6850079084e#ac7abacc9bb09503d6fd6a396bc0b6850079084e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5934,8 +5935,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sct"
-version = "0.80.7"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.7#35f9f2f64a652b6055a39ff227e504636436cb7e"
+version = "0.80.9"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=ac7abacc9bb09503d6fd6a396bc0b6850079084e#ac7abacc9bb09503d6fd6a396bc0b6850079084e"
 dependencies = [
  "anyhow",
  "ark-ff 0.4.2",
@@ -5970,8 +5971,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-tct"
-version = "0.80.7"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.7#35f9f2f64a652b6055a39ff227e504636436cb7e"
+version = "0.80.9"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=ac7abacc9bb09503d6fd6a396bc0b6850079084e#ac7abacc9bb09503d6fd6a396bc0b6850079084e"
 dependencies = [
  "ark-ed-on-bls12-377",
  "ark-ff 0.4.2",
@@ -5999,8 +6000,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-tower-trace"
-version = "0.80.7"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.7#35f9f2f64a652b6055a39ff227e504636436cb7e"
+version = "0.80.9"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=ac7abacc9bb09503d6fd6a396bc0b6850079084e#ac7abacc9bb09503d6fd6a396bc0b6850079084e"
 dependencies = [
  "futures",
  "hex",
@@ -6021,8 +6022,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-txhash"
-version = "0.80.7"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.80.7#35f9f2f64a652b6055a39ff227e504636436cb7e"
+version = "0.80.9"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=ac7abacc9bb09503d6fd6a396bc0b6850079084e#ac7abacc9bb09503d6fd6a396bc0b6850079084e"
 dependencies = [
  "anyhow",
  "blake2b_simd 1.0.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,9 +81,10 @@ itoa = "1.0.10"
 jsonrpsee = { version = "0.20" }
 pbjson-types = "0.6"
 # Note that when updating the penumbra versions, vendored types in `proto/sequencerapis/astria_vendored` may need to be updated as well.
-penumbra-ibc = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.80.7", default-features = false }
-penumbra-proto = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.80.7" }
-penumbra-tower-trace = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.80.7" }
+# can update to a tagged version when https://github.com/penumbra-zone/penumbra/commit/ac7abacc9bb09503d6fd6a396bc0b6850079084e is released
+penumbra-ibc = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "ac7abacc9bb09503d6fd6a396bc0b6850079084e", default-features = false }
+penumbra-proto = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "ac7abacc9bb09503d6fd6a396bc0b6850079084e" }
+penumbra-tower-trace = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "ac7abacc9bb09503d6fd6a396bc0b6850079084e" }
 pin-project-lite = "0.2.13"
 prost = "0.12"
 rand = "0.8.5"

--- a/crates/astria-sequencer/Cargo.toml
+++ b/crates/astria-sequencer/Cargo.toml
@@ -33,7 +33,7 @@ telemetry = { package = "astria-telemetry", path = "../astria-telemetry", featur
 ] }
 
 borsh = { version = "1.5.1", features = ["bytes", "derive"] }
-cnidarium = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.80.7", features = [
+cnidarium = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "ac7abacc9bb09503d6fd6a396bc0b6850079084e", features = [
   "metrics",
 ] }
 ibc-proto = { version = "0.41.0", features = ["server"] }


### PR DESCRIPTION
## Summary
bump penumbra dep to commit with ibc height fix as it was merged upstream: https://github.com/penumbra-zone/penumbra/commit/ac7abacc9bb09503d6fd6a396bc0b6850079084e

## Background
see #1691

## Changes
- bump penumbra dep to commit with ibc height fix 

## Testing
it has been tested on the current live networks already
