### PR TITLE
chore(sequencer): replace erroneous `expect` statement with docs

### DIFF
--- a/crates/astria-sequencer/src/sequencer.rs
+++ b/crates/astria-sequencer/src/sequencer.rs
@@ -47,7 +47,16 @@ use crate::{
 pub struct Sequencer;
 
 impl Sequencer {
-    #[expect(clippy::missing_errors_doc, reason = "not a public function")]
+    /// Runs the sequencer until it is either stopped by a signal or an error occurs.
+    ///
+    /// # Errors
+    /// Returns an error in the following cases:
+    /// - Database file does not exist, or cannot be loaded into storage
+    /// - The app fails to initialize
+    /// - Info service fails to initialize
+    /// - The server builder fails to return a server
+    /// - The gRPC address cannot be parsed
+    /// - The gRPC server fails to exit properly
     pub async fn run_until_stopped(config: Config, metrics: &'static Metrics) -> Result<()> {
         cnidarium::register_metrics();
         register_histogram_global("cnidarium_get_raw_duration_seconds");


### PR DESCRIPTION
## Summary
Replaced an erroneous `expect` statement for missing docs with the appropriate docs.

## Background
#1761 introduced an `expect` statement for `clippy::missing_docs` with an incorrect reason.

## Changes
- Added docs to `sequencer::run_until_stopped`

## Testing
No tests needed.

## Changelogs
No updates required.

## Related Issues
closes #1893
