### PR TITLE
fix(sequencer): update `put_price_for_currency_pair`

### DIFF
--- a/crates/astria-sequencer/src/app/vote_extension.rs
+++ b/crates/astria-sequencer/src/app/vote_extension.rs
@@ -599,16 +599,15 @@ pub(super) async fn apply_prices_from_vote_extensions<S: StateWriteExt>(
             },
             block_height: height,
         };
+        state
+            .put_price_for_currency_pair(price.currency_pair().clone(), quote_price)
+            .await
+            .wrap_err("failed to put price")?;
         debug!(
             "applied price from vote extension currency_pair=\"{}\" price={}",
             price.currency_pair(),
             price.price()
         );
-
-        state
-            .put_price_for_currency_pair(price.currency_pair().clone(), quote_price)
-            .await
-            .wrap_err("failed to put price")?;
     }
 
     Ok(())

--- a/crates/astria-sequencer/src/connect/oracle/state_ext.rs
+++ b/crates/astria-sequencer/src/connect/oracle/state_ext.rs
@@ -15,13 +15,11 @@ use astria_core::connect::{
     types::v2::{
         CurrencyPair,
         CurrencyPairId,
-        CurrencyPairNonce,
     },
 };
 use astria_eyre::{
     anyhow_to_eyre,
     eyre::{
-        ContextCompat as _,
         OptionExt as _,
         Result,
         WrapErr as _,
@@ -278,31 +276,17 @@ pub(crate) trait StateWriteExt: StateWrite {
         currency_pair: CurrencyPair,
         price: QuotePrice,
     ) -> Result<()> {
-        let state = if let Some(mut state) = self
+        let mut state = self
             .get_currency_pair_state(&currency_pair)
             .await
             .wrap_err("failed to get currency pair state")?
-        {
-            state.price = Some(price);
-            state.nonce = state
-                .nonce
-                .increment()
-                .ok_or_eyre("increment nonce overflowed")?;
-            state
-        } else {
-            let id = self
-                .get_next_currency_pair_id()
-                .await
-                .wrap_err("failed to read next currency pair ID")?;
-            let next_id = id.increment().wrap_err("increment ID overflowed")?;
-            self.put_next_currency_pair_id(next_id)
-                .wrap_err("failed to put next currency pair ID")?;
-            CurrencyPairState {
-                price: Some(price),
-                nonce: CurrencyPairNonce::new(0),
-                id,
-            }
-        };
+            .ok_or_eyre("currency pair state not found")?;
+
+        state.price = Some(price);
+        state.nonce = state
+            .nonce
+            .increment()
+            .ok_or_eyre("increment nonce overflowed")?;
         self.put_currency_pair_state(currency_pair, state)
             .wrap_err("failed to put currency pair state")
     }
@@ -356,6 +340,7 @@ mod tests {
     use astria_core::{
         connect::types::v2::{
             CurrencyPair,
+            CurrencyPairNonce,
             Price,
         },
         Timestamp,


### PR DESCRIPTION
## Summary
update `put_price_for_currency_pair` to error if state is not found. this is correct as the function is only called from `apply_prices_from_vote_extensions`, which only contains currency pairs that are already in the app state, as an invariant of the `id_to_currency_pair` validation done inside `validate_id_to_currency_pair_mapping`. thus, the previous `else` case where the state didn't exist would never be hit.

## Background
resolves oracle audit issue 3.1.

## Changes
- update `put_price_for_currency_pair` to error if state is not found. 

## Testing
existing unit tests

