### PR TITLE
feat(telemetry): emit span events for span construction, deletion

### DIFF
--- a/crates/astria-telemetry/CHANGELOG.md
+++ b/crates/astria-telemetry/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Emit events on span construction or deletion in human readable logs
+  [#1947](https://github.com/astriaorg/astria/pull/1947).
+
 ### Added
 
 - Initial release.

--- a/crates/astria-telemetry/src/lib.rs
+++ b/crates/astria-telemetry/src/lib.rs
@@ -34,6 +34,7 @@ use tracing_subscriber::{
         LevelFilter,
         ParseError,
     },
+    fmt::format::FmtSpan,
     layer::SubscriberExt as _,
     util::{
         SubscriberInitExt as _,
@@ -229,7 +230,11 @@ impl Config {
         let mut pretty_printer = None;
         if force_stdout || std::io::stdout().is_terminal() {
             if pretty_print {
-                pretty_printer = Some(tracing_subscriber::fmt::layer().compact());
+                pretty_printer = Some(
+                    tracing_subscriber::fmt::layer()
+                        .compact()
+                        .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE),
+                );
             } else {
                 tracer_provider = tracer_provider.with_simple_exporter(
                     SpanExporter::builder()


### PR DESCRIPTION
## Summary
Instructs the tracing formatting subscriber to emit span events for event construction and deletion.

## Background
Developers frequently add an event at the beginning of a function to get information on whether a function is invoked. In tracing telemetry this is strictly speaking superfluous because the existence of a span already implies this information. If Astriia's services were primarily observed via an opentelemetry platform, then this issue wouldn't arise in the first place. But since events/logs are still consumed as plain text, we should mimick this behavior by emitting events when a particular unit of processing is started or finished.

Note that this will lead to noisier logs, but that is a justifiable tradeoff because this information is frequently needed when debugging services.

## Changes
- Change Astria's human readable trace/event output to constructs events when spans are constructed or deleted (which usually means that an instrumented function or method is invoked or finished).

## Testing
These changes can be observed when running a service locally.

## Changelogs
Changelog updated.