### PR TITLE
feat(auctioneer): POC of an auctioneer smoke test

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -196,6 +196,22 @@ working both up and down the stack.
 > just ibc-test delete
 ```
 
+## Running an Auctioneer smoke test
+
+You can run a smoke test which tests the full auctioneer functionality end to end. 
+
+1. The bid is streamed from the flame node to the auctioneer node
+2. The auctioneer node wraps the winning bid in an allocation and sends it to the sequencer.
+3. The sequencer node includes the allocation in a block
+4. The flame node reads the allocation and places the winning tx at the top of the block
+
+```
+> just deploy cluster
+> just auctioneer-test deploy
+> just auctioneer-test run
+> just auctioneer-test delete
+```
+
 ## Examining Deployments
 
 [k9s](https://k9scli.io/) is a useful utility for inspecting deployed

--- a/charts/auctioneer-test.just
+++ b/charts/auctioneer-test.just
@@ -1,0 +1,124 @@
+_default:
+  @just --list auctioneer-test
+
+defaultTag := ""
+defaultNamespace := "astria-dev-cluster"
+evm_destination_address := "0x507056D8174aC4fb40Ec51578d18F853dFe000B2"
+smoke_test_image := "bharath123456/auctioneer-smoke-test:latest"
+sequencer_grpc_url := "grpc.sequencer.localdev.me"
+eth_rpc_url := "http://executor.astria.localdev.me"
+searcher_private_key := "5478c1df1db4867e4d29ab1cf6c6ed0ae0b2c3fbe7fc6e00edd0891d507d43f2"
+rollup_name := "astria"
+amount_to_send := "10000"
+
+delete:
+  -just delete celestia-local
+  -just delete sequencers
+  -just delete rollup
+
+@deploy tag=defaultTag:
+  echo "Deploying ingress controller..." && just deploy-ingress-controller > /dev/null
+  just wait-for-ingress-controller > /dev/null
+  echo "Deploying local celestia instance..."
+  helm install celestia-local-chart ./celestia-local --namespace {{defaultNamespace}} --set fast=true --create-namespace  > /dev/null
+  helm dependency update ./sequencer > /dev/null
+  helm dependency update ./evm-stack > /dev/null
+
+  echo "Setting up 3 astria sequencer nodes"
+  echo "Setting up the first astria sequencers..." && helm install \
+    -n astria-validator-node0 node0-sequencer-chart ./sequencer \
+    -f ../dev/values/validators/all.yml \
+    -f ../dev/values/validators/node0.yml \
+    --set sequencer.optimisticBlockApis.enabled=true \
+    {{ if tag != '' { replace('--set images.sequencer.devTag=# --set sequencer-relayer.images.sequencerRelayer.devTag=#', '#', tag) } else { '' } }} \
+    --create-namespace > /dev/null
+
+  echo "Setting up the second astria sequencer..." && helm install \
+    -n astria-validator-node1 node1-sequencer-chart ./sequencer \
+    -f ../dev/values/validators/all.yml \
+    -f ../dev/values/validators/node1.yml \
+    --set sequencer.optimisticBlockApis.enabled=true \
+    {{ if tag != '' { replace('--set images.sequencer.devTag=# --set sequencer-relayer.images.sequencerRelayer.devTag=#', '#', tag) } else { '' } }} \
+    --create-namespace > /dev/null
+
+  echo "Setting up the third astria sequencer..." && helm install \
+    -n astria-validator-node2 node2-sequencer-chart ./sequencer \
+    -f ../dev/values/validators/all.yml \
+    -f ../dev/values/validators/node2.yml \
+    --set sequencer.optimisticBlockApis.enabled=true \
+    {{ if tag != '' { replace('--set images.sequencer.devTag=# --set sequencer-relayer.images.sequencerRelayer.devTag=#', '#', tag) } else { '' } }} \
+    --create-namespace > /dev/null
+
+  just wait-for-sequencer > /dev/null
+  echo "Starting Flame EVM rollup and the Auctioneer..." && helm install -n astria-dev-cluster astria-chain-chart ./evm-stack \
+    -f ../dev/values/rollup/auctioneer-test.yaml \
+    {{ if tag != '' { replace('--set evm-rollup.images.conductor.devTag=# --set auctioneer.images.auctioneer.devTag=# --set composer.images.composer.devTag=# --set evm-bridge-withdrawer.images.evmBridgeWithdrawer.devTag=#', '#', tag) } else { '' } }} \
+    --set blockscout-stack.enabled=false \
+    --set postgresql.enabled=false \
+    --set auctioneer.enabled=true \
+    --set config.geth.auctioneer=true \
+    --set evm-bridge-withdrawer.enabled=false \
+    --set evm-faucet.enabled=false > /dev/null
+  # TODO - don't wait for evm-bridge-withdrawer
+  just wait-for-rollup > /dev/null
+
+[no-cd]
+run tag=defaultTag:
+  #!/usr/bin/env bash
+  set +e
+  echo "Running auctioneer smoke test 5 times..."
+  echo
+
+  success=0
+  for i in {1..5} ; do
+    echo "Running test iteration $i..."
+    echo
+
+    echo "Getting initial balance of {{evm_destination_address}}"
+    initial_balance=$(just evm-get-balance {{evm_destination_address}})
+    echo "Initial balance: $initial_balance"
+    echo
+
+    expected_balance=$(echo "$initial_balance + {{amount_to_send}}" | bc)
+
+    docker run --rm \
+    --network host {{smoke_test_image}} \
+    --sequencer-url {{sequencer_grpc_url}} \
+    --eth-rpc-url {{eth_rpc_url}} \
+    --searcher-private-key {{searcher_private_key}} \
+    --rollup-name {{rollup_name}} \
+    --address-to-send {{evm_destination_address}} \
+    --amount-to-send {{amount_to_send}} \
+
+    if [ $? -ne 0 ]; then
+      echo
+      echo "Smoke test iteration $i failed!"
+      echo
+      continue
+    fi
+
+    echo
+    echo "Getting final balance of {{evm_destination_address}}"
+    final_balance=$(just evm-get-balance {{evm_destination_address}})
+
+    echo "Verifying if the final balance is as expected..."
+      if [ "$final_balance" -eq "$expected_balance" ]; then
+          (( success++ ))
+          echo "Smoke test iteration $i passed!"
+      else
+          echo "Smoke test iteration $i failed!"
+          echo "Expected balance: $expected_balance, Actual balance: $final_balance"
+      fi
+     echo
+  done
+  echo "Done with all iterations!"
+  echo
+  echo "Verifying if the smoke test passed at least 3 times..."
+  echo
+  echo "$success/5 tests has passed"
+  if [ "$success" -gt 2 ]; then
+    echo "Smoke test passed!"
+  else
+    echo "Smoke test failed!"
+    exit 1
+  fi

--- a/charts/auctioneer/values.yaml
+++ b/charts/auctioneer/values.yaml
@@ -9,9 +9,8 @@ images:
   auctioneer:
     repo: ghcr.io/astriaorg/auctioneer
     pullPolicy: IfNotPresent
-    # TODO - update to latest tag
-    tag: "pr-1839"
-    devTag: "pr-1839"
+    tag: sha-2db84ed
+    devTag: latest
 
 config:
   sequencerGrpcEndpoint: ""

--- a/charts/deploy.just
+++ b/charts/deploy.just
@@ -1,4 +1,5 @@
 mod ibc-test
+mod auctioneer-test
 
 ##############################################
 ## Deploying and Running using Helm and K8s ##

--- a/charts/flame-rollup/values.yaml
+++ b/charts/flame-rollup/values.yaml
@@ -11,7 +11,7 @@ images:
     repo: ghcr.io/astriaorg/flame
     pullPolicy: IfNotPresent
     tag: sha-457e1f9
-    devTag: sha-457e1f9
+    devTag: latest
   conductor:
     repo: ghcr.io/astriaorg/conductor
     pullPolicy: IfNotPresent

--- a/dev/values/rollup/auctioneer-test.yaml
+++ b/dev/values/rollup/auctioneer-test.yaml
@@ -1,0 +1,277 @@
+global:
+  useTTY: true
+  dev: true
+  evmChainId: 1337
+  rollupName: astria
+  sequencerRpc: http://node0-sequencer-rpc-service.astria-dev-cluster.svc.cluster.local:26657
+  sequencerGrpc: http://node0-sequencer-grpc-service.astria-dev-cluster.svc.cluster.local:8080
+  sequencerChainId: sequencer-test-chain-0
+  celestiaChainId: celestia-local-0
+
+evm-rollup:
+  enabled: false
+
+flame-rollup:
+  enabled: true
+  genesis:
+    ## These values are used to configure the genesis block of the rollup chain
+    ## no defaults as they are unique to each chain
+
+    # Block height to start syncing rollup from, lowest possible is 2
+    sequencerInitialHeight: 2
+    # The first Celestia height to utilize when looking for rollup data
+    celestiaInitialHeight: 2
+    # The variance in Celestia height to allow before halting the chain
+    celestiaHeightVariance: 10
+    # Will fill the extra data in each block, can be left empty
+    # can also fill with something unique for your chain.
+    extraDataOverride: ""
+
+    ## These are general configuration values with some recommended defaults
+
+    # Configure the gas Limit
+    gasLimit: "50000000"
+    # If set to true the genesis block will contain extra data
+    overrideGenesisExtraData: true
+    # The hrp for bech32m addresses, unlikely to be changed
+    sequencerAddressPrefix: "astria"
+
+    ## These values are used to configure astria native bridging
+    ## Many of the fields have commented out example fields
+
+    # Configure the sequencer bridge addresses and allowed assets if using
+    # the astria canonical bridge. Recommend removing alloc values if so.
+    bridgeAddresses:
+      - bridgeAddress: "astria13ahqz4pjqfmynk9ylrqv4fwe4957x2p0h5782u"
+        startHeight: 1
+        senderAddress: "0x0000000000000000000000000000000000000000"
+        assetDenom: "nria"
+        assetPrecision: 9
+
+
+    ## Fee configuration
+
+    # Configure the fee collector for the evm tx fees, activated at block heights.
+    # If not configured, all tx fees will be burned.
+    feeCollectors:
+      1: "0xaC21B97d35Bf75A7dAb16f35b111a50e78A72F30"
+    # Configure EIP-1559 params, activated at block heights
+    eip1559Params: {}
+      # 1:
+    #   minBaseFee: 0
+    #   elasticityMultiplier: 2
+    #   baseFeeChangeDenominator: 8
+    auctioneerAddresses:
+      1: "astria1sa4ykgdnqn9rg2zv39h2cghfeet6tjkmd0r6k0"
+    ## Standard Eth Genesis config values
+    # Configuration of Eth forks, setting to 0 will enable from height,
+    # left as is these forks will not activate.
+    cancunTime: ""
+    pragueTime: ""
+    verkleTime: ""
+    # Can configure the genesis allocs for the chain
+    alloc:
+      # Deploying the deterministic deploy proxy contract in genesis
+      # Forge and other tools use this for their CREATE2 usage, but
+      # can only be included through the genesis block after EIP-155
+      # https://github.com/Arachnid/deterministic-deployment-proxy
+      - address: "0x4e59b44847b379578588920cA78FbF26c0B4956C"
+        value:
+          balance: "0"
+          code: "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf3"
+      - address: "0xA58639fB5458e65E4fA917FF951C390292C24A15"
+        value:
+          balance: "0"
+          code: "0x6080604052600436106100f35760003560e01c8063b6476c7e1161008a578063e74b981b11610059578063e74b981b1461027b578063ebd090541461029b578063f2fde38b146102bb578063fc88d31b146102db57600080fd5b8063b6476c7e1461021c578063bab916d01461023e578063d294f09314610251578063db97dc981461026657600080fd5b80638da5cb5b116100c65780638da5cb5b146101a1578063a7eaa739146101d3578063a996e020146101f3578063ad2282471461020657600080fd5b80636f46384a146100f8578063715018a6146101215780637eb6dec7146101385780638897397914610181575b600080fd5b34801561010457600080fd5b5061010e60035481565b6040519081526020015b60405180910390f35b34801561012d57600080fd5b506101366102f1565b005b34801561014457600080fd5b5061016c7f000000000000000000000000000000000000000000000000000000000000000981565b60405163ffffffff9091168152602001610118565b34801561018d57600080fd5b5061013661019c3660046107a6565b610305565b3480156101ad57600080fd5b506000546001600160a01b03165b6040516001600160a01b039091168152602001610118565b3480156101df57600080fd5b506101366101ee3660046107a6565b610312565b610136610201366004610808565b61031f565b34801561021257600080fd5b5061010e60065481565b34801561022857600080fd5b50610231610414565b6040516101189190610874565b61013661024c3660046108c3565b6104a2565b34801561025d57600080fd5b50610136610588565b34801561027257600080fd5b506102316106b4565b34801561028757600080fd5b50610136610296366004610905565b6106c1565b3480156102a757600080fd5b506005546101bb906001600160a01b031681565b3480156102c757600080fd5b506101366102d6366004610905565b6106eb565b3480156102e757600080fd5b5061010e60045481565b6102f9610729565b6103036000610756565b565b61030d610729565b600455565b61031a610729565b600355565b3460045480821161034b5760405162461bcd60e51b815260040161034290610935565b60405180910390fd5b60007f000000000000000000000000000000000000000000000000000000003b9aca006103788385610998565b61038291906109b1565b1161039f5760405162461bcd60e51b8152600401610342906109d3565b600454600660008282546103b39190610a61565b90915550506004546103c59034610998565b336001600160a01b03167f0c64e29a5254a71c7f4e52b3d2d236348c80e00a00ba2e1961962bd2827c03fb888888886040516104049493929190610a9d565b60405180910390a3505050505050565b6002805461042190610acf565b80601f016020809104026020016040519081016040528092919081815260200182805461044d90610acf565b801561049a5780601f1061046f5761010080835404028352916020019161049a565b820191906000526020600020905b81548152906001019060200180831161047d57829003601f168201915b505050505081565b346003548082116104c55760405162461bcd60e51b815260040161034290610935565b60007f000000000000000000000000000000000000000000000000000000003b9aca006104f28385610998565b6104fc91906109b1565b116105195760405162461bcd60e51b8152600401610342906109d3565b6003546006600082825461052d9190610a61565b909155505060035461053f9034610998565b336001600160a01b03167f0f4961cab7530804898499aa89f5ec81d1a73102e2e4a1f30f88e5ae3513ba2a868660405161057a929190610b09565b60405180910390a350505050565b6005546001600160a01b031633146105f45760405162461bcd60e51b815260206004820152602960248201527f41737472696142726964676561626c6545524332303a206f6e6c7920666565206044820152681c9958da5c1a595b9d60ba1b6064820152608401610342565b6005546006546040516000926001600160a01b031691908381818185875af1925050503d8060008114610643576040519150601f19603f3d011682016040523d82523d6000602084013e610648565b606091505b50509050806106ac5760405162461bcd60e51b815260206004820152602a60248201527f41737472696142726964676561626c6545524332303a20666565207472616e7360448201526919995c8819985a5b195960b21b6064820152608401610342565b506000600655565b6001805461042190610acf565b6106c9610729565b600580546001600160a01b0319166001600160a01b0392909216919091179055565b6106f3610729565b6001600160a01b03811661071d57604051631e4fbdf760e01b815260006004820152602401610342565b61072681610756565b50565b6000546001600160a01b031633146103035760405163118cdaa760e01b8152336004820152602401610342565b600080546001600160a01b038381166001600160a01b0319831681178455604051919092169283917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e09190a35050565b6000602082840312156107b857600080fd5b5035919050565b60008083601f8401126107d157600080fd5b50813567ffffffffffffffff8111156107e957600080fd5b60208301915083602082850101111561080157600080fd5b9250929050565b6000806000806040858703121561081e57600080fd5b843567ffffffffffffffff8082111561083657600080fd5b610842888389016107bf565b9096509450602087013591508082111561085b57600080fd5b50610868878288016107bf565b95989497509550505050565b60006020808352835180602085015260005b818110156108a257858101830151858201604001528201610886565b506000604082860101526040601f19601f8301168501019250505092915050565b600080602083850312156108d657600080fd5b823567ffffffffffffffff8111156108ed57600080fd5b6108f9858286016107bf565b90969095509350505050565b60006020828403121561091757600080fd5b81356001600160a01b038116811461092e57600080fd5b9392505050565b6020808252602d908201527f417374726961576974686472617765723a20696e73756666696369656e74207760408201526c69746864726177616c2066656560981b606082015260800190565b634e487b7160e01b600052601160045260246000fd5b818103818111156109ab576109ab610982565b92915050565b6000826109ce57634e487b7160e01b600052601260045260246000fd5b500490565b60208082526062908201527f417374726961576974686472617765723a20696e73756666696369656e74207660408201527f616c75652c206d7573742062652067726561746572207468616e203130202a2a60608201527f20283138202d20424153455f434841494e5f41535345545f505245434953494f6080820152614e2960f01b60a082015260c00190565b808201808211156109ab576109ab610982565b81835281816020850137506000828201602090810191909152601f909101601f19169091010190565b604081526000610ab1604083018688610a74565b8281036020840152610ac4818587610a74565b979650505050505050565b600181811c90821680610ae357607f821691505b602082108103610b0357634e487b7160e01b600052602260045260246000fd5b50919050565b602081526000610b1d602083018486610a74565b94935050505056fea2646970667358221220842bd8104ffc1c611919341f64a8277f2fc808138b97720a6dc1382e5670099064736f6c63430008190033"
+      # Address used to submit txs to the auctioneer flame node
+      - address: "0x9aF4ebABf9eE4802f565B76AC0D30e6Def595991"
+        value:
+          balance: "1000000000000000000000"
+
+  config:
+    # The level at which core astria components will log out
+    # Options are: error, warn, info, and debug
+    logLevel: "debug"
+
+    geth:
+      auctioneer: true
+
+    conductor:
+      # Determines what will drive block execution, options are:
+      # - "SoftOnly" -> blocks are only pulled from the sequencer
+      # - "FirmOnly" -> blocks are only pulled from DA
+      # - "SoftAndFirm" -> blocks are pulled from both the sequencer and DA
+      executionCommitLevel: 'SoftAndFirm'
+      # The expected fastest block time possible from sequencer, determines polling
+      # rate. When running with the auctioneer side car, decrease this value in
+      # order to avoid race condition between executions (100ms recommended).
+      sequencerBlockTimeMs: 2000
+      # The maximum number of requests to make to the sequencer per second
+      sequencerRequestsPerSecond: 500
+
+    celestia:
+      rpc: "http://celestia-service.astria-dev-cluster.svc.cluster.local:26658"
+      token: ""
+
+  resources:
+    conductor:
+      requests:
+        cpu: 0.01
+        memory: 1Mi
+      limits:
+        cpu: 0.1
+        memory: 20Mi
+    geth:
+      requests:
+        cpu: 0.25
+        memory: 256Mi
+      limits:
+        cpu: 2
+        memory: 1Gi
+
+  storage:
+    enabled: false
+
+  ingress:
+    enabled: true
+    services:
+      rpc:
+        enabled: true
+      ws:
+        enabled: true
+
+auctioneer:
+  enabled: true
+  config:
+    sequencerPrivateKey:
+      devContent: "2ac982cbfd427da900a0d1d6aeae9a7b7f1794deb9f4434b19fc76678274891e"
+    feeAssetDenomination: "nria"
+    sequencerAddressPrefix: astria
+    rollupGrpcEndpoint: "http://astria-evm-service.astria-dev-cluster.svc.cluster.local:50051"
+    rollupId: "astria"
+    latencyMarginMs: 1000
+    logLevel: "debug"
+
+
+celestia-node:
+  enabled: false
+
+composer:
+  enabled: false
+  config:
+    privateKey:
+      devContent: "2bd806c97f0e00af1a1fc3328fa763a9269723c8db8fac4f93af71db186d6e90"
+
+evm-bridge-withdrawer:
+  enabled: false
+  config:
+    minExpectedFeeAssetBalance: "0"
+    sequencerBridgeAddress: "astria13ahqz4pjqfmynk9ylrqv4fwe4957x2p0h5782u"
+    feeAssetDenom: "nria"
+    rollupAssetDenom: "nria"
+    evmContractAddress: "0xA58639fB5458e65E4fA917FF951C390292C24A15"
+    sequencerPrivateKey:
+      devContent: "dfa7108e38ab71f89f356c72afc38600d5758f11a8c337164713e4471411d2e0"
+
+evm-faucet:
+  enabled: true
+  ingress:
+    enabled: true
+  config:
+    privateKey:
+      devContent: "8b3a7999072c9c9314c084044fe705db11714c6c4ed7cddb64da18ea270dd203"
+
+postgresql:
+  enabled: true
+  nameOverride: blockscout-postegres
+  primary:
+    persistence:
+      enabled: false
+    resourcesPreset: "medium"
+  auth:
+    enablePostgresUser: true
+    postgresPassword: bigsecretpassword
+    username: blockscout
+    password: blockscout
+    database: blockscout
+  audit:
+    logHostname: true
+    logConnections: true
+    logDisconnections: true
+blockscout-stack:
+  enabled: true
+  config:
+    network:
+      id: 1337
+      name: Astria
+      shortname: Astria
+      currency:
+        name: RIA
+        symbol: RIA
+        decimals: 18
+    testnet: true
+    prometheus:
+      enabled: false
+  blockscout:
+    extraEnv:
+      - name: ECTO_USE_SSL
+        value: "false"
+      - name: DATABASE_URL
+        value: "postgres://postgres:bigsecretpassword@astria-chain-chart-blockscout-postegres.astria-dev-cluster.svc.cluster.local:5432/blockscout"
+      - name: ETHEREUM_JSONRPC_VARIANT
+        value: "geth"
+      - name: ETHEREUM_JSONRPC_HTTP_URL
+        value: "http://astria-evm-service.astria-dev-cluster.svc.cluster.local:8545/"
+      - name: ETHEREUM_JSONRPC_INSECURE
+        value: "true"
+      - name: ETHEREUM_JSONRPC_WS_URL
+        value: "ws://astria-evm-service.astria-dev-cluster.svc.cluster.local:8546/"
+      - name: INDEXER_DISABLE_BEACON_BLOB_FETCHER
+        value: "true"
+      - name: NETWORK
+        value: "Astria"
+      - name: SUBNETWORK
+        value: "Local"
+      - name: CONTRACT_VERIFICATION_ALLOWED_SOLIDITY_EVM_VERSIONS
+        value: "homestead,tangerineWhistle,spuriousDragon,byzantium,constantinople,petersburg,istanbul,berlin,london,paris,shanghai,default"
+      - name: CONTRACT_VERIFICATION_ALLOWED_VYPER_EVM_VERSIONS
+        value: "byzantium,constantinople,petersburg,istanbul,berlin,paris,shanghai,default"
+      - name: DISABLE_EXCHANGE_RATES
+        value: "true"
+
+    ingress:
+      enabled: true
+      hostname: explorer.astria.localdev.me
+      paths:
+        - path: /api
+          pathType: Prefix
+        - path: /socket
+          pathType: Prefix
+        - path: /sitemap.xml
+          pathType: ImplementationSpecific
+        - path: /public-metrics
+          pathType: Prefix
+        - path: /auth/auth0
+          pathType: Exact
+        - path: /auth/auth0/callback
+          pathType: Exact
+        - path: /auth/logout
+          pathType: Exact
+
+  frontend:
+    extraEnv:
+      - name: NEXT_PUBLIC_NETWORK_VERIFICATION_TYPE
+        value: "validation"
+      - name: NEXT_PUBLIC_AD_BANNER_PROVIDER
+        value: "none"
+      - name: NEXT_PUBLIC_API_PROTOCOL
+        value: "http"
+      - name: NEXT_PUBLIC_API_WEBSOCKET_PROTOCOL
+        value: "ws"
+      - name: NEXT_PUBLIC_NETWORK_CURRENCY_WEI_NAME
+        value: "aRia"
+      - name: NEXT_PUBLIC_AD_TEXT_PROVIDER
+        value: "none"
+    ingress:
+      enabled: true
+      hostname: explorer.astria.localdev.me

--- a/dev/values/validators/all.yml
+++ b/dev/values/validators/all.yml
@@ -36,6 +36,9 @@ genesis:
     # address of the bridge account. needs funds to sign bridge init tx
     - address: astria1d7zjjljc0dsmxa545xkpwxym86g8uvvwhtezcr
       balance: "69000000"
+    # address of the auctioneer account. needs funds to submit the allocation tx
+    - address: astria1sa4ykgdnqn9rg2zv39h2cghfeet6tjkmd0r6k0
+      balance: "69000000"
 
 sequencer:
   optimisticBlockApis:


### PR DESCRIPTION
## Summary
We add a smoke test to test the auctioneer setup e2e. 

## Background
The setup for auctioneer is complex as there are multiple components and moving parts involved. Having a smoke test can help us guarantee that things don't break early on while developing it further. 
To be able to write a reliable smoke test for auctioneer, we need to have a way to reliably guarantee inclusion. Since if we submit a bid too late into a block, it can miss making it to the next sequencer block. Note that this is not a bug in the system.
In the current design of auctioneer, if the bid doesn't make it into the sequencer block or if there is a bug in the read/write paths of auctioneer then in both cases, we only observe an unfinalized transaction. We cannot distinguish between a bid submitted too late or a bug in the pipeline. 
In order to achieve this, we use the code in https://github.com/astriaorg/auctioneer-searcher-simulation/tree/bharath/smoke-test-strip-down to run a smoke test. On a high level, we listen to the optimistic block and when we receive an optimistic block, we submit the bid. We submit the bid as early as possible to ensure reliably inclusion. 
In the smoke test, we submit 5 bids and the smoke test only passes when 3/5 bids successfully make it in a block.

## Changes
- Add auctioneer-test.just file with commands to deploy and run the auctioneer smoke test
- Add dev/values/rollup/auctioneer-test.yaml to have flame configs specific to auctioneer. 
- Add a new sequencer public key to the sequencer genesis to have a funded key for auctioneer. 

## Testing
Locally deploying and running the smoke test.

## Related Issues
closes https://github.com/astriaorg/astria/issues/1971
