### PR TITLE
fix(ci): tag images with full commit sha

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -67,7 +67,8 @@ jobs:
           tags: |
             type=ref,event=pr
             type=match,pattern=refs/tags/${{ inputs.binary-name }}-v(.*),group=1,enable=${{ startsWith(env.FULL_REF, 'refs/tags/') }},value=${{ env.FULL_REF }}
-            type=sha
+            type=sha,format=short
+            type=sha,format=long
             # set the actual commit SHA from the PR head instead of from the PR merge commit (alternatively, we could checkout the PR head in actions/checkout)
             type=raw,value=sha-${{ github.event.pull_request.head.sha || github.sha }},enable=${{ startsWith(env.FULL_REF, 'refs/pull/') }}
             # set latest tag for `main` branch


### PR DESCRIPTION
## Summary
Adds an additional tag to docker images corresponding to the full commit hash.  

## Background
Manually running github actions to build a docker image was not setting the full sha hash, which argocd uses to pull images. This should always set at least the full hash to the merge commit of a PR. 

## Changes
Updated the docker metadata step to include an additional tag

## Testing
Manually with PR commit and triggering GH action. 

## Changelogs
 "No updates required." 

