### PR TITLE
feat(charts)!: sequencer defaults for networks

### DIFF
--- a/charts/deploy.just
+++ b/charts/deploy.just
@@ -201,7 +201,7 @@ deploy-smoke-test tag=defaultTag:
     -n astria-validator-single single-sequencer-chart ./charts/sequencer \
     -f dev/values/validators/all.yml \
     -f dev/values/validators/single.yml \
-    {{ if tag != '' { replace('--set images.sequencer.devTag=# --set sequencer-relayer.images.sequencerRelayer.devTag=#', '#', tag) } else { '' } }} \
+    {{ if tag != '' { replace('--set images.sequencer.tag=# --set sequencer-relayer.images.sequencerRelayer.tag=#', '#', tag) } else { '' } }} \
     --create-namespace > /dev/null
   @just wait-for-sequencer > /dev/null
   @echo "Starting EVM rollup..." && helm install -n astria-dev-cluster astria-chain-chart ./charts/evm-stack -f dev/values/rollup/dev.yaml \
@@ -221,7 +221,7 @@ deploy-smoke-cli tag=defaultTag:
     -n astria-validator-single single-sequencer-chart ./charts/sequencer \
     -f dev/values/validators/all.yml \
     -f dev/values/validators/single.yml \
-    {{ if tag != '' { replace('--set images.sequencer.devTag=# --set sequencer-relayer.images.sequencerRelayer.devTag=#', '#', tag) } else { '' } }} \
+    {{ if tag != '' { replace('--set images.sequencer.tag=# --set sequencer-relayer.images.sequencerRelayer.tag=#', '#', tag) } else { '' } }} \
     --create-namespace > /dev/null
   @just wait-for-sequencer > /dev/null
   @echo "Starting EVM rollup..." && helm install -n astria-dev-cluster astria-chain-chart ./charts/evm-stack -f dev/values/rollup/dev.yaml \

--- a/charts/ibc-test.just
+++ b/charts/ibc-test.just
@@ -20,7 +20,7 @@ delete:
     -n astria-validator-single single-sequencer-chart ./sequencer \
     -f ../dev/values/validators/all.yml \
     -f ../dev/values/validators/single.yml \
-    {{ if tag != '' { replace('--set images.sequencer.devTag=# --set sequencer-relayer.images.sequencerRelayer.devTag=#', '#', tag) } else { '' } }} \
+    {{ if tag != '' { replace('--set images.sequencer.tag=# --set sequencer-relayer.images.sequencerRelayer.tag=#', '#', tag) } else { '' } }} \
     --create-namespace > /dev/null
   just wait-for-sequencer > /dev/null
   echo "Starting EVM rollup..." && helm install -n astria-dev-cluster astria-chain-chart ./evm-stack \
@@ -45,7 +45,7 @@ delete:
     -n astria-validator-single single-sequencer-chart ./sequencer \
     -f ../dev/values/validators/all-without-native.yml \
     -f ../dev/values/validators/single.yml \
-    {{ if tag != '' { replace('--set images.sequencer.devTag=# --set sequencer-relayer.images.sequencerRelayer.devTag=#', '#', tag) } else { '' } }} \
+    {{ if tag != '' { replace('--set images.sequencer.tag=# --set sequencer-relayer.images.sequencerRelayer.tag=#', '#', tag) } else { '' } }} \
     --create-namespace > /dev/null
   just wait-for-sequencer > /dev/null
   echo "Deploying Hermes"
@@ -63,7 +63,7 @@ delete:
     -n astria-validator-single single-sequencer-chart ./sequencer \
     -f ../dev/values/validators/all.yml \
     -f ../dev/values/validators/single.yml \
-    {{ if tag != '' { replace('--set images.sequencer.devTag=# --set sequencer-relayer.images.sequencerRelayer.devTag=#', '#', tag) } else { '' } }} \
+    {{ if tag != '' { replace('--set images.sequencer.tag=# --set sequencer-relayer.images.sequencerRelayer.tag=#', '#', tag) } else { '' } }} \
     --create-namespace > /dev/null
   just wait-for-sequencer > /dev/null
   echo "Starting EVM rollup..." && helm install -n astria-dev-cluster astria-chain-chart ./evm-stack \

--- a/charts/sequencer-relayer/Chart.yaml
+++ b/charts/sequencer-relayer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sequencer-relayer/templates/_helpers.tpl
+++ b/charts/sequencer-relayer/templates/_helpers.tpl
@@ -5,8 +5,40 @@ Namepsace to deploy elements into.
 {{- default .Release.Namespace .Values.global.namespaceOverride | trunc 63 | trimSuffix "-" -}}
 {{- end }}
 
+{{- define "sequencer-relayer.imageTag" -}}
+{{- if or (eq .Values.global.network "custom") (eq .Values.global.dev "true") }}{{ .Values.images.sequencerRelayer.tag }}
+{{- else if eq .Values.global.network "mainnet" }}1.0.0
+{{- else if eq .Values.global.network "dawn-1" }}1.0.0
+{{- else if eq .Values.global.network "dusk-11" }}1.0.0
+{{- end }}
+{{- end }}
+
 {{- define "sequencer-relayer.image" -}}
