### PR TITLE
feat(proto): create v2 execution API

### DIFF
--- a/crates/astria-core/src/generated/astria.execution.v2.rs
+++ b/crates/astria-core/src/generated/astria.execution.v2.rs
@@ -1,0 +1,1001 @@
+/// SequencerInfo contains the information needed to map sequencer block height
+/// to rollup block number for driving execution.
+///
+/// This information is used to determine which sequencer & celestia data to
+/// use from the Astria & Celestia networks, as well as define shutdown/restart
+/// behavior of the Conductor.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SequencerInfo {
+    /// The rollup_id is the unique identifier for the rollup chain.
+    #[prost(message, optional, tag = "1")]
+    pub rollup_id: ::core::option::Option<super::super::primitive::v1::RollupId>,
+    /// The first block height on the sequencer chain to use for rollup transactions.
+    /// This is mapped to `rollup_first_block_number`.
+    #[prost(uint32, tag = "2")]
+    pub sequencer_first_block_height: u32,
+    /// The first rollup block number to be executed. This is mapped to `sequencer_first_block_height`
+    #[prost(uint64, tag = "3")]
+    pub rollup_first_block_number: u64,
+    /// The final rollup block number to execute before either re-fetching sequencer
+    /// info (restarting) or shutting down (determined by `halt_at_rollup_stop_number`).
+    #[prost(uint64, tag = "4")]
+    pub rollup_stop_block_number: u64,
+    /// The allowed variance in celestia for sequencer blocks to have been posted.
+    #[prost(uint64, tag = "5")]
+    pub celestia_block_variance: u64,
+    /// The ID of the Astria Sequencer network to retrieve Sequencer blocks from.
+    /// Conductor implementations should verify that the Sequencer network they are connected to
+    /// have this chain ID (if fetching soft Sequencer blocks), and verify that the Sequencer metadata
+    /// blobs retrieved from Celestia contain this chain ID (if extracting firm Sequencer blocks from
+    /// Celestia blobs).
+    #[prost(string, tag = "6")]
+    pub sequencer_chain_id: ::prost::alloc::string::String,
+    /// The ID of the Celestia network to retrieve blobs from.
+    /// Conductor implementations should verify that the Celestia network they are connected to have
+    /// this chain ID (if extracting firm Sequencer blocks from Celestia blobs).
+    #[prost(string, tag = "7")]
+    pub celestia_chain_id: ::prost::alloc::string::String,
+    /// Requests that Conductor halt at `rollup_stop_block_number` instead of re-fetching
+    /// the sequencer info and continuing execution.
+    #[prost(bool, tag = "8")]
+    pub halt_at_rollup_stop_number: bool,
+}
+impl ::prost::Name for SequencerInfo {
+    const NAME: &'static str = "SequencerInfo";
+    const PACKAGE: &'static str = "astria.execution.v2";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.execution.v2.{}", Self::NAME)
+    }
+}
+/// The set of information which deterministic driver of block production
+/// must know about a given rollup Block
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Block {
+    /// The block number
+    #[prost(uint32, tag = "1")]
+    pub number: u32,
+    /// The hash of the block
+    #[prost(bytes = "bytes", tag = "2")]
+    pub hash: ::prost::bytes::Bytes,
+    /// The hash from the parent block
+    #[prost(bytes = "bytes", tag = "3")]
+    pub parent_block_hash: ::prost::bytes::Bytes,
+    /// Timestamp on the block, standardized to google protobuf standard.
+    #[prost(message, optional, tag = "4")]
+    pub timestamp: ::core::option::Option<::pbjson_types::Timestamp>,
+}
+impl ::prost::Name for Block {
+    const NAME: &'static str = "Block";
+    const PACKAGE: &'static str = "astria.execution.v2";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.execution.v2.{}", Self::NAME)
+    }
+}
+/// Fields which are indexed for finding blocks on a blockchain.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BlockIdentifier {
+    #[prost(oneof = "block_identifier::Identifier", tags = "1, 2")]
+    pub identifier: ::core::option::Option<block_identifier::Identifier>,
+}
+/// Nested message and enum types in `BlockIdentifier`.
+pub mod block_identifier {
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Identifier {
+        #[prost(uint32, tag = "1")]
+        BlockNumber(u32),
+        #[prost(bytes, tag = "2")]
+        BlockHash(::prost::bytes::Bytes),
+    }
+}
+impl ::prost::Name for BlockIdentifier {
+    const NAME: &'static str = "BlockIdentifier";
+    const PACKAGE: &'static str = "astria.execution.v2";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.execution.v2.{}", Self::NAME)
+    }
+}
+/// Used to fetch the current `SequencerInfo` from the rollup.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetSequencerInfoRequest {
+    /// The commitment type that the sequencer info is being fetched for. If the commitment
+    /// type is soft, the returned sequencer info should be based on the rollup's soft
+    /// commitment height. If the commitment type is firm, the returned sequencer info
+    /// should be based on the rollup's firm commitment height.
+    #[prost(enumeration = "CommitmentType", tag = "1")]
+    pub commitment_type: i32,
+}
+impl ::prost::Name for GetSequencerInfoRequest {
+    const NAME: &'static str = "GetSequencerInfoRequest";
+    const PACKAGE: &'static str = "astria.execution.v2";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.execution.v2.{}", Self::NAME)
+    }
+}
+/// Used in GetBlock to find a single block.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetBlockRequest {
+    #[prost(message, optional, tag = "1")]
+    pub identifier: ::core::option::Option<BlockIdentifier>,
+}
+impl ::prost::Name for GetBlockRequest {
+    const NAME: &'static str = "GetBlockRequest";
+    const PACKAGE: &'static str = "astria.execution.v2";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.execution.v2.{}", Self::NAME)
+    }
+}
+/// Used in BatchGetBlocks, will find all or none based on the list of
+/// identifiers.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BatchGetBlocksRequest {
+    #[prost(message, repeated, tag = "1")]
+    pub identifiers: ::prost::alloc::vec::Vec<BlockIdentifier>,
+}
+impl ::prost::Name for BatchGetBlocksRequest {
+    const NAME: &'static str = "BatchGetBlocksRequest";
+    const PACKAGE: &'static str = "astria.execution.v2";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.execution.v2.{}", Self::NAME)
+    }
+}
+/// The list of blocks in response to BatchGetBlocks.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BatchGetBlocksResponse {
+    #[prost(message, repeated, tag = "1")]
+    pub blocks: ::prost::alloc::vec::Vec<Block>,
+}
+impl ::prost::Name for BatchGetBlocksResponse {
+    const NAME: &'static str = "BatchGetBlocksResponse";
+    const PACKAGE: &'static str = "astria.execution.v2";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.execution.v2.{}", Self::NAME)
+    }
+}
+/// ExecuteBlockRequest contains all the information needed to create a new rollup
+/// block.
+///
+/// This information comes from previous rollup blocks, as well as from sequencer
+/// blocks.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ExecuteBlockRequest {
+    /// The hash of previous block, which new block will be created on top of.
+    #[prost(bytes = "bytes", tag = "1")]
+    pub prev_block_hash: ::prost::bytes::Bytes,
+    /// List of transactions to include in the new block.
+    #[prost(message, repeated, tag = "2")]
+    pub transactions: ::prost::alloc::vec::Vec<
+        super::super::sequencerblock::v1::RollupData,
+    >,
+    /// Timestamp to be used for new block.
+    #[prost(message, optional, tag = "3")]
+    pub timestamp: ::core::option::Option<::pbjson_types::Timestamp>,
+}
+impl ::prost::Name for ExecuteBlockRequest {
+    const NAME: &'static str = "ExecuteBlockRequest";
+    const PACKAGE: &'static str = "astria.execution.v2";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.execution.v2.{}", Self::NAME)
+    }
+}
+/// The CommitmentState holds the block at each stage of sequencer commitment
+/// level
+///
+/// A Valid CommitmentState:
+/// - Block numbers are such that soft >= firm.
+/// - No blocks ever decrease in block number.
+/// - The chain defined by soft is the head of the canonical chain the firm block
+///    must belong to.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CommitmentState {
+    /// Soft commitment is the rollup block matching latest sequencer block.
+    #[prost(message, optional, tag = "1")]
+    pub soft: ::core::option::Option<Block>,
+    /// Firm commitment is achieved when data has been seen in DA.
+    #[prost(message, optional, tag = "2")]
+    pub firm: ::core::option::Option<Block>,
+    /// The lowest block number of celestia chain to be searched for rollup blocks
+    /// given current state
+    #[prost(uint64, tag = "3")]
+    pub base_celestia_height: u64,
+}
+impl ::prost::Name for CommitmentState {
+    const NAME: &'static str = "CommitmentState";
+    const PACKAGE: &'static str = "astria.execution.v2";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.execution.v2.{}", Self::NAME)
+    }
+}
+/// There is only one CommitmentState object, so the request is empty.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetCommitmentStateRequest {}
+impl ::prost::Name for GetCommitmentStateRequest {
+    const NAME: &'static str = "GetCommitmentStateRequest";
+    const PACKAGE: &'static str = "astria.execution.v2";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.execution.v2.{}", Self::NAME)
+    }
+}
+/// The CommitmentState to set, must include complete state.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UpdateCommitmentStateRequest {
+    #[prost(message, optional, tag = "1")]
+    pub commitment_state: ::core::option::Option<CommitmentState>,
+}
+impl ::prost::Name for UpdateCommitmentStateRequest {
+    const NAME: &'static str = "UpdateCommitmentStateRequest";
+    const PACKAGE: &'static str = "astria.execution.v2";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.execution.v2.{}", Self::NAME)
+    }
+}
+/// Used in `GetSequencerInfoRequest` to obtain the corresponding sequencer info
+/// for the rollup block number with the given commitment type.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum CommitmentType {
+    Unspecified = 0,
+    Soft = 1,
+    Firm = 2,
+}
+impl CommitmentType {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            CommitmentType::Unspecified => "COMMITMENT_TYPE_UNSPECIFIED",
+            CommitmentType::Soft => "COMMITMENT_TYPE_SOFT",
+            CommitmentType::Firm => "COMMITMENT_TYPE_FIRM",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "COMMITMENT_TYPE_UNSPECIFIED" => Some(Self::Unspecified),
+            "COMMITMENT_TYPE_SOFT" => Some(Self::Soft),
+            "COMMITMENT_TYPE_FIRM" => Some(Self::Firm),
+            _ => None,
+        }
+    }
+}
+/// Generated client implementations.
+#[cfg(feature = "client")]
+pub mod execution_service_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
+    /// ExecutionService is used to drive deterministic production of blocks.
+    ///
+    /// The service can be implemented by any blockchain which wants to utilize the
+    /// Astria Shared Sequencer, and will have block production driven via the Astria
+    /// "Conductor".
+    #[derive(Debug, Clone)]
+    pub struct ExecutionServiceClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl ExecutionServiceClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> ExecutionServiceClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> ExecutionServiceClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
+        {
+            ExecutionServiceClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with the given encoding.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
+            self
+        }
+        /// Enable decompressing responses.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
+        /// GetSequencerInfo returns the necessary information for mapping sequencer block
+        /// height to rollup block number.
+        pub async fn get_sequencer_info(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetSequencerInfoRequest>,
+        ) -> std::result::Result<tonic::Response<super::SequencerInfo>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/astria.execution.v2.ExecutionService/GetSequencerInfo",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "astria.execution.v2.ExecutionService",
+                        "GetSequencerInfo",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        /// GetBlock will return a block given an identifier.
+        pub async fn get_block(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetBlockRequest>,
+        ) -> std::result::Result<tonic::Response<super::Block>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/astria.execution.v2.ExecutionService/GetBlock",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("astria.execution.v2.ExecutionService", "GetBlock"),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        /// BatchGetBlocks will return an array of Blocks given an array of block
+        /// identifiers.
+        pub async fn batch_get_blocks(
+            &mut self,
+            request: impl tonic::IntoRequest<super::BatchGetBlocksRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::BatchGetBlocksResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/astria.execution.v2.ExecutionService/BatchGetBlocks",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "astria.execution.v2.ExecutionService",
+                        "BatchGetBlocks",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        /// ExecuteBlock is called to deterministically derive a rollup block from
+        /// filtered sequencer block information.
+        pub async fn execute_block(
+            &mut self,
+            request: impl tonic::IntoRequest<super::ExecuteBlockRequest>,
+        ) -> std::result::Result<tonic::Response<super::Block>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/astria.execution.v2.ExecutionService/ExecuteBlock",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "astria.execution.v2.ExecutionService",
+                        "ExecuteBlock",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        /// GetCommitmentState fetches the current CommitmentState of the chain.
+        pub async fn get_commitment_state(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetCommitmentStateRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::CommitmentState>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/astria.execution.v2.ExecutionService/GetCommitmentState",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "astria.execution.v2.ExecutionService",
+                        "GetCommitmentState",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+        /// UpdateCommitmentState replaces the whole CommitmentState with a new
+        /// CommitmentState.
+        pub async fn update_commitment_state(
+            &mut self,
+            request: impl tonic::IntoRequest<super::UpdateCommitmentStateRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::CommitmentState>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/astria.execution.v2.ExecutionService/UpdateCommitmentState",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "astria.execution.v2.ExecutionService",
+                        "UpdateCommitmentState",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+    }
+}
+/// Generated server implementations.
+#[cfg(feature = "server")]
+pub mod execution_service_server {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    /// Generated trait containing gRPC methods that should be implemented for use with ExecutionServiceServer.
+    #[async_trait]
+    pub trait ExecutionService: Send + Sync + 'static {
+        /// GetSequencerInfo returns the necessary information for mapping sequencer block
+        /// height to rollup block number.
+        async fn get_sequencer_info(
+            self: std::sync::Arc<Self>,
+            request: tonic::Request<super::GetSequencerInfoRequest>,
+        ) -> std::result::Result<tonic::Response<super::SequencerInfo>, tonic::Status>;
+        /// GetBlock will return a block given an identifier.
+        async fn get_block(
+            self: std::sync::Arc<Self>,
+            request: tonic::Request<super::GetBlockRequest>,
+        ) -> std::result::Result<tonic::Response<super::Block>, tonic::Status>;
+        /// BatchGetBlocks will return an array of Blocks given an array of block
+        /// identifiers.
+        async fn batch_get_blocks(
+            self: std::sync::Arc<Self>,
+            request: tonic::Request<super::BatchGetBlocksRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::BatchGetBlocksResponse>,
+            tonic::Status,
+        >;
+        /// ExecuteBlock is called to deterministically derive a rollup block from
+        /// filtered sequencer block information.
+        async fn execute_block(
+            self: std::sync::Arc<Self>,
+            request: tonic::Request<super::ExecuteBlockRequest>,
+        ) -> std::result::Result<tonic::Response<super::Block>, tonic::Status>;
+        /// GetCommitmentState fetches the current CommitmentState of the chain.
+        async fn get_commitment_state(
+            self: std::sync::Arc<Self>,
+            request: tonic::Request<super::GetCommitmentStateRequest>,
+        ) -> std::result::Result<tonic::Response<super::CommitmentState>, tonic::Status>;
+        /// UpdateCommitmentState replaces the whole CommitmentState with a new
+        /// CommitmentState.
+        async fn update_commitment_state(
+            self: std::sync::Arc<Self>,
+            request: tonic::Request<super::UpdateCommitmentStateRequest>,
+        ) -> std::result::Result<tonic::Response<super::CommitmentState>, tonic::Status>;
+    }
+    /// ExecutionService is used to drive deterministic production of blocks.
+    ///
+    /// The service can be implemented by any blockchain which wants to utilize the
+    /// Astria Shared Sequencer, and will have block production driven via the Astria
+    /// "Conductor".
+    #[derive(Debug)]
+    pub struct ExecutionServiceServer<T: ExecutionService> {
+        inner: _Inner<T>,
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
+    }
+    struct _Inner<T>(Arc<T>);
+    impl<T: ExecutionService> ExecutionServiceServer<T> {
+        pub fn new(inner: T) -> Self {
+            Self::from_arc(Arc::new(inner))
+        }
+        pub fn from_arc(inner: Arc<T>) -> Self {
+            let inner = _Inner(inner);
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
+            }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
+        where
+            F: tonic::service::Interceptor,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
+    }
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for ExecutionServiceServer<T>
+    where
+        T: ExecutionService,
+        B: Body + Send + 'static,
+        B::Error: Into<StdError> + Send + 'static,
+    {
+        type Response = http::Response<tonic::body::BoxBody>;
+        type Error = std::convert::Infallible;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<std::result::Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
+            let inner = self.inner.clone();
+            match req.uri().path() {
+                "/astria.execution.v2.ExecutionService/GetSequencerInfo" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetSequencerInfoSvc<T: ExecutionService>(pub Arc<T>);
+                    impl<
+                        T: ExecutionService,
+                    > tonic::server::UnaryService<super::GetSequencerInfoRequest>
+                    for GetSequencerInfoSvc<T> {
+                        type Response = super::SequencerInfo;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::GetSequencerInfoRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as ExecutionService>::get_sequencer_info(inner, request)
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = GetSequencerInfoSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/astria.execution.v2.ExecutionService/GetBlock" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetBlockSvc<T: ExecutionService>(pub Arc<T>);
+                    impl<
+                        T: ExecutionService,
+                    > tonic::server::UnaryService<super::GetBlockRequest>
+                    for GetBlockSvc<T> {
+                        type Response = super::Block;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::GetBlockRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as ExecutionService>::get_block(inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = GetBlockSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/astria.execution.v2.ExecutionService/BatchGetBlocks" => {
+                    #[allow(non_camel_case_types)]
+                    struct BatchGetBlocksSvc<T: ExecutionService>(pub Arc<T>);
+                    impl<
+                        T: ExecutionService,
+                    > tonic::server::UnaryService<super::BatchGetBlocksRequest>
+                    for BatchGetBlocksSvc<T> {
+                        type Response = super::BatchGetBlocksResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::BatchGetBlocksRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as ExecutionService>::batch_get_blocks(inner, request)
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = BatchGetBlocksSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/astria.execution.v2.ExecutionService/ExecuteBlock" => {
+                    #[allow(non_camel_case_types)]
+                    struct ExecuteBlockSvc<T: ExecutionService>(pub Arc<T>);
+                    impl<
+                        T: ExecutionService,
+                    > tonic::server::UnaryService<super::ExecuteBlockRequest>
+                    for ExecuteBlockSvc<T> {
+                        type Response = super::Block;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::ExecuteBlockRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as ExecutionService>::execute_block(inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = ExecuteBlockSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/astria.execution.v2.ExecutionService/GetCommitmentState" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetCommitmentStateSvc<T: ExecutionService>(pub Arc<T>);
+                    impl<
+                        T: ExecutionService,
+                    > tonic::server::UnaryService<super::GetCommitmentStateRequest>
+                    for GetCommitmentStateSvc<T> {
+                        type Response = super::CommitmentState;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::GetCommitmentStateRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as ExecutionService>::get_commitment_state(
+                                        inner,
+                                        request,
+                                    )
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = GetCommitmentStateSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/astria.execution.v2.ExecutionService/UpdateCommitmentState" => {
+                    #[allow(non_camel_case_types)]
+                    struct UpdateCommitmentStateSvc<T: ExecutionService>(pub Arc<T>);
+                    impl<
+                        T: ExecutionService,
+                    > tonic::server::UnaryService<super::UpdateCommitmentStateRequest>
+                    for UpdateCommitmentStateSvc<T> {
+                        type Response = super::CommitmentState;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::UpdateCommitmentStateRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as ExecutionService>::update_commitment_state(
+                                        inner,
+                                        request,
+                                    )
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = UpdateCommitmentStateSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
+            }
+        }
+    }
+    impl<T: ExecutionService> Clone for ExecutionServiceServer<T> {
+        fn clone(&self) -> Self {
+            let inner = self.inner.clone();
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
+            }
+        }
+    }
+    impl<T: ExecutionService> Clone for _Inner<T> {
+        fn clone(&self) -> Self {
+            Self(Arc::clone(&self.0))
+        }
+    }
+    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.0)
+        }
+    }
+    impl<T: ExecutionService> tonic::server::NamedService for ExecutionServiceServer<T> {
+        const NAME: &'static str = "astria.execution.v2.ExecutionService";
+    }
+}

--- a/crates/astria-core/src/generated/astria.execution.v2.serde.rs
+++ b/crates/astria-core/src/generated/astria.execution.v2.serde.rs
@@ -1,0 +1,1352 @@
+impl serde::Serialize for BatchGetBlocksRequest {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.identifiers.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.execution.v2.BatchGetBlocksRequest", len)?;
+        if !self.identifiers.is_empty() {
+            struct_ser.serialize_field("identifiers", &self.identifiers)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for BatchGetBlocksRequest {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "identifiers",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Identifiers,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "identifiers" => Ok(GeneratedField::Identifiers),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = BatchGetBlocksRequest;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.execution.v2.BatchGetBlocksRequest")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<BatchGetBlocksRequest, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut identifiers__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Identifiers => {
+                            if identifiers__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("identifiers"));
+                            }
+                            identifiers__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(BatchGetBlocksRequest {
+                    identifiers: identifiers__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.execution.v2.BatchGetBlocksRequest", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for BatchGetBlocksResponse {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.blocks.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.execution.v2.BatchGetBlocksResponse", len)?;
+        if !self.blocks.is_empty() {
+            struct_ser.serialize_field("blocks", &self.blocks)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for BatchGetBlocksResponse {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "blocks",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Blocks,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "blocks" => Ok(GeneratedField::Blocks),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = BatchGetBlocksResponse;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.execution.v2.BatchGetBlocksResponse")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<BatchGetBlocksResponse, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut blocks__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Blocks => {
+                            if blocks__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("blocks"));
+                            }
+                            blocks__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(BatchGetBlocksResponse {
+                    blocks: blocks__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.execution.v2.BatchGetBlocksResponse", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for Block {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.number != 0 {
+            len += 1;
+        }
+        if !self.hash.is_empty() {
+            len += 1;
+        }
+        if !self.parent_block_hash.is_empty() {
+            len += 1;
+        }
+        if self.timestamp.is_some() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.execution.v2.Block", len)?;
+        if self.number != 0 {
+            struct_ser.serialize_field("number", &self.number)?;
+        }
+        if !self.hash.is_empty() {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("hash", pbjson::private::base64::encode(&self.hash).as_str())?;
+        }
+        if !self.parent_block_hash.is_empty() {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("parentBlockHash", pbjson::private::base64::encode(&self.parent_block_hash).as_str())?;
+        }
+        if let Some(v) = self.timestamp.as_ref() {
+            struct_ser.serialize_field("timestamp", v)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for Block {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "number",
+            "hash",
+            "parent_block_hash",
+            "parentBlockHash",
+            "timestamp",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Number,
+            Hash,
+            ParentBlockHash,
+            Timestamp,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "number" => Ok(GeneratedField::Number),
+                            "hash" => Ok(GeneratedField::Hash),
+                            "parentBlockHash" | "parent_block_hash" => Ok(GeneratedField::ParentBlockHash),
+                            "timestamp" => Ok(GeneratedField::Timestamp),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = Block;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.execution.v2.Block")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Block, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut number__ = None;
+                let mut hash__ = None;
+                let mut parent_block_hash__ = None;
+                let mut timestamp__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Number => {
+                            if number__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("number"));
+                            }
+                            number__ = 
+                                Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::Hash => {
+                            if hash__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("hash"));
+                            }
+                            hash__ = 
+                                Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::ParentBlockHash => {
+                            if parent_block_hash__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("parentBlockHash"));
+                            }
+                            parent_block_hash__ = 
+                                Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::Timestamp => {
+                            if timestamp__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("timestamp"));
+                            }
+                            timestamp__ = map_.next_value()?;
+                        }
+                    }
+                }
+                Ok(Block {
+                    number: number__.unwrap_or_default(),
+                    hash: hash__.unwrap_or_default(),
+                    parent_block_hash: parent_block_hash__.unwrap_or_default(),
+                    timestamp: timestamp__,
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.execution.v2.Block", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for BlockIdentifier {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.identifier.is_some() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.execution.v2.BlockIdentifier", len)?;
+        if let Some(v) = self.identifier.as_ref() {
+            match v {
+                block_identifier::Identifier::BlockNumber(v) => {
+                    struct_ser.serialize_field("blockNumber", v)?;
+                }
+                block_identifier::Identifier::BlockHash(v) => {
+                    #[allow(clippy::needless_borrow)]
+                    struct_ser.serialize_field("blockHash", pbjson::private::base64::encode(&v).as_str())?;
+                }
+            }
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for BlockIdentifier {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "block_number",
+            "blockNumber",
+            "block_hash",
+            "blockHash",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            BlockNumber,
+            BlockHash,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "blockNumber" | "block_number" => Ok(GeneratedField::BlockNumber),
+                            "blockHash" | "block_hash" => Ok(GeneratedField::BlockHash),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = BlockIdentifier;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.execution.v2.BlockIdentifier")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<BlockIdentifier, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut identifier__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::BlockNumber => {
+                            if identifier__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("blockNumber"));
+                            }
+                            identifier__ = map_.next_value::<::std::option::Option<::pbjson::private::NumberDeserialize<_>>>()?.map(|x| block_identifier::Identifier::BlockNumber(x.0));
+                        }
+                        GeneratedField::BlockHash => {
+                            if identifier__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("blockHash"));
+                            }
+                            identifier__ = map_.next_value::<::std::option::Option<::pbjson::private::BytesDeserialize<_>>>()?.map(|x| block_identifier::Identifier::BlockHash(x.0));
+                        }
+                    }
+                }
+                Ok(BlockIdentifier {
+                    identifier: identifier__,
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.execution.v2.BlockIdentifier", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for CommitmentState {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.soft.is_some() {
+            len += 1;
+        }
+        if self.firm.is_some() {
+            len += 1;
+        }
+        if self.base_celestia_height != 0 {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.execution.v2.CommitmentState", len)?;
+        if let Some(v) = self.soft.as_ref() {
+            struct_ser.serialize_field("soft", v)?;
+        }
+        if let Some(v) = self.firm.as_ref() {
+            struct_ser.serialize_field("firm", v)?;
+        }
+        if self.base_celestia_height != 0 {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("baseCelestiaHeight", ToString::to_string(&self.base_celestia_height).as_str())?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for CommitmentState {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "soft",
+            "firm",
+            "base_celestia_height",
+            "baseCelestiaHeight",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Soft,
+            Firm,
+            BaseCelestiaHeight,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "soft" => Ok(GeneratedField::Soft),
+                            "firm" => Ok(GeneratedField::Firm),
+                            "baseCelestiaHeight" | "base_celestia_height" => Ok(GeneratedField::BaseCelestiaHeight),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = CommitmentState;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.execution.v2.CommitmentState")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<CommitmentState, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut soft__ = None;
+                let mut firm__ = None;
+                let mut base_celestia_height__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Soft => {
+                            if soft__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("soft"));
+                            }
+                            soft__ = map_.next_value()?;
+                        }
+                        GeneratedField::Firm => {
+                            if firm__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("firm"));
+                            }
+                            firm__ = map_.next_value()?;
+                        }
+                        GeneratedField::BaseCelestiaHeight => {
+                            if base_celestia_height__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("baseCelestiaHeight"));
+                            }
+                            base_celestia_height__ = 
+                                Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                    }
+                }
+                Ok(CommitmentState {
+                    soft: soft__,
+                    firm: firm__,
+                    base_celestia_height: base_celestia_height__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.execution.v2.CommitmentState", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for CommitmentType {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let variant = match self {
+            Self::Unspecified => "COMMITMENT_TYPE_UNSPECIFIED",
+            Self::Soft => "COMMITMENT_TYPE_SOFT",
+            Self::Firm => "COMMITMENT_TYPE_FIRM",
+        };
+        serializer.serialize_str(variant)
+    }
+}
+impl<'de> serde::Deserialize<'de> for CommitmentType {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "COMMITMENT_TYPE_UNSPECIFIED",
+            "COMMITMENT_TYPE_SOFT",
+            "COMMITMENT_TYPE_FIRM",
+        ];
+
+        struct GeneratedVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = CommitmentType;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(formatter, "expected one of: {:?}", &FIELDS)
+            }
+
+            fn visit_i64<E>(self, v: i64) -> std::result::Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                i32::try_from(v)
+                    .ok()
+                    .and_then(|x| x.try_into().ok())
+                    .ok_or_else(|| {
+                        serde::de::Error::invalid_value(serde::de::Unexpected::Signed(v), &self)
+                    })
+            }
+
+            fn visit_u64<E>(self, v: u64) -> std::result::Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                i32::try_from(v)
+                    .ok()
+                    .and_then(|x| x.try_into().ok())
+                    .ok_or_else(|| {
+                        serde::de::Error::invalid_value(serde::de::Unexpected::Unsigned(v), &self)
+                    })
+            }
+
+            fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                match value {
+                    "COMMITMENT_TYPE_UNSPECIFIED" => Ok(CommitmentType::Unspecified),
+                    "COMMITMENT_TYPE_SOFT" => Ok(CommitmentType::Soft),
+                    "COMMITMENT_TYPE_FIRM" => Ok(CommitmentType::Firm),
+                    _ => Err(serde::de::Error::unknown_variant(value, FIELDS)),
+                }
+            }
+        }
+        deserializer.deserialize_any(GeneratedVisitor)
+    }
+}
+impl serde::Serialize for ExecuteBlockRequest {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.prev_block_hash.is_empty() {
+            len += 1;
+        }
+        if !self.transactions.is_empty() {
+            len += 1;
+        }
+        if self.timestamp.is_some() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.execution.v2.ExecuteBlockRequest", len)?;
+        if !self.prev_block_hash.is_empty() {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("prevBlockHash", pbjson::private::base64::encode(&self.prev_block_hash).as_str())?;
+        }
+        if !self.transactions.is_empty() {
+            struct_ser.serialize_field("transactions", &self.transactions)?;
+        }
+        if let Some(v) = self.timestamp.as_ref() {
+            struct_ser.serialize_field("timestamp", v)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for ExecuteBlockRequest {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "prev_block_hash",
+            "prevBlockHash",
+            "transactions",
+            "timestamp",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            PrevBlockHash,
+            Transactions,
+            Timestamp,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "prevBlockHash" | "prev_block_hash" => Ok(GeneratedField::PrevBlockHash),
+                            "transactions" => Ok(GeneratedField::Transactions),
+                            "timestamp" => Ok(GeneratedField::Timestamp),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = ExecuteBlockRequest;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.execution.v2.ExecuteBlockRequest")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<ExecuteBlockRequest, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut prev_block_hash__ = None;
+                let mut transactions__ = None;
+                let mut timestamp__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::PrevBlockHash => {
+                            if prev_block_hash__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("prevBlockHash"));
+                            }
+                            prev_block_hash__ = 
+                                Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::Transactions => {
+                            if transactions__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("transactions"));
+                            }
+                            transactions__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Timestamp => {
+                            if timestamp__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("timestamp"));
+                            }
+                            timestamp__ = map_.next_value()?;
+                        }
+                    }
+                }
+                Ok(ExecuteBlockRequest {
+                    prev_block_hash: prev_block_hash__.unwrap_or_default(),
+                    transactions: transactions__.unwrap_or_default(),
+                    timestamp: timestamp__,
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.execution.v2.ExecuteBlockRequest", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for GetBlockRequest {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.identifier.is_some() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.execution.v2.GetBlockRequest", len)?;
+        if let Some(v) = self.identifier.as_ref() {
+            struct_ser.serialize_field("identifier", v)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for GetBlockRequest {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "identifier",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Identifier,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "identifier" => Ok(GeneratedField::Identifier),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = GetBlockRequest;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.execution.v2.GetBlockRequest")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<GetBlockRequest, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut identifier__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Identifier => {
+                            if identifier__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("identifier"));
+                            }
+                            identifier__ = map_.next_value()?;
+                        }
+                    }
+                }
+                Ok(GetBlockRequest {
+                    identifier: identifier__,
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.execution.v2.GetBlockRequest", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for GetCommitmentStateRequest {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let len = 0;
+        let struct_ser = serializer.serialize_struct("astria.execution.v2.GetCommitmentStateRequest", len)?;
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for GetCommitmentStateRequest {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                            Err(serde::de::Error::unknown_field(value, FIELDS))
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = GetCommitmentStateRequest;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.execution.v2.GetCommitmentStateRequest")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<GetCommitmentStateRequest, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                while map_.next_key::<GeneratedField>()?.is_some() {
+                    let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                }
+                Ok(GetCommitmentStateRequest {
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.execution.v2.GetCommitmentStateRequest", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for GetSequencerInfoRequest {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.commitment_type != 0 {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.execution.v2.GetSequencerInfoRequest", len)?;
+        if self.commitment_type != 0 {
+            let v = CommitmentType::try_from(self.commitment_type)
+                .map_err(|_| serde::ser::Error::custom(format!("Invalid variant {}", self.commitment_type)))?;
+            struct_ser.serialize_field("commitmentType", &v)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for GetSequencerInfoRequest {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "commitment_type",
+            "commitmentType",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            CommitmentType,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "commitmentType" | "commitment_type" => Ok(GeneratedField::CommitmentType),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = GetSequencerInfoRequest;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.execution.v2.GetSequencerInfoRequest")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<GetSequencerInfoRequest, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut commitment_type__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::CommitmentType => {
+                            if commitment_type__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("commitmentType"));
+                            }
+                            commitment_type__ = Some(map_.next_value::<CommitmentType>()? as i32);
+                        }
+                    }
+                }
+                Ok(GetSequencerInfoRequest {
+                    commitment_type: commitment_type__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.execution.v2.GetSequencerInfoRequest", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for SequencerInfo {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.rollup_id.is_some() {
+            len += 1;
+        }
+        if self.sequencer_first_block_height != 0 {
+            len += 1;
+        }
+        if self.rollup_first_block_number != 0 {
+            len += 1;
+        }
+        if self.rollup_stop_block_number != 0 {
+            len += 1;
+        }
+        if self.celestia_block_variance != 0 {
+            len += 1;
+        }
+        if !self.sequencer_chain_id.is_empty() {
+            len += 1;
+        }
+        if !self.celestia_chain_id.is_empty() {
+            len += 1;
+        }
+        if self.halt_at_rollup_stop_number {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.execution.v2.SequencerInfo", len)?;
+        if let Some(v) = self.rollup_id.as_ref() {
+            struct_ser.serialize_field("rollupId", v)?;
+        }
+        if self.sequencer_first_block_height != 0 {
+            struct_ser.serialize_field("sequencerFirstBlockHeight", &self.sequencer_first_block_height)?;
+        }
+        if self.rollup_first_block_number != 0 {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("rollupFirstBlockNumber", ToString::to_string(&self.rollup_first_block_number).as_str())?;
+        }
+        if self.rollup_stop_block_number != 0 {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("rollupStopBlockNumber", ToString::to_string(&self.rollup_stop_block_number).as_str())?;
+        }
+        if self.celestia_block_variance != 0 {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("celestiaBlockVariance", ToString::to_string(&self.celestia_block_variance).as_str())?;
+        }
+        if !self.sequencer_chain_id.is_empty() {
+            struct_ser.serialize_field("sequencerChainId", &self.sequencer_chain_id)?;
+        }
+        if !self.celestia_chain_id.is_empty() {
+            struct_ser.serialize_field("celestiaChainId", &self.celestia_chain_id)?;
+        }
+        if self.halt_at_rollup_stop_number {
+            struct_ser.serialize_field("haltAtRollupStopNumber", &self.halt_at_rollup_stop_number)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for SequencerInfo {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "rollup_id",
+            "rollupId",
+            "sequencer_first_block_height",
+            "sequencerFirstBlockHeight",
+            "rollup_first_block_number",
+            "rollupFirstBlockNumber",
+            "rollup_stop_block_number",
+            "rollupStopBlockNumber",
+            "celestia_block_variance",
+            "celestiaBlockVariance",
+            "sequencer_chain_id",
+            "sequencerChainId",
+            "celestia_chain_id",
+            "celestiaChainId",
+            "halt_at_rollup_stop_number",
+            "haltAtRollupStopNumber",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            RollupId,
+            SequencerFirstBlockHeight,
+            RollupFirstBlockNumber,
+            RollupStopBlockNumber,
+            CelestiaBlockVariance,
+            SequencerChainId,
+            CelestiaChainId,
+            HaltAtRollupStopNumber,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "rollupId" | "rollup_id" => Ok(GeneratedField::RollupId),
+                            "sequencerFirstBlockHeight" | "sequencer_first_block_height" => Ok(GeneratedField::SequencerFirstBlockHeight),
+                            "rollupFirstBlockNumber" | "rollup_first_block_number" => Ok(GeneratedField::RollupFirstBlockNumber),
+                            "rollupStopBlockNumber" | "rollup_stop_block_number" => Ok(GeneratedField::RollupStopBlockNumber),
+                            "celestiaBlockVariance" | "celestia_block_variance" => Ok(GeneratedField::CelestiaBlockVariance),
+                            "sequencerChainId" | "sequencer_chain_id" => Ok(GeneratedField::SequencerChainId),
+                            "celestiaChainId" | "celestia_chain_id" => Ok(GeneratedField::CelestiaChainId),
+                            "haltAtRollupStopNumber" | "halt_at_rollup_stop_number" => Ok(GeneratedField::HaltAtRollupStopNumber),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = SequencerInfo;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.execution.v2.SequencerInfo")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<SequencerInfo, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut rollup_id__ = None;
+                let mut sequencer_first_block_height__ = None;
+                let mut rollup_first_block_number__ = None;
+                let mut rollup_stop_block_number__ = None;
+                let mut celestia_block_variance__ = None;
+                let mut sequencer_chain_id__ = None;
+                let mut celestia_chain_id__ = None;
+                let mut halt_at_rollup_stop_number__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::RollupId => {
+                            if rollup_id__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("rollupId"));
+                            }
+                            rollup_id__ = map_.next_value()?;
+                        }
+                        GeneratedField::SequencerFirstBlockHeight => {
+                            if sequencer_first_block_height__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("sequencerFirstBlockHeight"));
+                            }
+                            sequencer_first_block_height__ = 
+                                Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::RollupFirstBlockNumber => {
+                            if rollup_first_block_number__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("rollupFirstBlockNumber"));
+                            }
+                            rollup_first_block_number__ = 
+                                Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::RollupStopBlockNumber => {
+                            if rollup_stop_block_number__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("rollupStopBlockNumber"));
+                            }
+                            rollup_stop_block_number__ = 
+                                Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::CelestiaBlockVariance => {
+                            if celestia_block_variance__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("celestiaBlockVariance"));
+                            }
+                            celestia_block_variance__ = 
+                                Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::SequencerChainId => {
+                            if sequencer_chain_id__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("sequencerChainId"));
+                            }
+                            sequencer_chain_id__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::CelestiaChainId => {
+                            if celestia_chain_id__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("celestiaChainId"));
+                            }
+                            celestia_chain_id__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::HaltAtRollupStopNumber => {
+                            if halt_at_rollup_stop_number__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("haltAtRollupStopNumber"));
+                            }
+                            halt_at_rollup_stop_number__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(SequencerInfo {
+                    rollup_id: rollup_id__,
+                    sequencer_first_block_height: sequencer_first_block_height__.unwrap_or_default(),
+                    rollup_first_block_number: rollup_first_block_number__.unwrap_or_default(),
+                    rollup_stop_block_number: rollup_stop_block_number__.unwrap_or_default(),
+                    celestia_block_variance: celestia_block_variance__.unwrap_or_default(),
+                    sequencer_chain_id: sequencer_chain_id__.unwrap_or_default(),
+                    celestia_chain_id: celestia_chain_id__.unwrap_or_default(),
+                    halt_at_rollup_stop_number: halt_at_rollup_stop_number__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.execution.v2.SequencerInfo", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for UpdateCommitmentStateRequest {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.commitment_state.is_some() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.execution.v2.UpdateCommitmentStateRequest", len)?;
+        if let Some(v) = self.commitment_state.as_ref() {
+            struct_ser.serialize_field("commitmentState", v)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for UpdateCommitmentStateRequest {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "commitment_state",
+            "commitmentState",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            CommitmentState,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "commitmentState" | "commitment_state" => Ok(GeneratedField::CommitmentState),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = UpdateCommitmentStateRequest;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.execution.v2.UpdateCommitmentStateRequest")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<UpdateCommitmentStateRequest, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut commitment_state__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::CommitmentState => {
+                            if commitment_state__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("commitmentState"));
+                            }
+                            commitment_state__ = map_.next_value()?;
+                        }
+                    }
+                }
+                Ok(UpdateCommitmentStateRequest {
+                    commitment_state: commitment_state__,
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.execution.v2.UpdateCommitmentStateRequest", FIELDS, GeneratedVisitor)
+    }
+}

