### PR TITLE
feat(auctioneer): add metrics

### DIFF
--- a/crates/astria-auctioneer/CHANGELOG.md
+++ b/crates/astria-auctioneer/CHANGELOG.md
@@ -11,4 +11,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Initial release [#1839](https://github.com/astriaorg/astria/pull/1839)
+- Added initial set of metrics [#1953](https://github.com/astriaorg/astria/pull/1953).
+- Initial release [#1839](https://github.com/astriaorg/astria/pull/1839).

--- a/crates/astria-auctioneer/Cargo.toml
+++ b/crates/astria-auctioneer/Cargo.toml
@@ -12,11 +12,9 @@ homepage = "https://astria.org"
 astria-build-info = { path = "../astria-build-info", features = ["runtime"] }
 astria-core = { path = "../astria-core", features = ["serde", "client"] }
 astria-eyre = { path = "../astria-eyre" }
+astria-telemetry = { path = "../astria-telemetry", features = ["display"] }
 config = { package = "astria-config", path = "../astria-config" }
 sequencer_client = { package = "astria-sequencer-client", path = "../astria-sequencer-client" }
-telemetry = { package = "astria-telemetry", path = "../astria-telemetry", features = [
-  "display",
-] }
 
 base64 = { workspace = true }
 bytes = { workspace = true }

--- a/crates/astria-auctioneer/src/auctioneer/auction/allocation_rule.rs
+++ b/crates/astria-auctioneer/src/auctioneer/auction/allocation_rule.rs
@@ -11,12 +11,14 @@ use super::Bid;
 
 pub(super) struct FirstPrice {
     highest_bid: Option<Arc<Bid>>,
+    bids_seen: usize,
 }
 
 impl FirstPrice {
     pub(super) fn new() -> Self {
         Self {
             highest_bid: None,
+            bids_seen: 0,
         }
     }
 
@@ -29,6 +31,7 @@ impl FirstPrice {
         candidate.bid = candidate.bid(),
     ))]
     pub(super) fn bid(&mut self, candidate: &Arc<Bid>) {
+        self.bids_seen = self.bids_seen.saturating_add(1);
         let winner = if let Some(current) = self.highest_bid.as_mut() {
             if candidate.bid() > current.bid() {
                 *current = candidate.clone();
@@ -43,8 +46,12 @@ impl FirstPrice {
         info!("highest bidder is {winner}");
     }
 
+    pub(super) fn bids_seen(&self) -> usize {
+        self.bids_seen
+    }
+
     /// Returns the winner of the auction, if one exists.
-    pub(super) fn winner(self) -> Option<Arc<Bid>> {
-        self.highest_bid
+    pub(super) fn take_winner(&mut self) -> Option<Arc<Bid>> {
+        self.highest_bid.take()
     }
 }

--- a/crates/astria-auctioneer/src/auctioneer/auction/factory.rs
+++ b/crates/astria-auctioneer/src/auctioneer/auction/factory.rs
@@ -42,6 +42,7 @@ pub(in crate::auctioneer) struct Factory {
     /// nonce from Sequencer in time. Starts unset at the beginning of the program and
     /// is set externally via `Factory::set_last_succesful_nonce`.
     pub(in crate::auctioneer) last_successful_nonce: Option<u32>,
+    pub(in crate::auctioneer) metrics: &'static crate::Metrics,
 }
 
 impl Factory {
@@ -70,6 +71,7 @@ impl Factory {
             rollup_id: self.rollup_id,
             cancellation_token: cancellation_token.clone(),
             last_successful_nonce: self.last_successful_nonce,
+            metrics: self.metrics,
         };
 
         Auction {

--- a/crates/astria-auctioneer/src/auctioneer/auction/factory.rs
+++ b/crates/astria-auctioneer/src/auctioneer/auction/factory.rs
@@ -84,6 +84,8 @@ impl Factory {
             bids: bids_tx,
             cancellation_token,
             worker: tokio::task::spawn(auction.run()),
+            metrics: self.metrics,
+            started_at: std::time::Instant::now(),
         }
     }
 

--- a/crates/astria-auctioneer/src/auctioneer/auction/worker.rs
+++ b/crates/astria-auctioneer/src/auctioneer/auction/worker.rs
@@ -200,8 +200,8 @@ impl Worker {
                 }, if latency_margin_timer.is_some() => {
                     info!("timer is up; bids left unprocessed: {}", self.bids.len());
 
-                    self.metrics.record_auction_bids_admitted_histogram(allocation_rule.bids_seen());
                     self.metrics.record_auction_bids_dropped_histogram(self.bids.len());
+                    self.metrics.record_auction_bids_processed_histogram(allocation_rule.bids_seen());
 
                     let winner = allocation_rule.take_winner();
                     if let Some(winner) = &winner {

--- a/crates/astria-auctioneer/src/auctioneer/auction/worker.rs
+++ b/crates/astria-auctioneer/src/auctioneer/auction/worker.rs
@@ -203,8 +203,13 @@ impl Worker {
                     self.metrics.record_auction_bids_admitted_histogram(allocation_rule.bids_seen());
                     self.metrics.record_auction_bids_dropped_histogram(self.bids.len());
 
+                    let winner = allocation_rule.take_winner();
+                    if let Some(winner) = &winner {
+                        self.metrics.record_auction_winning_bid_histogram(winner.bid());
+                    }
+
                     break Ok(AuctionItems {
-                        winner: allocation_rule.take_winner(),
+                        winner,
                         nonce_fetch,
                     })
                 }

--- a/crates/astria-auctioneer/src/lib.rs
+++ b/crates/astria-auctioneer/src/lib.rs
@@ -73,7 +73,6 @@ use astria_eyre::eyre::{
 pub use build_info::BUILD_INFO;
 pub use config::Config;
 pub use metrics::Metrics;
-pub use telemetry;
 use tokio::task::{
     JoinError,
     JoinHandle,
@@ -92,9 +91,9 @@ impl Auctioneer {
     ///
     /// # Errors
     /// Returns an error if the Auctioneer cannot be initialized.
-    pub fn spawn(cfg: Config, _metrics: &'static Metrics) -> eyre::Result<Self> {
+    pub fn spawn(cfg: Config, metrics: &'static Metrics) -> eyre::Result<Self> {
         let shutdown_token = CancellationToken::new();
-        let inner = auctioneer::Auctioneer::new(cfg, shutdown_token.child_token())?;
+        let inner = auctioneer::Auctioneer::new(cfg, metrics, shutdown_token.child_token())?;
         let task = tokio::spawn(inner.run());
 
         Ok(Self {

--- a/crates/astria-auctioneer/src/main.rs
+++ b/crates/astria-auctioneer/src/main.rs
@@ -28,7 +28,7 @@ use tracing::{
 async fn main() -> ExitCode {
     astria_eyre::install().expect("astria eyre hook must be the first hook installed");
 
-    eprintln!("{}", telemetry::display::json(&BUILD_INFO));
+    eprintln!("{}", astria_telemetry::display::json(&BUILD_INFO));
 
     let cfg: Config = match config::get() {
         Err(err) => {
@@ -39,23 +39,23 @@ async fn main() -> ExitCode {
     };
     eprintln!(
         "starting with configuration:\n{}",
-        telemetry::display::json(&cfg),
+        astria_telemetry::display::json(&cfg),
     );
 
-    let mut telemetry_conf = telemetry::configure()
+    let mut astria_telemetry_conf = astria_telemetry::configure()
         .set_no_otel(cfg.no_otel)
         .set_force_stdout(cfg.force_stdout)
         .set_pretty_print(cfg.pretty_print)
         .set_filter_directives(&cfg.log);
 
     if !cfg.no_metrics {
-        telemetry_conf =
-            telemetry_conf.set_metrics(&cfg.metrics_http_listener_addr, env!("CARGO_PKG_NAME"));
+        astria_telemetry_conf = astria_telemetry_conf
+            .set_metrics(&cfg.metrics_http_listener_addr, env!("CARGO_PKG_NAME"));
     }
 
-    let (metrics, _telemetry_guard) = match telemetry_conf
+    let (metrics, _astria_telemetry_guard) = match astria_telemetry_conf
         .try_init(&())
-        .wrap_err("failed to setup telemetry")
+        .wrap_err("failed to setup astria_telemetry")
     {
         Err(e) => {
             eprintln!("initializing auctioneer failed:\n{e:?}");

--- a/crates/astria-auctioneer/src/metrics.rs
+++ b/crates/astria-auctioneer/src/metrics.rs
@@ -1,25 +1,153 @@
-use telemetry::{
+use astria_telemetry::{
     metric_names,
     metrics::{
         self,
+        Counter,
+        Gauge,
+        IntoF64,
         RegisteringBuilder,
     },
 };
 
-pub struct Metrics {}
+const AUCTION_BIDS_PROCESSED_LABEL: &str = "auction_bids_processed";
+const AUCTION_BIDS_PROCESSED_ADMITTED: &str = "admitted";
+const AUCTION_BIDS_PROCESSED_DROPPED: &str = "dropped";
 
-impl Metrics {}
+pub struct Metrics {
+    auction_bids_admitted_gauge: Gauge,
+    auction_bids_dropped_gauge: Gauge,
+    auction_bids_received_count: Counter,
+    auctions_cancelled_count: Counter,
+    auctions_submitted_count: Counter,
+    block_commitments_received_count: Counter,
+    executed_blocks_received_count: Counter,
+    optimistic_blocks_received_count: Counter,
+}
 
-impl metrics::Metrics for Metrics {
+impl Metrics {
+    pub(crate) fn increment_auction_bids_admitted_gauge(&self) {
+        self.auction_bids_admitted_gauge.increment(1);
+    }
+
+    pub(crate) fn increment_auction_bids_received_counter(&self) {
+        self.auction_bids_received_count.increment(1);
+    }
+
+    pub(crate) fn increment_auctions_cancelled_count(&self) {
+        self.auctions_cancelled_count.increment(1);
+    }
+
+    pub(crate) fn increment_auctions_submitted_count(&self) {
+        self.auctions_submitted_count.increment(1);
+    }
+
+    pub(crate) fn increment_block_commitments_received_counter(&self) {
+        self.block_commitments_received_count.increment(1);
+    }
+
+    pub(crate) fn increment_executed_blocks_received_counter(&self) {
+        self.executed_blocks_received_count.increment(1);
+    }
+
+    pub(crate) fn increment_optimistic_blocks_received_counter(&self) {
+        self.optimistic_blocks_received_count.increment(1);
+    }
+
+    pub(crate) fn reset_auction_bids_admitted_gauge(&self) {
+        self.auction_bids_admitted_gauge.set(0);
+    }
+
+    pub(crate) fn set_auction_bids_dropped_gauge(&self, val: impl IntoF64) {
+        self.auction_bids_dropped_gauge.set(val);
+    }
+}
+
+impl astria_telemetry::metrics::Metrics for Metrics {
     type Config = ();
 
     fn register(
-        _builder: &mut RegisteringBuilder,
+        builder: &mut RegisteringBuilder,
         _config: &Self::Config,
     ) -> Result<Self, metrics::Error> {
-        Ok(Self {})
+        let block_commitments_received_count = builder
+            .new_counter_factory(
+                BLOCK_COMMITMENTS_RECEIVED,
+                "the number of block commitments received from the Sequencer node",
+            )?
+            .register()?;
+
+        let executed_blocks_received_count = builder
+            .new_counter_factory(
+                EXECUTED_BLOCKS_RECEIVED,
+                "the number of executed blocks received from the Rollup node",
+            )?
+            .register()?;
+
+        let optimistic_blocks_received_count = builder
+            .new_counter_factory(
+                OPTIMISTIC_BLOCKS_RECEIVED,
+                "the number of optimistic blocks received from the Sequencer node",
+            )?
+            .register()?;
+
+        let auction_bids_received_count = builder
+            .new_counter_factory(
+                AUCTION_BIDS_RECEIVED,
+                "the number of auction bids received from the Rollup node (total number over the \
+                 runtime of auctioneer)",
+            )?
+            .register()?;
+
+        let mut auction_bids_processed_factory = builder.new_gauge_factory(
+            AUCTION_BIDS_PROCESSED,
+            "the number of auction bids processed during an auction (either admitted or dropped \
+             because the time was up or due to some other issue)",
+        )?;
+        let auction_bids_admitted_gauge =
+            auction_bids_processed_factory.register_with_labels(&[(
+                AUCTION_BIDS_PROCESSED_LABEL,
+                AUCTION_BIDS_PROCESSED_ADMITTED.to_string(),
+            )])?;
+        let auction_bids_dropped_gauge =
+            auction_bids_processed_factory.register_with_labels(&[(
+                AUCTION_BIDS_PROCESSED_LABEL,
+                AUCTION_BIDS_PROCESSED_DROPPED.to_string(),
+            )])?;
+
+        let auctions_cancelled_count = builder
+            .new_counter_factory(
+                AUCTIONS_CANCELLED,
+                "the number of auctions that were cancelled due to a proposed block pre-empting a \
+                 prior proposed block",
+            )?
+            .register()?;
+
+        let auctions_submitted_count = builder
+            .new_counter_factory(
+                AUCTIONS_SUBMITTED,
+                "the number of successfully submitted auctions",
+            )?
+            .register()?;
+
+        Ok(Self {
+            auction_bids_admitted_gauge,
+            auction_bids_dropped_gauge,
+            auction_bids_received_count,
+            auctions_cancelled_count,
+            auctions_submitted_count,
+            block_commitments_received_count,
+            executed_blocks_received_count,
+            optimistic_blocks_received_count,
+        })
     }
 }
 
 metric_names!(const METRICS_NAMES:
+    BLOCK_COMMITMENTS_RECEIVED,
+    EXECUTED_BLOCKS_RECEIVED,
+    OPTIMISTIC_BLOCKS_RECEIVED,
+    AUCTIONS_CANCELLED,
+    AUCTIONS_SUBMITTED,
+    AUCTION_BIDS_PROCESSED,
+    AUCTION_BIDS_RECEIVED,
 );

--- a/crates/astria-auctioneer/src/metrics.rs
+++ b/crates/astria-auctioneer/src/metrics.rs
@@ -17,6 +17,7 @@ pub struct Metrics {
     auction_bids_admitted_histogram: Histogram,
     auction_bids_dropped_histogram: Histogram,
     auction_bids_received_count: Counter,
+    auction_winning_bid_histogram: Histogram,
     auctions_cancelled_count: Counter,
     auctions_submitted_count: Counter,
     block_commitments_received_count: Counter,
@@ -55,6 +56,10 @@ impl Metrics {
 
     pub(crate) fn record_auction_bids_dropped_histogram(&self, val: impl IntoF64) {
         self.auction_bids_dropped_histogram.record(val);
+    }
+
+    pub(crate) fn record_auction_winning_bid_histogram(&self, val: impl IntoF64) {
+        self.auction_winning_bid_histogram.record(val);
     }
 }
 
@@ -125,10 +130,15 @@ impl astria_telemetry::metrics::Metrics for Metrics {
             )?
             .register()?;
 
+        let auction_winning_bid_histogram = builder
+            .new_histogram_factory(AUCTION_WINNING_BID, "the amount bid by the auction winner")?
+            .register()?;
+
         Ok(Self {
             auction_bids_admitted_histogram,
             auction_bids_dropped_histogram,
             auction_bids_received_count,
+            auction_winning_bid_histogram,
             auctions_cancelled_count,
             auctions_submitted_count,
             block_commitments_received_count,
@@ -146,4 +156,5 @@ metric_names!(const METRICS_NAMES:
     AUCTIONS_SUBMITTED,
     AUCTION_BIDS_PROCESSED,
     AUCTION_BIDS_RECEIVED,
+    AUCTION_WINNING_BID,
 );

--- a/crates/astria-auctioneer/src/metrics.rs
+++ b/crates/astria-auctioneer/src/metrics.rs
@@ -14,6 +14,7 @@ const AUCTION_BIDS_PROCESSED: &str = "processed";
 const AUCTION_BIDS_DROPPED: &str = "dropped";
 
 pub struct Metrics {
+    auction_bid_delay_since_start: Histogram,
     auction_bids_dropped_histogram: Histogram,
     auction_bids_processed_histogram: Histogram,
     auction_bids_received_count: Counter,
@@ -56,6 +57,10 @@ impl Metrics {
 
     pub(crate) fn record_auction_bids_dropped_histogram(&self, val: impl IntoF64) {
         self.auction_bids_dropped_histogram.record(val);
+    }
+
+    pub(crate) fn record_auction_bid_delay_since_start(&self, val: impl IntoF64) {
+        self.auction_bid_delay_since_start.record(val);
     }
 
     pub(crate) fn record_auction_winning_bid_histogram(&self, val: impl IntoF64) {
@@ -128,7 +133,16 @@ impl astria_telemetry::metrics::Metrics for Metrics {
             .new_histogram_factory(AUCTION_WINNING_BID, "the amount bid by the auction winner")?
             .register()?;
 
+        let auction_bid_delay_since_start = builder
+            .new_histogram_factory(
+                AUCTION_BID_DELAY_SINCE_START,
+                "the duration from the start of an auction to when a bid for that auction was \
+                 received",
+            )?
+            .register()?;
+
         Ok(Self {
+            auction_bid_delay_since_start,
             auction_bids_dropped_histogram,
             auction_bids_processed_histogram,
             auction_bids_received_count,
@@ -148,6 +162,7 @@ metric_names!(const METRICS_NAMES:
     OPTIMISTIC_BLOCKS_RECEIVED,
     AUCTIONS_CANCELLED,
     AUCTIONS_SUBMITTED,
+    AUCTION_BID_DELAY_SINCE_START,
     AUCTION_BIDS,
     AUCTION_BIDS_RECEIVED,
     AUCTION_WINNING_BID,


### PR DESCRIPTION
## Summary
Extend Auctioneer by a first set of metrics.

## Background
Astria services must be observable, metrics are low hanging fruit.

## Changes
- Added metrics (see metrics section below for a list).

## Testing
This needs to be observed on a telemetry platform.

## Changelogs
Changelogs updated.

## Metrics

- astria_auctioneer_executed_blocks_received: counter
- astria_auctioneer_optimistic_blocks_received: coubter
- astria_auctioneer_auctions_cancelled: coubter
- astria_auctioneer_auctions_submitted: counter
- astria_auctioneer_auction_bids_processed: gauge (labels "processed" and "dropped")
- astria_auctioneer_auction_bids_received: counter

## Related Issues
closes #1915 