-{{ .Values.images.sequencerRelayer.repo }}:{{ if .Values.global.dev }}{{ .Values.images.sequencerRelayer.devTag }}{{ else }}{{ .Values.images.sequencerRelayer.tag }}{{ end }}
+{{ .Values.images.sequencerRelayer.repo }}:{{ include "sequencer-relayer.imageTag" . }}
+{{- end }}
+
+{{- define "sequencer-relayer.sequencerChainId" -}}
+{{- if eq .Values.global.network "custom" }}{{ .Values.config.relayer.sequencerChainId }}
+{{- else if eq .Values.global.network "mainnet" }}astria
+{{- else if eq .Values.global.network "dawn-1" }}dawn-1
+{{- else if eq .Values.global.network "dusk-11" }}astria-dusk-11
+{{- end }}
+{{- end }}
+
+{{- define "sequencer-relayer.celestiaChainId" -}}
+{{- if eq .Values.global.network "custom" }}{{ .Values.config.relayer.celestiaChainId }}
+{{- else if eq .Values.global.network "mainnet" }}celestia
+{{- else if eq .Values.global.network "dawn-1" }}mocha-4
+{{- else if eq .Values.global.network "dusk-11" }}mocha-4
+{{- end }}
+{{- end }}
+
+{{- define "sequencer-relayer.blockTimeMs" -}}
+{{- if or (eq .Values.global.network "custom") (eq .Values.global.dev "true") }}{{ .Values.config.relayer.blockTimeMs }}
+{{- else if eq .Values.global.network "mainnet" }}1000
+{{- else if eq .Values.global.network "dawn-1" }}1000
+{{- else if eq .Values.global.network "dusk-11" }}1000
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/sequencer-relayer/templates/configmaps.yaml
+++ b/charts/sequencer-relayer/templates/configmaps.yaml
@@ -6,7 +6,7 @@ metadata:
 data:
   ASTRIA_SEQUENCER_RELAYER_LOG: "astria_sequencer_relayer=debug"
   ASTRIA_SEQUENCER_RELAYER_SUBMISSION_STATE_PATH: "{{ include "sequencer-relayer.storage.submissionStatePath" . }}"
-  ASTRIA_SEQUENCER_RELAYER_BLOCK_TIME: "{{ .Values.config.relayer.blockTimeMs }}"
+  ASTRIA_SEQUENCER_RELAYER_BLOCK_TIME: "{{ include "sequencer-relayer.blockTimeMs" . }}"
   ASTRIA_SEQUENCER_RELAYER_COMETBFT_ENDPOINT: "{{ .Values.config.relayer.cometbftRpc }}"
   ASTRIA_SEQUENCER_RELAYER_SEQUENCER_GRPC_ENDPOINT: "{{ .Values.config.relayer.sequencerGrpc }}"
   ASTRIA_SEQUENCER_RELAYER_CELESTIA_APP_GRPC_ENDPOINT: "{{ .Values.config.relayer.celestiaAppGrpc }}"
@@ -26,8 +26,8 @@ data:
   OTEL_EXPORTER_OTLP_TRACE_HEADERS: "{{ tpl .Values.otel.traceHeaders . }}"
   OTEL_SERVICE_NAME: "{{ tpl .Values.otel.serviceName . }}"
   ASTRIA_SEQUENCER_RELAYER_ONLY_INCLUDE_ROLLUPS: "{{ .Values.config.relayer.onlyIncludeRollups }}"
-  ASTRIA_SEQUENCER_RELAYER_SEQUENCER_CHAIN_ID: "{{ .Values.config.relayer.sequencerChainId }}"
-  ASTRIA_SEQUENCER_RELAYER_CELESTIA_CHAIN_ID: "{{ .Values.config.relayer.celestiaChainId }}"
+  ASTRIA_SEQUENCER_RELAYER_SEQUENCER_CHAIN_ID: "{{ include "sequencer-relayer.sequencerChainId" . }}"
+  ASTRIA_SEQUENCER_RELAYER_CELESTIA_CHAIN_ID: "{{ include "sequencer-relayer.celestiaChainId" . }}"
   {{- if not .Values.global.dev }}
   {{- else }}
   {{- end }}

--- a/charts/sequencer-relayer/values.yaml
+++ b/charts/sequencer-relayer/values.yaml
@@ -8,23 +8,30 @@ global:
   # Best to be false in production environments, true for clean logs on local dev.
   useTTY: true
   dev: false
+  # Supported options are `custom`, `mainnet`, `dawn-1`, or `dusk-11`.
+  # When set to a specific network, there are default values for some
+  # values which are used and cannot be changed.
+  network: "custom"
 
 # sequencer core images
 images:
   sequencerRelayer:
     repo: ghcr.io/astriaorg/sequencer-relayer
     pullPolicy: IfNotPresent
-    tag: 1.0.0
-    devTag: latest
+    # Only used when global.dev is true OR global.network is set to `custom`
+    tag: latest
 
 config:
   relayer:
+    # only configurable in custom network
     sequencerChainId: ""
+    # only configurable in custom network
     celestiaChainId: ""
     celestiaAppGrpc: ""
     cometbftRpc: ""
     sequencerGrpc: ""
     onlyIncludeRollups: ""
+    # Only used when global.network is set to `custom` or global.dev is true
     blockTimeMs: "1000"
 
     metrics:

--- a/charts/sequencer/Chart.lock
+++ b/charts/sequencer/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: sequencer-relayer
   repository: file://../sequencer-relayer
-  version: 1.0.1
-digest: sha256:3b3ce65ff473606fcc86027653cadd212ba45ac8b39d5806d713b48f695ad235
-generated: "2024-11-20T11:24:11.85775+02:00"
+  version: 1.0.2
+digest: sha256:ccc0f6b082973f9f5efae28d83589f3ede213f4b6dcc1392f079d37ed6295d32
+generated: "2025-02-20T10:18:48.213464-08:00"

--- a/charts/sequencer/Chart.yaml
+++ b/charts/sequencer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.5
+version: 1.0.6
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -24,7 +24,7 @@ appVersion: "1.0.0"
 
 dependencies:
   - name: sequencer-relayer
-    version: "1.0.1"
+    version: "1.0.2"
     repository: "file://../sequencer-relayer"
     condition: sequencer-relayer.enabled
 

--- a/charts/sequencer/files/cometbft/config/config.toml
+++ b/charts/sequencer/files/cometbft/config/config.toml
@@ -111,7 +111,7 @@ grpc_laddr = ""
 # 0 - unlimited.
 # Should be < {ulimit -Sn} - {MaxNumInboundPeers} - {MaxNumOutboundPeers} - {N of wal, db and other open files}
 # 1024 - 40 - 10 - 50 = 924 = ~900
