### PR TITLE
fix(sequencer)!: use bridge address to determine asset in bridge unlock cost estimation instead of signer

### DIFF
--- a/crates/astria-sequencer/CHANGELOG.md
+++ b/crates/astria-sequencer/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensure all deposit assets are trace prefixed [#1807](https://github.com/astriaorg/astria/pull/1807).
 - Update `idna` dependency to resolve cargo audit warning [#1869](https://github.com/astriaorg/astria/pull/1869).
 - Remove events reporting on state storage creation [#1892](https://github.com/astriaorg/astria/pull/1892).
+- Fix bridge unlock cost calculation [#1905](https://github.com/astriaorg/astria/pull/1905).
 
 ## [1.0.0] - 2024-10-25
 

--- a/crates/astria-sequencer/CHANGELOG.md
+++ b/crates/astria-sequencer/CHANGELOG.md
@@ -16,7 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensure all deposit assets are trace prefixed [#1807](https://github.com/astriaorg/astria/pull/1807).
 - Update `idna` dependency to resolve cargo audit warning [#1869](https://github.com/astriaorg/astria/pull/1869).
 - Remove events reporting on state storage creation [#1892](https://github.com/astriaorg/astria/pull/1892).
-- Use bridge address to estimate bridge unlock cost instead of signer [#1905](https://github.com/astriaorg/astria/pull/1905).
+- Use bridge address to determine asset in bridge unlock cost estimation instead
+of signer [#1905](https://github.com/astriaorg/astria/pull/1905).
 
 ## [1.0.0] - 2024-10-25
 

--- a/crates/astria-sequencer/CHANGELOG.md
+++ b/crates/astria-sequencer/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensure all deposit assets are trace prefixed [#1807](https://github.com/astriaorg/astria/pull/1807).
 - Update `idna` dependency to resolve cargo audit warning [#1869](https://github.com/astriaorg/astria/pull/1869).
 - Remove events reporting on state storage creation [#1892](https://github.com/astriaorg/astria/pull/1892).
-- Fix bridge unlock cost calculation [#1905](https://github.com/astriaorg/astria/pull/1905).
+- Use bridge address to estimate bridge unlock cost instead of signer [#1905](https://github.com/astriaorg/astria/pull/1905).
 
 ## [1.0.0] - 2024-10-25
 

--- a/crates/astria-sequencer/src/transaction/checks.rs
+++ b/crates/astria-sequencer/src/transaction/checks.rs
@@ -100,7 +100,7 @@ pub(crate) async fn get_total_transaction_cost<S: StateRead>(
             }
             Action::BridgeUnlock(act) => {
                 let asset = state
-                    .get_bridge_account_ibc_asset(&tx)
+                    .get_bridge_account_ibc_asset(&act.bridge_address)
                     .await
                     .wrap_err("failed to get bridge account asset id")?;
                 cost_by_asset

--- a/crates/astria-sequencer/src/transaction/checks.rs
+++ b/crates/astria-sequencer/src/transaction/checks.rs
@@ -160,12 +160,20 @@ mod tests {
             StateReadExt,
             StateWriteExt as _,
         },
-        app::test_utils::*,
+        app::{
+            benchmark_and_test_utils::{
+                ALICE_ADDRESS,
+                BOB_ADDRESS,
+            },
+            test_utils::*,
+        },
         assets::StateWriteExt as _,
         benchmark_and_test_utils::{
+            astria_address_from_hex_string,
             nria,
             ASTRIA_PREFIX,
         },
+        bridge::StateWriteExt,
         fees::{
             StateReadExt as _,
             StateWriteExt as _,
@@ -348,5 +356,58 @@ mod tests {
                 .to_string()
                 .contains(&other_asset.to_ibc_prefixed().to_string())
         );
+    }
+
+    #[tokio::test]
+    async fn get_total_transaction_cost_bridge_unlock_with_withdrawer_address_ok() {
+        let storage = cnidarium::TempStorage::new().await.unwrap();
+        let snapshot = storage.latest_snapshot();
+        let mut state_tx = StateDelta::new(snapshot);
+
+        let withdrawer = get_alice_signing_key();
+        let withdrawer_address = astria_address_from_hex_string(ALICE_ADDRESS);
+        let bridge_address = astria_address_from_hex_string(BOB_ADDRESS);
+
+        state_tx.put_base_prefix("astria".to_string()).unwrap();
+        state_tx.put_native_asset(nria()).unwrap();
+        state_tx
+            .put_fees(FeeComponents::<BridgeUnlock>::new(0, 0))
+            .unwrap();
+        state_tx
+            .put_account_balance(&bridge_address, &nria(), 1000)
+            .unwrap();
+        state_tx
+            .put_account_balance(&withdrawer_address, &nria(), 1000)
+            .unwrap();
+        state_tx
+            .put_bridge_account_ibc_asset(&bridge_address, nria())
+            .unwrap();
+        state_tx
+            .put_bridge_account_rollup_id(&bridge_address, [0; 32].into())
+            .unwrap();
+        state_tx
+            .put_bridge_account_withdrawer_address(&bridge_address, withdrawer_address)
+            .unwrap();
+
+        let actions = vec![Action::BridgeUnlock(BridgeUnlock {
+            to: withdrawer_address,
+            amount: 100,
+            fee_asset: nria().into(),
+            bridge_address,
+            memo: String::new(),
+            rollup_block_number: 1,
+            rollup_withdrawal_event_id: String::new(),
+        })];
+
+        let tx = TransactionBody::builder()
+            .actions(actions)
+            .chain_id("test-chain-id")
+            .try_build()
+            .unwrap();
+
+        let signed_tx = tx.sign(&withdrawer);
+        check_balance_for_total_fees_and_transfers(&signed_tx, &state_tx)
+            .await
+            .unwrap();
     }
 }

--- a/crates/astria-sequencer/src/transaction/checks.rs
+++ b/crates/astria-sequencer/src/transaction/checks.rs
@@ -157,7 +157,7 @@ mod tests {
     use crate::{
         accounts::StateWriteExt as _,
         address::{
-            StateReadExt,
+            StateReadExt as _,
             StateWriteExt as _,
         },
         app::{
@@ -173,7 +173,7 @@ mod tests {
             nria,
             ASTRIA_PREFIX,
         },
-        bridge::StateWriteExt,
+        bridge::StateWriteExt as _,
         fees::{
             StateReadExt as _,
             StateWriteExt as _,
@@ -368,8 +368,6 @@ mod tests {
         let withdrawer_address = astria_address_from_hex_string(ALICE_ADDRESS);
         let bridge_address = astria_address_from_hex_string(BOB_ADDRESS);
 
-        state_tx.put_base_prefix("astria".to_string()).unwrap();
-        state_tx.put_native_asset(nria()).unwrap();
         state_tx
             .put_fees(FeeComponents::<BridgeUnlock>::new(0, 0))
             .unwrap();


### PR DESCRIPTION
## Summary
Changed bridge unlock cost calculation to use bridge address instead of signer address.

## Background
Previously, the `get_total_transaction_cost` attempted to retrieve the bridge account asset by the tx signer instead of by the bridge address. This works fine if the sender is a bridge account, but if it is the authorized bridge withdrawer, it will fail.

## Changes
- Change `BridgeUnlock` cost calculation to retrieve asset based on the action's bridge address instead of the transaction signer.

## Testing
Added unit test to ensure function works correctly when submitting a `BridgeUnlock` from the bridge withdrawer address.

Synced to mainnet from genesis to ensure this would not be a network breaking change.

## Changelogs
Changelog updates.

## Breaking Changelist
- This change is breaking since previous `BridgeUnlock` submitted from the withdrawer address would fail. This has been synced to mainnet successfully from genesis as of January 13, 2025 at 2:32pm CST.

## Related Issues
closes #1904
