### PR TITLE
feat(charts): update evm-rollup charts for auctioneer

### DIFF
--- a/charts/evm-rollup/Chart.yaml
+++ b/charts/evm-rollup/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.0.0"
+appVersion: "1.0.1"
 
 maintainers:
   - name: wafflesvonmaple

--- a/charts/evm-rollup/files/genesis/geth-genesis.json
+++ b/charts/evm-rollup/files/genesis/geth-genesis.json
@@ -38,9 +38,10 @@
         "astriaBridgeAddresses": {{ toPrettyJson .Values.genesis.bridgeAddresses | indent 8 | trim }},
         "astriaFeeCollectors": {{ toPrettyJson .Values.genesis.feeCollectors | indent 8 | trim }},
         "astriaEIP1559Params": {{ toPrettyJson .Values.genesis.eip1559Params | indent 8 | trim }},
-        "astriaSequencerAddressPrefix": "{{ .Values.genesis.sequencerAddressPrefix }}"
+        "astriaSequencerAddressPrefix": "{{ .Values.genesis.sequencerAddressPrefix }}"{{- if .Values.global.dev }},{{ end }}
         {{- if not .Values.global.dev }}
         {{- else }}
+        "astriaAuctioneerAddresses": {{ toPrettyJson .Values.genesis.auctioneerAddresses | indent 8 | trim }}
         {{- end }}
     },
     "difficulty": "0",

--- a/charts/evm-rollup/values.yaml
+++ b/charts/evm-rollup/values.yaml
@@ -70,6 +70,7 @@ genesis:
     #   minBaseFee: 0
     #   elasticityMultiplier: 2
     #   baseFeeChangeDenominator: 8
+  auctioneerAddresses: {}
 
   ## Standard Eth Genesis config values
   # An EVM chain number id, different from the astria rollup name

--- a/charts/evm-stack/Chart.lock
+++ b/charts/evm-stack/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.4.0
 - name: evm-rollup
   repository: file://../evm-rollup
-  version: 1.0.1
+  version: 1.0.2
 - name: composer
   repository: file://../composer
   version: 1.0.0
@@ -20,5 +20,5 @@ dependencies:
 - name: blockscout-stack
   repository: https://blockscout.github.io/helm-charts
   version: 1.6.8
-digest: sha256:371c35af96fc5d82aa2b4d894dc7d2e11e150380fd6f09eb0ca94b4202b24698
-generated: "2025-01-08T11:22:41.273867-08:00"
+digest: sha256:fe5a1fc6ae84217c619ef95494f0ce8999f332c373ee127bc78935628d3167b4
+generated: "2025-01-09T20:52:50.206866+05:30"

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.7
+version: 1.0.8
 
 dependencies:
   - name: celestia-node
@@ -23,7 +23,7 @@ dependencies:
     repository: "file://../celestia-node"
     condition: celestia-node.enabled
   - name: evm-rollup
-    version: 1.0.1
+    version: 1.0.2
     repository: "file://../evm-rollup"
   - name: composer
     version: 1.0.0
@@ -50,7 +50,7 @@ dependencies:
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.0.0"
+appVersion: "1.0.1"
 
 maintainers:
   - name: wafflesvonmaple

--- a/dev/values/rollup/dev.yaml
+++ b/dev/values/rollup/dev.yaml
@@ -57,7 +57,8 @@ evm-rollup:
       #   minBaseFee: 0
       #   elasticityMultiplier: 2
     #   baseFeeChangeDenominator: 8
-
+    auctioneerAddresses:
+      1: "astria1ferdmm38w7zr4ankmntst0g0qg8e7ygeu3vxcy"
     ## Standard Eth Genesis config values
     # Configuration of Eth forks, setting to 0 will enable from height,
     # left as is these forks will not activate.


### PR DESCRIPTION
## Summary
Update the evm-rollup genesis charts to include `astriaAuctioneerAddresses` which is a map of block height to auctioneer addresses. We also add a new flag to geth called `auctioneer` which enables auctioneer functionality in the flame node.

## Background
The auctioneer binary submits a signed bundle to the sequencer which the flame side of the auctioneer unbundles and verifies. To verify the bundle signature, the flame side requires the bech32 address of the sequencer key which signed bundle. We pass the bech32 address of the sequencer key to the flame side by adding it as a field in the genesis file of the flame EVM rollup.

We also add a new flag in geth `auctioneer` which enables the auctioneer funcationality in a geth node.

## Changes
- Add a field `astriaAuctioneerAddresses` to the `charts/evm-rollup/files/genesis/geth-genesis.json` which is parameterized by `auctioneerAddresses`
- Add a field in the `charts/evm-rollup/values.yaml` and `dev/rollup/dev.yaml` called `auctioneerAddresses` 

## Testing
By running the charts locally.

## Related Issues
closes https://github.com/astriaorg/astria/issues/1829
