### PR TITLE
Switch to OSS bitnami postgresql chart

### DIFF
--- a/charts/evm-stack/Chart.lock
+++ b/charts/evm-stack/Chart.lock
@@ -15,10 +15,10 @@ dependencies:
   repository: file://../evm-bridge-withdrawer
   version: 1.0.1
 - name: postgresql
-  repository: https://charts.bitnami.com/bitnami
+  repository: oci://registry-1.docker.io/bitnamicharts
   version: 15.2.4
 - name: blockscout-stack
   repository: https://blockscout.github.io/helm-charts
   version: 1.6.8
-digest: sha256:4715e557b6ceb0fa85c9efe86f5b26d665783f0be9162728efe808fa3a35d727
-generated: "2024-12-12T19:52:24.992658+02:00"
+digest: sha256:371c35af96fc5d82aa2b4d894dc7d2e11e150380fd6f09eb0ca94b4202b24698
+generated: "2025-01-08T11:22:41.273867-08:00"

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.6
+version: 1.0.7
 
 dependencies:
   - name: celestia-node
@@ -39,7 +39,7 @@ dependencies:
     condition: evm-bridge-withdrawer.enabled
   - name: postgresql
     version: "15.2.4"
-    repository: "https://charts.bitnami.com/bitnami"
+    repository: "oci://registry-1.docker.io/bitnamicharts"
     condition: postgresql.enabled
   - name: blockscout-stack
     repository: "https://blockscout.github.io/helm-charts"


### PR DESCRIPTION
## Summary
Update the postgresql chart dependency for evm-stack

## Background
The existing charts no longer work due to VMWare requiring a paid subscription

## Changes
- Update chart URL to point to the OSS oci:// repo

## Testing
Github's smoke-tests
