### PR TITLE
chore(sequencer): add missing storage key tests

### DIFF
--- a/crates/astria-sequencer/src/fees/storage/keys.rs
+++ b/crates/astria-sequencer/src/fees/storage/keys.rs
@@ -48,6 +48,7 @@ mod tests {
         protocol::transaction::v1::action::{
             BridgeLock,
             BridgeSudoChange,
+            BridgeTransfer,
             BridgeUnlock,
             FeeAssetChange,
             FeeChange,
@@ -94,6 +95,7 @@ mod tests {
         check::<SudoAddressChange>();
         check::<Transfer>();
         check::<ValidatorUpdate>();
+        check::<BridgeTransfer>();
         assert_snapshot!("allowed_asset_prefix", ALLOWED_ASSET_PREFIX);
         assert_snapshot!("allowed_asset_key", allowed_asset(&test_asset()));
     }
@@ -114,6 +116,7 @@ mod tests {
         assert!(name::<IbcRelayerChange>().starts_with(COMPONENT_PREFIX));
         assert!(name::<SudoAddressChange>().starts_with(COMPONENT_PREFIX));
         assert!(name::<IbcSudoChange>().starts_with(COMPONENT_PREFIX));
+        assert!(name::<BridgeTransfer>().starts_with(COMPONENT_PREFIX));
         assert!(ALLOWED_ASSET_PREFIX.starts_with(COMPONENT_PREFIX));
         assert!(allowed_asset(&test_asset()).starts_with(COMPONENT_PREFIX));
     }

--- a/crates/astria-sequencer/src/fees/storage/snapshots/astria_sequencer__fees__storage__keys__tests__bridge_transfer_fees_key.snap
+++ b/crates/astria-sequencer/src/fees/storage/snapshots/astria_sequencer__fees__storage__keys__tests__bridge_transfer_fees_key.snap
@@ -1,0 +1,5 @@
+---
+source: crates/astria-sequencer/src/fees/storage/keys.rs
+expression: "name::<F>()"
+---
+fees/bridge_transfer


### PR DESCRIPTION
## Summary
Added missing `BridgeTransfer` fee storage key tests

## Background
These tests were a minor oversight in the implementation of `BridgeTransfer`, but an easy fix to get in. As a followup, we should get together some documentation for adding new actions such that there's a quantitative list of items like this which are easy to miss.

## Changes
- Added storage key snapshot and fee component prefix test for `BridgeTransfer` fees

## Testing
Passing tests

## Changelogs
No updates required

## Breaking Changelist
- Not breaking, just noting that this added a snapshot

## Related Issues
closes #1988
