### PR TITLE
fix(sequencer)!: fix fungible token packet data import

### DIFF
--- a/crates/astria-sequencer/src/action_handler/impls/ics20_withdrawal.rs
+++ b/crates/astria-sequencer/src/action_handler/impls/ics20_withdrawal.rs
@@ -26,7 +26,6 @@ use cnidarium::{
     StateRead,
     StateWrite,
 };
-use ibc_proto::ibc::apps::transfer::v2::FungibleTokenPacketData;
 use ibc_types::core::channel::{
     ChannelId,
     PortId,
@@ -37,6 +36,7 @@ use penumbra_ibc::component::packet::{
     SendPacketWrite as _,
     Unchecked,
 };
+use penumbra_proto::core::component::ibc::v1::FungibleTokenPacketData;
 
 use crate::{
     accounts::{


### PR DESCRIPTION
## Summary
Restored original `FungibleTokenPacketData` import.

## Background
#1759 imported a slightly differing version of `FungibleTokenPacketData`, whose `serde` implementation did not exclude empty fields, breaking consensus.

## Changes
- Restored original `FungibleTokenPacketData` import.

## Testing
@joroshiba has successfully fully synced with this change.

## Changelogs
No updates required

## Breaking Changelist
- Technically a breaking change, but unbreaking a previous mistake.
