### PR TITLE
fix(charts): geth flags

### DIFF
--- a/charts/evm-rollup/Chart.yaml
+++ b/charts/evm-rollup/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.0
+version: 1.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/evm-rollup/files/scripts/init-geth.sh
+++ b/charts/evm-rollup/files/scripts/init-geth.sh
@@ -9,9 +9,13 @@ if [ ! -d "$data_dir/" ]; then
 
   exec geth \
     {{- range $arg := .Values.config.geth.flags -}}
-    {{- if $arg.condition | default true -}}
+    {{- if hasKey $arg "condition" -}}
+    {{- if eq (tpl $arg.condition $) "true" -}}
     --{{ $arg.name }}{{ if $arg.value }}={{ tpl $arg.value $ }}{{ end }} \
-    {{ end }}
+    {{- end -}}
+    {{- else }}
+    --{{ $arg.name }}{{ if $arg.value }}={{ tpl $arg.value $ }}{{ end }} \
+    {{- end }}
     {{- end -}}
     init $home_dir/genesis.json
 elif ! cmp -s "/scripts/geth-genesis.json" "$home_dir/genesis.json"; then

--- a/charts/evm-rollup/files/scripts/init-geth.sh
+++ b/charts/evm-rollup/files/scripts/init-geth.sh
@@ -9,11 +9,8 @@ if [ ! -d "$data_dir/" ]; then
 
   exec geth \
     {{- range $arg := .Values.config.geth.flags -}}
-    {{- if hasKey $arg "condition" -}}
-    {{- if eq (tpl $arg.condition $) "true" -}}
-    --{{ $arg.name }}{{ if $arg.value }}={{ tpl $arg.value $ }}{{ end }} \
-    {{- end -}}
-    {{- else }}
+    {{- $noCondition := not (hasKey $arg "condition") }}
+    {{- if or ($noCondition) (eq (tpl $arg.condition $) "true") }}
     --{{ $arg.name }}{{ if $arg.value }}={{ tpl $arg.value $ }}{{ end }} \
     {{- end }}
     {{- end -}}

--- a/charts/evm-rollup/templates/statefulsets.yaml
+++ b/charts/evm-rollup/templates/statefulsets.yaml
@@ -67,11 +67,8 @@ spec:
           command: [ "geth" ]
           args:
             {{- range $arg := .Values.config.geth.flags }}
-            {{- if hasKey $arg "condition" }}
-            {{- if eq (tpl $arg.condition $) "true" }}
-            - --{{ $arg.name }}{{ if $arg.value }}={{ tpl $arg.value $ }}{{ end }}
-            {{- end }}
-            {{- else }}
+            {{- $noCondition := not (hasKey $arg "condition") }}
+            {{- if or ($noCondition) (eq (tpl $arg.condition $) "true") }}
             - --{{ $arg.name }}{{ if $arg.value }}={{ tpl $arg.value $ }}{{ end }}
             {{- end }}
             {{- end }}

--- a/charts/evm-rollup/templates/statefulsets.yaml
+++ b/charts/evm-rollup/templates/statefulsets.yaml
@@ -67,7 +67,11 @@ spec:
           command: [ "geth" ]
           args:
             {{- range $arg := .Values.config.geth.flags }}
-            {{- if $arg.condition | default true }}
+            {{- if hasKey $arg "condition" }}
+            {{- if eq (tpl $arg.condition $) "true" }}
+            - --{{ $arg.name }}{{ if $arg.value }}={{ tpl $arg.value $ }}{{ end }}
+            {{- end }}
+            {{- else }}
             - --{{ $arg.name }}{{ if $arg.value }}={{ tpl $arg.value $ }}{{ end }}
             {{- end }}
             {{- end }}

--- a/charts/evm-rollup/values.yaml
+++ b/charts/evm-rollup/values.yaml
@@ -174,13 +174,13 @@ config:
       - name: history.state
         value: "{{- if .Values.config.geth.archiveNode -}} 0 {{- else -}} 540000 {{- end }}"
       - name: metrics
-        condition: .Values.metrics.enabled
+        condition: "{{- if .Values.metrics.enabled -}} true {{- else -}} false {{- end }}"
       - name: metrics.addr
         value: 0.0.0.0
