### PR TITLE
chore(charts): Auctioneer: Expose grpc port of the evm-rollup

### DIFF
--- a/charts/evm-rollup/templates/service.yaml
+++ b/charts/evm-rollup/templates/service.yaml
@@ -13,6 +13,9 @@ spec:
     - name: ws-rpc-svc
       port: {{ .Values.ports.wsRPC }}
       targetPort: ws-rpc
+    - name: exec-grpc-svc
+      port: {{ .Values.ports.executionGRPC }}
+      targetPort: execution-grpc
 ---
 {{- if .Values.metrics.enabled }}
 kind: Service


### PR DESCRIPTION
## Summary
The grpc port of the evm-rollup needs to exposed in order for the auctioneer node to send optimistic blocks to be executed.

## Changes
- exposed the grpc port in the `evm-rollup/templates/service.yaml` file

## Testing
Deployed the auctioneer setup locally and sent a bundle
