### PR TITLE
fix(charts): auctioneer metrics port

### DIFF
--- a/charts/auctioneer/Chart.yaml
+++ b/charts/auctioneer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1
+version: 0.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/auctioneer/templates/service.yaml
+++ b/charts/auctioneer/templates/service.yaml
@@ -10,7 +10,7 @@ spec:
   selector:
     {{ include "auctioneer.selectorLabels" . }}
   ports:
-    - name: metrics
+    - name: auct-metrics
       port: {{ .Values.ports.metrics }}
       targetPort: auct-metrics
 {{- end }}

--- a/charts/evm-stack/Chart.lock
+++ b/charts/evm-stack/Chart.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 1.0.0
 - name: auctioneer
   repository: file://../auctioneer
-  version: 0.0.1
+  version: 0.0.2
 - name: evm-faucet
   repository: file://../evm-faucet
   version: 0.1.4
@@ -26,5 +26,5 @@ dependencies:
 - name: blockscout-stack
   repository: https://blockscout.github.io/helm-charts
   version: 1.6.8
-digest: sha256:feffdb4dbba53d3261e49eeb082718be4e3673ae7bc7c6118dddff2f19218273
-generated: "2025-02-19T10:43:16.548953+02:00"
+digest: sha256:ec55e7e1427dd7af6b3764d7cedc7b5b168ec2443fa140cb3000c8ed68d711ac
+generated: "2025-02-20T10:44:04.460576+02:00"

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.11
+version: 1.0.12
 dependencies:
   - name: celestia-node
     version: 0.4.0
@@ -34,7 +34,7 @@ dependencies:
     repository: "file://../composer"
     condition: composer.enabled
   - name: auctioneer
-    version: 0.0.1
+    version: 0.0.2
     repository: "file://../auctioneer"
     condition: auctioneer.enabled
   - name: evm-faucet


### PR DESCRIPTION
## Summary
auctioneer metric port name update to match `serviceMonitor` port

## Background
The port name tracked by auctioneer `serviceMonitor` does not match the metric service.
## Changes
- change metrics port name (`metrics -> auct-metrics`) 

## Testing
Tested while resolving auctioneer grafana dashboards on testnet.

## Changelogs
No updates required.

Note: Bumping the auctioneer chart version may also resolve an issue with our initial auctioneer chart release.
