### PR TITLE
feat(chart): add auctioneer chart and just commands

### DIFF
--- a/charts/auctioneer/Chart.yaml
+++ b/charts/auctioneer/Chart.yaml
@@ -1,0 +1,28 @@
+apiVersion: v2
+name: auctioneer
+description: Astria auctioneer helm chart
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.0.1
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.0.1"
+
+maintainers:
+  - name: itamarreif
+    url: astria.org

--- a/charts/auctioneer/templates/_helpers.tpl
+++ b/charts/auctioneer/templates/_helpers.tpl
@@ -1,0 +1,31 @@
+{{/*
+Namepsace to deploy elements into.
+*/}}
+{{- define "auctioneer.namespace" -}}
+{{- default .Release.Namespace .Values.global.namespaceOverride | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{/*
+application name to deploy elements into.
+*/}}
+{{- define "auctioneer.appName" -}}
+auctioneer
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "auctioneer.labels" -}}
+{{ include "auctioneer.selectorLabels" . }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "auctioneer.selectorLabels" -}}
+app: {{ include "auctioneer.appName" . }}
+{{- end }}
+
+{{- define "auctioneer.image" -}}
+{{ .Values.images.auctioneer.repo }}:{{ if .Values.global.dev }}{{ .Values.images.auctioneer.devTag }}{{ else }}{{ .Values.images.auctioneer.tag }}{{ end }}
+{{- end }}

