### PR TITLE
chore(clippy): ignore CometBFT as an identifier

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+doc-valid-idents = ["CometBFT", ".."]


### PR DESCRIPTION
## Summary
Allows writing CometBFT without backticks in Rust doc comments.

## Background
Clippy's pedantic settings consider CometBFT a Rust identifier because of its CamelCase. That's annoying, because it's actually the name of the consensus implementation we are using.

## Changes
- Create a `clippy.toml` in the root of the repository.
- Add `doc-allowed-idents = ["CometBFT"]` to it.

## Testing
Writing `CometBFT` in a Rust doc no longer triggers a clippy warning (no lines in this PR).