### PR TITLE
fix(sequencer-cli): poll TX status to avoid looping indefinitely

### DIFF
--- a/crates/astria-bridge-withdrawer/src/bridge_withdrawer/submitter/mod.rs
+++ b/crates/astria-bridge-withdrawer/src/bridge_withdrawer/submitter/mod.rs
@@ -296,13 +296,10 @@ async fn submit_tx(
 
     ensure!(check_tx.code.is_ok(), "check_tx failed: {}", check_tx.log);
 
-    let tx_response = client.wait_for_tx_inclusion(check_tx.hash).await;
-
-    ensure!(
-        tx_response.tx_result.code.is_ok(),
-        "deliver_tx failed: {}",
-        tx_response.tx_result.log
-    );
+    let tx_response = client
+        .confirm_tx_inclusion(check_tx.hash)
+        .await
+        .wrap_err("failed to confirm transaction inclusion")?;
 
     Ok((check_tx, tx_response))
 }

--- a/crates/astria-cli/src/bridge/submit.rs
+++ b/crates/astria-cli/src/bridge/submit.rs
@@ -144,13 +144,11 @@ async fn submit_transaction(
         .await
         .wrap_err("failed to submit transaction")?;
 
-    let tx_response = client.wait_for_tx_inclusion(res.hash).await;
-
     ensure!(res.code.is_ok(), "failed to check tx: {}", res.log);
-    ensure!(
-        tx_response.tx_result.code.is_ok(),
-        "failed to execute tx: {}",
-        tx_response.tx_result.log
-    );
+
+    let tx_response = client
+        .confirm_tx_inclusion(res.hash)
+        .await
+        .wrap_err("failed to confirm transaction inclusion")?;
     Ok(tx_response)
 }

--- a/crates/astria-cli/src/sequencer/submit.rs
+++ b/crates/astria-cli/src/sequencer/submit.rs
@@ -41,13 +41,10 @@ impl Command {
 
         ensure!(res.code.is_ok(), "failed to check tx: {}", res.log);
 
-        let tx_response = sequencer_client.wait_for_tx_inclusion(res.hash).await;
-
-        ensure!(
-            tx_response.tx_result.code.is_ok(),
-            "failed to execute tx: {}",
-            tx_response.tx_result.log
-        );
+        let tx_response = sequencer_client
+            .confirm_tx_inclusion(res.hash)
+            .await
+            .wrap_err("failed to confirm transaction inclusion")?;
 
         println!("Submission completed!");
         println!("Included in block: {}", tx_response.height);

--- a/crates/astria-cli/src/utils.rs
+++ b/crates/astria-cli/src/utils.rs
@@ -52,7 +52,7 @@ pub(crate) async fn submit_transaction(
 
     ensure!(res.code.is_ok(), "failed to check tx: {}", res.log);
 
-    let tx_response = sequencer_client.wait_for_tx_inclusion(res.hash).await;
+    let tx_response = sequencer_client.confirm_tx_inclusion(res.hash).await?;
 
     ensure!(
         tx_response.tx_result.code.is_ok(),

--- a/crates/astria-core/src/generated/astria.protocol.transaction.v1.rs
+++ b/crates/astria-core/src/generated/astria.protocol.transaction.v1.rs
@@ -517,3 +517,52 @@ impl ::prost::Name for TransactionParams {
         ::prost::alloc::format!("astria.protocol.transaction.v1.{}", Self::NAME)
     }
 }
+/// The response payload for a `transaction/status` ABCI query
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TransactionStatusResponse {
+    #[prost(enumeration = "TransactionStatus", tag = "2")]
+    pub status: i32,
+}
+impl ::prost::Name for TransactionStatusResponse {
+    const NAME: &'static str = "TransactionStatusResponse";
+    const PACKAGE: &'static str = "astria.protocol.transaction.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.protocol.transaction.v1.{}", Self::NAME)
+    }
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum TransactionStatus {
+    Unspecified = 0,
+    Parked = 1,
+    Pending = 2,
+    RemovalCache = 3,
+    Unknown = 4,
+}
+impl TransactionStatus {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            TransactionStatus::Unspecified => "TRANSACTION_STATUS_UNSPECIFIED",
+            TransactionStatus::Parked => "TRANSACTION_STATUS_PARKED",
+            TransactionStatus::Pending => "TRANSACTION_STATUS_PENDING",
+            TransactionStatus::RemovalCache => "TRANSACTION_STATUS_REMOVAL_CACHE",
+            TransactionStatus::Unknown => "TRANSACTION_STATUS_UNKNOWN",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "TRANSACTION_STATUS_UNSPECIFIED" => Some(Self::Unspecified),
+            "TRANSACTION_STATUS_PARKED" => Some(Self::Parked),
+            "TRANSACTION_STATUS_PENDING" => Some(Self::Pending),
+            "TRANSACTION_STATUS_REMOVAL_CACHE" => Some(Self::RemovalCache),
+            "TRANSACTION_STATUS_UNKNOWN" => Some(Self::Unknown),
+            _ => None,
+        }
+    }
+}