--- a/charts/auctioneer/templates/configmap.yaml
+++ b/charts/auctioneer/templates/configmap.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: auctioneer-env
+  namespace: {{ include "auctioneer.namespace" . }}
+data:
+  ASTRIA_AUCTIONEER_SEQUENCER_GRPC_ENDPOINT: "{{ .Values.config.sequencerGrpcEndpoint }}"
+  ASTRIA_AUCTIONEER_SEQUENCER_ABCI_ENDPOINT: "{{ .Values.config.sequencerAbciEndpoint }}"
+  ASTRIA_AUCTIONEER_SEQUENCER_CHAIN_ID: "{{ .Values.config.sequencerChainId }}"
+  ASTRIA_AUCTIONEER_SEQUENCER_PRIVATE_KEY_PATH: "/var/secrets/{{ .Values.config.sequencerPrivateKey.secret.filename }}"
+  ASTRIA_AUCTIONEER_FEE_ASSET_DENOMINATION: "{{ .Values.config.feeAssetDenomination }}"
+  ASTRIA_AUCTIONEER_SEQUENCER_ADDRESS_PREFIX: "{{ .Values.config.sequencerAddressPrefix }}"
+  ASTRIA_AUCTIONEER_ROLLUP_GRPC_ENDPOINT: "{{ .Values.config.rollupGrpcEndpoint }}"
+  ASTRIA_AUCTIONEER_ROLLUP_ID: "{{ .Values.config.rollupId }}"
+  ASTRIA_AUCTIONEER_LATENCY_MARGIN_MS: "{{ .Values.config.latencyMarginMs }}"
+  ASTRIA_AUCTIONEER_LOG: "astria_auctioneer={{ .Values.config.logLevel }}"
+  ASTRIA_AUCTIONEER_FORCE_STDOUT: "{{ .Values.global.useTTY }}"
+  ASTRIA_AUCTIONEER_PRETTY_PRINT: "{{ .Values.global.useTTY }}"
+  NO_COLOR: "{{ .Values.global.useTTY }}"
+  ASTRIA_AUCTIONEER_NO_METRICS: "{{ not .Values.metrics.enabled }}"
+  ASTRIA_AUCTIONEER_METRICS_HTTP_LISTENER_ADDR: "0.0.0.0:{{ .Values.ports.metrics }}"
+  ASTRIA_AUCTIONEER_NO_OTEL: "{{ not .Values.otel.enabled }}"
+  ASTRIA_AUCTIONEER_NO_METRICS: "{{ not .Values.metrics.enabled }}"
+  ASTRIA_AUCTIONEER_METRICS_HTTP_LISTENER_ADDR: "0.0.0.0:{{ .Values.ports.metrics }}"
+  OTEL_EXPORTER_OTLP_ENDPOINT: "{{ tpl .Values.otel.endpoint . }}"
+  OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: "{{ tpl .Values.otel.tracesEndpoint . }}"
+  OTEL_EXPORTER_OTLP_TRACES_TIMEOUT: "{{ tpl .Values.otel.tracesTimeout . }}"
+  OTEL_EXPORTER_OTLP_TRACES_COMPRESSION: "{{ tpl .Values.otel.tracesCompression . }}"
+  OTEL_EXPORTER_OTLP_HEADERS: "{{ tpl .Values.otel.otlpHeaders . }}"
+  OTEL_EXPORTER_OTLP_TRACE_HEADERS: "{{ tpl .Values.otel.traceHeaders . }}"
+  OTEL_SERVICE_NAME: "{{ tpl .Values.otel.serviceName . }}"
+  {{- if not .Values.global.dev }}
+  {{- else }}
+  {{- end }}
+---
+{{- if not .Values.secretProvider.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: {{ include "auctioneer.namespace" .  }}
+  name: auctioneer-private-key
+data:
+  {{ .Values.config.sequencerPrivateKey.secret.filename }}: |
+    {{ .Values.config.sequencerPrivateKey.devContent }}
+---
+{{- end }}

--- a/charts/auctioneer/templates/deployment.yaml
+++ b/charts/auctioneer/templates/deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "auctioneer.appName" . }}
+  namespace: {{ include "auctioneer.namespace" . }}
+  labels:
+    {{ include "auctioneer.labels" . }}
+spec:
+  replicas: {{ .Values.global.replicaCount }}
+  selector:
+    matchLabels:
+      {{ include "auctioneer.labels" . }}
+  template:
+    metadata:
+      labels:
+        {{ include "auctioneer.labels" . }}
+    spec:
+      containers:
+        - name: auctioneer
+          image: {{ include "auctioneer.image" . }}
+          imagePullPolicy: {{ .Values.images.auctioneer.pullPolicy }}
+          command: ["/usr/local/bin/astria-auctioneer"]
+          stdin: {{ .Values.global.useTTY }}
+          tty: {{ .Values.global.useTTY }}
+          envFrom:
+            - configMapRef:
+                name: auctioneer-env
+          volumeMounts:
+            - mountPath: "/var/secrets"
+              name: auctioneer-private-key
+          {{- if .Values.metrics.enabled }}
+          ports:
+            - containerPort: {{ .Values.ports.metrics }}
+              name: auctioneer-metrics
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | trim | nindent 12 }}
+      volumes:
+        - name: auctioneer-private-key
+          {{- if .Values.secretProvider.enabled }}
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: auctioneer-private-key
+          {{- else }}
+          configMap:
+            name: auctioneer-private-key
+              {{- end }}

--- a/charts/auctioneer/templates/prometheusrule.yaml
+++ b/charts/auctioneer/templates/prometheusrule.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.alerting.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "auctioneer.appName" . }}-alerting
+{{- if .Values.alerting.prometheusRule.namespace }}
+  namespace: {{ .Values.alerting.prometheusRule.namespace | quote }}
+{{- end }}
+  labels:
+    {{- include "auctioneer.labels" . | nindent 4 }}
+  {{- if .Values.alerting.prometheusRule.additionalLabels }}
+    {{- toYaml .Values.alerting.prometheusRule.additionalLabels | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.alerting.prometheusRule.rules }}
+  groups:
+    - name: {{ template "auctioneer.appName" . }}
+      rules: {{- toYaml .Values.alerting.prometheusRule.rules | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/auctioneer/templates/secretproviderclass.yaml
+++ b/charts/auctioneer/templates/secretproviderclass.yaml
@@ -1,0 +1,13 @@
+---
+{{- if .Values.secretProvider.enabled }}
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: auctioneer-private-key
+spec:
+  provider: {{ .Values.secretProvider.provider }}
+  parameters:
+    {{- $_ := set $ "key" .Values.config.privateKey.secret }}
+    {{- tpl $.Values.secretProvider.parametersTemplate $ | nindent 4 }}
+---
+{{- end }}

--- a/charts/auctioneer/templates/service.yaml
+++ b/charts/auctioneer/templates/service.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.metrics.enabled }}
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ include "auctioneer.appName" . }}-metrics
+  namespace: {{ include "auctioneer.namespace" . }}
+  labels:
+    {{ include "auctioneer.labels" . }}
+spec:
+  selector:
+    {{ include "auctioneer.selectorLabels" . }}
+  ports:
+    - name: metrics
+      port: {{ .Values.ports.metrics }}
+      targetPort: auctioneer-metrics
+{{- end }}

