### PR TITLE
chore(sequencer): remove misplaced logs

### DIFF
--- a/crates/astria-sequencer/CHANGELOG.md
+++ b/crates/astria-sequencer/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Consolidate action handling to single module [#1759](https://github.com/astriaorg/astria/pull/1759).
 - Ensure all deposit assets are trace prefixed [#1807](https://github.com/astriaorg/astria/pull/1807).
 - Update `idna` dependency to resolve cargo audit warning [#1869](https://github.com/astriaorg/astria/pull/1869).
+- Remove events reporting on state storage creation [#1892](https://github.com/astriaorg/astria/pull/1892).
 
 ## [1.0.0] - 2024-10-25
 

--- a/crates/astria-sequencer/src/sequencer.rs
+++ b/crates/astria-sequencer/src/sequencer.rs
@@ -54,26 +54,6 @@ impl Sequencer {
         register_histogram_global("cnidarium_nonverifiable_get_raw_duration_seconds");
         let span = info_span!("Sequencer::run_until_stopped");
 
-        if config
-            .db_filepath
-            .try_exists()
-            .context("failed checking for existence of db storage file")?
-        {
-            span.in_scope(|| {
-                info!(
-                    path = %config.db_filepath.display(),
-                    "opening storage db"
-                );
-            });
-        } else {
-            span.in_scope(|| {
-                info!(
-                    path = %config.db_filepath.display(),
-                    "creating storage db"
-                );
-            });
-        }
-
         let mut signals = spawn_signal_handler();
 
         let substore_prefixes = vec![penumbra_ibc::IBC_SUBSTORE_PREFIX];


### PR DESCRIPTION
## Summary

Remove events from `Sequencer::run_until_stopped`
that report on whether whether a state DB will be
opened or created.

## Background

Cnidarium already reports which paths it will read.

More egregious however is that
`Sequencer::run_until_stopped` is the wrong place
to emit these events because it does not have
authority over which actions cnidarium will take.
Should the constructor ever change, then the events
will be immediately out of whack, which will lead
to confusion.

## Changes
- Remove state storage creation events from `Sequencer::run_until_stopped`.

## Testing
No testing necessary. These are just some limited events.

## Changelogs
Changelogs updated.
