### PR TITLE
chore(ci): update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,33 @@
-* @joroshiba @SuperFluffy @noot
+* @joroshiba
 
-*.snap @joroshiba
+astria-bridge-contracts/ @SuperFluffy @joroshiba
+astria-bridge-withdrawer/ @SuperFluffy @joroshiba
+astria-build-info/ @SuperFluffy @joroshiba
+astria-cli/ @SuperFluffy @joroshiba
+astria-composer/ @SuperFluffy @joroshiba
+astria-conductor/ @SuperFluffy @joroshiba
+astria-config/ @SuperFluffy @joroshiba
+astria-core/ @SuperFluffy @fraser999
+astria-core-address/ @SuperFluffy @fraser999
+astria-core-consts/ @SuperFluffy @fraser999
+astria-core-crypto/ @SuperFluffy @fraser999
+astria-eyre/ @SuperFluffy @fraser999
+astria-grpc-mock/ @SuperFluffy @fraser999
+astria-grpc-mock-test/ @SuperFluffy @fraser999
+astria-grpc-mock-test-codegen/ @SuperFluffy @fraser999
+astria-merkle/ @SuperFluffy @joroshiba
+astria-sequencer/ @noot @fraser999
+astria-sequencer-client/ @SuperFluffy @fraser999
+astria-sequencer-relayer/ @fraser999 @SuperFluffy
+astria-sequencer-utils/ @fraser999 @noot
+astria-telemetry/ @SuperFluffy @fraser999
+astria-test-utils/ @SuperFluffy @joroshiba
+
+tools/astria-address @SuperFluffy @joroshiba
+tools/protobuf-compiler @SuperFluffy @joroshiba
+tools/solidity-compiler @SuperFluffy @joroshiba
+
+*.snap @joroshiba @SuperFluffy @fraser999
 
 specs/ @astriaorg/engineering
 justfile @astriaorg/engineering
@@ -10,7 +37,9 @@ taplo.toml @astriaorg/engineering
 .gitignore @astriaorg/engineering
 
 /.github/ @astriaorg/infra
-/containerfiles/ @astriaorg/infra
+/.github/workflows/lint.yml @superfluffy @fraser999
+/.github/workflows/test.yml @superfluffy @fraser999
+/containerfiles/ @superfluffy @fraser999
 /charts/ @astriaorg/infra
 /dev/ @astriaorg/infra
 .dockerignore @astriaorg/infra
@@ -22,11 +51,9 @@ buf.lock @astriaorg/api-reviewers
 buf.yaml @astriaorg/api-reviewers
 buf.work.yaml @astriaorg/api-reviewers
 
-*.rs @astriaorg/rust-reviewers
-Cargo.toml @astriaorg/rust-reviewers
-Cargo.lock @astriaorg/rust-reviewers
-rust-toolchain @astriaorg/rust-reviewers
-.cargo/ @astriaorg/rust-reviewers
-nextest.toml @astriaorg/rust-reviewers
-rusfmt.toml @astriaorg/rust-reviewers
-crates/*/CHANGELOG.md @astriaorg/rust-reviewers
+/Cargo.toml @SuperFluffy @fraser999
+/Cargo.lock @SuperFluffy @fraser999
+/rust-toolchain @SuperFluffy @fraser999
+/.cargo/ @SuperFluffy @fraser999
+/nextest.toml @SuperFluffy @fraser999
+/rusfmt.toml @SuperFluffy @fraser999


### PR DESCRIPTION
## Summary

Update CODEOWNERS allocate by project.

## Background
The previous CODEOWNERS file assigned reviews mainly by language (which is rust), which is no longer workable for a growing project leading to a) review bottlenecks, and b) unclear responsibilities over project-local styles and cognitive models on how to evolve the codebase.

The present changes have a BDFL model in mind, where the CODEOWNERS get the final vote over modifications to their crates.

## Changes
- Remove any `@astriaorg/rust-reviewers` from the CODEOWNERS file
- Allocate crate ownership by project to @Fraser999, @noot, @SuperFluffy, and @joroshiba.
- Remove the `*.rs` catchall
- Assign rust-specific config files (`Cargo.toml`, and `Cargo.lock`, `rustfmt.toml`, `nextest.toml`, `rust-toolchain`, `.cargo/`) relative to CODEWONERS at the repository root to @SuperFluffy and @Fraser999 
- Reassign ownership of the workflows `.github/workflows/test.yml` and `.github/workflows/lint.yml` to @Fraser999 and @SuperFluffy

## Testing
Github confirms this is a valid CODEOWNERS file. Other than that this cannot be tested.

## Changelogs
No updates required.

