### PR TITLE
chore: make @ethanoroshiba conductor codeowner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,7 +5,7 @@ astria-bridge-withdrawer/ @SuperFluffy @joroshiba
 astria-build-info/ @SuperFluffy @joroshiba
 astria-cli/ @SuperFluffy @joroshiba
 astria-composer/ @SuperFluffy @joroshiba
-astria-conductor/ @SuperFluffy @joroshiba
+astria-conductor/ @SuperFluffy @ethanoroshiba @joroshiba
 astria-config/ @SuperFluffy @joroshiba
 astria-core/ @SuperFluffy @fraser999
 astria-core-address/ @SuperFluffy @fraser999


### PR DESCRIPTION
## Summary
Adds @ethanoroshiba to the `crates/astria-conductor` line in CODEOWNERS.