### PR TITLE
feat(core)!: use newtype sequencer block hashes

### DIFF
--- a/crates/astria-conductor/src/celestia/block_verifier.rs
+++ b/crates/astria-conductor/src/celestia/block_verifier.rs
@@ -224,7 +224,10 @@ mod tests {
         generated::astria::sequencerblock::v1::SequencerBlockHeader as RawSequencerBlockHeader,
         primitive::v1::RollupId,
         sequencerblock::v1::{
-            block::SequencerBlockHeader,
+            block::{
+                self,
+                SequencerBlockHeader,
+            },
             celestia::UncheckedSubmittedMetadata,
         },
     };
@@ -237,7 +240,6 @@ mod tests {
             block::Commit,
             validator,
             validator::Info as Validator,
-            Hash,
         },
         tendermint_proto,
         tendermint_rpc::endpoint::validators,
@@ -345,7 +347,7 @@ mod tests {
         let header = SequencerBlockHeader::try_from_raw(header).unwrap();
 
         let sequencer_blob = UncheckedSubmittedMetadata {
-            block_hash: [0u8; 32],
+            block_hash: block::Hash::new([0u8; 32]),
             header,
             rollup_ids: vec![],
             rollup_transactions_proof,
@@ -390,7 +392,7 @@ mod tests {
         let header = SequencerBlockHeader::try_from_raw(header).unwrap();
 
         let sequencer_blob = UncheckedSubmittedMetadata {
-            block_hash: [0u8; 32],
+            block_hash: block::Hash::new([0u8; 32]),
             header,
             rollup_ids: vec![rollup_id],
             rollup_transactions_proof,
@@ -510,12 +512,12 @@ mod tests {
             round: 0u16.into(),
             block_id: tendermint::block::Id {
                 hash: "74BD4E7F7EF902A84D55589F2AA60B332F1C2F34DDE7652C80BFEB8E7471B1DA"
-                    .parse::<Hash>()
+                    .parse::<tendermint::Hash>()
                     .unwrap(),
                 part_set_header: tendermint::block::parts::Header::new(
                     1,
                     "7632FFB5D84C3A64279BC9EA86992418ED23832C66E0C3504B7025A9AF42C8C4"
-                        .parse::<Hash>()
+                        .parse::<tendermint::Hash>()
                         .unwrap(),
                 )
                 .unwrap(),

--- a/crates/astria-conductor/src/celestia/mod.rs
+++ b/crates/astria-conductor/src/celestia/mod.rs
@@ -6,7 +6,10 @@ use std::{
 
 use astria_core::{
     primitive::v1::RollupId,
-    sequencerblock::v1::block::SequencerBlockHeader,
+    sequencerblock::v1::block::{
+        self,
+        SequencerBlockHeader,
+    },
 };
 use astria_eyre::eyre::{
     self,
@@ -103,12 +106,16 @@ use crate::{
 #[derive(Clone, Debug)]
 pub(crate) struct ReconstructedBlock {
     pub(crate) celestia_height: u64,
-    pub(crate) block_hash: [u8; 32],
+    pub(crate) block_hash: block::Hash,
     pub(crate) header: SequencerBlockHeader,
     pub(crate) transactions: Vec<Bytes>,
 }
 
 impl ReconstructedBlock {
+    pub(crate) fn block_hash(&self) -> &block::Hash {
+        &self.block_hash
+    }
+
     pub(crate) fn sequencer_height(&self) -> SequencerHeight {
         self.header.height()
     }
@@ -459,7 +466,7 @@ impl RunningReader {
                     error = %eyre::Report::new(e),
                     source_celestia_height = celestia_height,
                     sequencer_height,
-                    block_hash = %base64(&block_hash),
+                    block_hash = %block_hash,
                     "failed pushing reconstructed block into sequential cache; dropping it",
                 );
             }

--- a/crates/astria-conductor/src/celestia/reconstruct.rs
+++ b/crates/astria-conductor/src/celestia/reconstruct.rs
@@ -3,12 +3,12 @@ use std::collections::HashMap;
 use astria_core::{
     primitive::v1::RollupId,
     sequencerblock::v1::{
+        block,
         celestia::UncheckedSubmittedMetadata,
         SubmittedMetadata,
         SubmittedRollupData,
     },
 };
-use telemetry::display::base64;
 use tracing::{
     info,
     warn,
@@ -72,7 +72,7 @@ pub(super) fn reconstruct_blocks_from_verified_blobs(
                 "no sequencer header blob matching the rollup blob's block hash found"
             };
             info!(
-                block_hash = %base64(&rollup.sequencer_block_hash()),
+                block_hash = %rollup.sequencer_block_hash(),
                 reason,
                 "dropping rollup blob",
             );
@@ -83,7 +83,7 @@ pub(super) fn reconstruct_blocks_from_verified_blobs(
     for header_blob in header_blobs.into_values() {
         if header_blob.contains_rollup_id(rollup_id) {
             warn!(
-                block_hash = %base64(header_blob.block_hash()),
+                block_hash = %header_blob.block_hash(),
                 "sequencer header blob contains the target rollup ID, but no matching rollup blob was found; dropping it",
             );
         } else {
@@ -99,7 +99,7 @@ pub(super) fn reconstruct_blocks_from_verified_blobs(
 }
 
 fn remove_header_blob_matching_rollup_blob(
-    headers: &mut HashMap<[u8; 32], SubmittedMetadata>,
+    headers: &mut HashMap<block::Hash, SubmittedMetadata>,
     rollup: &SubmittedRollupData,
 ) -> Option<SubmittedMetadata> {
     // chaining methods and returning () to use the ? operator and to not bind the value

--- a/crates/astria-conductor/src/celestia/reporting.rs
+++ b/crates/astria-conductor/src/celestia/reporting.rs
@@ -4,7 +4,6 @@ use serde::ser::{
     SerializeSeq,
     SerializeStruct,
 };
-use telemetry::display::base64;
 
 use super::{
     ReconstructedBlock,
@@ -53,10 +52,23 @@ impl<'a> Serialize for ReportReconstructedBlock<'a> {
         ];
         let mut state = serializer.serialize_struct("ReconstructedBlockInfo", FIELDS.len())?;
         state.serialize_field(FIELDS[0], &self.0.celestia_height)?;
-        // TODO: use the block hash's Display impl for this
-        state.serialize_field(FIELDS[1], &base64(&*self.0.block_hash))?;
+        state.serialize_field(FIELDS[1], &SerializeDisplay(&self.0.block_hash))?;
         state.serialize_field(FIELDS[2], &self.0.transactions.len())?;
         state.serialize_field(FIELDS[3], &self.0.celestia_height)?;
         state.end()
+    }
+}
+
+struct SerializeDisplay<'a, T>(&'a T);
+
+impl<'a, T> Serialize for SerializeDisplay<'a, T>
+where
+    T: std::fmt::Display,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_str(self.0)
     }
 }

--- a/crates/astria-conductor/src/celestia/reporting.rs
+++ b/crates/astria-conductor/src/celestia/reporting.rs
@@ -53,7 +53,8 @@ impl<'a> Serialize for ReportReconstructedBlock<'a> {
         ];
         let mut state = serializer.serialize_struct("ReconstructedBlockInfo", FIELDS.len())?;
         state.serialize_field(FIELDS[0], &self.0.celestia_height)?;
-        state.serialize_field(FIELDS[1], &base64(&self.0.block_hash))?;
+        // TODO: use the block hash's Display impl for this
+        state.serialize_field(FIELDS[1], &base64(&*self.0.block_hash))?;
         state.serialize_field(FIELDS[2], &self.0.transactions.len())?;
         state.serialize_field(FIELDS[3], &self.0.celestia_height)?;
         state.end()

--- a/crates/astria-conductor/src/celestia/verify.rs
+++ b/crates/astria-conductor/src/celestia/verify.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use astria_core::sequencerblock::v1::{
+    block,
     SubmittedMetadata,
     SubmittedRollupData,
 };
@@ -25,7 +26,6 @@ use sequencer_client::{
     Client as _,
     HttpClient as SequencerClient,
 };
-use telemetry::display::base64;
 use tokio_util::task::JoinMap;
 use tower::{
     util::BoxService,
@@ -58,7 +58,7 @@ use crate::executor::{
 
 pub(super) struct VerifiedBlobs {
     celestia_height: u64,
-    header_blobs: HashMap<[u8; 32], SubmittedMetadata>,
+    header_blobs: HashMap<block::Hash, SubmittedMetadata>,
     rollup_blobs: Vec<SubmittedRollupData>,
 }
 
@@ -75,7 +75,7 @@ impl VerifiedBlobs {
         self,
     ) -> (
         u64,
-        HashMap<[u8; 32], SubmittedMetadata>,
+        HashMap<block::Hash, SubmittedMetadata>,
         Vec<SubmittedRollupData>,
     ) {
         (self.celestia_height, self.header_blobs, self.rollup_blobs)
@@ -88,7 +88,7 @@ impl VerifiedBlobs {
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 struct VerificationTaskKey {
     index: usize,
-    block_hash: [u8; 32],
+    block_hash: block::Hash,
     sequencer_height: SequencerHeight,
 }
 
@@ -142,7 +142,7 @@ pub(super) async fn verify_metadata(
                         .get(dropped_entry.block_hash())
                         .expect("must exist; just inserted an item under the same key");
                     info!(
-                        block_hash = %base64(&dropped_entry.block_hash()),
+                        block_hash = %dropped_entry.block_hash(),
                         dropped_blob.sequencer_height = dropped_entry.height().value(),
                         accepted_blob.sequencer_height = accepted_entry.height().value(),
                         "two Sequencer header blobs were well formed and validated against \
@@ -154,7 +154,7 @@ pub(super) async fn verify_metadata(
             Ok(None) => {}
             Err(error) => {
                 info!(
-                    block_hash = %base64(&key.block_hash),
+                    block_hash = %key.block_hash,
                     sequencer_height = %key.sequencer_height,
                     %error,
                     "verification of sequencer blob was cancelled abruptly; dropping it"
@@ -552,10 +552,13 @@ fn ensure_chain_ids_match(in_commit: &str, in_header: &str) -> eyre::Result<()> 
     Ok(())
 }
 
-fn ensure_block_hashes_match(in_commit: &[u8], in_header: &[u8]) -> eyre::Result<()> {
+fn ensure_block_hashes_match(in_commit: &[u8], in_header: &block::Hash) -> eyre::Result<()> {
     use base64::prelude::*;
+    // NOTE: we still re-encode the block hash using base64 instead of its display impl
+    // to ensure that the formatting of the two byte slices doesn't accidentally go
+    // out of whack should the display impl change.
     ensure!(
-        in_commit == in_header,
+        in_commit == in_header.as_ref(),
         "expected block hash `{}` (from commit), but found `{}` in retrieved metadata",
         BASE64_STANDARD.encode(in_commit),
         BASE64_STANDARD.encode(in_header),

--- a/crates/astria-conductor/src/celestia/verify.rs
+++ b/crates/astria-conductor/src/celestia/verify.rs
@@ -5,46 +5,46 @@ use std::{
 };
 
 use astria_core::sequencerblock::v1::{
-    block,
     SubmittedMetadata,
     SubmittedRollupData,
+    block,
 };
 use astria_eyre::{
     eyre,
     eyre::{
-        ensure,
         WrapErr as _,
+        ensure,
     },
 };
 use moka::future::Cache;
 use sequencer_client::{
-    tendermint::block::{
-        signed_header::SignedHeader,
-        Height as SequencerHeight,
-    },
-    tendermint_rpc,
     Client as _,
     HttpClient as SequencerClient,
+    tendermint::block::{
+        Height as SequencerHeight,
+        signed_header::SignedHeader,
+    },
+    tendermint_rpc,
 };
 use tokio_util::task::JoinMap;
 use tower::{
-    util::BoxService,
     BoxError,
     Service as _,
     ServiceExt as _,
+    util::BoxService,
 };
 use tracing::{
+    Instrument,
+    Level,
     info,
     instrument,
     warn,
-    Instrument,
-    Level,
 };
 use tryhard::{
-    backoff_strategies::BackoffStrategy,
-    retry_fn,
     RetryFutureConfig,
     RetryPolicy,
+    backoff_strategies::BackoffStrategy,
+    retry_fn,
 };
 
 use super::{
@@ -558,10 +558,10 @@ fn ensure_block_hashes_match(in_commit: &[u8], in_header: &block::Hash) -> eyre:
     // to ensure that the formatting of the two byte slices doesn't accidentally go
     // out of whack should the display impl change.
     ensure!(
-        in_commit == in_header.as_ref(),
+        in_commit == in_header.as_bytes(),
         "expected block hash `{}` (from commit), but found `{}` in retrieved metadata",
         BASE64_STANDARD.encode(in_commit),
-        BASE64_STANDARD.encode(in_header),
+        BASE64_STANDARD.encode(in_header.as_bytes()),
     );
     Ok(())
 }

--- a/crates/astria-conductor/src/celestia/verify.rs
+++ b/crates/astria-conductor/src/celestia/verify.rs
@@ -5,46 +5,46 @@ use std::{
 };
 
 use astria_core::sequencerblock::v1::{
+    block,
     SubmittedMetadata,
     SubmittedRollupData,
-    block,
 };
 use astria_eyre::{
     eyre,
     eyre::{
-        WrapErr as _,
         ensure,
+        WrapErr as _,
     },
 };
 use moka::future::Cache;
 use sequencer_client::{
-    Client as _,
-    HttpClient as SequencerClient,
     tendermint::block::{
-        Height as SequencerHeight,
         signed_header::SignedHeader,
+        Height as SequencerHeight,
     },
     tendermint_rpc,
+    Client as _,
+    HttpClient as SequencerClient,
 };
 use tokio_util::task::JoinMap;
 use tower::{
+    util::BoxService,
     BoxError,
     Service as _,
     ServiceExt as _,
-    util::BoxService,
 };
 use tracing::{
-    Instrument,
-    Level,
     info,
     instrument,
     warn,
+    Instrument,
+    Level,
 };
 use tryhard::{
-    RetryFutureConfig,
-    RetryPolicy,
     backoff_strategies::BackoffStrategy,
     retry_fn,
+    RetryFutureConfig,
+    RetryPolicy,
 };
 
 use super::{

--- a/crates/astria-conductor/src/executor/mod.rs
+++ b/crates/astria-conductor/src/executor/mod.rs
@@ -7,6 +7,7 @@ use astria_core::{
     },
     primitive::v1::RollupId,
     sequencerblock::v1::block::{
+        self,
         FilteredSequencerBlock,
         FilteredSequencerBlockParts,
     },
@@ -283,7 +284,7 @@ impl Executor {
                 {
                     debug_span!("conductor::Executor::run_until_stopped").in_scope(||debug!(
                         block.height = %block.sequencer_height(),
-                        block.hash = %telemetry::display::base64(&block.block_hash),
+                        block.hash = %block.block_hash(),
                         "received block from celestia reader",
                     ));
                     if let Err(error) = self.execute_firm(block).await {
@@ -296,7 +297,7 @@ impl Executor {
                 {
                     debug_span!("conductor::Executor::run_until_stopped").in_scope(||debug!(
                         block.height = %block.height(),
-                        block.hash = %telemetry::display::base64(&block.block_hash()),
+                        block.hash = %block.block_hash(),
                         "received block from sequencer reader",
                     ));
                     if let Err(error) = self.execute_soft(block).await {
@@ -386,7 +387,7 @@ impl Executor {
     }
 
     #[instrument(skip_all, fields(
-        block.hash = %telemetry::display::base64(&block.block_hash()),
+        block.hash = %block.block_hash(),
         block.height = block.height().value(),
         err,
     ))]
@@ -450,7 +451,7 @@ impl Executor {
     }
 
     #[instrument(skip_all, fields(
-        block.hash = %telemetry::display::base64(&block.block_hash),
+        block.hash = %block.block_hash(),
         block.height = block.sequencer_height().value(),
         err,
     ))]
@@ -530,7 +531,7 @@ impl Executor {
     /// This function is called via [`Executor::execute_firm`] or [`Executor::execute_soft`],
     /// and should not be called directly.
     #[instrument(skip_all, fields(
-        block.hash = %telemetry::display::base64(&block.hash),
+        block.hash = %block.hash,
         block.height = block.height.value(),
         block.num_of_transactions = block.transactions.len(),
         rollup.parent_hash = %telemetry::display::base64(&parent_hash),
@@ -688,7 +689,7 @@ enum Update {
 
 #[derive(Debug)]
 struct ExecutableBlock {
-    hash: [u8; 32],
+    hash: block::Hash,
     height: SequencerHeight,
     timestamp: pbjson_types::Timestamp,
     transactions: Vec<Bytes>,

--- a/crates/astria-conductor/tests/blackbox/helpers/mod.rs
+++ b/crates/astria-conductor/tests/blackbox/helpers/mod.rs
@@ -642,7 +642,7 @@ pub fn make_commit(height: u32) -> tendermint::block::Commit {
         height: height.into(),
         round: 0u16.into(),
         block_id: Some(tendermint::block::Id {
-            hash: tendermint::Hash::Sha256(block_hash),
+            hash: tendermint::Hash::Sha256(block_hash.get()),
             part_set_header: tendermint::block::parts::Header::default(),
         }),
         timestamp: Some(timestamp),
@@ -657,7 +657,7 @@ pub fn make_commit(height: u32) -> tendermint::block::Commit {
         height: height.into(),
         round: 0u16.into(),
         block_id: tendermint::block::Id {
-            hash: tendermint::Hash::Sha256(block_hash),
+            hash: tendermint::Hash::Sha256(block_hash.get()),
             part_set_header: tendermint::block::parts::Header::default(),
         },
         signatures: vec![tendermint::block::CommitSig::BlockIdFlagCommit {

--- a/crates/astria-core/CHANGELOG.md
+++ b/crates/astria-core/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to `astria_core::generated::astria`
   [#1825](https://github.com/astriaorg/astria/pull/1825).
 - Update `idna` dependency to resolve cargo audit warning [#1869](https://github.com/astriaorg/astria/pull/1869).
+- Replaced all instances of `[u8; 32]` by newtype
+  `astria_core::sequencerblock::v1::block::Hash` where appropriate [#1884](https://github.com/astriaorg/astria/pull/1884).
 
 ### Removed
 

--- a/crates/astria-core/src/sequencerblock/v1/block.rs
+++ b/crates/astria-core/src/sequencerblock/v1/block.rs
@@ -9,8 +9,8 @@ use bytes::Bytes;
 use indexmap::IndexMap;
 use sha2::Sha256;
 use tendermint::{
-    account,
     Time,
+    account,
 };
 
 use super::{
@@ -24,22 +24,22 @@ use super::{
     raw,
 };
 use crate::{
+    Protobuf as _,
     primitive::v1::{
-        asset,
-        derive_merkle_tree_from_rollup_txs,
         Address,
         AddressError,
         IncorrectRollupIdLength,
         RollupId,
         TransactionId,
         TransactionIdError,
+        asset,
+        derive_merkle_tree_from_rollup_txs,
     },
     protocol::transaction::v1::{
-        action,
         Transaction,
         TransactionError,
+        action,
     },
-    Protobuf as _,
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -599,9 +599,9 @@ pub struct SequencerBlockParts {
 ///    (ethereum) 32 byte hashes.
 /// 2. to provide a hex formatted display impl, which is the convention for block hashes.
 ///
-/// Note that hex based `Display` impl of [`Hash`] does not follow the pbjson
+/// Note that hex based [`Display`] impl of [`Hash`] does not follow the pbjson
 /// convention to display protobuf `bytes` using base64 encoding. To get the
-/// display formatting faithful to pbjson convetion use the alternative formatting selector,
+/// display formatting faithful to pbjson convention use the alternative formatting selector,
 /// `{block_hash:#}` instead.
 ///
 /// # Examples
@@ -936,14 +936,11 @@ impl SequencerBlock {
             let proof = rollup_transaction_tree
                 .construct_proof(i)
                 .expect("the proof must exist because the tree was derived with the same leaf");
-            rollup_transactions.insert(
+            rollup_transactions.insert(rollup_id, RollupTransactions {
                 rollup_id,
-                RollupTransactions {
-                    rollup_id,
-                    transactions: data, // TODO: rename this field?
-                    proof,
-                },
-            );
+                transactions: data, // TODO: rename this field?
+                proof,
+            });
         }
         rollup_transactions.sort_unstable_keys();
 

--- a/crates/astria-core/src/sequencerblock/v1/block.rs
+++ b/crates/astria-core/src/sequencerblock/v1/block.rs
@@ -8,8 +8,8 @@ use bytes::Bytes;
 use indexmap::IndexMap;
 use sha2::Sha256;
 use tendermint::{
-    Time,
     account,
+    Time,
 };
 
 use super::{
@@ -23,22 +23,22 @@ use super::{
     raw,
 };
 use crate::{
-    Protobuf as _,
     primitive::v1::{
+        asset,
+        derive_merkle_tree_from_rollup_txs,
         Address,
         AddressError,
         IncorrectRollupIdLength,
         RollupId,
         TransactionId,
         TransactionIdError,
-        asset,
-        derive_merkle_tree_from_rollup_txs,
     },
     protocol::transaction::v1::{
+        action,
         Transaction,
         TransactionError,
-        action,
     },
+    Protobuf as _,
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -928,11 +928,14 @@ impl SequencerBlock {
             let proof = rollup_transaction_tree
                 .construct_proof(i)
                 .expect("the proof must exist because the tree was derived with the same leaf");
-            rollup_transactions.insert(rollup_id, RollupTransactions {
+            rollup_transactions.insert(
                 rollup_id,
-                transactions: data, // TODO: rename this field?
-                proof,
-            });
+                RollupTransactions {
+                    rollup_id,
+                    transactions: data, // TODO: rename this field?
+                    proof,
+                },
+            );
         }
         rollup_transactions.sort_unstable_keys();
 

--- a/crates/astria-core/src/sequencerblock/v1/block.rs
+++ b/crates/astria-core/src/sequencerblock/v1/block.rs
@@ -638,12 +638,6 @@ impl Hash {
     }
 }
 
-impl AsRef<[u8]> for Hash {
-    fn as_ref(&self) -> &[u8] {
-        &self.0
-    }
-}
-
 #[derive(Debug, thiserror::Error)]
 #[error("block hash requires 32 bytes, but slice contained `{actual}`")]
 pub struct HashFromSliceError {
@@ -781,7 +775,7 @@ impl SequencerBlock {
             rollup_ids_proof,
         } = self;
         raw::SequencerBlock {
-            block_hash: Bytes::copy_from_slice(block_hash.as_ref()),
+            block_hash: Bytes::copy_from_slice(block_hash.as_bytes()),
             header: Some(header.into_raw()),
             rollup_transactions: rollup_transactions
                 .into_values()

--- a/crates/astria-core/src/sequencerblock/v1/block.rs
+++ b/crates/astria-core/src/sequencerblock/v1/block.rs
@@ -1,7 +1,6 @@
 use std::{
     collections::HashMap,
     fmt::Display,
-    ops::Deref,
     vec::IntoIter,
 };
 
@@ -9,8 +8,8 @@ use bytes::Bytes;
 use indexmap::IndexMap;
 use sha2::Sha256;
 use tendermint::{
-    account,
     Time,
+    account,
 };
 
 use super::{
@@ -24,22 +23,22 @@ use super::{
     raw,
 };
 use crate::{
+    Protobuf as _,
     primitive::v1::{
-        asset,
-        derive_merkle_tree_from_rollup_txs,
         Address,
         AddressError,
         IncorrectRollupIdLength,
         RollupId,
         TransactionId,
         TransactionIdError,
+        asset,
+        derive_merkle_tree_from_rollup_txs,
     },
     protocol::transaction::v1::{
-        action,
         Transaction,
         TransactionError,
+        action,
     },
-    Protobuf as _,
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -624,26 +623,23 @@ pub struct Hash([u8; 32]);
 
 impl Hash {
     #[must_use]
-    pub fn new(inner: [u8; 32]) -> Self {
+    pub const fn new(inner: [u8; 32]) -> Self {
         Self(inner)
     }
 
     #[must_use]
-    pub fn get(&self) -> [u8; 32] {
+    pub const fn get(self) -> [u8; 32] {
         self.0
+    }
+
+    #[must_use]
+    pub const fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
     }
 }
 
 impl AsRef<[u8]> for Hash {
     fn as_ref(&self) -> &[u8] {
-        &self.0
-    }
-}
-
-impl Deref for Hash {
-    type Target = [u8; 32];
-
-    fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
@@ -938,14 +934,11 @@ impl SequencerBlock {
             let proof = rollup_transaction_tree
                 .construct_proof(i)
                 .expect("the proof must exist because the tree was derived with the same leaf");
-            rollup_transactions.insert(
+            rollup_transactions.insert(rollup_id, RollupTransactions {
                 rollup_id,
-                RollupTransactions {
-                    rollup_id,
-                    transactions: data, // TODO: rename this field?
-                    proof,
-                },
-            );
+                transactions: data, // TODO: rename this field?
+                proof,
+            });
         }
         rollup_transactions.sort_unstable_keys();
 
@@ -1212,7 +1205,7 @@ impl FilteredSequencerBlock {
             ..
         } = self;
         raw::FilteredSequencerBlock {
-            block_hash: Bytes::copy_from_slice(&*block_hash),
+            block_hash: Bytes::copy_from_slice(block_hash.as_bytes()),
             header: Some(header.into_raw()),
             rollup_transactions: rollup_transactions
                 .into_values()

--- a/crates/astria-core/src/sequencerblock/v1/block.rs
+++ b/crates/astria-core/src/sequencerblock/v1/block.rs
@@ -9,8 +9,8 @@ use bytes::Bytes;
 use indexmap::IndexMap;
 use sha2::Sha256;
 use tendermint::{
-    Time,
     account,
+    Time,
 };
 
 use super::{
@@ -24,22 +24,22 @@ use super::{
     raw,
 };
 use crate::{
-    Protobuf as _,
     primitive::v1::{
+        asset,
+        derive_merkle_tree_from_rollup_txs,
         Address,
         AddressError,
         IncorrectRollupIdLength,
         RollupId,
         TransactionId,
         TransactionIdError,
-        asset,
-        derive_merkle_tree_from_rollup_txs,
     },
     protocol::transaction::v1::{
+        action,
         Transaction,
         TransactionError,
-        action,
     },
+    Protobuf as _,
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -938,11 +938,14 @@ impl SequencerBlock {
             let proof = rollup_transaction_tree
                 .construct_proof(i)
                 .expect("the proof must exist because the tree was derived with the same leaf");
-            rollup_transactions.insert(rollup_id, RollupTransactions {
+            rollup_transactions.insert(
                 rollup_id,
-                transactions: data, // TODO: rename this field?
-                proof,
-            });
+                RollupTransactions {
+                    rollup_id,
+                    transactions: data, // TODO: rename this field?
+                    proof,
+                },
+            );
         }
         rollup_transactions.sort_unstable_keys();
 

--- a/crates/astria-core/src/sequencerblock/v1/block.rs
+++ b/crates/astria-core/src/sequencerblock/v1/block.rs
@@ -9,8 +9,8 @@ use bytes::Bytes;
 use indexmap::IndexMap;
 use sha2::Sha256;
 use tendermint::{
-    account,
     Time,
+    account,
 };
 
 use super::{
@@ -24,22 +24,22 @@ use super::{
     raw,
 };
 use crate::{
+    Protobuf as _,
     primitive::v1::{
-        asset,
-        derive_merkle_tree_from_rollup_txs,
         Address,
         AddressError,
         IncorrectRollupIdLength,
         RollupId,
         TransactionId,
         TransactionIdError,
+        asset,
+        derive_merkle_tree_from_rollup_txs,
     },
     protocol::transaction::v1::{
-        action,
         Transaction,
         TransactionError,
+        action,
     },
-    Protobuf as _,
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -623,10 +623,12 @@ pub struct SequencerBlockParts {
 pub struct Hash([u8; 32]);
 
 impl Hash {
+    #[must_use]
     pub fn new(inner: [u8; 32]) -> Self {
         Self(inner)
     }
 
+    #[must_use]
     pub fn get(&self) -> [u8; 32] {
         self.0
     }
@@ -936,14 +938,11 @@ impl SequencerBlock {
             let proof = rollup_transaction_tree
                 .construct_proof(i)
                 .expect("the proof must exist because the tree was derived with the same leaf");
-            rollup_transactions.insert(
+            rollup_transactions.insert(rollup_id, RollupTransactions {
                 rollup_id,
-                RollupTransactions {
-                    rollup_id,
-                    transactions: data, // TODO: rename this field?
-                    proof,
-                },
-            );
+                transactions: data, // TODO: rename this field?
+                proof,
+            });
         }
         rollup_transactions.sort_unstable_keys();
 

--- a/crates/astria-core/src/sequencerblock/v1/block.rs
+++ b/crates/astria-core/src/sequencerblock/v1/block.rs
@@ -9,8 +9,8 @@ use bytes::Bytes;
 use indexmap::IndexMap;
 use sha2::Sha256;
 use tendermint::{
-    Time,
     account,
+    Time,
 };
 
 use super::{
@@ -24,22 +24,22 @@ use super::{
     raw,
 };
 use crate::{
-    Protobuf as _,
     primitive::v1::{
+        asset,
+        derive_merkle_tree_from_rollup_txs,
         Address,
         AddressError,
         IncorrectRollupIdLength,
         RollupId,
         TransactionId,
         TransactionIdError,
-        asset,
-        derive_merkle_tree_from_rollup_txs,
     },
     protocol::transaction::v1::{
+        action,
         Transaction,
         TransactionError,
-        action,
     },
+    Protobuf as _,
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -936,11 +936,14 @@ impl SequencerBlock {
             let proof = rollup_transaction_tree
                 .construct_proof(i)
                 .expect("the proof must exist because the tree was derived with the same leaf");
-            rollup_transactions.insert(rollup_id, RollupTransactions {
+            rollup_transactions.insert(
                 rollup_id,
-                transactions: data, // TODO: rename this field?
-                proof,
-            });
+                RollupTransactions {
+                    rollup_id,
+                    transactions: data, // TODO: rename this field?
+                    proof,
+                },
+            );
         }
         rollup_transactions.sort_unstable_keys();
 

--- a/crates/astria-core/src/sequencerblock/v1/block.rs
+++ b/crates/astria-core/src/sequencerblock/v1/block.rs
@@ -1,5 +1,7 @@
 use std::{
     collections::HashMap,
+    fmt::Display,
+    ops::Deref,
     vec::IntoIter,
 };
 
@@ -580,11 +582,105 @@ enum SequencerBlockHeaderErrorKind {
 /// Exists to provide convenient access to fields of a [`SequencerBlock`].
 #[derive(Clone, Debug, PartialEq)]
 pub struct SequencerBlockParts {
-    pub block_hash: [u8; 32],
+    pub block_hash: Hash,
     pub header: SequencerBlockHeader,
     pub rollup_transactions: IndexMap<RollupId, RollupTransactions>,
     pub rollup_transactions_proof: merkle::Proof,
     pub rollup_ids_proof: merkle::Proof,
+}
+
+/// A newtype wrapper around `[u8; 32]` to represent the hash of a [`SequencerBlock`].
+///
+/// [`Hash`] is the cometbft constructed hash of block.
+///
+/// There are two main purposes of this type:
+///
+/// 1. avoid confusion with other hashes of the form `[u8; 32]` common in Astria, like rollup
+///    (ethereum) 32 byte hashes.
+/// 2. to provide a hex formatted display impl, which is the convention for block hashes.
+///
+/// Note that hex based `Display` impl of [`Hash`] does not follow the pbjson
+/// convention to display protobuf `bytes` using base64 encoding. To get the
+/// display formatting faithful to pbjson convetion use the alternative formatting selector,
+/// `{block_hash:#}` instead.
+///
+/// # Examples
+///
+/// ```
+/// use astria_core::sequencerblock::v1::block;
+///
+/// let block_hash = block::Hash::new([42; 32]);
+/// assert_eq!(
+///     "2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a",
+///     format!("{block_hash}"),
+/// );
+/// assert_eq!(
+///     "KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKio=",
+///     format!("{block_hash:#}"),
+/// );
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Hash([u8; 32]);
+
+impl Hash {
+    pub fn new(inner: [u8; 32]) -> Self {
+        Self(inner)
+    }
+
+    pub fn get(&self) -> [u8; 32] {
+        self.0
+    }
+}
+
+impl AsRef<[u8]> for Hash {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl Deref for Hash {
+    type Target = [u8; 32];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("block hash requires 32 bytes, but slice contained `{actual}`")]
+pub struct HashFromSliceError {
+    actual: usize,
+    source: std::array::TryFromSliceError,
+}
+
+impl<'a> TryFrom<&'a [u8]> for Hash {
+    type Error = HashFromSliceError;
+
+    fn try_from(value: &'a [u8]) -> Result<Self, Self::Error> {
+        let inner = value.try_into().map_err(|source| Self::Error {
+            actual: value.len(),
+            source,
+        })?;
+        Ok(Self(inner))
+    }
+}
+
+impl Display for Hash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use base64::{
+            display::Base64Display,
+            engine::general_purpose::STANDARD,
+        };
+
+        if f.alternate() {
+            Base64Display::new(&self.0, &STANDARD).fmt(f)?;
+        } else {
+            for byte in self.0 {
+                write!(f, "{byte:02x}")?;
+            }
+        }
+        Ok(())
+    }
 }
 
 /// `SequencerBlock` is constructed from a tendermint/cometbft block by
@@ -597,7 +693,7 @@ pub struct SequencerBlockParts {
 pub struct SequencerBlock {
     /// The result of hashing the cometbft header. Guaranteed to not be `None` as compared to
     /// the cometbft/tendermint-rs return type.
-    block_hash: [u8; 32],
+    block_hash: Hash,
     /// the block header, which contains the cometbft header and additional sequencer-specific
     /// commitments.
     header: SequencerBlockHeader,
@@ -622,7 +718,7 @@ impl SequencerBlock {
     ///
     /// This is done by hashing the `CometBFT` header stored in this block.
     #[must_use]
-    pub fn block_hash(&self) -> &[u8; 32] {
+    pub fn block_hash(&self) -> &Hash {
         &self.block_hash
     }
 
@@ -687,7 +783,7 @@ impl SequencerBlock {
             rollup_ids_proof,
         } = self;
         raw::SequencerBlock {
-            block_hash: Bytes::copy_from_slice(&block_hash),
+            block_hash: Bytes::copy_from_slice(block_hash.as_ref()),
             header: Some(header.into_raw()),
             rollup_transactions: rollup_transactions
                 .into_values()
@@ -863,7 +959,7 @@ impl SequencerBlock {
         );
 
         Ok(Self {
-            block_hash,
+            block_hash: Hash(block_hash),
             header: SequencerBlockHeader {
                 chain_id,
                 height,
@@ -1032,7 +1128,7 @@ where
 /// Exists to provide convenient access to fields of a [`FilteredSequencerBlock`].
 #[derive(Debug, Clone, PartialEq)]
 pub struct FilteredSequencerBlockParts {
-    pub block_hash: [u8; 32],
+    pub block_hash: Hash,
     pub header: SequencerBlockHeader,
     // filtered set of rollup transactions
     pub rollup_transactions: IndexMap<RollupId, RollupTransactions>,
@@ -1050,7 +1146,7 @@ pub struct FilteredSequencerBlockParts {
     reason = "we want consistent and specific naming"
 )]
 pub struct FilteredSequencerBlock {
-    block_hash: [u8; 32],
+    block_hash: Hash,
     header: SequencerBlockHeader,
     // filtered set of rollup transactions
     rollup_transactions: IndexMap<RollupId, RollupTransactions>,
@@ -1064,7 +1160,7 @@ pub struct FilteredSequencerBlock {
 
 impl FilteredSequencerBlock {
     #[must_use]
-    pub fn block_hash(&self) -> &[u8; 32] {
+    pub fn block_hash(&self) -> &Hash {
         &self.block_hash
     }
 
@@ -1114,7 +1210,7 @@ impl FilteredSequencerBlock {
             ..
         } = self;
         raw::FilteredSequencerBlock {
-            block_hash: Bytes::copy_from_slice(&block_hash),
+            block_hash: Bytes::copy_from_slice(&*block_hash),
             header: Some(header.into_raw()),
             rollup_transactions: rollup_transactions
                 .into_values()

--- a/crates/astria-core/src/sequencerblock/v1/celestia.rs
+++ b/crates/astria-core/src/sequencerblock/v1/celestia.rs
@@ -5,8 +5,6 @@ use sha2::{
 };
 
 use super::{
-    IncorrectRollupIdLength,
-    RollupId,
     block::{
         self,
         RollupTransactionsParts,
@@ -15,6 +13,8 @@ use super::{
         SequencerBlockHeaderError,
     },
     raw,
+    IncorrectRollupIdLength,
+    RollupId,
 };
 use crate::Protobuf;
 

--- a/crates/astria-core/src/sequencerblock/v1/celestia.rs
+++ b/crates/astria-core/src/sequencerblock/v1/celestia.rs
@@ -5,6 +5,8 @@ use sha2::{
 };
 
 use super::{
+    IncorrectRollupIdLength,
+    RollupId,
     block::{
         self,
         RollupTransactionsParts,
@@ -13,8 +15,6 @@ use super::{
         SequencerBlockHeaderError,
     },
     raw,
-    IncorrectRollupIdLength,
-    RollupId,
 };
 use crate::Protobuf;
 
@@ -236,7 +236,7 @@ impl SubmittedRollupData {
             proof,
         } = self;
         raw::SubmittedRollupData {
-            sequencer_block_hash: Bytes::copy_from_slice(&*sequencer_block_hash),
+            sequencer_block_hash: Bytes::copy_from_slice(sequencer_block_hash.as_bytes()),
             rollup_id: Some(rollup_id.to_raw()),
             transactions,
             proof: Some(proof.into_raw()),
@@ -618,7 +618,7 @@ impl SubmittedMetadata {
             ..
         } = self;
         raw::SubmittedMetadata {
-            block_hash: Bytes::copy_from_slice(&*block_hash),
+            block_hash: Bytes::copy_from_slice(block_hash.as_bytes()),
             header: Some(header.into_raw()),
             rollup_ids: rollup_ids.into_iter().map(RollupId::into_raw).collect(),
             rollup_transactions_proof: Some(rollup_transactions_proof.into_raw()),

--- a/crates/astria-core/src/sequencerblock/v1/celestia.rs
+++ b/crates/astria-core/src/sequencerblock/v1/celestia.rs
@@ -6,6 +6,7 @@ use sha2::{
 
 use super::{
     block::{
+        self,
         RollupTransactionsParts,
         SequencerBlock,
         SequencerBlockHeader,
@@ -134,7 +135,7 @@ enum SubmittedRollupDataErrorKind {
 /// they can be converted directly into one another. This can change in the future.
 pub struct UncheckedSubmittedRollupData {
     /// The hash of the sequencer block. Must be 32 bytes.
-    pub sequencer_block_hash: [u8; 32],
+    pub sequencer_block_hash: block::Hash,
     /// The 32 bytes identifying the rollup this blob belongs to. Matches
     /// `astria.sequencerblock.v1.RollupTransactions.rollup_id`
     pub rollup_id: RollupId,
@@ -154,7 +155,7 @@ impl UncheckedSubmittedRollupData {
 #[derive(Clone, Debug)]
 pub struct SubmittedRollupData {
     /// The hash of the sequencer block. Must be 32 bytes.
-    sequencer_block_hash: [u8; 32],
+    sequencer_block_hash: block::Hash,
     /// The 32 bytes identifying the rollup this blob belongs to. Matches
     /// `astria.sequencerblock.v1.RollupTransactions.rollup_id`
     rollup_id: RollupId,
@@ -181,7 +182,7 @@ impl SubmittedRollupData {
     }
 
     #[must_use]
-    pub fn sequencer_block_hash(&self) -> &[u8; 32] {
+    pub fn sequencer_block_hash(&self) -> &block::Hash {
         &self.sequencer_block_hash
     }
 
@@ -235,7 +236,7 @@ impl SubmittedRollupData {
             proof,
         } = self;
         raw::SubmittedRollupData {
-            sequencer_block_hash: Bytes::copy_from_slice(&sequencer_block_hash),
+            sequencer_block_hash: Bytes::copy_from_slice(&*sequencer_block_hash),
             rollup_id: Some(rollup_id.to_raw()),
             transactions,
             proof: Some(proof.into_raw()),
@@ -382,7 +383,7 @@ enum SubmittedMetadataErrorKind {
 /// access the sequencer block's internal types.
 #[derive(Clone, Debug)]
 pub struct UncheckedSubmittedMetadata {
-    pub block_hash: [u8; 32],
+    pub block_hash: block::Hash,
     /// The original `CometBFT` header that is the input to this blob's original sequencer block.
     /// Corresponds to `astria.SequencerBlock.header`.
     pub header: SequencerBlockHeader,
@@ -474,7 +475,7 @@ impl UncheckedSubmittedMetadata {
 #[derive(Clone, Debug)]
 pub struct SubmittedMetadata {
     /// The block hash obtained from hashing `.header`.
-    block_hash: [u8; 32],
+    block_hash: block::Hash,
     /// The sequencer block header.
     header: SequencerBlockHeader,
     /// The rollup IDs for which `SubmittedRollupData`s were submitted to celestia.
@@ -507,7 +508,7 @@ impl<'a> Iterator for RollupIdIter<'a> {
 impl SubmittedMetadata {
     /// Returns the block hash of the tendermint header stored in this blob.
     #[must_use]
-    pub fn block_hash(&self) -> &[u8; 32] {
+    pub fn block_hash(&self) -> &block::Hash {
         &self.block_hash
     }
 
@@ -617,7 +618,7 @@ impl SubmittedMetadata {
             ..
         } = self;
         raw::SubmittedMetadata {
-            block_hash: Bytes::copy_from_slice(&block_hash),
+            block_hash: Bytes::copy_from_slice(&*block_hash),
             header: Some(header.into_raw()),
             rollup_ids: rollup_ids.into_iter().map(RollupId::into_raw).collect(),
             rollup_transactions_proof: Some(rollup_transactions_proof.into_raw()),

--- a/crates/astria-sequencer-utils/src/blob_parser.rs
+++ b/crates/astria-sequencer-utils/src/blob_parser.rs
@@ -14,13 +14,13 @@ use std::{
 use astria_core::{
     brotli::decompress_bytes,
     generated::astria::sequencerblock::v1::{
-        rollup_data::Value as RawRollupDataValue,
         Deposit as RawDeposit,
         RollupData as RawRollupData,
         SubmittedMetadata as RawSubmittedMetadata,
         SubmittedMetadataList as RawSubmittedMetadataList,
         SubmittedRollupData as RawSubmittedRollupData,
         SubmittedRollupDataList as RawSubmittedRollupDataList,
+        rollup_data::Value as RawRollupDataValue,
     },
     primitive::v1::RollupId,
     sequencerblock::v1::{
@@ -37,26 +37,26 @@ use astria_core::{
     },
 };
 use astria_eyre::eyre::{
-    bail,
     Result,
     WrapErr,
+    bail,
 };
 use astria_merkle::audit::Proof;
 use base64::{
-    prelude::BASE64_STANDARD,
     Engine,
+    prelude::BASE64_STANDARD,
 };
 use clap::ValueEnum;
 use colour::write_blue;
 use ethers_core::types::{
-    transaction::eip2930::AccessListItem,
     Transaction,
+    transaction::eip2930::AccessListItem,
 };
 use indenter::indented;
 use itertools::Itertools;
 use prost::{
-    bytes::Bytes,
     Message,
+    bytes::Bytes,
 };
 use serde::Serialize;
 
@@ -304,7 +304,7 @@ impl BriefSequencerBlockMetadata {
             .map(RollupId::to_string)
             .collect();
         BriefSequencerBlockMetadata {
-            sequencer_block_hash: BASE64_STANDARD.encode(metadata.block_hash),
+            sequencer_block_hash: BASE64_STANDARD.encode(metadata.block_hash.as_bytes()),
             sequencer_block_header: PrintableSequencerBlockHeader::from(&metadata.header),
             rollup_ids,
         }
@@ -343,7 +343,7 @@ impl VerboseSequencerBlockMetadata {
             .map(RollupId::to_string)
             .collect();
         VerboseSequencerBlockMetadata {
-            sequencer_block_hash: BASE64_STANDARD.encode(metadata.block_hash),
+            sequencer_block_hash: BASE64_STANDARD.encode(metadata.block_hash.as_bytes()),
             sequencer_block_header: PrintableSequencerBlockHeader::from(&metadata.header),
             rollup_ids,
             rollup_transactions_proof: PrintableMerkleProof::from(
@@ -380,7 +380,8 @@ struct BriefRollupData {
 impl BriefRollupData {
     fn new(rollup_data: &UncheckedSubmittedRollupData) -> Self {
         BriefRollupData {
-            sequencer_block_hash: BASE64_STANDARD.encode(rollup_data.sequencer_block_hash),
+            sequencer_block_hash: BASE64_STANDARD
+                .encode(rollup_data.sequencer_block_hash.as_bytes()),
             rollup_id: rollup_data.rollup_id.to_string(),
             transaction_count: rollup_data.transactions.len(),
         }
@@ -655,7 +656,8 @@ impl VerboseRollupData {
             .collect();
         let item_count = transactions_and_deposits.len();
         VerboseRollupData {
-            sequencer_block_hash: BASE64_STANDARD.encode(rollup_data.sequencer_block_hash),
+            sequencer_block_hash: BASE64_STANDARD
+                .encode(rollup_data.sequencer_block_hash.as_bytes()),
             rollup_id: rollup_data.rollup_id.to_string(),
             transactions_and_deposits,
             item_count,

--- a/crates/astria-sequencer-utils/src/blob_parser.rs
+++ b/crates/astria-sequencer-utils/src/blob_parser.rs
@@ -14,13 +14,13 @@ use std::{
 use astria_core::{
     brotli::decompress_bytes,
     generated::astria::sequencerblock::v1::{
+        rollup_data::Value as RawRollupDataValue,
         Deposit as RawDeposit,
         RollupData as RawRollupData,
         SubmittedMetadata as RawSubmittedMetadata,
         SubmittedMetadataList as RawSubmittedMetadataList,
         SubmittedRollupData as RawSubmittedRollupData,
         SubmittedRollupDataList as RawSubmittedRollupDataList,
-        rollup_data::Value as RawRollupDataValue,
     },
     primitive::v1::RollupId,
     sequencerblock::v1::{
@@ -37,26 +37,26 @@ use astria_core::{
     },
 };
 use astria_eyre::eyre::{
+    bail,
     Result,
     WrapErr,
-    bail,
 };
 use astria_merkle::audit::Proof;
 use base64::{
-    Engine,
     prelude::BASE64_STANDARD,
+    Engine,
 };
 use clap::ValueEnum;
 use colour::write_blue;
 use ethers_core::types::{
-    Transaction,
     transaction::eip2930::AccessListItem,
+    Transaction,
 };
 use indenter::indented;
 use itertools::Itertools;
 use prost::{
-    Message,
     bytes::Bytes,
+    Message,
 };
 use serde::Serialize;
 

--- a/crates/astria-sequencer/src/grpc/sequencer.rs
+++ b/crates/astria-sequencer/src/grpc/sequencer.rs
@@ -1,17 +1,17 @@
 use std::sync::Arc;
 
 use astria_core::{
+    Protobuf,
     generated::astria::sequencerblock::v1::{
-        sequencer_service_server::SequencerService,
         FilteredSequencerBlock as RawFilteredSequencerBlock,
         GetFilteredSequencerBlockRequest,
         GetPendingNonceRequest,
         GetPendingNonceResponse,
         GetSequencerBlockRequest,
         SequencerBlock as RawSequencerBlock,
+        sequencer_service_server::SequencerService,
     },
     primitive::v1::RollupId,
-    Protobuf,
 };
 use bytes::Bytes;
 use cnidarium::Storage;
@@ -160,7 +160,7 @@ impl SequencerService for SequencerServer {
         let all_rollup_ids = all_rollup_ids.into_iter().map(RollupId::into_raw).collect();
 
         let block = RawFilteredSequencerBlock {
-            block_hash: Bytes::copy_from_slice(&*block_hash),
+            block_hash: Bytes::copy_from_slice(block_hash.as_bytes()),
             header: Some(header.into_raw()),
             rollup_transactions,
             rollup_transactions_proof: Some(rollup_transactions_proof.into_raw()),
@@ -231,12 +231,12 @@ mod tests {
     use super::*;
     use crate::{
         app::{
+            StateWriteExt as _,
             benchmark_and_test_utils::{
                 mock_balances,
                 mock_tx_cost,
             },
             test_utils::get_alice_signing_key,
-            StateWriteExt as _,
         },
         benchmark_and_test_utils::astria_address,
         grpc::StateWriteExt as _,

--- a/crates/astria-sequencer/src/grpc/sequencer.rs
+++ b/crates/astria-sequencer/src/grpc/sequencer.rs
@@ -160,7 +160,7 @@ impl SequencerService for SequencerServer {
         let all_rollup_ids = all_rollup_ids.into_iter().map(RollupId::into_raw).collect();
 
         let block = RawFilteredSequencerBlock {
-            block_hash: Bytes::copy_from_slice(&block_hash),
+            block_hash: Bytes::copy_from_slice(&*block_hash),
             header: Some(header.into_raw()),
             rollup_transactions,
             rollup_transactions_proof: Some(rollup_transactions_proof.into_raw()),

--- a/crates/astria-sequencer/src/grpc/sequencer.rs
+++ b/crates/astria-sequencer/src/grpc/sequencer.rs
@@ -1,17 +1,17 @@
 use std::sync::Arc;
 
 use astria_core::{
-    Protobuf,
     generated::astria::sequencerblock::v1::{
+        sequencer_service_server::SequencerService,
         FilteredSequencerBlock as RawFilteredSequencerBlock,
         GetFilteredSequencerBlockRequest,
         GetPendingNonceRequest,
         GetPendingNonceResponse,
         GetSequencerBlockRequest,
         SequencerBlock as RawSequencerBlock,
-        sequencer_service_server::SequencerService,
     },
     primitive::v1::RollupId,
+    Protobuf,
 };
 use bytes::Bytes;
 use cnidarium::Storage;
@@ -231,12 +231,12 @@ mod tests {
     use super::*;
     use crate::{
         app::{
-            StateWriteExt as _,
             benchmark_and_test_utils::{
                 mock_balances,
                 mock_tx_cost,
             },
             test_utils::get_alice_signing_key,
+            StateWriteExt as _,
         },
         benchmark_and_test_utils::astria_address,
         grpc::StateWriteExt as _,

--- a/crates/astria-sequencer/src/grpc/state_ext.rs
+++ b/crates/astria-sequencer/src/grpc/state_ext.rs
@@ -189,7 +189,7 @@ pub(crate) trait StateWriteExt: StateWrite {
     }
 }
 
-#[instrument(skip_all, fields(hash = %hex::encode(hash)), err(level = Level::DEBUG))]
+#[instrument(skip_all, fields(%hash), err(level = Level::DEBUG))]
 async fn get_sequencer_block_by_hash<S: StateRead + ?Sized>(
     state: &S,
     hash: &block::Hash,

--- a/crates/astria-sequencer/src/grpc/state_ext.rs
+++ b/crates/astria-sequencer/src/grpc/state_ext.rs
@@ -11,9 +11,9 @@ use astria_core::{
 use astria_eyre::{
     anyhow_to_eyre,
     eyre::{
-        bail,
         Result,
         WrapErr as _,
+        bail,
     },
 };
 use async_trait::async_trait;
@@ -22,8 +22,8 @@ use cnidarium::{
     StateWrite,
 };
 use tracing::{
-    instrument,
     Level,
+    instrument,
 };
 
 use super::storage::{
@@ -55,7 +55,7 @@ pub(crate) trait StateReadExt: StateRead {
         hash: &block::Hash,
     ) -> Result<SequencerBlockHeader> {
         let Some(bytes) = self
-            .nonverifiable_get_raw(keys::sequencer_block_header_by_hash(hash).as_bytes())
+            .nonverifiable_get_raw(keys::sequencer_block_header_by_hash(hash.as_bytes()).as_bytes())
             .await
             .map_err(anyhow_to_eyre)
             .wrap_err("failed to read raw sequencer block from state")?
@@ -72,7 +72,7 @@ pub(crate) trait StateReadExt: StateRead {
     #[instrument(skip_all, fields(%hash), err(level = Level::WARN))]
     async fn get_rollup_ids_by_block_hash(&self, hash: &block::Hash) -> Result<Vec<RollupId>> {
         let Some(bytes) = self
-            .nonverifiable_get_raw(keys::rollup_ids_by_hash(hash).as_bytes())
+            .nonverifiable_get_raw(keys::rollup_ids_by_hash(hash.as_bytes()).as_bytes())
             .await
             .map_err(anyhow_to_eyre)
             .wrap_err("failed to read rollup IDs by block hash from state")?
@@ -95,15 +95,15 @@ pub(crate) trait StateReadExt: StateRead {
             .wrap_err("failed to get sequencer block by hash")
     }
 
-    #[instrument(skip_all, fields(hash = %hex::encode(hash), %rollup_id), err(level = Level::WARN))]
+    #[instrument(skip_all, fields(%hash, %rollup_id), err(level = Level::WARN))]
     async fn get_rollup_data(
         &self,
-        hash: &[u8; 32],
+        hash: &block::Hash,
         rollup_id: &RollupId,
     ) -> Result<RollupTransactions> {
         let Some(bytes) = self
             .nonverifiable_get_raw(
-                keys::rollup_data_by_hash_and_rollup_id(hash, rollup_id).as_bytes(),
+                keys::rollup_data_by_hash_and_rollup_id(hash.as_bytes(), rollup_id).as_bytes(),
             )
             .await
             .map_err(anyhow_to_eyre)
@@ -120,13 +120,15 @@ pub(crate) trait StateReadExt: StateRead {
             .wrap_err("invalid rollup transactions bytes")
     }
 
-    #[instrument(skip_all, fields(hash = %hex::encode(hash)), err(level = Level::WARN))]
+    #[instrument(skip_all, fields(%hash), err(level = Level::WARN))]
     async fn get_rollup_transactions_proof_by_block_hash(
         &self,
-        hash: &[u8; 32],
+        hash: &block::Hash,
     ) -> Result<merkle::Proof> {
         let Some(bytes) = self
-            .nonverifiable_get_raw(keys::rollup_transactions_proof_by_hash(hash).as_bytes())
+            .nonverifiable_get_raw(
+                keys::rollup_transactions_proof_by_hash(hash.as_bytes()).as_bytes(),
+            )
             .await
             .map_err(anyhow_to_eyre)
             .wrap_err("failed to read rollup transactions proof by block hash from state")?
@@ -138,10 +140,13 @@ pub(crate) trait StateReadExt: StateRead {
             .wrap_err("invalid rollup transactions proof bytes")
     }
 
-    #[instrument(skip_all, fields(hash = %hex::encode(hash)), err(level = Level::WARN))]
-    async fn get_rollup_ids_proof_by_block_hash(&self, hash: &[u8; 32]) -> Result<merkle::Proof> {
+    #[instrument(skip_all, fields(%hash), err(level = Level::WARN))]
+    async fn get_rollup_ids_proof_by_block_hash(
+        &self,
+        hash: &block::Hash,
+    ) -> Result<merkle::Proof> {
         let Some(bytes) = self
-            .nonverifiable_get_raw(keys::rollup_ids_proof_by_hash(hash).as_bytes())
+            .nonverifiable_get_raw(keys::rollup_ids_proof_by_hash(hash.as_bytes()).as_bytes())
             .await
             .map_err(anyhow_to_eyre)
             .wrap_err("failed to read rollup IDs proof by block hash from state")?
@@ -246,14 +251,17 @@ fn put_block_hash<S: StateWrite + ?Sized>(
 
 fn put_rollup_ids<S: StateWrite + ?Sized, I: Iterator<Item = RollupId>>(
     state: &mut S,
-    block_hash: &[u8; 32],
+    block_hash: &block::Hash,
     rollup_ids: I,
 ) -> Result<()> {
     let rollup_ids: Vec<_> = rollup_ids.collect();
     let bytes = StoredValue::from(storage::RollupIds::from(rollup_ids.iter()))
         .serialize()
         .context("failed to serialize rollup ids")?;
-    state.nonverifiable_put_raw(keys::rollup_ids_by_hash(block_hash).into(), bytes);
+    state.nonverifiable_put_raw(
+        keys::rollup_ids_by_hash(block_hash.as_bytes()).into(),
+        bytes,
+    );
     Ok(())
 }
 
@@ -263,14 +271,14 @@ fn put_rollup_ids<S: StateWrite + ?Sized, I: Iterator<Item = RollupId>>(
 )]
 fn put_block_header<S: StateWrite + ?Sized>(
     state: &mut S,
-    block_hash: &[u8; 32],
+    block_hash: &block::Hash,
     block_header: SequencerBlockHeader,
 ) -> Result<()> {
     let bytes = StoredValue::from(storage::SequencerBlockHeader::from(&block_header))
         .serialize()
         .context("failed to serialize sequencer block header")?;
     state.nonverifiable_put_raw(
-        keys::sequencer_block_header_by_hash(block_hash).into(),
+        keys::sequencer_block_header_by_hash(block_hash.as_bytes()).into(),
         bytes,
     );
     Ok(())
@@ -278,7 +286,7 @@ fn put_block_header<S: StateWrite + ?Sized>(
 
 fn put_rollups_transactions<S, I>(
     state: &mut S,
-    block_hash: &[u8; 32],
+    block_hash: &block::Hash,
     all_rollups_txs: I,
 ) -> Result<()>
 where
@@ -291,7 +299,7 @@ where
             .serialize()
             .context("failed to serialize rollup transactions")?;
         state.nonverifiable_put_raw(
-            keys::rollup_data_by_hash_and_rollup_id(block_hash, id).into(),
+            keys::rollup_data_by_hash_and_rollup_id(block_hash.as_bytes(), id).into(),
             bytes,
         );
         Ok(())
@@ -304,14 +312,14 @@ where
 )]
 fn put_rollups_transactions_proof<S: StateWrite + ?Sized>(
     state: &mut S,
-    block_hash: &[u8; 32],
+    block_hash: &block::Hash,
     proof: merkle::Proof,
 ) -> Result<()> {
     let bytes = StoredValue::from(storage::Proof::from(&proof))
         .serialize()
         .context("failed to serialize rollups transactions proof")?;
     state.nonverifiable_put_raw(
-        keys::rollup_transactions_proof_by_hash(block_hash).into(),
+        keys::rollup_transactions_proof_by_hash(block_hash.as_bytes()).into(),
         bytes,
     );
     Ok(())
@@ -323,13 +331,16 @@ fn put_rollups_transactions_proof<S: StateWrite + ?Sized>(
 )]
 fn put_rollup_ids_proof<S: StateWrite + ?Sized>(
     state: &mut S,
-    block_hash: &[u8; 32],
+    block_hash: &block::Hash,
     proof: merkle::Proof,
 ) -> Result<()> {
     let bytes = StoredValue::from(storage::Proof::from(&proof))
         .serialize()
         .context("failed to serialize rollup ids proof")?;
-    state.nonverifiable_put_raw(keys::rollup_ids_proof_by_hash(block_hash).into(), bytes);
+    state.nonverifiable_put_raw(
+        keys::rollup_ids_proof_by_hash(block_hash.as_bytes()).into(),
+        bytes,
+    );
     Ok(())
 }
 

--- a/crates/astria-sequencer/src/grpc/state_ext.rs
+++ b/crates/astria-sequencer/src/grpc/state_ext.rs
@@ -11,9 +11,9 @@ use astria_core::{
 use astria_eyre::{
     anyhow_to_eyre,
     eyre::{
+        bail,
         Result,
         WrapErr as _,
-        bail,
     },
 };
 use async_trait::async_trait;
@@ -22,8 +22,8 @@ use cnidarium::{
     StateWrite,
 };
 use tracing::{
-    Level,
     instrument,
+    Level,
 };
 
 use super::storage::{

--- a/crates/astria-sequencer/src/grpc/storage/values/block_hash.rs
+++ b/crates/astria-sequencer/src/grpc/storage/values/block_hash.rs
@@ -22,6 +22,9 @@ use super::{
 #[derive(BorshSerialize, BorshDeserialize)]
 pub(in crate::grpc) struct BlockHash<'a>(Cow<'a, [u8; 32]>);
 
+// NOTE(janis): Is it confusing that the display impl at the service level is hex,
+// while here it's base64? This probably makes sense because storage is closer to
+// the wire format, which itself followes the base64 pbjson convention.
 impl<'a> Debug for BlockHash<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{}", base64(self.0.as_slice()))
@@ -30,7 +33,7 @@ impl<'a> Debug for BlockHash<'a> {
 
 impl<'a> From<&'a astria_core::sequencerblock::v1::block::Hash> for BlockHash<'a> {
     fn from(block_hash: &'a astria_core::sequencerblock::v1::block::Hash) -> Self {
-        BlockHash(Cow::Borrowed(block_hash))
+        BlockHash(Cow::Borrowed(block_hash.as_bytes()))
     }
 }
 

--- a/crates/astria-sequencer/src/grpc/storage/values/block_hash.rs
+++ b/crates/astria-sequencer/src/grpc/storage/values/block_hash.rs
@@ -28,15 +28,15 @@ impl<'a> Debug for BlockHash<'a> {
     }
 }
 
-impl<'a> From<&'a [u8; 32]> for BlockHash<'a> {
-    fn from(block_hash: &'a [u8; 32]) -> Self {
+impl<'a> From<&'a astria_core::sequencerblock::v1::block::Hash> for BlockHash<'a> {
+    fn from(block_hash: &'a astria_core::sequencerblock::v1::block::Hash) -> Self {
         BlockHash(Cow::Borrowed(block_hash))
     }
 }
 
-impl<'a> From<BlockHash<'a>> for [u8; 32] {
+impl<'a> From<BlockHash<'a>> for astria_core::sequencerblock::v1::block::Hash {
     fn from(block_hash: BlockHash<'a>) -> Self {
-        block_hash.0.into_owned()
+        Self::new(block_hash.0.into_owned())
     }
 }
 


### PR DESCRIPTION
## Summary
Adds a newtype `astria_core::sequencerblock::v1::block::Hash` to represent Sequencer block hash (an array of 32 bytes).

The standard formatting of the newtype's `std::format:Display` implementation uses lower case hex, while its alternative selector uses standard base64. Note that the latter was introduced to provide a way to format the hash using the same conventions as pbjson for the protobuf wire types.

```rust
use astria_core::sequencerblock::v1::block;
let block_hash = block::Hash::new([42; 32]);
assert_eq!(
    "2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a",
    format!("{block_hash}"),
);
assert_eq!(
    "KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKio=",
    format!("{block_hash:#}"),
};
```

## Background
During work on the Astria Auctioneer it was discovered that representing Sequencer Block Hashes with a distinct type is desirable for two reasons:

1. to distinguish Sequencer block hashes from other objects represented by an array of 32 bytes (`[u8; 32]`) that show up in the Astria ecosystem, for example Rollup block hashes.
2. to have a unified `std::format::Display` implementation for all Astria block hashes using a hexadecimal representation.

## Changes
- Introduce the `astria_core::sequencerblock::v1::block::Hash` newtype for `[u8; 32]` objects representing Astria block hashes, and replace all domain types with it.

## Testing
Added doc tests for the `Hash` constructor and normal and alternative display impl.

## Changelogs
Changelogs updated.

## Breaking Changelist
- This is a breaking change in `astria-core` but not in any of the services (because the return value of public getters was changed).
- This is not network breaking.