### PR TITLE
refactor(sequencer): clarify transaction cost estimation

### DIFF
--- a/crates/astria-sequencer/src/transaction/checks.rs
+++ b/crates/astria-sequencer/src/transaction/checks.rs
@@ -77,6 +77,18 @@ pub(crate) async fn get_total_transaction_cost<S: StateRead>(
             .await
             .context("failed to get fees for transaction")?;
 
+    add_total_transfers_for_transaction(tx, state, &mut cost_by_asset)
+        .await
+        .context("failed to add total transfers for transaction")?;
+
+    Ok(cost_by_asset)
+}
+
+async fn add_total_transfers_for_transaction<S: StateRead>(
+    tx: &Transaction,
+    state: &S,
+    cost_by_asset: &mut HashMap<asset::IbcPrefixed, u128>,
+) -> Result<()> {
     // add values transferred within the tx to the cost
     for action in tx.actions() {
         match action {
@@ -123,7 +135,7 @@ pub(crate) async fn get_total_transaction_cost<S: StateRead>(
         }
     }
 
-    Ok(cost_by_asset)
+    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
Refactored calculation of total transfers made in a transaction to helper function for clarity.

## Background
See here: https://github.com/astriaorg/astria/pull/1905#pullrequestreview-2542728784

> I think we should remove this function entirely in favor of two functions, `calculate_fees_for_transaction` (already exists) and `calculate_funds_moved_by_transaction` (essentially move the loop over the actions to it). The check for enough funds would then take the result of both methods.

## Changes
- Moved calculation of all transfers made in a transaction to helper function, and called this helper function in `get_total_transaction_cost()`.

## Testing
Passing all tests, no additional tests needed.

## Changelogs
No updates required.

## Related Issues
closes #1907
