### PR TITLE
chore(charts, cometbft): upgrade cometbft version to v0.38.17 and hermes usage

### DIFF
--- a/charts/hermes/Chart.yaml
+++ b/charts/hermes/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.2
+version: 0.5.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hermes/Chart.yaml
+++ b/charts/hermes/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.3
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.3.0"
+appVersion: "0.4.0"
 
 maintainers:
   - name: wafflesvonmaple

--- a/charts/hermes/values.yaml
+++ b/charts/hermes/values.yaml
@@ -3,7 +3,7 @@ global:
   replicaCount: 1
   logLevel: debug
 
-image: ghcr.io/astriaorg/hermes:0.3.0
+image: ghcr.io/astriaorg/hermes:pr-26
 imagePullPolicy: IfNotPresent
 
 fullnameOverride: ""

--- a/charts/hermes/values.yaml
+++ b/charts/hermes/values.yaml
@@ -3,7 +3,7 @@ global:
   replicaCount: 1
   logLevel: debug
 
-image: ghcr.io/astriaorg/hermes:pr-26
+image: ghcr.io/astriaorg/hermes:0.4.0
 imagePullPolicy: IfNotPresent
 
 fullnameOverride: ""

--- a/charts/sequencer/Chart.yaml
+++ b/charts/sequencer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.4
+version: 1.0.5
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/sequencer/values.yaml
+++ b/charts/sequencer/values.yaml
@@ -28,8 +28,8 @@ images:
   cometBFT:
     repo: docker.io/cometbft/cometbft
     pullPolicy: IfNotPresent
-    tag: v0.38.8
-    devTag: v0.38.8
+    tag: v0.38.17
+    devTag: v0.38.17
   sequencer:
     repo: ghcr.io/astriaorg/sequencer
     pullPolicy: IfNotPresent

--- a/dev/values/hermes/local.yaml
+++ b/dev/values/hermes/local.yaml
@@ -57,9 +57,8 @@ chains:
         filename: celestia.json
         key: token
     eventSource:
-      mode: push
-      url: ws://celestia-app-service.astria-dev-cluster.svc.cluster.local:26657/websocket
-      batchDelay: 200ms
+      mode: pull
+      interval: 1s
     gasDenom: "utia"
     gasPrice: 0.0026
     gasMultiplier: 1.2


### PR DESCRIPTION
## Summary
upgrades cometbft version from `v0.38.8 -> v0.38.17 `
## Background
cometbft [v0.38.17](https://github.com/cometbft/cometbft/blob/v0.38.17/CHANGELOG.md#v03817) includes two security fixes. 
## Changes
- bumps cometbft version to v0.38.17
- hermes now uses serde patched image ( but in the `block_result` response)
- hermes now uses pull instead of push method for events.

## Testing
locally running smoke tests against a local cluster.

closes #1980 