### PR TITLE
chore(conductor): use build patterns instead of macros for mounting Mocks

### DIFF
--- a/crates/astria-conductor/tests/blackbox/helpers/macros.rs
+++ b/crates/astria-conductor/tests/blackbox/helpers/macros.rs
@@ -1,21 +1,6 @@
 #[macro_export]
-macro_rules! block {
-    (number: $number:expr,hash: $hash:expr,parent: $parent:expr $(,)?) => {
-        ::astria_core::generated::astria::execution::v2::Block {
-            number: $number,
-            hash: ::bytes::Bytes::from(Vec::from($hash)),
-            parent_block_hash: ::bytes::Bytes::from(Vec::from($parent)),
-            timestamp: Some(::pbjson_types::Timestamp {
-                seconds: 1,
-                nanos: 1,
-            }),
-        }
-    };
-}
-
-#[macro_export]
 macro_rules! celestia_network_head {
-    (height: $height:expr) => {
+    (height: $height:expr $(,)?) => {
         celestia_network_head!(height: $height, chain_id: $crate::helpers::CELESTIA_CHAIN_ID)
     };
     (height: $height:expr,chain_id: $chain_id:expr $(,)?) => {
@@ -55,37 +40,25 @@ macro_rules! celestia_network_head {
 #[macro_export]
 macro_rules! commitment_state {
     (
-        firm: (number: $firm_number:expr,hash: $firm_hash:expr,parent: $firm_parent:expr $(,)?),
-        soft: (number: $soft_number:expr,hash: $soft_hash:expr,parent: $soft_parent:expr $(,)?),
-        base_celestia_height: $base_celestia_height:expr $(,)?
+        firm:
+        (number: $firm_number:expr,hash: $firm_hash:expr,parent: $firm_parent:expr $(,)?),soft:
+        (number: $soft_number:expr,hash: $soft_hash:expr,parent: $soft_parent:expr $(,)?),base_celestia_height:
+        $base_celestia_height:expr $(,)?
     ) => {
-       ::astria_core::generated::astria::execution::v2::CommitmentState {
-            firm: Some($crate::block!(
-                number: $firm_number,
-                hash: $firm_hash,
-                parent: $firm_parent,
+        ::astria_core::generated::astria::execution::v2::CommitmentState {
+            firm: Some($crate::helpers::make_block(
+                $firm_number,
+                $firm_hash,
+                $firm_parent,
             )),
-            soft: Some($crate::block!(
-                number: $soft_number,
-                hash: $soft_hash,
-                parent: $soft_parent,
+            soft: Some($crate::helpers::make_block(
+                $soft_number,
+                $soft_hash,
+                $soft_parent,
             )),
-           base_celestia_height: $base_celestia_height,
+            base_celestia_height: $base_celestia_height,
         }
     };
-}
-
-#[macro_export]
-macro_rules! filtered_sequencer_block {
-    (sequencer_height: $height:expr) => {{
-        let block = ::astria_core::protocol::test_utils::ConfigureSequencerBlock {
-            height: $height,
-            sequence_data: vec![($crate::ROLLUP_ID, $crate::helpers::data())],
-            ..Default::default()
-        }
-        .make();
-        block.into_filtered_block([$crate::ROLLUP_ID]).into_raw()
-    }};
 }
 
 // XXX: We have to live with rustfmt mangling the pattern match. Fixing it triggers warnings:
@@ -130,11 +103,6 @@ macro_rules! genesis_info {
 }
 
 #[macro_export]
-macro_rules! signed_header {
-    (height: $height:expr,block_hash: $block_hash:expr $(,)?) => {};
-}
-
-#[macro_export]
 macro_rules! mount_celestia_blobs {
     (
         $test_env:ident,
@@ -173,350 +141,5 @@ macro_rules! mount_celestia_blobs {
                 $delay,
             )
             .await
-    }};
-}
-
-#[macro_export]
-macro_rules! mount_celestia_header_network_head {
-    (
-        $test_env:ident,
-        height: $height:expr $(,)?
-    ) => {
-        $test_env
-            .mount_celestia_header_network_head(
-                $crate::celestia_network_head!(height: $height, chain_id: $crate::helpers::CELESTIA_CHAIN_ID),
-            )
-            .await;
-    }
-}
-
-#[macro_export]
-macro_rules! mount_get_commitment_state {
-    (
-        $test_env:ident,
-        firm: ( number: $firm_number:expr, hash: $firm_hash:expr, parent: $firm_parent:expr$(,)? ),
-        soft: ( number: $soft_number:expr, hash: $soft_hash:expr, parent: $soft_parent:expr$(,)? ),
-        base_celestia_height: $base_celestia_height:expr
-        $(,)?
-    ) => {
-        mount_get_commitment_state!(
-            $test_env,
-            firm: ( number: $firm_number, hash: $firm_hash, parent: $firm_parent, ),
-            soft: ( number: $soft_number, hash: $soft_hash, parent: $soft_parent, ),
-            base_celestia_height: $base_celestia_height,
-            up_to_n_times: 1,
-        )
-    };
-    (
-        $test_env:ident,
-        firm: ( number: $firm_number:expr, hash: $firm_hash:expr, parent: $firm_parent:expr$(,)? ),
-        soft: ( number: $soft_number:expr, hash: $soft_hash:expr, parent: $soft_parent:expr$(,)? ),
-        base_celestia_height: $base_celestia_height:expr,
-        up_to_n_times: $up_to_n_times:expr
-        $(,)?
-    ) => {
-        $test_env
-            .mount_get_commitment_state($crate::commitment_state!(
-                firm: (
-                    number: $firm_number,
-                    hash: $firm_hash,
-                    parent: $firm_parent,
-                ),
-                soft: (
-                    number: $soft_number,
-                    hash: $soft_hash,
-                    parent: $soft_parent,
-                ),
-                base_celestia_height: $base_celestia_height,
-            ), $up_to_n_times)
-        .await
-    };
-}
-
-#[macro_export]
-macro_rules! mount_update_commitment_state {
-    (
-        $test_env:ident,
-        firm: ( number: $firm_number:expr, hash: $firm_hash:expr, parent: $firm_parent:expr$(,)? ),
-        soft: ( number: $soft_number:expr, hash: $soft_hash:expr, parent: $soft_parent:expr$(,)? ),
-        base_celestia_height: $base_celestia_height:expr
-        $(,)?
-    ) => {
-        mount_update_commitment_state!(
-            $test_env,
-            mock_name: None,
-            firm: ( number: $firm_number, hash: $firm_hash, parent: $firm_parent, ),
-            soft: ( number: $soft_number, hash: $soft_hash, parent: $soft_parent, ),
-            base_celestia_height: $base_celestia_height,
-            expected_calls: 1,
-        )
-    };
-    (
-        $test_env:ident,
-        mock_name: $mock_name:expr,
-        firm: ( number: $firm_number:expr, hash: $firm_hash:expr, parent: $firm_parent:expr$(,)? ),
-        soft: ( number: $soft_number:expr, hash: $soft_hash:expr, parent: $soft_parent:expr$(,)? ),
-        base_celestia_height: $base_celestia_height:expr
-        $(,)?
-    ) => {
-        mount_update_commitment_state!(
-            $test_env,
-            mock_name: $mock_name,
-            firm: ( number: $firm_number, hash: $firm_hash, parent: $firm_parent, ),
-            soft: ( number: $soft_number, hash: $soft_hash, parent: $soft_parent, ),
-            base_celestia_height: $base_celestia_height,
-            expected_calls: 1,
-        )
-    };
-    (
-        $test_env:ident,
-        mock_name: $mock_name:expr,
-        firm: ( number: $firm_number:expr, hash: $firm_hash:expr, parent: $firm_parent:expr$(,)? ),
-        soft: ( number: $soft_number:expr, hash: $soft_hash:expr, parent: $soft_parent:expr$(,)? ),
-        base_celestia_height: $base_celestia_height:expr,
-        expected_calls: $expected_calls:expr
-        $(,)?
-    ) => {
-        $test_env
-            .mount_update_commitment_state(
-                $mock_name.into(),
-                $crate::commitment_state!(
-                    firm: (
-                        number: $firm_number,
-                        hash: $firm_hash,
-                        parent: $firm_parent,
-                    ),
-                    soft: (
-                        number: $soft_number,
-                        hash: $soft_hash,
-                        parent: $soft_parent,
-                    ),
-                    base_celestia_height: $base_celestia_height,
-                ),
-                $expected_calls,
-        )
-        .await
-    };
-}
-
-#[macro_export]
-macro_rules! mount_abci_info {
-    ($test_env:ident,latest_sequencer_height: $height:expr $(,)?) => {
-        $test_env.mount_abci_info($height).await;
-    };
-}
-
-#[macro_export]
-macro_rules! mount_executed_block {
-    (
-        $test_env:ident,
-        mock_name: $mock_name:expr,
-        number: $number:expr,
-        hash: $hash:expr,
-        parent: $parent:expr,
-        expected_calls: $expected_calls:expr $(,)?
-    ) => {{
-        use ::base64::prelude::*;
-        $test_env.mount_execute_block(
-            $mock_name.into(),
-            ::serde_json::json!({
-                "prevBlockHash": BASE64_STANDARD.encode($parent),
-                "transactions": [{"sequencedData": BASE64_STANDARD.encode($crate::helpers::data())}],
-            }),
-            $crate::block!(
-                number: $number,
-                hash: $hash,
-                parent: $parent,
-            ),
-            $expected_calls,
-        )
-        .await
-    }};
-    (
-        $test_env:ident,
-        mock_name: $mock_name:expr,
-        number: $number:expr,
-        hash: $hash:expr,
-        parent: $parent:expr,
-    ) => {
-        mount_executed_block!(
-            $test_env,
-            mock_name: None,
-            number: $number,
-            hash: $hash,
-            parent: $parent,
-            expected_calls: 1,
-        )
-    };
-    (
-        $test_env:ident,
-        number: $number:expr,
-        hash: $hash:expr,
-        parent: $parent:expr $(,)?
-    ) => {
-        mount_executed_block!(
-            $test_env,
-            mock_name: None,
-            number: $number,
-            hash: $hash,
-            parent: $parent,
-        )
-    };
-}
-
-#[macro_export]
-macro_rules! mount_get_filtered_sequencer_block {
-    ($test_env:ident, sequencer_height: $height:expr, delay: $delay:expr $(,)?) => {
-        $test_env
-            .mount_get_filtered_sequencer_block(
-                ::astria_core::generated::astria::sequencerblock::v1::GetFilteredSequencerBlockRequest {
-                    height: $height,
-                    rollup_ids: vec![$crate::ROLLUP_ID.to_raw()],
-                },
-                $crate::filtered_sequencer_block!(sequencer_height: $height),
-                $delay,
-            )
-            .await;
-    };
-    ($test_env:ident, sequencer_height: $height:expr$(,)?) => {
-        mount_get_filtered_sequencer_block!(
-            $test_env,
-            sequencer_height: $height,
-            delay: Duration::from_secs(0),
-        )
-    };
-}
-
-#[macro_export]
-macro_rules! mount_get_genesis_info {
-    (
-        $test_env:ident,
-        sequencer_start_height: $start_height:expr,
-        celestia_block_variance: $variance:expr,
-        rollup_start_block_number: $rollup_start_block_number:expr,
-        rollup_stop_block_number: $rollup_stop_block_number:expr
-        $(,)?
-    ) => {
-        mount_get_genesis_info!(
-            $test_env,
-            sequencer_start_height: $start_height,
-            celestia_block_variance: $variance,
-            rollup_start_block_number: $rollup_start_block_number,
-            rollup_stop_block_number: $rollup_stop_block_number,
-            up_to_n_times: 1,
-        )
-    };
-    (
-        $test_env:ident,
-        sequencer_start_height: $start_height:expr,
-        celestia_block_variance: $variance:expr,
-        rollup_start_block_number: $rollup_start_block_number:expr,
-        rollup_stop_block_number: $rollup_stop_block_number:expr,
-        up_to_n_times: $up_to_n_times:expr
-        $(,)?
-    ) => {
-        mount_get_genesis_info!(
-            $test_env,
-            sequencer_start_height: $start_height,
-            celestia_block_variance: $variance,
-            rollup_start_block_number: $rollup_start_block_number,
-            rollup_stop_block_number: $rollup_stop_block_number,
-            up_to_n_times: $up_to_n_times,
-            halt_at_rollup_stop_number: false,
-            expected_calls: 1,
-        )
-    };
-    (
-        $test_env:ident,
-        sequencer_start_height: $start_height:expr,
-        celestia_block_variance: $variance:expr,
-        rollup_start_block_number: $rollup_start_block_number:expr,
-        rollup_stop_block_number: $rollup_stop_block_number:expr,
-        up_to_n_times: $up_to_n_times:expr,
-        halt_at_rollup_stop_number: $halt_at_rollup_stop_number:expr,
-        expected_calls: $expected_calls:expr
-        $(,)?
-    ) => {
-        $test_env.mount_get_genesis_info(
-            $crate::genesis_info!(
-                sequencer_start_height: $start_height,
-                celestia_block_variance: $variance,
-                rollup_start_block_number: $rollup_start_block_number,
-                rollup_stop_block_number: $rollup_stop_block_number,
-                halt_at_rollup_stop_number: $halt_at_rollup_stop_number,
-            ),
-            $up_to_n_times,
-            $expected_calls,
-        ).await;
-    };
-}
-
-#[macro_export]
-macro_rules! mount_sequencer_commit {
-    ($test_env:ident,height: $height:expr $(,)?) => {
-        $test_env
-            .mount_commit($crate::helpers::make_signed_header($height))
-            .await;
-    };
-}
-
-#[macro_export]
-macro_rules! mount_sequencer_validator_set {
-    ($test_env:ident,height: $height:expr $(,)?) => {
-        $test_env
-            .mount_validator_set($crate::helpers::make_validator_set($height))
-            .await
-    };
-}
-
-#[macro_export]
-macro_rules! mount_sequencer_genesis {
-    ($test_env:ident) => {
-        $test_env.mount_genesis(SEQUENCER_CHAIN_ID).await;
-    };
-}
-
-#[macro_export]
-macro_rules! mount_get_block {
-    (
-        $test_env:ident,
-        number: $number:expr,
-        hash: $hash:expr,
-        parent: $parent:expr $(,)?
-    ) => {{
-        let block = $crate::block!(
-            number: $number,
-            hash: $hash,
-            parent: $parent,
-        );
-        let identifier = ::astria_core::generated::astria::execution::v2::BlockIdentifier {
-            identifier: Some(
-                ::astria_core::generated::astria::execution::v2::block_identifier::Identifier::BlockNumber(block.number)
-        )};
-        $test_env.mount_get_block(
-            ::astria_core::generated::astria::execution::v2::GetBlockRequest {
-                identifier: Some(identifier),
-            },
-            block,
-        )
-        .await
-    }};
-}
-
-#[macro_export]
-macro_rules! mount_execute_block_tonic_code {
-    (
-        $test_env:ident,
-        parent: $parent:expr,
-        status_code: $status_code:expr $(,)?
-    ) => {{
-        use ::base64::prelude::*;
-        $test_env.mount_tonic_status_code(
-            ::serde_json::json!({
-                "prevBlockHash": BASE64_STANDARD.encode($parent),
-                "transactions": [{"sequencedData": BASE64_STANDARD.encode($crate::helpers::data())}],
-            }),
-            $status_code
-        ).await
     }};
 }


### PR DESCRIPTION
## Summary
Mostly (1 exception) switched from using macros to mount Mocks to using build patterns.

## Background
Scaling the need for differing patterns based on mock use cases was becoming unwieldy and hard to read/understand. For example, if we had the need for a mock to use a delay in one test, and expect a certain number of calls in another, then use both of these functionalities in another, we would need to create 3 new patterns to match on to provide each of these functionalities. Opting for a build pattern allows us to abstract these methods onto builders for open-ended scaling potential and cleaner code.

## Changes
- Created `GrpcMockBuilder` and `JsonRpcMockBuilder`, which are returned by all `mock_*` methods (except `mount_celestia_blob_get_all` on `TestConductor` and contain all necessary information for mounting the mock. These also implement typical methods used with mocks, such as `expect()`, `up_to_n_times()`, etc. The reason behind not returning a `Mock` itself is that these structs can contain information about which server they are to be mounted to, so that when writing tests the developer doesn't need to specify this (similar to how the macros functioned). Additionally, responding with a delay requires putting the delay on the responder before the `Mock` is constructed, so we mustn't construct the `Mock` immediately.
- Changed all `mount_*` methods to `mock_*` to accurately reflect what they are returning.
- Changed all tests to utilize these new methods.

## Testing
Passing all tests

## Changelogs
No updates required.

## Related Issues
closes #1927
