### PR TITLE
chore(ci): update rust lint workflows and `just` recipes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -73,7 +73,7 @@ jobs:
           toolchain: nightly-2024-09-15
           components: rustfmt
       - name: run rustfmt
-        run: cargo +nightly-2024-09-15 fmt --all -- --check
+        run: just _lint-rust-fmt
 
   toml:
     runs-on: ubuntu-22.04

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -73,7 +73,7 @@ jobs:
           toolchain: nightly-2024-09-15
           components: rustfmt
       - name: run rustfmt
-        run: just _lint-rust-fmt
+        run: just lint rust-fmt
 
   toml:
     runs-on: ubuntu-22.04

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -68,6 +68,8 @@ jobs:
     if: needs.run_checker.outputs.run_lint_rust == 'true'
     steps:
       - uses: actions/checkout@v4
+      - name: Install just
+        uses: taiki-e/install-action@just
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2024-09-15

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -217,6 +217,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: 'true'
+      - name: Install just
+        uses: taiki-e/install-action@just
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUSTUP_TOOLCHAIN }}
@@ -243,6 +245,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: 'true'
+      - name: Install just
+        uses: taiki-e/install-action@just
       - uses: dtolnay/rust-toolchain@master
         with:
           # This has to match `rust-toolchain` in the rust-toolchain file of the dylint lints

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -230,10 +230,10 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: run pedantic clippy on workspace crates
         run: |
-          just _lint-rust-clippy
+          just lint rust-clippy
       - name: run pedantic clippy on tools/protobuf-compiler
         run: |
-          just _lint-rust-clippy-tools
+          just lint rust-clippy-tools
 
   custom-lints:
     runs-on: buildjet-8vcpu-ubuntu-2204
@@ -261,7 +261,7 @@ jobs:
         run: |
           : # list all lint packages here to have clippy explicitly test them
           : # uses the same nightly installed above to work around the entry in rust-toolchain.toml 
-          just _lint-rust-clippy-custom
+          just lint rust-clippy-custom
       - name: run dylint clippy on workspace crates
         env:
           # set the dylint driver path to the target/ directory so that it's hopefully cached by rust-cache
@@ -269,7 +269,7 @@ jobs:
           DYLINT_RUSTFLAGS: "-D warnings"
         run: |
           mkdir -p "$DYLINT_DRIVER_PATH"
-          just _lint-rust-dylint
+          just lint rust-dylint
 
   test:
     if: ${{ always() && !cancelled() }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -230,15 +230,10 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: run pedantic clippy on workspace crates
         run: |
-          cargo clippy --all-targets --all-features \
-          -- --warn clippy::pedantic --warn clippy::arithmetic-side-effects \
-          --warn clippy::allow_attributes --warn clippy::allow_attributes_without_reason \
-          --deny warnings
+          just _lint-rust-clippy
       - name: run pedantic clippy on tools/protobuf-compiler
         run: |
-          cargo clippy --manifest-path tools/protobuf-compiler/Cargo.toml \
-          --all-targets --all-features \
-          -- --warn clippy::pedantic --deny warnings
+          just _lint-rust-clippy-tools
 
   custom-lints:
     runs-on: buildjet-8vcpu-ubuntu-2204
@@ -266,9 +261,7 @@ jobs:
         run: |
           : # list all lint packages here to have clippy explicitly test them
           : # uses the same nightly installed above to work around the entry in rust-toolchain.toml 
-          cargo +nightly-2024-09-05 clippy --all-targets --all-features \
-          -p tracing_debug_field \
-          -- --warn clippy::pedantic --deny warnings
+          just _lint-rust-clippy-custom
       - name: run dylint clippy on workspace crates
         env:
           # set the dylint driver path to the target/ directory so that it's hopefully cached by rust-cache
@@ -276,7 +269,7 @@ jobs:
           DYLINT_RUSTFLAGS: "-D warnings"
         run: |
           mkdir -p "$DYLINT_DRIVER_PATH"
-          cargo dylint --all --workspace
+          just _lint-rust-dylint
 
   test:
     if: ${{ always() && !cancelled() }}

--- a/justfile
+++ b/justfile
@@ -101,7 +101,7 @@ _lint-rust:
   cargo clippy --manifest-path tools/protobuf-compiler/Cargo.toml \
           --all-targets --all-features \
           -- --warn clippy::pedantic --deny warnings
-  cargo dylint --all
+  cargo dylint --all --workspace
 
 [no-exit-message]
 _fmt-toml:

--- a/justfile
+++ b/justfile
@@ -94,7 +94,13 @@ _fmt-rust:
 [no-exit-message]
 _lint-rust:
   cargo +nightly-2024-09-15 fmt --all -- --check
-  cargo clippy -- --warn clippy::pedantic
+  cargo clippy --all-targets --all-features \
+          -- --warn clippy::pedantic --warn clippy::arithmetic-side-effects \
+          --warn clippy::allow_attributes --warn clippy::allow_attributes_without_reason \
+          --deny warnings
+  cargo clippy --manifest-path tools/protobuf-compiler/Cargo.toml \
+          --all-targets --all-features \
+          -- --warn clippy::pedantic --deny warnings
   cargo dylint --all
 
 [no-exit-message]

--- a/justfile
+++ b/justfile
@@ -73,6 +73,8 @@ fmt lang=default_lang:
   @just _fmt-{{lang}}
 
 # Can lint 'rust', 'toml', 'proto', 'md' or 'all'. Defaults to all.
+# Can also run the following sub-lints for rust: 'rust-fmt', 'rust-clippy',
+# 'rust-clippy-custom', 'rust-clippy-tools', 'rust-dylint'
 lint lang=default_lang:
   @just _lint-{{lang}}
 

--- a/justfile
+++ b/justfile
@@ -93,14 +93,37 @@ _fmt-rust:
 
 [no-exit-message]
 _lint-rust:
+  just _lint-rust-fmt
+  just _lint-rust-clippy
+  just _lint-rust-clippy-custom
+  just _lint-rust-clippy-tools
+  just _lint-rust-dylint
+
+[no-exit-message]
+_lint-rust-fmt:
   cargo +nightly-2024-09-15 fmt --all -- --check
+
+[no-exit-message]
+_lint-rust-clippy:
   cargo clippy --all-targets --all-features \
           -- --warn clippy::pedantic --warn clippy::arithmetic-side-effects \
           --warn clippy::allow_attributes --warn clippy::allow_attributes_without_reason \
           --deny warnings
+
+[no-exit-message]
+_lint-rust-clippy-custom:
+  cargo +nightly-2024-09-05 clippy --all-targets --all-features \
+          -p tracing_debug_field \
+          -- --warn clippy::pedantic --deny warnings
+
+[no-exit-message]
+_lint-rust-clippy-tools:
   cargo clippy --manifest-path tools/protobuf-compiler/Cargo.toml \
           --all-targets --all-features \
           -- --warn clippy::pedantic --deny warnings
+
+[no-exit-message]
+_lint-rust-dylint:
   cargo dylint --all --workspace
 
 [no-exit-message]


### PR DESCRIPTION
## Summary
Moved rust lints to just recipes, added all to lint rust recipe.

## Background
Discrepancies between the just recipe and GH workflow made it so that the lint command might succeed but then fail when a PR is opened. This is meant to make it easier to match the GH workflow locally and test to ensure this status check will pass.

## Changes
- Moved all rust lints to just recipes.
- Changed `_lint-rust` to call all of the above recipes.

## Testing
Manually tested

## Changelogs
No updates required
