### PR TITLE
fix(charts, evm-faucet): configurable interval, secretProvider template fix

### DIFF
--- a/charts/evm-faucet/Chart.yaml
+++ b/charts/evm-faucet/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.1.3
+version: 0.1.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/evm-faucet/templates/configmap.yaml
+++ b/charts/evm-faucet/templates/configmap.yaml
@@ -8,6 +8,7 @@ data:
   ETH_FAUCET_PORT: "{{ .Values.ports.faucet }}"
   ETH_FAUCET_EVM_PROVIDER_URL: "{{ tpl .Values.config.providerUrl . }}"
   ETH_FAUCET_AMOUNT: "{{ .Values.config.amount }}"
+  ETH_FAUCET_INTERVAL: "{{ .Values.config.intervalMinutes }}"
   {{- if not .Values.secretProvider.enabled }}
   ETH_FAUCET_EVM_PRIVATE_KEY: "{{ .Values.config.privateKey.devContent }}"
   {{- end }}

--- a/charts/evm-faucet/templates/deployment.yaml
+++ b/charts/evm-faucet/templates/deployment.yaml
@@ -24,6 +24,7 @@ spec:
             - -wallet.provider=$(ETH_FAUCET_EVM_PROVIDER_URL)
             - -wallet.privkey=$(ETH_FAUCET_EVM_PRIVATE_KEY)
             - -faucet.amount=$(ETH_FAUCET_AMOUNT)
+            - -faucet.minutes=$(ETH_FAUCET_INTERVAL)
             - -proxycount=$(ETH_FAUCET_PROXYCOUNT)
           image: {{ .Values.images.faucet.repo }}:{{ .Values.images.faucet.tag }}
           imagePullPolicy: {{ .Values.images.faucet.pullPolicy }}
@@ -58,6 +59,6 @@ spec:
             driver: secrets-store.csi.k8s.io
             readOnly: true
             volumeAttributes:
-              secretProviderClass: evm-faucet-private-key
+              secretProviderClass: faucet-private-key
         {{- end }}
 ---

--- a/charts/evm-faucet/values.yaml
+++ b/charts/evm-faucet/values.yaml
@@ -27,6 +27,7 @@ config:
       key: token
   # The amount of token to give per request
   amount: 1
+  intervalMinutes: 100
   providerUrl: http://{{ .Values.config.rollupName }}-evm-service.{{ include "evmFaucet.namespace" . }}.svc.cluster.local:8545
 
 ingress:

--- a/charts/evm-stack/Chart.lock
+++ b/charts/evm-stack/Chart.lock
@@ -10,7 +10,7 @@ dependencies:
   version: 1.0.0
 - name: evm-faucet
   repository: file://../evm-faucet
-  version: 0.1.3
+  version: 0.1.4
 - name: evm-bridge-withdrawer
   repository: file://../evm-bridge-withdrawer
   version: 1.0.1
@@ -20,5 +20,5 @@ dependencies:
 - name: blockscout-stack
   repository: https://blockscout.github.io/helm-charts
   version: 1.6.8
-digest: sha256:d89234a3481aa511fb32e38b9d5799efb5848f490e67dc67e837e4eb6af670d1
-generated: "2024-12-12T18:24:37.475398+02:00"
+digest: sha256:4715e557b6ceb0fa85c9efe86f5b26d665783f0be9162728efe808fa3a35d727
+generated: "2024-12-12T19:52:24.992658+02:00"

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.5
+version: 1.0.6
 
 dependencies:
   - name: celestia-node
@@ -30,7 +30,7 @@ dependencies:
     repository: "file://../composer"
     condition: composer.enabled
   - name: evm-faucet
-    version: 0.1.3
+    version: 0.1.4
     repository: "file://../evm-faucet"
     condition: evm-faucet.enabled
   - name: evm-bridge-withdrawer


### PR DESCRIPTION
## Summary
Current `evm-faucet` chart deployment does not support configuring request rate limit interval. 

## Background
Configurable request limit for production deployments

## Changes
- fix secretProvider template 
- configurable request interval limit

## Testing
Locally against a cluster

## Changelogs
No updates required.
