### PR TITLE
chore(composer): improve blackbox test efficiency

### DIFF
--- a/crates/astria-composer/tests/blackbox/geth_collector.rs
+++ b/crates/astria-composer/tests/blackbox/geth_collector.rs
@@ -24,9 +24,12 @@ async fn tx_from_one_rollup_is_received_by_sequencer() {
         .push_tx(Transaction::default())
         .unwrap();
 
-    // wait for 1 sequencer block time to make sure the bundle is preempted
+    // manually tick block timer to preempt next bundle
+    test_composer.tick_block_timer().await;
+
+    // give composer 100ms after sequencer block time to broadcast tx
     tokio::time::timeout(
-        Duration::from_millis(test_composer.cfg.block_time_ms),
+        Duration::from_millis(100),
         mock_guard.wait_until_satisfied(),
     )
     .await
@@ -56,11 +59,13 @@ async fn collector_restarts_after_exit() {
         .push_tx(Transaction::default())
         .unwrap();
 
-    // wait for 1 sequencer block time to make sure the bundle is preempted
-    // we added an extra 1000ms to the block time to make sure the collector has restarted
+    // manually tick block timer to preempt next bundle
+    test_composer.tick_block_timer().await;
+
+    // Allow an extra 100ms to the block time to make sure the collector has restarted
     // as the collector has to establish a new subscription on start up.
     tokio::time::timeout(
-        Duration::from_millis(test_composer.cfg.block_time_ms + 1000),
+        Duration::from_millis(100),
         mock_guard.wait_until_satisfied(),
     )
     .await
@@ -97,9 +102,12 @@ async fn invalid_nonce_causes_resubmission_under_different_nonce() {
         .push_tx(Transaction::default())
         .unwrap();
 
-    // wait for 1 sequencer block time to make sure the bundle is preempted
+    // manually ticker block timer to preempt next bundle
+    test_composer.tick_block_timer().await;
+
+    // give composer 100ms after block time to hit invalid nonce guard
     tokio::time::timeout(
-        Duration::from_millis(test_composer.cfg.block_time_ms),
+        Duration::from_millis(100),
         invalid_nonce_guard.wait_until_satisfied(),
     )
     .await
@@ -143,9 +151,12 @@ async fn nonce_taken_causes_resubmission_under_different_nonce() {
         .push_tx(Transaction::default())
         .unwrap();
 
-    // wait for 1 sequencer block time to make sure the bundle is preempted
+    // manually ticker block timer to preempt next bundle
+    test_composer.tick_block_timer().await;
+
+    // give composer 100ms after block time to hit invalid nonce guard
     tokio::time::timeout(
-        Duration::from_millis(test_composer.cfg.block_time_ms + 1000),
+        Duration::from_millis(100),
         invalid_nonce_guard.wait_until_satisfied(),
     )
     .await
@@ -171,9 +182,12 @@ async fn single_rollup_tx_payload_integrity() {
 
     test_composer.rollup_nodes["test1"].push_tx(tx).unwrap();
 
-    // wait for 1 sequencer block time to make sure the bundle is preempted
+    // manually tick block timer to preempt next bundle
+    test_composer.tick_block_timer().await;
+
+    // give composer 100ms after sequencer block time to broadcast tx
     tokio::time::timeout(
-        Duration::from_millis(test_composer.cfg.block_time_ms),
+        Duration::from_millis(100),
         mock_guard.wait_until_satisfied(),
     )
     .await

--- a/crates/astria-composer/tests/blackbox/grpc_collector.rs
+++ b/crates/astria-composer/tests/blackbox/grpc_collector.rs
@@ -42,9 +42,12 @@ async fn tx_from_one_rollup_is_received_by_sequencer() {
         .await
         .expect("rollup transactions should have been submitted successfully to grpc collector");
 
-    // wait for 1 sequencer block time to make sure the bundle is preempted
+    // manually tick block timer to preempt next bundle
+    test_composer.tick_block_timer().await;
+
+    // give composer 100ms after sequencer block time to broadcast tx
     tokio::time::timeout(
-        Duration::from_millis(test_composer.cfg.block_time_ms),
+        Duration::from_millis(100),
         mock_guard.wait_until_satisfied(),
     )
     .await
@@ -91,9 +94,12 @@ async fn invalid_nonce_causes_resubmission_under_different_nonce() {
         .await
         .expect("rollup transactions should have been submitted successfully to grpc collector");
 
-    // wait for 1 sequencer block time to make sure the bundle is preempted
+    // manually tick block timer to preempt next bundle
+    test_composer.tick_block_timer().await;
+
+    // give composer 100ms to hit invalid nonce guard
     tokio::time::timeout(
-        Duration::from_millis(test_composer.cfg.block_time_ms),
+        Duration::from_millis(100),
         invalid_nonce_guard.wait_until_satisfied(),
     )
     .await
@@ -133,9 +139,12 @@ async fn single_rollup_tx_payload_integrity() {
         .await
         .expect("rollup transactions should have been submitted successfully to grpc collector");
 
-    // wait for 1 sequencer block time to make sure the bundle is preempted
+    // manually tick block timer to preempt next bundle
+    test_composer.tick_block_timer().await;
+
+    // give composer 100ms after sequencer block time to broadcast tx
     tokio::time::timeout(
-        Duration::from_millis(test_composer.cfg.block_time_ms),
+        Duration::from_millis(100),
         mock_guard.wait_until_satisfied(),
     )
     .await

--- a/crates/astria-composer/tests/blackbox/helper/mod.rs
+++ b/crates/astria-composer/tests/blackbox/helper/mod.rs
@@ -116,16 +116,14 @@ pub struct TestComposer {
 impl TestComposer {
     pub async fn tick_block_timer(&self) {
         use tokio::time::{
-            pause,
-            resume,
-            sleep,
+            self,
             Duration,
         };
 
-        sleep(Duration::from_millis(10)).await;
-        pause();
-        sleep(Duration::from_millis(self.cfg.block_time_ms)).await;
-        resume();
+        time::sleep(Duration::from_millis(10)).await;
+        time::pause();
+        time::advance(Duration::from_millis(self.cfg.block_time_ms)).await;
+        time::resume();
     }
 }
 

--- a/crates/astria-composer/tests/blackbox/helper/mod.rs
+++ b/crates/astria-composer/tests/blackbox/helper/mod.rs
@@ -122,7 +122,7 @@ impl TestComposer {
             Duration,
         };
 
-        sleep(Duration::from_millis(100)).await;
+        sleep(Duration::from_millis(10)).await;
         pause();
         sleep(Duration::from_millis(self.cfg.block_time_ms)).await;
         resume();


### PR DESCRIPTION
## Summary
Improves composer testing efficiency by manually ticking the executor's block timer to preempt bundle submission instead of waiting.

## Background
Previously, `loop_until_composer_is_ready()` had a minimum of a 1 second delay, which many of the blackbox tests became reliant on to trigger bundle submission. This change removes the delay in looping until composer is ready, opting to manually tick the block timer via `tokio::time`.

## Changes
- Removed delay in `loop_until_composer_is_ready()` in favor of `tokio::task::yield_now()`.
- Added `TestComposer` method `tick_block_timer`, which sleeps for 10ms to allow for tx submission from the rollup before ticking the block timer (lowest latency I found to be consistently successful), then advances time by `block_time_ms` to trigger bundle submission.
- Made all testing timeouts 100ms and added calls to `tick_block_timer`

## Testing
All tests passing consistently, blackbox tests now run consistently within ~2s locally.

## Changelogs
No updates required.

## Related Issues
closes #1920
