### PR TITLE
fix(conductor): remove panic source on shutdown

### DIFF
--- a/crates/astria-conductor/CHANGELOG.md
+++ b/crates/astria-conductor/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update `idna` dependency to resolve cargo audit warning [#1869](https://github.com/astriaorg/astria/pull/1869).
+- Remove panic source on shutdown [#1919](https://github.com/astriaorg/astria/pull/1919).
 
 ## [1.0.0] - 2024-10-25
 

--- a/crates/astria-conductor/src/conductor/inner.rs
+++ b/crates/astria-conductor/src/conductor/inner.rs
@@ -44,6 +44,16 @@ pub(super) enum RestartOrShutdown {
     Shutdown,
 }
 
+impl std::fmt::Display for RestartOrShutdown {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let msg = match self {
+            RestartOrShutdown::Restart => "restarting",
+            RestartOrShutdown::Shutdown => "shutting down",
+        };
+        f.write_str(msg)
+    }
+}
+
 enum ExitReason {
     ShutdownSignal,
     TaskFailed {


### PR DESCRIPTION
## Summary
Removes a panic source in the conductor frontend by moving around the restart logic.

## Background
`Conductor::run_until_stopped` contains a loop to allow restarting its backend business logic. This loop delegates to a `Conductor::restart_or_shutdown` method to execute the restart of the backend, and then immediately reenters the loop no matter a restart happened or not.

While refactoring the inner conductor business logic (which lead to slightly different return values in turn affecting the blackbox test assertions) it was found that behavior can lead to the conductor backend panicking because it's being polled again even after running to completion.


## Changes
- Rename `Conductor::shutdown_or_restart` to `Conductor::restart_or_shutdown` to match the enum it's branching on.
- Execute the restart inside the frontend loop to not reentering it, avoiding to poll the already completed backend task.

## Testing 
This can't really be tested. But it does fix the panic in the refactor PR.

## Changelogs
Changelogs updated.