-grpc_max_open_connections = {{ .Values.cometbft.config.grpc.maxOpenConnections }} 
+grpc_max_open_connections = {{ .Values.cometbft.config.grpc.maxOpenConnections }}
 
 # Activate unsafe RPC commands like /dial_seeds and /unsafe_flush_mempool
 unsafe = false
@@ -409,21 +409,21 @@ version = "v0"
 wal_file = "data/cs.wal/wal"
 
 # How long we wait for a proposal block before prevoting nil
-timeout_propose = "{{ .Values.cometbft.config.consensus.timeoutPropose }}"
+timeout_propose = "{{ include "cometBFT.timeouts.propose" . }}"
 # How much timeout_propose increases with each round
-timeout_propose_delta =  "{{ .Values.cometbft.config.consensus.timeoutProposeDelta }}"
+timeout_propose_delta =  "{{ include "cometBFT.timeouts.proposeDelta" . }}"
 # How long we wait after receiving +2/3 prevotes for “anything” (ie. not a single block or nil)
-timeout_prevote =  "{{ .Values.cometbft.config.consensus.timeoutPrevote }}"
+timeout_prevote =  "{{ include "cometBFT.timeouts.prevote" . }}"
 # How much the timeout_prevote increases with each round
-timeout_prevote_delta =  "{{ .Values.cometbft.config.consensus.timeoutPrevoteDelta }}"
+timeout_prevote_delta =  "{{ include "cometBFT.timeouts.prevoteDelta" . }}"
 # How long we wait after receiving +2/3 precommits for “anything” (ie. not a single block or nil)
-timeout_precommit =  "{{ .Values.cometbft.config.consensus.timeoutPrecommit }}"
+timeout_precommit =  "{{ include "cometBFT.timeouts.precommit" . }}"
 # How much the timeout_precommit increases with each round
-timeout_precommit_delta =  "{{ .Values.cometbft.config.consensus.timeoutPrecommitDelta }}"
+timeout_precommit_delta =  "{{ include "cometBFT.timeouts.precommitDelta" . }}"
 # How long we wait after committing a block, before starting on the new
 # height (this gives us a chance to receive some more precommits, even
 # though we already have +2/3).
-timeout_commit = "{{ .Values.cometbft.config.consensus.timeoutCommit }}"
+timeout_commit = "{{ include "cometBFT.timeouts.commit" . }}"
 
 # How many blocks to look back to check existence of the node's consensus votes before joining consensus
 # When non-zero, the node will panic upon restart

--- a/charts/sequencer/files/cometbft/config/custom.genesis.json
+++ b/charts/sequencer/files/cometbft/config/custom.genesis.json
@@ -122,7 +122,7 @@
     ]
     {{- if not .Values.global.dev }}
     {{- else }}