--- a/crates/astria-core/src/generated/mod.rs
+++ b/crates/astria-core/src/generated/mod.rs
@@ -64,6 +64,15 @@ pub mod astria {
                 include!("astria.execution.v1.serde.rs");
             }
         }
+        pub mod v2 {
+            include!("astria.execution.v2.rs");
+
+            #[cfg(feature = "serde")]
+            mod _serde_impl {
+                use super::*;
+                include!("astria.execution.v2.serde.rs");
+            }
+        }
     }
 
     #[path = ""]

--- a/proto/executionapis/astria/execution/v2/execution.proto
+++ b/proto/executionapis/astria/execution/v2/execution.proto
@@ -1,0 +1,164 @@
+syntax = 'proto3';
+
+package astria.execution.v2;
+
+import "astria/primitive/v1/types.proto";
+import "astria/sequencerblock/v1/block.proto";
+import "google/protobuf/timestamp.proto";
+
+// SequencerInfo contains the information needed to map sequencer block height
+// to rollup block number for driving execution.
+//
+// This information is used to determine which sequencer & celestia data to
+// use from the Astria & Celestia networks, as well as define shutdown/restart
+// behavior of the Conductor.
+message SequencerInfo {
+  // The rollup_id is the unique identifier for the rollup chain.
+  astria.primitive.v1.RollupId rollup_id = 1;
+  // The first block height on the sequencer chain to use for rollup transactions.
+  // This is mapped to `rollup_first_block_number`.
+  uint32 sequencer_first_block_height = 2;
+  // The first rollup block number to be executed. This is mapped to `sequencer_first_block_height`
+  uint64 rollup_first_block_number = 3;
+  // The final rollup block number to execute before either re-fetching sequencer
+  // info (restarting) or shutting down (determined by `halt_at_rollup_stop_number`).
+  uint64 rollup_stop_block_number = 4;
+  // The allowed variance in celestia for sequencer blocks to have been posted.
+  uint64 celestia_block_variance = 5;
+  // The ID of the Astria Sequencer network to retrieve Sequencer blocks from.
+  // Conductor implementations should verify that the Sequencer network they are connected to
+  // have this chain ID (if fetching soft Sequencer blocks), and verify that the Sequencer metadata
+  // blobs retrieved from Celestia contain this chain ID (if extracting firm Sequencer blocks from
+  // Celestia blobs).
+  string sequencer_chain_id = 6;
+  // The ID of the Celestia network to retrieve blobs from.
+  // Conductor implementations should verify that the Celestia network they are connected to have
+  // this chain ID (if extracting firm Sequencer blocks from Celestia blobs).
+  string celestia_chain_id = 7;
+  // Requests that Conductor halt at `rollup_stop_block_number` instead of re-fetching
+  // the sequencer info and continuing execution.
+  bool halt_at_rollup_stop_number = 8;
+}
+
+// The set of information which deterministic driver of block production
+// must know about a given rollup Block
+message Block {
+  // The block number
+  uint32 number = 1;
+  // The hash of the block
+  bytes hash = 2;
+  // The hash from the parent block
+  bytes parent_block_hash = 3;
+  // Timestamp on the block, standardized to google protobuf standard.
+  google.protobuf.Timestamp timestamp = 4;
+}
+
+// Fields which are indexed for finding blocks on a blockchain.
+message BlockIdentifier {
+  oneof identifier {
+    uint32 block_number = 1;
+    bytes block_hash = 2;
+  }
+}
+
+// Used to fetch the current `SequencerInfo` from the rollup.
+message GetSequencerInfoRequest {
+  // The commitment type that the sequencer info is being fetched for. If the commitment
+  // type is soft, the returned sequencer info should be based on the rollup's soft
+  // commitment height. If the commitment type is firm, the returned sequencer info
+  // should be based on the rollup's firm commitment height.
+  CommitmentType commitment_type = 1;
+}
+
+// Used in `GetSequencerInfoRequest` to obtain the corresponding sequencer info
+// for the rollup block number with the given commitment type.
+enum CommitmentType {
+  COMMITMENT_TYPE_UNSPECIFIED = 0;
+  COMMITMENT_TYPE_SOFT = 1;
+  COMMITMENT_TYPE_FIRM = 2;
+}
+
+// Used in GetBlock to find a single block.
+message GetBlockRequest {
+  BlockIdentifier identifier = 1;
+}
+
+// Used in BatchGetBlocks, will find all or none based on the list of
+// identifiers.
+message BatchGetBlocksRequest {
+  repeated BlockIdentifier identifiers = 1;
+}
+
+// The list of blocks in response to BatchGetBlocks.
+message BatchGetBlocksResponse {
+  repeated Block blocks = 1;
+}
+
+// ExecuteBlockRequest contains all the information needed to create a new rollup
+// block.
+//
+// This information comes from previous rollup blocks, as well as from sequencer
+// blocks.
+message ExecuteBlockRequest {
+  // The hash of previous block, which new block will be created on top of.
+  bytes prev_block_hash = 1;
+  // List of transactions to include in the new block.
+  repeated astria.sequencerblock.v1.RollupData transactions = 2;
+  // Timestamp to be used for new block.
+  google.protobuf.Timestamp timestamp = 3;
+}
+
+// The CommitmentState holds the block at each stage of sequencer commitment
+// level
+//
+// A Valid CommitmentState:
+// - Block numbers are such that soft >= firm.
+// - No blocks ever decrease in block number.
+// - The chain defined by soft is the head of the canonical chain the firm block
+//   must belong to.
+message CommitmentState {
+  // Soft commitment is the rollup block matching latest sequencer block.
+  Block soft = 1;
+  // Firm commitment is achieved when data has been seen in DA.
+  Block firm = 2;
+  // The lowest block number of celestia chain to be searched for rollup blocks
+  // given current state
+  uint64 base_celestia_height = 3;
+}
+
+// There is only one CommitmentState object, so the request is empty.
+message GetCommitmentStateRequest {}
+
+// The CommitmentState to set, must include complete state.
+message UpdateCommitmentStateRequest {
+  CommitmentState commitment_state = 1;
+}
+
+// ExecutionService is used to drive deterministic production of blocks.
+//
+// The service can be implemented by any blockchain which wants to utilize the
+// Astria Shared Sequencer, and will have block production driven via the Astria
+// "Conductor".
+service ExecutionService {
+  // GetSequencerInfo returns the necessary information for mapping sequencer block
+  // height to rollup block number.
+  rpc GetSequencerInfo(GetSequencerInfoRequest) returns (SequencerInfo);
+
+  // GetBlock will return a block given an identifier.
+  rpc GetBlock(GetBlockRequest) returns (Block);
+
+  // BatchGetBlocks will return an array of Blocks given an array of block
+  // identifiers.
+  rpc BatchGetBlocks(BatchGetBlocksRequest) returns (BatchGetBlocksResponse);
+
+  // ExecuteBlock is called to deterministically derive a rollup block from
+  // filtered sequencer block information.
+  rpc ExecuteBlock(ExecuteBlockRequest) returns (Block);
+
+  // GetCommitmentState fetches the current CommitmentState of the chain.
+  rpc GetCommitmentState(GetCommitmentStateRequest) returns (CommitmentState);
+
+  // UpdateCommitmentState replaces the whole CommitmentState with a new
+  // CommitmentState.
+  rpc UpdateCommitmentState(UpdateCommitmentStateRequest) returns (CommitmentState);
+}


### PR DESCRIPTION
## Summary
Creates v2 execution API to support upcoming v2 changes to Conductor and Geth.

## Background
These changes are meant to support the upcoming v2 upgrades to [Conductor](https://github.com/astriaorg/astria/pull/1928) and [astria-geth](https://github.com/astriaorg/astria-geth/pull/59), which will facilitate the ability to have rollup forks, driven by the need to migrate Forma to Mainnet.

## Changes from `v1`
- Removed `GenesisInfo` and associated RPC in favor of `SequencerInfo`, which contains the following changes from its predecessor:
     - Changed `sequencer_genesis_block_height` to `sequencer_first_block_height`.
     - Added `rollup_first_block_number` and `rollup_stop_block_number`, for determining which rollup height to start execution at along with the ability to shutdown/restart at a given height.
     - Added `sequencer_chain_id` and `celestia_chain_id`.
     - Added `halt_at_rollup_stop_block_number`, which indicates to the Conductor to halt execution at the stop number instead of restart and refetching the sequencer info.
- Added `commitment_type` field to `GetSequencerInfoRequest`, so that the rollup can respond with the correct sequencer info for the rollup block number with the given commitment level.

## Testing
No testing needed.

## Changelogs
Protos have no changelog