--- a/crates/astria-core/src/generated/astria.protocol.transaction.v1.serde.rs
+++ b/crates/astria-core/src/generated/astria.protocol.transaction.v1.serde.rs
@@ -2492,6 +2492,179 @@ impl<'de> serde::Deserialize<'de> for TransactionParams {
         deserializer.deserialize_struct("astria.protocol.transaction.v1.TransactionParams", FIELDS, GeneratedVisitor)
     }
 }
+impl serde::Serialize for TransactionStatus {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let variant = match self {
+            Self::Unspecified => "TRANSACTION_STATUS_UNSPECIFIED",
+            Self::Parked => "TRANSACTION_STATUS_PARKED",
+            Self::Pending => "TRANSACTION_STATUS_PENDING",
+            Self::RemovalCache => "TRANSACTION_STATUS_REMOVAL_CACHE",
+            Self::Unknown => "TRANSACTION_STATUS_UNKNOWN",
+        };
+        serializer.serialize_str(variant)
+    }
+}
+impl<'de> serde::Deserialize<'de> for TransactionStatus {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "TRANSACTION_STATUS_UNSPECIFIED",
+            "TRANSACTION_STATUS_PARKED",
+            "TRANSACTION_STATUS_PENDING",
+            "TRANSACTION_STATUS_REMOVAL_CACHE",
+            "TRANSACTION_STATUS_UNKNOWN",
+        ];
+
+        struct GeneratedVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = TransactionStatus;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(formatter, "expected one of: {:?}", &FIELDS)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> std::result::Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                i32::try_from(v)
+                    .ok()
+                    .and_then(|x| x.try_into().ok())
+                    .ok_or_else(|| {
+                        serde::de::Error::invalid_value(serde::de::Unexpected::Signed(v), &self)
+                    })
+            }
+
+            fn visit_u64<E>(self, v: u64) -> std::result::Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                i32::try_from(v)
+                    .ok()
+                    .and_then(|x| x.try_into().ok())
+                    .ok_or_else(|| {
+                        serde::de::Error::invalid_value(serde::de::Unexpected::Unsigned(v), &self)
+                    })
+            }
+
+            fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                match value {
+                    "TRANSACTION_STATUS_UNSPECIFIED" => Ok(TransactionStatus::Unspecified),
+                    "TRANSACTION_STATUS_PARKED" => Ok(TransactionStatus::Parked),
+                    "TRANSACTION_STATUS_PENDING" => Ok(TransactionStatus::Pending),
+                    "TRANSACTION_STATUS_REMOVAL_CACHE" => Ok(TransactionStatus::RemovalCache),
+                    "TRANSACTION_STATUS_UNKNOWN" => Ok(TransactionStatus::Unknown),
+                    _ => Err(serde::de::Error::unknown_variant(value, FIELDS)),
+                }
+            }
+        }
+        deserializer.deserialize_any(GeneratedVisitor)
+    }
+}
+impl serde::Serialize for TransactionStatusResponse {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.status != 0 {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.protocol.transaction.v1.TransactionStatusResponse", len)?;
+        if self.status != 0 {
+            let v = TransactionStatus::try_from(self.status)
+                .map_err(|_| serde::ser::Error::custom(format!("Invalid variant {}", self.status)))?;
+            struct_ser.serialize_field("status", &v)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for TransactionStatusResponse {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "status",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Status,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "status" => Ok(GeneratedField::Status),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = TransactionStatusResponse;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.protocol.transaction.v1.TransactionStatusResponse")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<TransactionStatusResponse, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut status__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Status => {
+                            if status__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("status"));
+                            }
+                            status__ = Some(map_.next_value::<TransactionStatus>()? as i32);
+                        }
+                    }
+                }
+                Ok(TransactionStatusResponse {
+                    status: status__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.protocol.transaction.v1.TransactionStatusResponse", FIELDS, GeneratedVisitor)
+    }
+}
 impl serde::Serialize for Transfer {
     #[allow(deprecated)]
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>

--- a/crates/astria-sequencer/src/accounts/query.rs
+++ b/crates/astria-sequencer/src/accounts/query.rs
@@ -37,6 +37,7 @@ use crate::{
     accounts::StateReadExt as _,
     app::StateReadExt as _,
     assets::StateReadExt as _,
+    mempool::Mempool,
 };
 
 #[instrument(skip_all, fields(%asset), err(level = Level::DEBUG))]
@@ -77,6 +78,7 @@ async fn get_trace_prefixed_account_balances<S: StateRead>(
 #[instrument(skip_all)]
 pub(crate) async fn balance_request(
     storage: Storage,
+    _mempool: Mempool,
     request: request::Query,
     params: Vec<(String, String)>,
 ) -> response::Query {
@@ -120,6 +122,7 @@ pub(crate) async fn balance_request(
 #[instrument(skip_all)]
 pub(crate) async fn nonce_request(
     storage: Storage,
+    _mempool: Mempool,
     request: request::Query,
     params: Vec<(String, String)>,
 ) -> response::Query {

--- a/crates/astria-sequencer/src/assets/query.rs
+++ b/crates/astria-sequencer/src/assets/query.rs
@@ -16,6 +16,7 @@ use tracing::instrument;
 use crate::{
     app::StateReadExt as _,
     assets::StateReadExt as _,
+    mempool::Mempool,
 };
 
 // Retrieve the full asset denomination given the asset ID.
@@ -25,6 +26,7 @@ use crate::{
 #[instrument(skip_all)]
 pub(crate) async fn denom_request(
     storage: Storage,
+    _mempool: Mempool,
     request: request::Query,
     params: Vec<(String, String)>,
 ) -> response::Query {

--- a/crates/astria-sequencer/src/fees/query.rs
+++ b/crates/astria-sequencer/src/fees/query.rs
@@ -78,6 +78,7 @@ use crate::{
         FeeHandler,
         StateReadExt as _,
     },
+    mempool::Mempool,
     storage::StoredValue,
 };
 
@@ -115,6 +116,7 @@ async fn get_allowed_fee_assets<S: StateRead>(state: &S) -> Vec<Denom> {
 #[instrument(skip_all)]
 pub(crate) async fn allowed_fee_assets_request(
     storage: Storage,
+    _mempool: Mempool,
     request: request::Query,
     _params: Vec<(String, String)>,
 ) -> response::Query {
@@ -160,6 +162,7 @@ pub(crate) async fn allowed_fee_assets_request(
 
 pub(crate) async fn components(
     storage: Storage,
+    _mempool: Mempool,
     request: request::Query,
     _params: Vec<(String, String)>,
 ) -> response::Query {
@@ -198,6 +201,7 @@ pub(crate) async fn components(
 
 pub(crate) async fn transaction_fee_request(
     storage: Storage,
+    _mempool: Mempool,
     request: request::Query,
     _params: Vec<(String, String)>,
 ) -> response::Query {

--- a/crates/astria-sequencer/src/mempool/query.rs
+++ b/crates/astria-sequencer/src/mempool/query.rs
@@ -1,0 +1,364 @@
+use astria_core::{
+    primitive::v1::{
+        TransactionId,
+        TRANSACTION_ID_LEN,
+    },
+    protocol::{
+        abci::AbciErrorCode,
+        transaction::v1::TransactionStatusResponse,
+    },
+    Protobuf as _,
+};
+use cnidarium::Storage;
+use prost::Message;
+use tendermint::{
+    abci::Code,
+    v0_38::abci::{
+        request,
+        response,
+    },
+};
+use tracing::instrument;
+
+use super::Mempool;
+use crate::app::StateReadExt;
+
+#[instrument(skip_all)]
+pub(crate) async fn transaction_status_request(
+    storage: Storage,
+    mempool: Mempool,
+    request: request::Query,
+    params: Vec<(String, String)>,
+) -> response::Query {
+    let tx_id = match preprocess_request(&params) {
+        Ok(tx_id) => tx_id,
+        Err(err) => return err,
+    };
+
+    let height = match storage.latest_snapshot().get_block_height().await {
+        Ok(height) => height,
+        Err(err) => {
+            return response::Query {
+                code: Code::Err(AbciErrorCode::INTERNAL_ERROR.value()),
+                info: "failed getting block height".into(),
+                log: format!("{err:?}"),
+                ..response::Query::default()
+            };
+        }
+    };
+
+    let height = match height.try_into() {
+        Ok(height) => height,
+        Err(err) => {
+            return response::Query {
+                code: Code::Err(AbciErrorCode::INTERNAL_ERROR.value()),
+                info: "failed converting `u64` block height to type `tendermint::block::Height`"
+                    .into(),
+                log: format!("{err:?}"),
+                ..response::Query::default()
+            };
+        }
+    };
+
+    let (status, reason) = mempool.get_transaction_status(&tx_id).await;
+
+    let log = reason.map_or(String::new(), |r| format!("removal reason: {r}"));
+
+    let payload = TransactionStatusResponse {
+        status,
+    }
+    .to_raw()
+    .encode_to_vec()
+    .into();
+
+    response::Query {
+        code: Code::Ok,
+        log,
+        key: request.path.clone().into_bytes().into(),
+        value: payload,
+        height,
+        ..response::Query::default()
+    }
+}
+
+#[instrument(skip_all)]
+fn preprocess_request(params: &[(String, String)]) -> Result<TransactionId, response::Query> {
+    let Some(tx_id) = params
+        .iter()
+        .find_map(|(key, value)| (key == "tx_id").then_some(value))
+    else {
+        return Err(response::Query {
+            code: Code::Err(AbciErrorCode::INVALID_PARAMETER.value()),
+            info: "missing required parameter `tx_id`".into(),
+            ..response::Query::default()
+        });
+    };
+
+    // Transaction hashes may or may not be prefixed with "0x", so it's good UX to support both
+    let tx_id = tx_id.trim_start_matches("0x");
+
+    let tx_id: [u8; TRANSACTION_ID_LEN] =
+        hex::decode(tx_id)
+            .unwrap()
+            .try_into()
+            .map_err(|err| response::Query {
+                code: Code::Err(AbciErrorCode::INVALID_PARAMETER.value()),
+                info: "failed to parse `tx_id` into type `[u8; 32]`".into(),
+                log: format!("{err:?}"),
+                ..response::Query::default()
+            })?;
+    Ok(TransactionId::new(tx_id))
+}
+
+#[cfg(test)]
+mod tests {
+    use astria_core::{
+        generated::astria::protocol::transaction::v1::TransactionStatusResponse as RawTransactionStatusResponse,
+        protocol::transaction::v1::TransactionStatus,
+    };
+    use telemetry::Metrics as _;
+
+    use super::*;
+    use crate::{
+        app::{
+            benchmark_and_test_utils::{
+                mock_balances,
+                mock_tx_cost,
+            },
+            test_utils::MockTxBuilder,
+            StateWriteExt as _,
+        },
+        mempool::RemovalReason,
+        Metrics,
+    };
+
+    #[tokio::test]
+    async fn transaction_status_request_pending_works_as_expected() {
+        let storage = cnidarium::TempStorage::new().await.unwrap();
+        let snapshot = storage.latest_snapshot();
+        let mut state = cnidarium::StateDelta::new(snapshot);
+
+        state.put_block_height(0).unwrap();
+
+        storage.commit(state).await.unwrap();
+
+        let metrics = Box::leak(Box::new(Metrics::noop_metrics(&()).unwrap()));
+        let mempool = Mempool::new(metrics, 10);
+
+        let account_balances = mock_balances(100, 100);
+        let tx_cost = mock_tx_cost(10, 10, 0);
+        let tx = MockTxBuilder::new().nonce(0).build();
+        mempool
+            .insert(tx.clone(), 0, account_balances.clone(), tx_cost.clone())
+            .await
+            .unwrap();
+
+        let request = request::Query {
+            data: vec![].into(),
+            path: format!("transaction/status/{}", tx.id()),
+            height: 0u32.into(),
+            prove: false,
+        };
+
+        let response_1 = transaction_status_request(
+            (*storage).clone(),
+            mempool.clone(),
+            request.clone(),
+            vec![("tx_id".to_string(), tx.id().to_string())],
+        )
+        .await;
+        let transaction_status = TransactionStatusResponse::try_from_raw(
+            RawTransactionStatusResponse::decode(response_1.value).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(response_1.code, Code::Ok);
+        assert_eq!(transaction_status.status, TransactionStatus::Pending);
+
+        // Check that the transaction hash can be formatted with or without the "0x" prefix
+        let response_2 = transaction_status_request(
+            (*storage).clone(),
+            mempool,
+            request,
+            vec![("tx_id".to_string(), format!("0x{}", tx.id()))],
+        )
+        .await;
+        let transaction_status = TransactionStatusResponse::try_from_raw(
+            RawTransactionStatusResponse::decode(response_2.value).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(response_2.code, Code::Ok);
+        assert_eq!(transaction_status.status, TransactionStatus::Pending);
+    }
+
+    #[tokio::test]
+    async fn transaction_status_request_parked_works_as_expected() {
+        let storage = cnidarium::TempStorage::new().await.unwrap();
+        let snapshot = storage.latest_snapshot();
+        let mut state = cnidarium::StateDelta::new(snapshot);
+
+        state.put_block_height(0).unwrap();
+
+        storage.commit(state).await.unwrap();
+
+        let metrics = Box::leak(Box::new(Metrics::noop_metrics(&()).unwrap()));
+        let mempool = Mempool::new(metrics, 10);
+
+        let account_balances = mock_balances(100, 100);
+        let tx_cost = mock_tx_cost(10, 10, 0);
+        let tx = MockTxBuilder::new().nonce(1).build(); // The nonce gap (1 vs. 0) will park the transaction
+        mempool
+            .insert(tx.clone(), 0, account_balances.clone(), tx_cost.clone())
+            .await
+            .unwrap();
+
+        let request = request::Query {
+            data: vec![].into(),
+            path: format!("transaction/status/{}", tx.id()),
+            height: 0u32.into(),
+            prove: false,
+        };
+
+        let response_1 = transaction_status_request(
+            (*storage).clone(),
+            mempool.clone(),
+            request.clone(),
+            vec![("tx_id".to_string(), tx.id().to_string())],
+        )
+        .await;
+        let transaction_status = TransactionStatusResponse::try_from_raw(
+            RawTransactionStatusResponse::decode(response_1.value).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(response_1.code, Code::Ok);
+        assert_eq!(transaction_status.status, TransactionStatus::Parked);
+
+        // Check that the transaction hash can be formatted with or without the "0x" prefix
+        let response_2 = transaction_status_request(
+            (*storage).clone(),
+            mempool,
+            request,
+            vec![("tx_id".to_string(), format!("0x{}", tx.id()))],
+        )
+        .await;
+        let transaction_status = TransactionStatusResponse::try_from_raw(
+            RawTransactionStatusResponse::decode(response_2.value).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(response_2.code, Code::Ok);
+        assert_eq!(transaction_status.status, TransactionStatus::Parked);
+    }
+
+    #[tokio::test]
+    async fn transaction_status_request_unknown_works_as_expected() {
+        let storage = cnidarium::TempStorage::new().await.unwrap();
+        let snapshot = storage.latest_snapshot();
+        let mut state = cnidarium::StateDelta::new(snapshot);
+
+        state.put_block_height(0).unwrap();
+
+        storage.commit(state).await.unwrap();
+
+        let metrics = Box::leak(Box::new(Metrics::noop_metrics(&()).unwrap()));
+        let mempool = Mempool::new(metrics, 10);
+
+        let tx_id = TransactionId::new([0u8; TRANSACTION_ID_LEN]);
+
+        let request = request::Query {
+            data: vec![].into(),
+            path: format!("transaction/status/{tx_id}"),
+            height: 0u32.into(),
+            prove: false,
+        };
+
+        let response_1 = transaction_status_request(
+            (*storage).clone(),
+            mempool.clone(),
+            request.clone(),
+            vec![("tx_id".to_string(), tx_id.to_string())],
+        )
+        .await;
+        let transaction_status = TransactionStatusResponse::try_from_raw(
+            RawTransactionStatusResponse::decode(response_1.value).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(response_1.code, Code::Ok);
+        assert_eq!(transaction_status.status, TransactionStatus::Unknown);
+
+        // Check that the transaction hash can be formatted with or without the "0x" prefix
+        let response_2 = transaction_status_request(
+            (*storage).clone(),
+            mempool,
+            request,
+            vec![("tx_id".to_string(), format!("0x{tx_id}"))],
+        )
+        .await;
+        let transaction_status = TransactionStatusResponse::try_from_raw(
+            RawTransactionStatusResponse::decode(response_2.value).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(response_2.code, Code::Ok);
+        assert_eq!(transaction_status.status, TransactionStatus::Unknown);
+    }
+
+    #[tokio::test]
+    async fn transaction_status_request_removal_cache_works_as_expected() {
+        let storage = cnidarium::TempStorage::new().await.unwrap();
+        let snapshot = storage.latest_snapshot();
+        let mut state = cnidarium::StateDelta::new(snapshot);
+
+        state.put_block_height(0).unwrap();
+
+        storage.commit(state).await.unwrap();
+
+        let metrics = Box::leak(Box::new(Metrics::noop_metrics(&()).unwrap()));
+        let mempool = Mempool::new(metrics, 10);
+
+        let account_balances = mock_balances(100, 100);
+        let tx_cost = mock_tx_cost(10, 10, 0);
+        let tx = MockTxBuilder::new().nonce(0).build();
+        mempool
+            .insert(tx.clone(), 0, account_balances.clone(), tx_cost.clone())
+            .await
+            .unwrap();
+        let reason = RemovalReason::FailedPrepareProposal("test".to_string());
+        mempool.remove_tx_invalid(tx.clone(), reason.clone()).await;
+
+        let request = request::Query {
+            data: vec![].into(),
+            path: format!("transaction/status/{}", tx.id()),
+            height: 0u32.into(),
+            prove: false,
+        };
+
+        let response_1 = transaction_status_request(
+            (*storage).clone(),
+            mempool.clone(),
+            request.clone(),
+            vec![("tx_id".to_string(), tx.id().to_string())],
+        )
+        .await;
+        let transaction_status = TransactionStatusResponse::try_from_raw(
+            RawTransactionStatusResponse::decode(response_1.value).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(response_1.code, Code::Ok);
+        assert_eq!(transaction_status.status, TransactionStatus::RemovalCache);
+        assert_eq!(response_1.log, format!("removal reason: {reason}"));
+
+        // Check that the transaction hash can be formatted with or without the "0x" prefix
+        let response_2 = transaction_status_request(
+            (*storage).clone(),
+            mempool,
+            request,
+            vec![("tx_id".to_string(), format!("0x{}", tx.id()))],
+        )
+        .await;
+        let transaction_status = TransactionStatusResponse::try_from_raw(
+            RawTransactionStatusResponse::decode(response_2.value).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(response_2.code, Code::Ok);
+        assert_eq!(transaction_status.status, TransactionStatus::RemovalCache);
+        assert_eq!(response_2.log, format!("removal reason: {reason}"));
+    }
+}

--- a/crates/astria-sequencer/src/mempool/transactions_container.rs
+++ b/crates/astria-sequencer/src/mempool/transactions_container.rs
@@ -11,7 +11,10 @@ use std::{
 };
 
 use astria_core::{
-    primitive::v1::asset::IbcPrefixed,
+    primitive::v1::{
+        asset::IbcPrefixed,
+        TransactionId,
+    },
     protocol::transaction::v1::{
         action::group::Group,
         Transaction,
@@ -489,7 +492,6 @@ pub(super) trait TransactionsForAccount: Default {
             .collect()
     }
 
-    #[cfg(test)]
     fn contains_tx(&self, tx_hash: &[u8; 32]) -> bool {
         self.txs().values().any(|ttx| ttx.tx_hash == *tx_hash)
     }
@@ -570,6 +572,13 @@ pub(super) trait TransactionsContainer<T: TransactionsForAccount> {
         T: 'a,
     {
         self.txs().keys()
+    }
+
+    /// Returns true if the given transaction ID is contained within this transaction container.
+    fn contains(&self, tx_id: &TransactionId) -> bool {
+        self.txs()
+            .values()
+            .any(|account_txs| account_txs.contains_tx(&tx_id.get()))
     }
 
     /// Recosts transactions for an account.

--- a/crates/astria-sequencer/src/sequencer.rs
+++ b/crates/astria-sequencer/src/sequencer.rs
@@ -150,8 +150,8 @@ impl Sequencer {
                 async move { service::Consensus::new(storage, app, queue).run().await }
             }));
         let mempool_service = service::Mempool::new(storage.clone(), mempool.clone(), metrics);
-        let info_service =
-            service::Info::new(storage.clone()).wrap_err("failed initializing info service")?;
+        let info_service = service::Info::new(storage.clone(), mempool.clone())
+            .wrap_err("failed initializing info service")?;
         let snapshot_service = service::Snapshot;
 
         let abci_server = Server::builder()

--- a/proto/protocolapis/astria/protocol/transaction/v1/types.proto
+++ b/proto/protocolapis/astria/protocol/transaction/v1/types.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package astria.protocol.transaction.v1;
+
+// The response payload for a `transaction/status` ABCI query
+message TransactionStatusResponse {
+  TransactionStatus status = 2;
+}
+
+enum TransactionStatus {
+  TRANSACTION_STATUS_UNSPECIFIED = 0;
+  TRANSACTION_STATUS_PARKED = 1;
+  TRANSACTION_STATUS_PENDING = 2;
+  TRANSACTION_STATUS_REMOVAL_CACHE = 3;
+  TRANSACTION_STATUS_UNKNOWN = 4;
+}


### PR DESCRIPTION
## Summary
Added a transaction status ABCI query to the sequencer and changed the Sequencer Client to poll that instead of CometBFT's `tx` RPC.

## Background
The Sequencer Client's method `wait_for_tx_inclusion` previously polled CometBFT's `tx` endpoint, which would return an error no matter whether the transaction was pending, failed, or never submitted in the first place. Because of this lack of distinction, the method would poll indefinitely if a transaction failed for some reason. This is similar to the issue mentioned in #1936.

## Changes
- Add transaction status ABCI query to the sequencer.
- Added `get_transaction_status` method to mempool, returning either `Pending`, `Parked`, `RemovalCache`, or `Unknown`.
- Added protos and native types for `TransactionStatus` and `TransactionStatusResponse`.
- Renamed `wait_for_tx_inclusion` to `confirm_tx_inclusion`, and changed the logic to continue looping after receiving a `Pending` or `Parked` response. If `Unknown`, it will poll until `MAX_WAIT_TIME_UNKNOWN` has elapsed, and will then return an error. If it receives `RemovalCache`, it will try CometBFT's `tx` RPC for a short time before erroring if there is no response.
- Changed reliant bits in the Bridge Withdrawer and Sequencer CLI to use the updated method.

## Testing
- Added unit tests for mempool's `get_transaction_status` method.
- Added unit tests for Sequencer transaction status ABCI query.
- Added unit tests for Sequencer Client's `confirm_tx_inclusion` method.

## Changelogs
Ensure all relevant changelog files are updated as necessary. See
[keepachangelog](https://keepachangelog.com/en/1.1.0/#how) for change
categories. Replace this text with e.g. "Changelogs updated." or "No updates
required." to acknowledge changelogs have been considered.

## Breaking Changelist
- Not breaking, but worth noting this adds to sequencer's public API.

## Related Issues
closes #1949
