### PR TITLE
chore(grpc-mock): make Times part of public API

### DIFF
--- a/crates/astria-grpc-mock/CHANGELOG.md
+++ b/crates/astria-grpc-mock/CHANGELOG.md
@@ -11,4 +11,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Export `Times` at the root of the crate. [#1945](https://github.com/astriaorg/astria/pull/1945)
 - Initial release.

--- a/crates/astria-grpc-mock/src/lib.rs
+++ b/crates/astria-grpc-mock/src/lib.rs
@@ -20,6 +20,7 @@ mod verification;
 pub use mock::{
     Match,
     Mock,
+    Times,
 };
 pub use mock_server::{
     MockGuard,


### PR DESCRIPTION
## Summary
Makes the `astria_grpc_mock::mock::Times` part of the public API.

## Background
Having `Times` (which itself is wrapper around `u64` or one of the Rust `Range*` types) part of the public API is useful when writing abstraction tests.

## Changes
- Export `astria_grpc_mock::mock::Times` at the root of the crate.

## Testing
Not applicable. The type is now available.

## Changelogs
Changelogs updated.