### PR TITLE
fix(charts): prague and verkle heights templating

### DIFF
--- a/charts/evm-rollup/Chart.yaml
+++ b/charts/evm-rollup/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.1
+version: 1.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/evm-rollup/files/genesis/geth-genesis.json
+++ b/charts/evm-rollup/files/genesis/geth-genesis.json
@@ -15,10 +15,10 @@
         {{- if .Values.genesis.cancunTime }}
         "cancunTime": {{ toString .Values.genesis.cancunTime | replace "\"" "" }},
         {{- end }}
-        {{- if .Values.genesis.cancunTime }}
+        {{- if .Values.genesis.pragueTime }}
         "pragueTime": {{ toString .Values.genesis.pragueTime | replace "\"" "" }},
         {{- end }}
-        {{- if .Values.genesis.cancunTime }}
+        {{- if .Values.genesis.verkleTime }}
         "verkleTime": {{ toString .Values.genesis.verkleTime | replace "\"" "" }},
         {{- end }}
         "terminalTotalDifficulty": 0,

--- a/charts/evm-stack/Chart.lock
+++ b/charts/evm-stack/Chart.lock
@@ -4,10 +4,10 @@ dependencies:
   version: 0.4.0
 - name: evm-rollup
   repository: file://../evm-rollup
-  version: 1.1.1
+  version: 1.1.2
 - name: flame-rollup
   repository: file://../flame-rollup
-  version: 0.0.1
+  version: 0.0.2
 - name: composer
   repository: file://../composer
   version: 1.0.0
@@ -26,5 +26,5 @@ dependencies:
 - name: blockscout-stack
   repository: https://blockscout.github.io/helm-charts
   version: 1.6.8
-digest: sha256:03f8e53fd90f307d09aa02db8e65d2838af3c9cea285272f06d800329a92a813
-generated: "2025-02-17T17:05:09.027931+02:00"
+digest: sha256:feffdb4dbba53d3261e49eeb082718be4e3673ae7bc7c6118dddff2f19218273
+generated: "2025-02-19T10:43:16.548953+02:00"

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -15,18 +15,18 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.10
+version: 1.0.11
 dependencies:
   - name: celestia-node
     version: 0.4.0
     repository: "file://../celestia-node"
     condition: celestia-node.enabled
   - name: evm-rollup
-    version: 1.1.1
+    version: 1.1.2
     repository: "file://../evm-rollup"
     condition: evm-rollup.enabled
   - name: flame-rollup
-    version: 0.0.1
+    version: 0.0.2
     repository: "file://../flame-rollup"
     condition: flame-rollup.enabled
   - name: composer

--- a/charts/flame-rollup/Chart.yaml
+++ b/charts/flame-rollup/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.0.1
+version: 0.0.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/flame-rollup/files/genesis/geth-genesis.json
+++ b/charts/flame-rollup/files/genesis/geth-genesis.json
@@ -15,10 +15,10 @@
         {{- if .Values.genesis.cancunTime }}
         "cancunTime": {{ toString .Values.genesis.cancunTime | replace "\"" "" }},
         {{- end }}
-        {{- if .Values.genesis.cancunTime }}
+        {{- if .Values.genesis.pragueTime }}
         "pragueTime": {{ toString .Values.genesis.pragueTime | replace "\"" "" }},
         {{- end }}
-        {{- if .Values.genesis.cancunTime }}
+        {{- if .Values.genesis.verkleTime }}
         "verkleTime": {{ toString .Values.genesis.verkleTime | replace "\"" "" }},
         {{- end }}
         "terminalTotalDifficulty": 0,


### PR DESCRIPTION
## Summary
prague and verkle heights in genesis are now configured based on the appropriate values.
## Background
we have a bug in our charts where if we set an enable Cancun height, we will end up printing out a height for prague and verkle heights.

## Changes
- prague and verkle heights are now set based on their values instead of cancun's.

## Testing
locally by running helm template command

## Changelogs
No updates required.