-        condition: .Values.metrics.enabled
+        condition: "{{- if .Values.metrics.enabled -}} true {{- else -}} false {{- end }}"
       - name: metrics.port
         value: "{{ .Values.ports.metrics }}"
-        condition: .Values.metrics.enabled
+        condition: "{{- if .Values.metrics.enabled -}} true {{- else -}} false {{- end }}"
       - name: txpool.nolocals
         value: "true"
 

--- a/charts/evm-rollup/values.yaml
+++ b/charts/evm-rollup/values.yaml
@@ -174,13 +174,13 @@ config:
       - name: history.state
         value: "{{- if .Values.config.geth.archiveNode -}} 0 {{- else -}} 540000 {{- end }}"
       - name: metrics
-        condition: "{{- if .Values.metrics.enabled -}} true {{- else -}} false {{- end }}"
+        condition : "{{ .Values.metrics.enabled }}"
       - name: metrics.addr
         value: 0.0.0.0
-        condition: "{{- if .Values.metrics.enabled -}} true {{- else -}} false {{- end }}"
+        condition : "{{ .Values.metrics.enabled }}"
       - name: metrics.port
         value: "{{ .Values.ports.metrics }}"
-        condition: "{{- if .Values.metrics.enabled -}} true {{- else -}} false {{- end }}"
+        condition : "{{ .Values.metrics.enabled }}"
       - name: txpool.nolocals
         value: "true"
 

--- a/charts/evm-rollup/values.yaml
+++ b/charts/evm-rollup/values.yaml
@@ -174,13 +174,13 @@ config:
       - name: history.state
         value: "{{- if .Values.config.geth.archiveNode -}} 0 {{- else -}} 540000 {{- end }}"
       - name: metrics
-        condition : "{{ .Values.metrics.enabled }}"
+        condition: "{{ .Values.metrics.enabled }}"
       - name: metrics.addr
         value: 0.0.0.0
-        condition : "{{ .Values.metrics.enabled }}"
+        condition: "{{ .Values.metrics.enabled }}"
       - name: metrics.port
         value: "{{ .Values.ports.metrics }}"
-        condition : "{{ .Values.metrics.enabled }}"
+        condition: "{{ .Values.metrics.enabled }}"
       - name: txpool.nolocals
         value: "true"
 

--- a/charts/evm-stack/Chart.lock
+++ b/charts/evm-stack/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.4.0
 - name: evm-rollup
   repository: file://../evm-rollup
-  version: 1.1.0
+  version: 1.1.1
 - name: flame-rollup
   repository: file://../flame-rollup
   version: 0.0.1
@@ -26,5 +26,5 @@ dependencies:
 - name: blockscout-stack
   repository: https://blockscout.github.io/helm-charts
   version: 1.6.8
-digest: sha256:6c61169417c2af9fd2cb20ae2fa46ac500a701575f0a15266633e0444695f7e9
-generated: "2025-02-11T19:40:53.84221+05:30"
+digest: sha256:03f8e53fd90f307d09aa02db8e65d2838af3c9cea285272f06d800329a92a813
+generated: "2025-02-17T17:05:09.027931+02:00"

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -15,14 +15,14 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.9
+version: 1.0.10
 dependencies:
   - name: celestia-node
     version: 0.4.0
     repository: "file://../celestia-node"
     condition: celestia-node.enabled
   - name: evm-rollup
-    version: 1.1.0
+    version: 1.1.1
     repository: "file://../evm-rollup"
     condition: evm-rollup.enabled
   - name: flame-rollup


### PR DESCRIPTION
## Summary
changes to how flags condition is evaluated and used.
## Background
Our current evm-rollup charts has a bug, the condition which helps configuring geth flags is not being evaluated and always acts as `true`. This PR changes the condition templating. 
## Changes
- conditions are now being templated based on the key value. Also makes sure this value is `true` if the condition exists.

## Testing
- locally running smoke test against a cluster 
- using the helm command for templating: ` helm template my-chart ./charts/evm-stack -f ./dev/values/rollup/dev.yaml`
## Changelogs
No updates required.