-    {{- end}}
+    {{- end }}
   },
   "chain_id": "{{ .Values.genesis.chainId }}",
   "consensus_params": {

--- a/charts/sequencer/files/cometbft/config/dawn-1.genesis.json
+++ b/charts/sequencer/files/cometbft/config/dawn-1.genesis.json
@@ -1,0 +1,208 @@
+{
+  "app_hash": "",
+  "app_state": {
+    "native_asset_base_denomination": "nria",
+    "fees": {
+      "bridge_lock": {
+        "base": { "lo": 0 },
+        "multiplier": { "lo": 1 }
+      },
+      "bridge_sudo_change": {
+        "base": { "lo": 24 },
+        "multiplier": { "lo": 0 }
+      },
+      "bridge_unlock": {
+        "base": { "lo": 0 },
+        "multiplier": { "lo": 0 }
+      },
+      "fee_asset_change": {
+        "base": { "lo": 0 },
+        "multiplier": { "lo": 0 }
+      },
+      "fee_change": {
+        "base": { "lo": 0 },
+        "multiplier": { "lo": 0 }
+      },
+      "ibc_relay": {
+        "base": { "lo": 0 },
+        "multiplier": { "lo": 0 }
+      },
+      "ibc_relayer_change": {
+        "base": { "lo": 0 },
+        "multiplier": { "lo": 0 }
+      },
+      "ibc_sudo_change": {
+        "base": { "lo": 0 },
+        "multiplier": { "lo": 0 }
+      },
+      "ics20_withdrawal": {
+        "base": { "lo": 24 },
+        "multiplier": { "lo": 0 }
+      },
+      "init_bridge_account": {
+        "base": { "lo": 48 },
+        "multiplier": { "lo": 0 }
+      },
+      "rollup_data_submission": {
+        "base": { "lo": 32 },
+        "multiplier": { "lo": 1 }
+      },
+      "sudo_address_change": {
+        "base": { "lo": 0 },
+        "multiplier": { "lo": 0 }
+      },
+      "transfer": {
+        "base": { "lo": 12 },
+        "multiplier": { "lo": 0 }
+      },
+      "validator_update": {
+        "base": { "lo": 0 },
+        "multiplier": { "lo": 0 }
+      }
+    },
+    "allowed_fee_assets": [
+    ],
+    "ibc_parameters": {
+      "ibc_enabled": true,
+      "inbound_ics20_transfers_enabled": true,
+      "outbound_ics20_transfers_enabled": true
+    },
+    "address_prefixes": {
+      "base": "astria",
+      "ibcCompat": "astriacompat"
+    },
+    "accounts": [
+      {
+        "address": { "bech32m": "astria1qzs2g8ft4z5nacr40n93uxufgjqya9uqjmhhuj" },
+        "balance": { "lo": 100000000000000000 }
+      }
+    ],
+    "authority_sudo_address": { "bech32m": "astria1qzs2g8ft4z5nacr40n93uxufgjqya9uqjmhhuj" },
+    "ibc_sudo_address": { "bech32m": "astria1p2lgmfyg2pszet8hstd22x7kzler7ahtf53w3r" },
+    "ibc_relayer_addresses": [
+    ]
+  },
+  "chain_id": "dawn-1",
+  "consensus_params": {
+    "block": {
+      "max_bytes": " 1048576",
+      "max_gas": "-1"
+    },
+    "evidence": {
+      "max_age_duration": "1209600000000000",
+      "max_age_num_blocks": " 4000000",
+      "max_bytes": "1048576"
+    },
+    "validator": {
+      "pub_key_types": [
+        "ed25519"
+      ]
+    },
+    "version": {
+      "app": "0"
+    }
+  },
+  "genesis_time": "2024-10-16T21:13:04.150435Z",
+  "initial_height": "0",
+  "validators": [
+    {
+      "address": "8F75C00017C59F326043A5A9054CB7C7421820D1",
+      "name": "astria0",
+      "power": "25",
+      "pub_key": {
+        "type": "tendermint/PubKeyEd25519",
+        "value": "lCInm5huYMUyplra1m67dfbhodnLX0YTo11xR9Za3Hw="
+      }
+    },
+    {
+      "address": "2DF1961B30F05D130F78BDEFC787CA5BF286A720",
+      "name": "astria1",
+      "power": "25",
+      "pub_key": {
+        "type": "tendermint/PubKeyEd25519",
+        "value": "oCF7nuz+1rKIBB7Yg8vqvZCLwC8fxdNRDmFMghKEcFM="
+      }
+    },
+    {
+      "address": "EFCB40DAFA5A579BC4EEB08BAF89B9BDFC415291",
+      "name": "astria2",
+      "power": "25",
+      "pub_key": {
+        "type": "tendermint/PubKeyEd25519",
+        "value": "VRru43aqcqEb1QP2SRHVoUf+ArdddJ9WGgxDwEsrSw8="
+      }
+    },
+    {
+      "address": "704DC2FBE0C2C88AFBDBE3AAC95E61C4865D0C4C",
+      "name": "astria3",
+      "power": "25",
+      "pub_key": {
+        "type": "tendermint/PubKeyEd25519",
+        "value": "p48+N7lI4xPaFIrRCAXqZSuzZO01vM4mSRDYqhwzGJA="
+      }
+    },
+    {
+      "address": "1E96A71EC2205C55065C249719B691C9C10846B9",
+      "name": "Nodes.Guru",
+      "power": "1",
+      "pub_key": {
+        "type": "tendermint/PubKeyEd25519",
+        "value": "GQ7oQo8pIZRcxvfm992cChf4nI5iRgNI3EzKK+4WrzY="
+      }
+    },
+    {
+      "address": "50803720316D985B2FCD94C74105AFB836F6AB51",
+      "name": "Qubelabs",
+      "power": "1",
+      "pub_key": {
+        "type": "tendermint/PubKeyEd25519",
+        "value": "pENCCfKZ+1qVxS7SSo3NYT1G0fUBql4nblaK2Wq6afA="
+      }
+    },
+    {
+      "address": "5EA04241DCFCCCBCC6CAD46C2EA41317D98EFAC3",
+      "name": "DSRV",
+      "power": "1",
+      "pub_key": {
+        "type": "tendermint/PubKeyEd25519",
+        "value": "FcCm9xUn8er0J+D6FnSVaJt7g/5J+JfUrigz91V+9BA="
+      }
+    },
+    {
+      "address": "F5BB9D2C9BC52D1F551D3B86A5AEB7C8B7AC97B9",
+      "name": "Nocturnal Labs",
+      "power": "1",
+      "pub_key": {
+        "type": "tendermint/PubKeyEd25519",
+        "value": "+KFHGN5eVHMpyxQdHYWiDFwQ4EWWNHWvpfUvlOGn7kM="
+      }
+    },
+    {
+      "address": "8E097B67FA4DAC2858CB94D7CFE00B0B82C9321F",
+      "name": "P-OPS Team",
+      "power": "1",
+      "pub_key": {
+        "type": "tendermint/PubKeyEd25519",
+        "value": "NSsJJkx8puK0CEX1iZc+7rHBBo/DNrpXFxTsAYdgvgY="
+      }
+    },
+    {
+      "address": "5F9F7087258A7ED9DA8217B9A8623FF04695978D",
+      "name": "Tessellated",
+      "power": "1",
+      "pub_key": {
+        "type": "tendermint/PubKeyEd25519",
+        "value": "r1151CNaMFBFa6ii3MyLyDzxsK49iTgZ9NqkPy59WPM="
+      }
+    },
+    {
+      "address": "7B87C3E324F871A123B24BD36CCBB9BEC5DFCC0F",
+      "name": "P2P.ORG - P2P Validator",
+      "power": "1",
+      "pub_key": {
+        "type": "tendermint/PubKeyEd25519",
+        "value": "5v6vQJ+DYLhIZEzw96TMLgqS1A73czffLz1ilDgziWs="
+      }
+    }
+  ]
+}

--- a/charts/sequencer/files/cometbft/config/dusk-11.genesis.json
+++ b/charts/sequencer/files/cometbft/config/dusk-11.genesis.json
@@ -1,0 +1,247 @@
+{
+  "app_hash": "",
+  "app_state": {
+    "native_asset_base_denomination": "nria",
+    "fees": {
+      "bridge_lock": {
+        "base": {
+          "lo": 0
+        },
+        "multiplier": {
+          "lo": 1
+        }
+      },
+      "bridge_sudo_change": {
+        "base": {
+          "lo": 24
+        },
+        "multiplier": {
+          "lo": 0
+        }
+      },
+      "bridge_unlock": {
+        "base": {
+          "lo": 0
+        },
+        "multiplier": {
+          "lo": 0
+        }
+      },
+      "fee_asset_change": {
+        "base": {
+          "lo": 0
+        },
+        "multiplier": {
+          "lo": 0
+        }
+      },
+      "fee_change": {
+        "base": {
+          "lo": 0
+        },
+        "multiplier": {
+          "lo": 0
+        }
+      },
+      "ibc_relay": {
+        "base": {
+          "lo": 0
+        },
+        "multiplier": {
+          "lo": 0
+        }
+      },
+      "ibc_relayer_change": {
+        "base": {
+          "lo": 0
+        },
+        "multiplier": {
+          "lo": 0
+        }
+      },
+      "ibc_sudo_change": {
+        "base": {
+          "lo": 0
+        },
+        "multiplier": {
+          "lo": 0
+        }
+      },
+      "ics20_withdrawal": {
+        "base": {
+          "lo": 24
+        },
+        "multiplier": {
+          "lo": 0
+        }
+      },
+      "init_bridge_account": {
+        "base": {
+          "lo": 48
+        },
+        "multiplier": {
+          "lo": 0
+        }
+      },
+      "rollup_data_submission": {
+        "base": {
+          "lo": 32
+        },
+        "multiplier": {
+          "lo": 1
+        }
+      },
+      "sudo_address_change": {
+        "base": {
+          "lo": 0
+        },
+        "multiplier": {
+          "lo": 0
+        }
+      },
+      "transfer": {
+        "base": {
+          "lo": 12
+        },
+        "multiplier": {
+          "lo": 0
+        }
+      },
+      "validator_update": {
+        "base": {
+          "lo": 0
+        },
+        "multiplier": {
+          "lo": 0
+        }
+      }
+    },
+    "allowed_fee_assets": [],
+    "ibc_parameters": {
+      "ibc_enabled": true,
+      "inbound_ics20_transfers_enabled": true,
+      "outbound_ics20_transfers_enabled": true
+    },
+    "address_prefixes": {
+      "base": "astria",
+      "ibcCompat": "astriacompat"
+    },
+    "accounts": [
+      {
+        "address": {
+          "bech32m": "astria1hwxgjjp8f7a46a2sr0mxffn5r7udkpfrcavpul"
+        },
+        "balance": {
+          "lo": 333333333333333333
+        }
+      },
+      {
+        "address": {
+          "bech32m": "astria1luwmgezc63qg0jt4aw5ey207tw7dcd20fqt44z"
+        },
+        "balance": {
+          "lo": 333333333333333333
+        }
+      },
+      {
+        "address": {
+          "bech32m": "astria1g9p32uu5r4am2uae0n0xfnxpnqmlymrh9yrqng"
+        },
+        "balance": {
+          "lo": 333333333333333333
+        }
+      },
+      {
+        "address": {
+          "bech32m": "astria1ved3v3k2a80wad756xhwd7r75ycuaf6z9y60rl"
+        },
+        "balance": {
+          "lo": 333333333333333333
+        }
+      },
+      {
+        "address": {
+          "bech32m": "astria1yqdjnnmrp7w5ygwj0dkldsgzjhv5vcakp7yeu9"
+        },
+        "balance": {
+          "lo": 60
+        }
+      },
+      {
+        "address": {
+          "bech32m": "astria1f0dw5muma062mwfz7g46229adaycpjevnyw9fc"
+        },
+        "balance": {
+          "lo": 1000000000000
+        }
+      }
+    ],
+    "authority_sudo_address": {
+      "bech32m": "astria1hwxgjjp8f7a46a2sr0mxffn5r7udkpfrcavpul"
+    },
+    "ibc_sudo_address": {
+      "bech32m": "astria10z89e25n2fs754a0v9nnsh0kvzh90wf4ukk6jc"
+    },
+    "ibc_relayer_addresses": []
+  },
+  "chain_id": "astria-dusk-11",
+  "consensus_params": {
+    "block": {
+      "max_bytes": " 1048576",
+      "max_gas": "-1"
+    },
+    "evidence": {
+      "max_age_duration": "1209600000000000",
+      "max_age_num_blocks": " 4000000",
+      "max_bytes": "1048576"
+    },
+    "validator": {
+      "pub_key_types": [
+        "ed25519"
+      ]
+    },
+    "version": {
+      "app": "0"
+    }
+  },
+  "genesis_time": "2024-07-27T00:49:11.964127Z",
+  "initial_height": "0",
+  "validators": [
+    {
+      "address": "FDDBAF2EFB176DD25A3EDDE9106E78D329A38562",
+      "name": "node0",
+      "power": "1",
+      "pub_key": {
+        "type": "tendermint/PubKeyEd25519",
+        "value": "U46eweNkf5swUyu45cK0qABsaxFoPL7OK+Hqqahr8fg="
+      }
+    },
+    {
+      "address": "2F5AEE50975F56F59C4C5248277CB1E4A8320593",
+      "name": "node1",
+      "power": "1",
+      "pub_key": {
+        "type": "tendermint/PubKeyEd25519",
+        "value": "pJeqSiLKgjKHYIKSCxEGeJiMhhlLDC4SoE3Pb1Noi7I="
+      }
+    },
+    {
+      "address": "C8FAD5B264F7D5B5446978E96AEC3549E41F1353",
+      "name": "node2",
+      "power": "1",
+      "pub_key": {
+        "type": "tendermint/PubKeyEd25519",
+        "value": "/zck8pXQM9AzdBaDsfaoTkRxQgQQyGoCC3q1Ohirlbc="
+      }
+    },
+    {
+      "address": "0DC9BAF2CB94F4897F2A569EF2A33EE1D4E7B50B",
+      "name": "node3",
+      "power": "1",
+      "pub_key": {
+        "type": "tendermint/PubKeyEd25519",
+        "value": "E6gYdFSWp8SQYd60JSZBhADZgB8lV8FAbqsmAvX6RPY="
+      }
+    }
+  ]
+}

--- a/charts/sequencer/files/cometbft/config/mainnet.genesis.json
+++ b/charts/sequencer/files/cometbft/config/mainnet.genesis.json
@@ -1,0 +1,227 @@
+{
+  "genesis_time": "2024-10-25T21:20:00Z",
+  "chain_id": "astria",
+  "initial_height": "1",
+  "consensus_params": {
+    "block": {
+      "max_bytes": "1048576",
+      "max_gas": "-1"
+    },
+    "evidence": {
+      "max_age_num_blocks": "4000000",
+      "max_age_duration": "1209600000000000",
+      "max_bytes": "1048576"
+    },
+    "validator": {
+      "pub_key_types": [
+        "ed25519"
+      ]
+    },
+    "version": {
+      "app": "0"
+    },
+    "abci": {
+      "vote_extensions_enable_height": "0"
+    }
+  },
+  "validators": [
+    {
+      "address": "63FD0CE49F485F167A8B94B9E80DBBD351FA9F98",
+      "pub_key": {
+        "type": "tendermint/PubKeyEd25519",
+        "value": "8rPKInUBqFKv7Wie/O4G9P6wHWccMfifpeU/BlhFaHw="
+      },
+      "power": "100",
+      "name": "astria0"
+    },
+    {
+      "address": "4E72A7432B5C0FAEC21CF251535781723A8248A7",
+      "pub_key": {
+        "type": "tendermint/PubKeyEd25519",
+        "value": "IzGYindOUk15ZL6bh6j8+fjSRgjeoL93txgA9ETfFXI="
+      },
+      "power": "100",
+      "name": "astria1"
+    },
+    {
+      "address": "47BD55BC6E3CA4A8519C372744AEE40C9340B8B4",
+      "pub_key": {
+        "type": "tendermint/PubKeyEd25519",
+        "value": "S9VKKZgwdtiWWll3PT1yn+xgqZLci+MMtPmH2wuux+w="
+      },
+      "power": "100",
+      "name": "astria2"
+    },
+    {
+      "address": "3A7E64DFA6E11958B5A0903EA4C3D5A8E662C503",
+      "pub_key": {
+        "type": "tendermint/PubKeyEd25519",
+        "value": "XntgAVoWJS7SE7hSw9OHyHBrP50+l8mZc/ctaQWIseQ="
+      },
+      "power": "100",
+      "name": "astria3"
+    },
+    {
+      "address": "8F6D2388C4C068A0217F75E914C3FBA8E28079B7",
+      "pub_key": {
+        "type": "tendermint/PubKeyEd25519",
+        "value": "S4vhA0z7Gw5p3Yszwnlm+BdXELSOeRH4/jBL2r55zo8="
+      },
+      "power": "25",
+      "name": "Nodes.Guru"
+    },
+    {
+      "address": "3CB3760D29B485C711D27D5AC5CE6B4AF048263D",
+      "pub_key": {
+        "type": "tendermint/PubKeyEd25519",
+        "value": "KA/DKcILRpYVybz9ZHh784yZr9WvvCHRKzy+Av9KlUg="
+      },
+      "power": "25",
+      "name": "Qubelabs"
+    },
+    {
+      "address": "19685F5CFF69B64EF6C50E8BB4BA506DB1E1BB5C",
+      "pub_key": {
+        "type": "tendermint/PubKeyEd25519",
+        "value": "jqnJZ1Op4TPiNTHNVFyvXtdRuObhDhnl1cKyH/FO3kY="
+      },
+      "power": "25",
+      "name": "DSRV"
+    },
+    {
+      "address": "816B7C75D3C43D5F700D67975F020D938AF882F9",
+      "pub_key": {
+        "type": "tendermint/PubKeyEd25519",
+        "value": "IdsrfKarwcDa0ToNrDfRXPByuYdlwSDxvwJlJM0mc9A="
+      },
+      "power": "25",
+      "name": "Nocturnal Labs"
+    },
+    {
+      "address": "4E8AD81B9361FBF6DBC853514F1B259A75B2D5C0",
+      "pub_key": {
+        "type": "tendermint/PubKeyEd25519",
+        "value": "hCbuIHcC8Ivufr1hR/cPUPetS0snT9fSzgMQgWKZx9c="
+      },
+      "power": "25",
+      "name": "P-OPS Team"
+    },
+    {
+      "address": "666CBCE466D0DECDBBB3982AF747B74E0BD44030",
+      "pub_key": {
+        "type": "tendermint/PubKeyEd25519",
+        "value": "gyhVdvDyxSV2XH0jby1vnmQitPowjm/pn1CDVprre2c="
+      },
+      "power": "25",
+      "name": "Tessellated"
+    },
+    {
+      "address": "4FBB2E3BF3B5DDD7FCD5C4A028336F680098A1FB",
+      "pub_key": {
+        "type": "tendermint/PubKeyEd25519",
+        "value": "GLN47O9Iea9yKR9m8FMpZ180KL52Ht1i3yO9xu760Ew="
+      },
+      "power": "25",
+      "name": "P2P.ORG - P2P Validator"
+    }
+  ],
+  "app_hash": "",
+  "app_state": {
+    "fees": {
+      "fee_change": {
+        "base": {
+          "lo": 0
+        },
+        "multiplier": {
+          "lo": 0
+        }
+      },
+      "bridge_sudo_change": {
+        "base": {
+          "lo": 1000000
+        },
+        "multiplier": {
+          "lo": 0
+        }
+      },
+      "fee_asset_change": {
+        "base": {
+          "lo": 0
+        },
+        "multiplier": {
+          "lo": 0
+        }
+      },
+      "ibc_relay": {
+        "base": {
+          "lo": 0
+        },
+        "multiplier": {
+          "lo": 0
+        }
+      },
+      "ibc_relayer_change": {
+        "base": {
+          "lo": 0
+        },
+        "multiplier": {
+          "lo": 0
+        }
+      },
+      "ibc_sudo_change": {
+        "base": {
+          "lo": 0
+        },
+        "multiplier": {
+          "lo": 0
+        }
+      },
+      "init_bridge_account": {
+        "base": {
+          "lo": 10000000
+        },
+        "multiplier": {
+          "lo": 0
+        }
+      },
+      "sudo_address_change": {
+        "base": {
+          "lo": 0
+        },
+        "multiplier": {
+          "lo": 0
+        }
+      },
+      "validator_update": {
+        "base": {
+          "lo": 0
+        },
+        "multiplier": {
+          "lo": 0
+        }
+      }
+    },
+    "allowed_fee_assets": [],
+    "ibc_parameters": {
+      "ibc_enabled": true,
+      "inbound_ics20_transfers_enabled": true,
+      "outbound_ics20_transfers_enabled": true
+    },
+    "address_prefixes": {
+      "base": "astria",
+      "ibcCompat": "astriacompat"
+    },
+    "accounts": [],
+    "authority_sudo_address": {
+      "bech32m": "astria1f7d96l29kz22q2tcwrpg925dxt7z8jtsjgs9uh"
+    },
+    "ibc_sudo_address": {
+      "bech32m": "astria1v70qrgnua42f4x3kl40d60ae2zftftmqe4c7gy"
+    },
+    "ibc_relayer_addresses": [
+      {
+        "bech32m": "astria1pz0txxwcenc98vx6alnprcef46kyrvrya8cs8p"
+      }
+    ]
+  }
+}

--- a/charts/sequencer/templates/_helpers.tpl
+++ b/charts/sequencer/templates/_helpers.tpl
@@ -5,12 +5,85 @@ Namepsace to deploy elements into.
 {{- default .Release.Namespace .Values.global.namespaceOverride | trunc 63 | trimSuffix "-" -}}
 {{- end }}
 
+{{- define "sequencer.imageTag" -}}
+{{- if or (eq .Values.global.network "custom") (eq .Values.global.dev true) }}{{ .Values.images.sequencer.tag }}
+{{- else if eq .Values.global.network "mainnet" }}1.0.0
+{{- else if eq .Values.global.network "dawn-1" }}1.0.0
+{{- else if eq .Values.global.network "dusk-11" }}1.0.0
+{{- end }}
+{{- end }}
+
+{{- define "cometBFT.imageTag" -}}
+{{- if or (eq .Values.global.network "custom") (eq .Values.global.dev true) }}{{ .Values.images.cometBFT.tag }}
+{{- else if eq .Values.global.network "mainnet" }}1.0.0
+{{- else if eq .Values.global.network "dawn-1" }}1.0.0
+{{- else if eq .Values.global.network "dusk-11" }}1.0.0
+{{- end }}
+{{- end }}
+
 {{- define "sequencer.image" -}}
-{{ .Values.images.sequencer.repo }}:{{ if .Values.global.dev }}{{ .Values.images.sequencer.devTag }}{{ else }}{{ .Values.images.sequencer.tag }}{{ end }}
+{{ .Values.images.sequencer.repo }}:{{ include "sequencer.imageTag" . }}
 {{- end }}
 {{- define "cometBFT.image" -}}
-{{ .Values.images.cometBFT.repo }}:{{ if .Values.global.dev }}{{ .Values.images.cometBFT.devTag }}{{ else }}{{ .Values.images.cometBFT.tag }}{{ end }}
+{{ .Values.images.cometBFT.repo }}:{{ include "cometBFT.imageTag" . }}
 {{- end }}
+
+{{- define "cometBFT.timeouts.propose" -}}
+{{- if eq .Values.global.network "custom" }}{{ .Values.cometbft.config.consensus.timeoutPropose }}
+{{- else if eq .Values.global.network "mainnet" }}2s
+{{- else if eq .Values.global.network "dawn-1" }}2s
+{{- else if eq .Values.global.network "dusk-11" }}2s
+{{- end }}
+{{- end }}
+
+{{- define "cometBFT.timeouts.proposeDelta" -}}
+{{- if eq .Values.global.network "custom" }}{{ .Values.cometbft.config.consensus.timeoutProposeDelta }}
+{{- else if eq .Values.global.network "mainnet" }}500ms
+{{- else if eq .Values.global.network "dawn-1" }}500ms
+{{- else if eq .Values.global.network "dusk-11" }}500ms
+{{- end }}
+{{- end }}
+
+{{- define "cometBFT.timeouts.prevote" -}}
+{{- if eq .Values.global.network "custom" }}{{ .Values.cometbft.config.consensus.timeoutPrevote }}
+{{- else if eq .Values.global.network "mainnet" }}1s
+{{- else if eq .Values.global.network "dawn-1" }}1s
+{{- else if eq .Values.global.network "dusk-11" }}1s
+{{- end }}
+{{- end }}
+
+{{- define "cometBFT.timeouts.prevoteDelta" -}}
+{{- if eq .Values.global.network "custom" }}{{ .Values.cometbft.config.consensus.timeoutPrevoteDelta }}
+{{- else if eq .Values.global.network "mainnet" }}500ms
+{{- else if eq .Values.global.network "dawn-1" }}500ms
+{{- else if eq .Values.global.network "dusk-11" }}500ms
+{{- end }}
+{{- end }}
+
+{{- define "cometBFT.timeouts.precommit" -}}
+{{- if eq .Values.global.network "custom" }}{{ .Values.cometbft.config.consensus.timeoutPrecommit }}
+{{- else if eq .Values.global.network "mainnet" }}1s
+{{- else if eq .Values.global.network "dawn-1" }}1s
+{{- else if eq .Values.global.network "dusk-11" }}1s
+{{- end }}
+{{- end }}
+
+{{- define "cometBFT.timeouts.precommitDelta" -}}
+{{- if eq .Values.global.network "custom" }}{{ .Values.cometbft.config.consensus.timeoutPrecommitDelta }}
+{{- else if eq .Values.global.network "mainnet" }}500ms
+{{- else if eq .Values.global.network "dawn-1" }}500ms
+{{- else if eq .Values.global.network "dusk-11" }}500ms
+{{- end }}
+{{- end }}
+
+{{- define "cometBFT.timeouts.commit" -}}
+{{- if eq .Values.global.network "custom" }}{{ .Values.cometbft.config.consensus.timeoutCommit }}
+{{- else if eq .Values.global.network "mainnet" }}1500ms
+{{- else if eq .Values.global.network "dawn-1" }}1500ms
+{{- else if eq .Values.global.network "dusk-11" }}1500ms
+{{- end }}
+{{- end }}
+
 
 {{/*
 Return if ingress is stable.

--- a/charts/sequencer/templates/configmaps.yaml
+++ b/charts/sequencer/templates/configmaps.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ include "sequencer.namespace" . }}
 data:
   genesis.json: |
-    {{- tpl (.Files.Get "files/cometbft/config/genesis.json") $ | nindent 4 }}
+    {{- tpl (.Files.Get (tpl "files/cometbft/config/{{ .Values.global.network }}.genesis.json" .)) $ | nindent 4 }}
   config.toml: |
     {{- tpl (.Files.Get "files/cometbft/config/config.toml") $ | nindent 4 }}
 ---

--- a/charts/sequencer/values.yaml
+++ b/charts/sequencer/values.yaml
@@ -8,6 +8,13 @@ global:
   # Best to be false in production environments, true for clean logs on local dev.
   useTTY: true
   dev: false
+  # Supported options are `custom`, `mainnet`, `dawn-1`, or `dusk-11`.
+  # If you are using a custom network, you should provide the genesis
+  # configuration via values.
+  #
+  # When set to a specific network, there are default images and genesis files
+  # that are used.
+  network: "custom"
 
 snapshotLoad:
   enabled: false
@@ -19,24 +26,29 @@ snapshotLoad:
     endpoint: https://fb1caa337c8e4e3101363ca1240e03ca.r2.cloudflarestorage.com
     acl: private
 
-# sequencer core images
+# Image settings for various services
 images:
   init:
     repo: rclone/rclone
     pullPolicy: IfNotPresent
     tag: 1.56.0
+  # CometBFT image will default to a tag based on the configured network.
+  # If the global.network is custom OR global.dev is true, will use the tag.
   cometBFT:
     repo: docker.io/cometbft/cometbft
     pullPolicy: IfNotPresent
     tag: v0.38.17
-    devTag: v0.38.17
   sequencer:
     repo: ghcr.io/astriaorg/sequencer
     pullPolicy: IfNotPresent
-    tag: 1.0.0
-    devTag: latest
+    tag: latest
 
+# Moniker is used for the cometbft node name, and various chart names.
+# This must be set.
 moniker: ""
+
+# Only used if the global.network is custom, otherwise utilize correct genesis for the
+# network.
 genesis:
   chainId: ""
   genesisTime: ""  # '2023-09-22T17:22:35.092832Z'
@@ -196,6 +208,7 @@ cometbft:
       maxTxsBytes: 100000000
       cacheSize: 10000
 
+    # Consensus timeout values are only overrideable in custom networks
     consensus:
       timeoutPropose: 2s
       timeoutProposeDelta: 500ms
@@ -325,7 +338,7 @@ storage:
   local: true
   entities:
     sequencerSharedStorage:
-      size: "50Gi"
+      size: "100Gi"
       persistentVolumeName: "sequencer-shared-storage"
       path: "/data/sequencer-data"
 

--- a/dev/argocd/pr-preview-envs/sequencer-appset.yaml
+++ b/dev/argocd/pr-preview-envs/sequencer-appset.yaml
@@ -94,7 +94,7 @@ spec:
 
               images:
                 sequencer:
-                  devTag: sha-{{.head_sha}}
+                  tag: sha-{{.head_sha}}
                   pullPolicy: Always
               ingress:
                 grpc:

--- a/dev/values/validators/mainnet.yml
+++ b/dev/values/validators/mainnet.yml
@@ -1,0 +1,54 @@
+global:
+  dev: true
+  network: mainnet
+
+moniker: "jordan-main-test"
+
+sequencer:
+  optimisticBlockApis:
+    # set to true to enable optimistic block APIs
+    enabled: false
+cometbft:
+  secrets:
+    nodeKey:
+      devContent:
+        priv_key:
+          value: HGWRtLbV8WLGFgbYhaGyaLe++DC+DBoc7O3bri81vs2ZlpR28IFfQScoO1aNOE/ygs8LIPM9UzLzbaab4VMggQ==
+    privValidatorKey:
+      devContent:
+        address: 091E47761C58C474534F4D414AF104A6CAF90C22
+        pub_key:
+          value: lV57+rGs2vac7mvkGHP1oBFGHPJM3a+WoAzeFDCJDNU=
+        priv_key:
+          value: dGOTAweQV8Do9P2n+A8m5EnboDrlxgD3dg4vrYpdIRqVXnv6saza9pzua+QYc/WgEUYc8kzdr5agDN4UMIkM1Q==
+  config:
+    p2p:
+      # List of nodes to keep persistent connections to
+      persistentPeers:
+        - 472667f76caa59499d023836f34305fb1b879202@34.146.155.71:26656
+        - 7c63e5951433cd144dcd28ff822b696294e747ce@35.243.92.67:26656
+        - 845cd82094c83188af13f3a6a33cf825a2764ba2@34.84.168.120:26656
+        - 2c5f26275c1b2f09712792d19247f83095b2e21a@34.84.217.48:26656
+
+resources:
+  cometbft:
+    requests:
+      cpu: 1000m
+      memory: 500Mi
+    limits:
+      cpu: 1000m
+      memory: 500Mi
+  sequencer:
+    requests:
+      cpu: 1000m
+      memory: 500Mi
+    limits:
+      cpu: 1000m
+      memory: 500Mi
+
+storage:
+  enabled: true
+
+ingress:
+  rpc:
+    enabled: true


### PR DESCRIPTION
## Summary
Moves settings which should not change for various sequencer networks into top level global field. When deploying to different networks, this makes it such that values files will only need to unique configuration for a given node set as opposed to many values being unable to be changed. Makes it more difficult to misconfigure a node setting. 

## Background
Brief background on why these changes were made, ie "why?"

## Changes
- Add global setting of `network` to sequencer & sequencer-relayer charts.
- Configure the genesis & block timing parameters to defaults w/o override options for core networks
- Configure default images for individual networks, with optional overrides in "dev" mode. 

## Testing
CI/CD testing, and syncing of a mainnet node. 

## Changelogs
No updates required.

## Breaking Changelist
The default here is still custom to ensure backwards compatibility.

