### PR TITLE
feat: enforce length constraints on destination_chain_address

### DIFF
--- a/crates/astria-core/CHANGELOG.md
+++ b/crates/astria-core/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update `idna` dependency to resolve cargo audit warning [#1869](https://github.com/astriaorg/astria/pull/1869).
 - Replaced all instances of `[u8; 32]` by newtype
   `astria_core::sequencerblock::v1::block::Hash` where appropriate [#1884](https://github.com/astriaorg/astria/pull/1884).
+- Enforce length constraints on `destination_chain_address` in BridgeTransfer and BridgeLock [#1977](https://github.com/astriaorg/astria/pull/1977).
 
 ### Removed
 

--- a/crates/astria-core/src/protocol/transaction/v1/action/mod.rs
+++ b/crates/astria-core/src/protocol/transaction/v1/action/mod.rs
@@ -1556,7 +1556,7 @@ impl Protobuf for BridgeLock {
     /// - if the `to` field is not set
     /// - if the `to` field is invalid
     /// - if the `asset` field is invalid
-    /// - if the `fee_asset` field is invalid 
+    /// - if the `fee_asset` field is invalid
     /// - if `destination_chain_address` is not set
     /// - if the `destination_chain_address` is over 256 bytes long
     fn try_from_raw(proto: raw::BridgeLock) -> Result<Self, BridgeLockError> {
@@ -1652,7 +1652,7 @@ enum BridgeLockErrorKind {
     InvalidAsset(#[source] asset::ParseDenomError),
     #[error("the `fee_asset` field was invalid")]
     InvalidFeeAsset(#[source] asset::ParseDenomError),
-    #[error("the destination_chain_address length is 0 or greater than 256")]
+    #[error("the destination_chain_address length is greater than 256 bytes")]
     InvalidDestinationChainAddressLength,
 }
 
@@ -2005,11 +2005,10 @@ impl Protobuf for BridgeTransfer {
                 "destination_chain_address",
             ));
         }
-        if destination_chain_address.as_bytes().is_empty()
-        {
+        if destination_chain_address.as_bytes().is_empty() {
             return Err(BridgeTransferError::null_destination_chain_address());
         }
-        if destination_chain_address.as_bytes().len() > 256{
+        if destination_chain_address.as_bytes().len() > 256 {
             return Err(BridgeTransferError::invalid_destination_chain_address());
         }
 

--- a/crates/astria-core/src/protocol/transaction/v1/action/mod.rs
+++ b/crates/astria-core/src/protocol/transaction/v1/action/mod.rs
@@ -1,6 +1,9 @@
 use bytes::Bytes;
 use ibc_types::{
-    core::{channel::ChannelId, client::Height as IbcHeight},
+    core::{
+        channel::ChannelId,
+        client::Height as IbcHeight,
+    },
     IdentifierError,
 };
 use penumbra_ibc::IbcRelay;
@@ -9,10 +12,19 @@ use prost::Name as _;
 use super::raw;
 use crate::{
     primitive::v1::{
-        asset::{self, Denom},
-        Address, AddressError, IncorrectRollupIdLength, RollupId,
+        asset::{
+            self,
+            Denom,
+        },
+        Address,
+        AddressError,
+        IncorrectRollupIdLength,
+        RollupId,
     },
-    protocol::fees::v1::{FeeComponentError, FeeComponents},
+    protocol::fees::v1::{
+        FeeComponentError,
+        FeeComponents,
+    },
     Protobuf,
 };
 
@@ -66,7 +78,9 @@ impl Protobuf for Action {
             Action::BridgeTransfer(act) => Value::BridgeTransfer(act.to_raw()),
             Action::FeeChange(act) => Value::FeeChange(act.to_raw()),
         };
-        raw::Action { value: Some(kind) }
+        raw::Action {
+            value: Some(kind),
+        }
     }
 
     /// Attempt to convert from a reference to raw, unchecked protobuf [`raw::Action`].
@@ -87,7 +101,9 @@ impl Protobuf for Action {
     /// to a native action fails.
     fn try_from_raw(proto: raw::Action) -> Result<Self, Error> {
         use raw::action::Value;
-        let raw::Action { value } = proto;
+        let raw::Action {
+            value,
+        } = proto;
         let Some(action) = value else {
             return Err(Error::unset());
         };
@@ -595,7 +611,9 @@ impl ValidatorUpdateError {
     }
 
     fn verification_key(source: crate::crypto::Error) -> Self {
-        Self(ValidatorUpdateErrorKind::VerificationKey { source })
+        Self(ValidatorUpdateErrorKind::VerificationKey {
+            source,
+        })
     }
 }
 
@@ -1538,8 +1556,7 @@ impl Protobuf for BridgeLock {
     /// - if the `to` field is not set
     /// - if the `to` field is invalid
     /// - if the `asset` field is invalid
-    /// - if the `fee_asset` field is invalid
-    ///     /// - if `destination_chain_address` is not set
+    /// - if the `fee_asset` field is invalid /// - if `destination_chain_address` is not set
     /// - if the `destination_chain_address` is not 256 bytes long
     fn try_from_raw(proto: raw::BridgeLock) -> Result<Self, BridgeLockError> {
         let Some(to) = proto.to else {
@@ -1556,9 +1573,7 @@ impl Protobuf for BridgeLock {
             .parse()
             .map_err(BridgeLockError::invalid_fee_asset)?;
         if proto.destination_chain_address.is_empty() {
-            return Err(BridgeLockError::field_not_set(
-                "destination_chain_address",
-            ));
+            return Err(BridgeLockError::field_not_set("destination_chain_address"));
         }
         if proto.destination_chain_address.as_bytes().len() != 256 {
             return Err(BridgeLockError::invalid_destination_chain_address());
@@ -1636,7 +1651,7 @@ enum BridgeLockErrorKind {
     InvalidAsset(#[source] asset::ParseDenomError),
     #[error("the `fee_asset` field was invalid")]
     InvalidFeeAsset(#[source] asset::ParseDenomError),
-    #[error("the `destination_chain_address` length is not 256")]
+    #[error("the destination_chain_address length is 0 or greater than 256")]
     InvalidDestinationChainAddressLength,
 }
 
@@ -1989,7 +2004,9 @@ impl Protobuf for BridgeTransfer {
                 "destination_chain_address",
             ));
         }
-        if destination_chain_address.as_bytes().len() != 256 {
+        if destination_chain_address.as_bytes().len() > 0
+            && destination_chain_address.as_bytes().len() <= 256
+        {
             return Err(BridgeTransferError::invalid_destination_chain_address());
         }
 
@@ -2068,7 +2085,7 @@ enum BridgeTransferErrorKind {
     FeeAsset { source: asset::ParseDenomError },
     #[error("the `bridge_address` field was invalid")]
     BridgeAddress { source: AddressError },
-    #[error("the `destination_chain_address` length is not 256")]
+    #[error("the `destination_chain_address` length is 0 or greater than 256")]
     InvalidDestinationChainAddressLength,
 }
 
@@ -2078,13 +2095,17 @@ pub struct FeeChangeError(FeeChangeErrorKind);
 
 impl FeeChangeError {
     fn field_unset(name: &'static str) -> Self {
-        Self(FeeChangeErrorKind::FieldUnset { name })
+        Self(FeeChangeErrorKind::FieldUnset {
+            name,
+        })
     }
 }
 
 impl From<FeeComponentError> for FeeChangeError {
     fn from(source: FeeComponentError) -> Self {
-        Self(FeeChangeErrorKind::FeeComponent { source })
+        Self(FeeChangeErrorKind::FeeComponent {
+            source,
+        })
     }
 }
 


### PR DESCRIPTION
## Summary

Enforces length constraints on `destination_chain_address` in BridgeTransfer and BridgeLock

## Background

Invalid `destination_chain_address` could have been passed before as there as no check


## Changes

In `crates/astria-core/src/protocol/transaction/v1/mod.rs



## Changelogs
Changelogs updated



## Related Issues

#1961 

closes #1961 
