### PR TITLE
chore(sequencer): implement market endpoint

### DIFF
--- a/crates/astria-sequencer/src/sequencer.rs
+++ b/crates/astria-sequencer/src/sequencer.rs
@@ -5,10 +5,7 @@ use astria_core::generated::{
     connect::{
         marketmap::v2::query_server::QueryServer as MarketMapQueryServer,
         oracle::v2::query_server::QueryServer as OracleQueryServer,
-        service::v2::{
-            oracle_client::OracleClient,
-            QueryPricesRequest,
-        },
+        service::v2::oracle_client::OracleClient,
     },
 };
 use astria_eyre::{
@@ -385,16 +382,12 @@ async fn new_oracle_client(config: &Config) -> Result<Option<OracleClient<Channe
 
 #[instrument(skip_all, err(level = tracing::Level::WARN))]
 async fn connect_to_oracle(endpoint: &Endpoint, uri: &Uri) -> Result<OracleClient<Channel>> {
-    let mut oracle_client = OracleClient::new(
+    let oracle_client = OracleClient::new(
         endpoint
             .connect()
             .await
             .wrap_err("failed to connect to oracle sidecar")?,
     );
-    let _ = oracle_client
-        .prices(QueryPricesRequest::default())
-        .await
-        .wrap_err("oracle sidecar responded with error to query for prices");
     debug!(uri = %uri, "oracle sidecar is reachable");
     Ok(oracle_client)
 }


### PR DESCRIPTION
## Summary
This is a small PR to address a couple of minor omissions: implementing a query endpoint, and removing a needless RPC call.

## Background
These are likely just small omissions from previous work/discussions.

## Changes
- Updated `MarketMapQueryService::market` to not always return a "not implemented" error response.
- Changed initial connection attempts to oracle sidecar to not actually send a request.

## Testing
Manually tested both changes locally.  The former would ideally have unit tests, but this entire module is not unit tested.  The latter is harder to create a meaningful unit test for, but new smoke tests using the sidecar will make it apparent if this function is broken.

## Changelogs
No updates required.
