### PR TITLE
chore(charts): bump celestia node version

### DIFF
--- a/charts/celestia-node/Chart.yaml
+++ b/charts/celestia-node/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/celestia-node/values.yaml
+++ b/charts/celestia-node/values.yaml
@@ -20,7 +20,7 @@ config:
 
 images:
   pullPolicy: IfNotPresent
-  node: ghcr.io/celestiaorg/celestia-node:v0.18.3-mocha
+  node: ghcr.io/celestiaorg/celestia-node:v0.20.4
 
 ports:
   celestia:

--- a/charts/evm-stack/Chart.lock
+++ b/charts/evm-stack/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: celestia-node
   repository: file://../celestia-node
-  version: 0.4.0
+  version: 0.4.1
 - name: evm-rollup
   repository: file://../evm-rollup
   version: 1.0.1
@@ -20,5 +20,5 @@ dependencies:
 - name: blockscout-stack
   repository: https://blockscout.github.io/helm-charts
   version: 1.6.8
-digest: sha256:d89234a3481aa511fb32e38b9d5799efb5848f490e67dc67e837e4eb6af670d1
-generated: "2024-12-12T18:24:37.475398+02:00"
+digest: sha256:d6be3a673844eaa443094b85600848c7c5aab7ea99b6c74fbf280630162bc7c5
+generated: "2024-12-12T19:38:44.749099+02:00"

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -15,11 +15,11 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.5
+version: 1.0.6
 
 dependencies:
   - name: celestia-node
-    version: 0.4.0
+    version: 0.4.1
     repository: "file://../celestia-node"
     condition: celestia-node.enabled
   - name: evm-rollup


### PR DESCRIPTION
## Summary
bumps [`celestia-node`](https://github.com/celestiaorg/celestia-node/releases/tag/v0.20.4) to the mainnet running version `v0.20.4`
## Background
Followup on celestia mainnet upgrade
## Changes
- `celestia-node:v0.18.3-mocha -> celestia-node:v0.20.4`

## Testing
Locally against a cluster

## Changelogs
No updates required.