--- a/charts/auctioneer/templates/servicemonitor.yaml
+++ b/charts/auctioneer/templates/servicemonitor.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: auctioneer-metrics
+  labels:
+    {{- with .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  jobLabel: auctioneer-metrics
+  namespaceSelector:
+    matchNames:
+      - {{ include "auctioneer.namespace" . }}
+  selector:
+    matchLabels:
+      app: auctioneer
+  endpoints:
+    - port: auctioneer-metrics
+      path: /
+      {{- with .Values.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.scrapeTimeout  }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+{{- end }}

--- a/charts/auctioneer/values.yaml
+++ b/charts/auctioneer/values.yaml
@@ -1,0 +1,95 @@
+global:
+  namespaceOverride: ""
+  replicaCount: 1
+  # Whether to use tty readable logging for astria services, when false use json.
+  useTTY: false
+  dev: false
+
+images:
+  auctioneer:
+    repo: ghcr.io/astriaorg/astria-auctioneer
+    pullPolicy: IfNotPresent
+    tag: 0.0.1
+    devTag: 0.0.1
+
+config:
+  sequencerGrpcEndpoint: ""
+  sequencerAbciEndpoint: ""
+  sequencerChainId: ""
+  sequencerPrivateKey:
+    devContent: ""
+    secret:
+      filename: "key.hex"
+      resourceName: "projects/$PROJECT_ID/secrets/sequencerPrivateKey/versions/latest"
+  feeAssetDenomination: ""
+  sequencerAddressPrefix: astria
+  rollupGrpcEndpoint: ""
+  rollupId: ""
+  latencyMarginMs: ""
+  logLevel: "info"
+
+otel:
+  enabled: false
+  serviceName: "auctioneer"
+  endpoint: ""
+  tracesEndpoint: ""
+  tracesCompression: "gzip"
+  tracesTimeout: "10"
+  otlpHeaders: ""
+  traceHeaders: ""
+
+metrics:
+  enabled: false
+
+serviceMonitor:
+  # set to enable port svc and service monitor
+  enabled: false
+  port: 6060
+  additionalLabels:
+    release: kube-prometheus-stack
+
+alerting:
+  enabled: false
+  interval: ""
+  additionalLabels:
+    release: kube-prometheus-stack
+  annotations: {}
+  # scrapeTimeout: 10s
+  # path: /metrics
+  prometheusRule:
+    enabled: true
+    additionalLabels:
+      release: kube-prometheus-stack
+    namespace: monitoring
+    rules:
+      - alert: Auctioneer_Node_Down
+        expr: up{container="auctioneer"} == 0  # Insert your query Expression
+        for: 1m  # Rough number but should be enough to init warn
+        labels:
+          severity: warning
+        annotations:
+          summary: Auctioneer is Down (instance {{ $labels.instance }})
+          description: "auctioneer node '{{ $labels.namespace }}' has disappeared from Prometheus target discovery.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+
+# When deploying in a production environment should use a secret provider
+# This is configured for use with GCP, need to set own resource names
+# and keys
+secretProvider:
+  enabled: false
+  provider: gcp
+  parametersTemplate: |-
+    secrets: |
+      - resourceName: {{ .key.resourceName }}
+        fileName: "{{ .key.filename }}"
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 100Mi
+  limits:
+    cpu: 1000m
+    memory: 1Gi
+
+# Default service ports
+ports:
+  metrics: 6060

--- a/charts/auctioneer/values.yaml
+++ b/charts/auctioneer/values.yaml
@@ -9,8 +9,9 @@ images:
   auctioneer:
     repo: ghcr.io/astriaorg/astria-auctioneer
     pullPolicy: IfNotPresent
-    tag: 0.0.1
-    devTag: 0.0.1
+    # TODO - update to latest tag
+    tag: "pr-1822"
+    devTag: "pr-1822"
 
 config:
   sequencerGrpcEndpoint: ""

--- a/charts/deploy.just
+++ b/charts/deploy.just
@@ -136,6 +136,15 @@ delete-dev-rollup rollupName=defaultRollupName:
 wait-for-dev-rollup rollupName=defaultRollupName:
   kubectl rollout status --watch statefulset/{{rollupName}}-geth -n astria-dev-cluster --timeout=600s
 
+deploy-auctioneer:
+  helm dependency update charts/auctioneer > /dev/null
+  helm install auctioneer-chart ./charts/auctioneer \
+      --namespace astria-dev-cluster \
+      -f dev/values/auctioneer/values.yaml
+
+delete-auctioneer:
+  @just delete chart auctioneer astria-dev-cluster
+
 deploy-bridge-withdrawer:
   helm install evm-bridge-withdrawer-chart ./charts/evm-bridge-withdrawer \
     --namespace astria-dev-cluster \

--- a/dev/values/auctioneer/values.yaml
+++ b/dev/values/auctioneer/values.yaml
@@ -1,0 +1,28 @@
+global:
+  namespaceOverride: ""
+  replicaCount: 1
+  # Whether to use tty readable logging for astria services, when false use json.
+  useTTY: true
+  dev: true
+
+config:
+  sequencerGrpcEndpoint: "http://node0-sequencer-grpc-service.astria-dev-cluster.svc.cluster.local:8080"
+  sequencerAbciEndpoint: "http://node0-sequencer-rpc-service.astria-dev-cluster.svc.cluster.local:26657"
+  sequencerChainId: "sequencer-test-chain-0"
+  sequencerPrivateKey:
+    devContent: "b8da3289343cb92a235af079d74bae435f16272df38b9ab3ab468e62c632e2f8"
+  feeAssetDenomination: "nria"
+  sequencerAddressPrefix: astria
+  rollupGrpcEndpoint: "http://astria-evm-service.astria-dev-cluster.svc.cluster.local:50051"
+  rollupId: "astria"
+  latencyMarginMs: 1000
+  logLevel: "debug"
+
+otel:
+  enabled: false
+
+metrics:
+  enabled: false
+
+serviceMonitor:
+  enabled: false


### PR DESCRIPTION
## Summary
Adds a Helm chart for deploying the Auctioneer.

## Background
[PR #1556](https://github.com/astriaorg/astria/pull/1556) adds the auctioneer binary. This binary has clients to both rollup  and sequencer nodes.

## Changes
- Add the `charts/auctioneer` directory for the auctioneer binary
- Add commands to `charts/deploy.just` for deploying/deleting the auctioneer chart in our k8s cluster
- Add `dev/auctioneer/values.yaml` for dev values for the auctioneer.
- Add the auctioneer's dev wallet to the genesis allocations in `dev/validators/all.yaml` so that the auctioneer has a balance while testing against the dev cluster.
- Expose the bundle grpc service from the rollup chart so that the auctioneer can talk to it from within the cluster

## Testing
How are these changes tested?

## Breaking Changelist
- Bulleted list of breaking changes, any notes on migration. Delete section if none.

## Related Issues
Link any issues that are related, prefer full github links.

closes https://github.com/astriaorg/astria/issues/1766
