### PR TITLE
feat(charts): snapshot startup for sequencer

### DIFF
--- a/charts/sequencer/Chart.yaml
+++ b/charts/sequencer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/sequencer/files/scripts/init-cometbft.sh
+++ b/charts/sequencer/files/scripts/init-cometbft.sh
@@ -4,13 +4,39 @@ set -o errexit -o nounset
 
 # Only need to configure cometbft data if not already initialized
 if [ ! -d "/cometbft/data" ]; then
+  # Load the snapshot on load if enabled
+  {{- if .Values.snapshotLoad.enabled }}
+  echo "Downdloading snapshot..."
+  rclone config create r2 s3 \
+    provider={{ .Values.snapshotLoad.config.provider }} \
+    access_key_id={{ .Values.snapshotLoad.config.accessKeyId }} \
+    secret_access_key={{ .Values.snapshotLoad.config.secretAccessKey }} \
+    region={{ .Values.snapshotLoad.config.region }} \
+    endpoint={{ .Values.snapshotLoad.config.endpoint }} \
+    acl={{ .Values.snapshotLoad.config.acl }}
+  rclone copy -P r2:astria-mainnet-snapshots/ /snapshot/
+
+  echo "Extracting snapshot..."
+  mkdir /cometbft/data
+  mkdir /sequencer/penumbra.db
+  tar -C /cometbft/data/ --strip-components=2 -xzf /snapshot/cometbft_*.tar.gz cometbft/data
+  tar -C /sequencer/penumbra.db/ --strip-components=2 -xzf /snapshot/sequencer_*.tar.gz sequencer/penumbra.db
+  rm /snapshot/cometbft_*.tar.gz /snapshot/sequencer_*.tar.gz
+  {{- else }}
+  # Otherwise initialize with basic values
+  echo "Intializing cometbft with empty data directory..."
   cp -LR /data/ /cometbft/data
+  {{- end }}
+else
+  echo "CometBFT data directory already initialized"
 fi
 
 # Don't replace the config directory if it already exists
 if [ ! -d "/cometbft/config" ]; then
+  echo "Creating Config Directory..."
   cp -LR /config/ /cometbft/config
 else
+  echo "Updating config directory..."
   cp /config/* /cometbft/config/
 fi
 

--- a/charts/sequencer/templates/statefulsets.yaml
+++ b/charts/sequencer/templates/statefulsets.yaml
@@ -31,6 +31,12 @@ spec:
             - mountPath: /cometbft
               name: sequencer-shared-storage-vol
               subPath: {{ .Values.moniker }}/cometbft
+            - mountPath: /sequencer
+              name: sequencer-shared-storage-vol
+              subPath: {{ .Values.moniker }}/sequencer
+            - mountPath: /snapshot
+              name: sequencer-shared-storage-vol
+              subPath: {{ .Values.moniker }}/snapshot
       containers:
         - name: sequencer
           image: {{ include "sequencer.image" . }}

--- a/charts/sequencer/values.yaml
+++ b/charts/sequencer/values.yaml
@@ -9,12 +9,22 @@ global:
   useTTY: true
   dev: false
 
+snapshotLoad:
+  enabled: true
+  config:
+    provider: Cloudflare
+    accessKeyId: 0d8d8005e468dd86498bde6dfa02044f
+    secretAccessKey: e33ea43e00d9b655cb72d8a8107fa2957bd6b77e5718df0a26f259956532bba8
+    region: auto
+    endpoint: https://fb1caa337c8e4e3101363ca1240e03ca.r2.cloudflarestorage.com
+    acl: private
+
 # sequencer core images
 images:
   init:
-    repo: ghcr.io/tomwright/dasel
+    repo: rclone/rclone
     pullPolicy: IfNotPresent
-    tag: alpine
+    tag: 1.56.0
   cometBFT:
     repo: docker.io/cometbft/cometbft
     pullPolicy: IfNotPresent
@@ -24,7 +34,7 @@ images:
     repo: ghcr.io/astriaorg/sequencer
     pullPolicy: IfNotPresent
     tag: 1.0.0
-    devTag: latest
+    devTag: local
 
 moniker: ""
 genesis:

--- a/charts/sequencer/values.yaml
+++ b/charts/sequencer/values.yaml
@@ -34,7 +34,7 @@ images:
     repo: ghcr.io/astriaorg/sequencer
     pullPolicy: IfNotPresent
     tag: 1.0.0
-    devTag: local
+    devTag: latest
 
 moniker: ""
 genesis:

--- a/charts/sequencer/values.yaml
+++ b/charts/sequencer/values.yaml
@@ -10,7 +10,7 @@ global:
   dev: false
 
 snapshotLoad:
-  enabled: true
+  enabled: false
   config:
     provider: Cloudflare
     accessKeyId: 0d8d8005e468dd86498bde6dfa02044f


### PR DESCRIPTION
## Summary
Adds the ability to start a sequencer node with a snapshot load, speeding up the startup time of a new node.

## Background
Starting a new node within k8s requires either manual intervention on the PVC right now, or syncing from genesis. Doing a sync from genesis can be correct but not ideal for scaling infrastructure.

## Changes
- Changes sequencer chart `initContainer` for to use rclone
- Pull `snapshot` if `snapshotLoad` enabled during `initContainer` script run.

## Testing
Ran locally, and confirmed startup and syncs.

## Changelogs
No updates required.

## Issues
closes https://github.com/astriaorg/astria/issues/1912