### PR TITLE
fix(charts): Update auctioneer image tags and flame devtag

### DIFF
--- a/charts/auctioneer/Chart.yaml
+++ b/charts/auctioneer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1
+version: 0.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/auctioneer/values.yaml
+++ b/charts/auctioneer/values.yaml
@@ -9,9 +9,8 @@ images:
   auctioneer:
     repo: ghcr.io/astriaorg/auctioneer
     pullPolicy: IfNotPresent
-    # TODO - update to latest tag
-    tag: "pr-1839"
-    devTag: "pr-1839"
+    tag: sha-2db84ed
+    devTag: latest
 
 config:
   sequencerGrpcEndpoint: ""

--- a/charts/evm-stack/Chart.lock
+++ b/charts/evm-stack/Chart.lock
@@ -7,13 +7,13 @@ dependencies:
   version: 1.1.0
 - name: flame-rollup
   repository: file://../flame-rollup
-  version: 0.0.1
+  version: 0.0.2
 - name: composer
   repository: file://../composer
   version: 1.0.0
 - name: auctioneer
   repository: file://../auctioneer
-  version: 0.0.1
+  version: 0.0.2
 - name: evm-faucet
   repository: file://../evm-faucet
   version: 0.1.4
@@ -26,5 +26,5 @@ dependencies:
 - name: blockscout-stack
   repository: https://blockscout.github.io/helm-charts
   version: 1.6.8
-digest: sha256:6c61169417c2af9fd2cb20ae2fa46ac500a701575f0a15266633e0444695f7e9
-generated: "2025-02-11T19:40:53.84221+05:30"
+digest: sha256:ec3e3e94f6df53a563595332c22e966a4fa9b39e52ef77ec2b9182cd48370f8b
+generated: "2025-02-14T19:01:17.769309+05:30"

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -26,7 +26,7 @@ dependencies:
     repository: "file://../evm-rollup"
     condition: evm-rollup.enabled
   - name: flame-rollup
-    version: 0.0.1
+    version: 0.0.2
     repository: "file://../flame-rollup"
     condition: flame-rollup.enabled
   - name: composer
@@ -34,7 +34,7 @@ dependencies:
     repository: "file://../composer"
     condition: composer.enabled
   - name: auctioneer
-    version: 0.0.1
+    version: 0.0.2
     repository: "file://../auctioneer"
     condition: auctioneer.enabled
   - name: evm-faucet

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.9
+version: 1.0.10
 dependencies:
   - name: celestia-node
     version: 0.4.0

--- a/charts/flame-rollup/Chart.yaml
+++ b/charts/flame-rollup/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.0.1
+version: 0.0.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/flame-rollup/values.yaml
+++ b/charts/flame-rollup/values.yaml
@@ -11,7 +11,7 @@ images:
     repo: ghcr.io/astriaorg/flame
     pullPolicy: IfNotPresent
     tag: sha-457e1f9
-    devTag: sha-457e1f9
+    devTag: latest
   conductor:
     repo: ghcr.io/astriaorg/conductor
     pullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary
This PR updates the image tag of the auctioneer in the auctioneer chart to use the latest sha post merge https://github.com/orgs/astriaorg/packages/container/auctioneer/355800545?tag=sha-2db84ed. 
We also update the devtag of the flame image to use the `latest` image.

## Background
We were using images built from a PR for auctioneer before merging it to main. Now we can start using the latest sha tags built from the auctioneer code in main branch.

## Changes
- Update the auctioneer image tag
- Update the flame devtag

## Testing
Deployed locally and tested it

closes <!-- list any issues closed here -->
