### PR TITLE
chore(sequencer-relayer): box large enum variant

### DIFF
--- a/crates/astria-sequencer-relayer/tests/blackbox/helpers/mock_sequencer_server.rs
+++ b/crates/astria-sequencer-relayer/tests/blackbox/helpers/mock_sequencer_server.rs
@@ -99,7 +99,7 @@ impl MockSequencerServer {
 pub enum SequencerBlockToMount {
     GoodAtHeight(u32),
     BadAtHeight(u32),
-    Block(SequencerBlock),
+    Block(Box<SequencerBlock>),
 }
 
 struct SequencerServiceImpl(MockServer);
@@ -152,7 +152,7 @@ fn prepare_sequencer_block_response(
             ..Default::default()
         }
         .make(),
-        SequencerBlockToMount::Block(block) => block,
+        SequencerBlockToMount::Block(block) => *block,
     };
 
     let mut block = block.into_raw();

--- a/crates/astria-sequencer-relayer/tests/blackbox/main.rs
+++ b/crates/astria-sequencer-relayer/tests/blackbox/main.rs
@@ -263,7 +263,7 @@ async fn should_filter_rollup() {
         ..Default::default()
     }
     .make();
-    let block_to_mount = SequencerBlockToMount::Block(block);
+    let block_to_mount = SequencerBlockToMount::Block(Box::new(block));
 
     sequencer_relayer.mount_abci_response(1).await;
     sequencer_relayer


### PR DESCRIPTION
## Summary
Boxed large error variant

## Background
Large enum variants should be avoided since enums are as large as their largest variant: https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant

Wasn't caught by clippy until running with Rust 1.83.0 in #1857.

## Changes
- Boxed `Block` variant of `SequencerBlockToMount`.

## Testing
Passing all tests

## Changelogs
No updates needed.

## Breaking Changes
Overridden code freeze since this is a very small, non breaking change that shouldn't have any bearing since our previous audit.

## Related Issues
closes #1859
