### PR TITLE
fix(core): use i128 for price instead of u128

### DIFF
--- a/crates/astria-core/src/connect/types.rs
+++ b/crates/astria-core/src/connect/types.rs
@@ -448,5 +448,11 @@ pub mod v2 {
             "ETH /USD".parse::<CurrencyPair>().unwrap_err();
             "ETH/ USD".parse::<CurrencyPair>().unwrap_err();
         }
+
+        #[test]
+        fn can_parse_negative_price() {
+            let price = "-1".parse::<Price>().unwrap();
+            assert_eq!(price.get(), -1);
+        }
     }
 }

--- a/crates/astria-core/src/connect/types.rs
+++ b/crates/astria-core/src/connect/types.rs
@@ -14,16 +14,16 @@ pub mod v2 {
     use crate::generated::connect::types::v2 as raw;
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-    pub struct Price(u128);
+    pub struct Price(i128);
 
     impl Price {
         #[must_use]
-        pub const fn new(value: u128) -> Self {
+        pub const fn new(value: i128) -> Self {
             Self(value)
         }
 
         #[must_use]
-        pub fn get(self) -> u128 {
+        pub fn get(self) -> i128 {
             self.0
         }
     }
@@ -33,7 +33,7 @@ pub mod v2 {
             self.get().checked_add(rhs.get()).map(Self)
         }
 
-        pub fn checked_div(self, rhs: u128) -> Option<Self> {
+        pub fn checked_div(self, rhs: i128) -> Option<Self> {
             self.get().checked_div(rhs).map(Self)
         }
     }
@@ -73,7 +73,7 @@ pub mod v2 {
             let be_bytes = <[u8; 16]>::try_from(&*input).map_err(|_| Self::Error {
                 input,
             })?;
-            Ok(Price::new(u128::from_be_bytes(be_bytes)))
+            Ok(Price::new(i128::from_be_bytes(be_bytes)))
         }
     }
 

--- a/crates/astria-core/src/connect/utils.rs
+++ b/crates/astria-core/src/connect/utils.rs
@@ -177,7 +177,7 @@ mod test {
         }
     }
 
-    fn oracle_vote_extension<I: IntoIterator<Item = u128>>(prices: I) -> OracleVoteExtension {
+    fn oracle_vote_extension<I: IntoIterator<Item = i128>>(prices: I) -> OracleVoteExtension {
         OracleVoteExtension {
             prices: prices
                 .into_iter()
@@ -221,7 +221,7 @@ mod test {
 
     #[test]
     fn should_calculate_median() {
-        fn prices<I: IntoIterator<Item = u128>>(prices: I) -> Vec<Price> {
+        fn prices<I: IntoIterator<Item = i128>>(prices: I) -> Vec<Price> {
             prices.into_iter().map(Price::new).collect()
         }
 
@@ -245,14 +245,14 @@ mod test {
 
         // Should handle large values in a set with odd number of entries.
         assert_eq!(
-            u128::MAX,
-            median(prices([u128::MAX, u128::MAX, 1])).unwrap().get()
+            i128::MAX,
+            median(prices([i128::MAX, i128::MAX, 1])).unwrap().get()
         );
 
         // Should handle large values in a set with even number of entries.
         assert_eq!(
-            u128::MAX - 1,
-            median(prices([u128::MAX, u128::MAX, u128::MAX - 1, u128::MAX - 1]))
+            i128::MAX - 1,
+            median(prices([i128::MAX, i128::MAX, i128::MAX - 1, i128::MAX - 1]))
                 .unwrap()
                 .get()
         );

--- a/crates/astria-core/src/generated/astria.primitive.v1.rs
+++ b/crates/astria-core/src/generated/astria.primitive.v1.rs
@@ -1,4 +1,4 @@
-/// A 128 bit unsigned integer encoded in protobuf.,
+/// A 128 bit unsigned integer encoded in protobuf.
 ///
 /// Protobuf does not support integers larger than 64 bits,
 /// so this message encodes a u128 by splitting it into its
@@ -20,6 +20,32 @@ pub struct Uint128 {
 }
 impl ::prost::Name for Uint128 {
     const NAME: &'static str = "Uint128";
+    const PACKAGE: &'static str = "astria.primitive.v1";
+    fn full_name() -> ::prost::alloc::string::String {
+        ::prost::alloc::format!("astria.primitive.v1.{}", Self::NAME)
+    }
+}
+/// A 128 bit signed integer encoded in protobuf.
+///
+/// Protobuf does not support integers larger than 64 bits,
+/// so this message encodes a i128 by splitting it into its
+/// upper 64 and lower 64 bits, each encoded as a uint64.
+///
+/// A native i128 x can then be constructed by casting both
+/// integers to i128, left shifting hi by 64 positions and
+/// adding lo:
+///
+/// x = (hi as i128) << 64 + (lo as i128)
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Int128 {
+    #[prost(uint64, tag = "1")]
+    pub lo: u64,
+    #[prost(uint64, tag = "2")]
+    pub hi: u64,
+}
+impl ::prost::Name for Int128 {
+    const NAME: &'static str = "Int128";
     const PACKAGE: &'static str = "astria.primitive.v1";
     fn full_name() -> ::prost::alloc::string::String {
         ::prost::alloc::format!("astria.primitive.v1.{}", Self::NAME)

--- a/crates/astria-core/src/generated/astria.primitive.v1.serde.rs
+++ b/crates/astria-core/src/generated/astria.primitive.v1.serde.rs
@@ -201,6 +201,120 @@ impl<'de> serde::Deserialize<'de> for Denom {
         deserializer.deserialize_struct("astria.primitive.v1.Denom", FIELDS, GeneratedVisitor)
     }
 }
+impl serde::Serialize for Int128 {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.lo != 0 {
+            len += 1;
+        }
+        if self.hi != 0 {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.primitive.v1.Int128", len)?;
+        if self.lo != 0 {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("lo", ToString::to_string(&self.lo).as_str())?;
+        }
+        if self.hi != 0 {
+            #[allow(clippy::needless_borrow)]
+            struct_ser.serialize_field("hi", ToString::to_string(&self.hi).as_str())?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for Int128 {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "lo",
+            "hi",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Lo,
+            Hi,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "lo" => Ok(GeneratedField::Lo),
+                            "hi" => Ok(GeneratedField::Hi),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = Int128;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.primitive.v1.Int128")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<Int128, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut lo__ = None;
+                let mut hi__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Lo => {
+                            if lo__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("lo"));
+                            }
+                            lo__ = 
+                                Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::Hi => {
+                            if hi__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("hi"));
+                            }
+                            hi__ = 
+                                Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                    }
+                }
+                Ok(Int128 {
+                    lo: lo__.unwrap_or_default(),
+                    hi: hi__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.primitive.v1.Int128", FIELDS, GeneratedVisitor)
+    }
+}
 impl serde::Serialize for Proof {
     #[allow(deprecated)]
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>

--- a/crates/astria-core/src/generated/astria.sequencerblock.v1.rs
+++ b/crates/astria-core/src/generated/astria.sequencerblock.v1.rs
@@ -263,7 +263,7 @@ pub struct Price {
         super::super::super::connect::types::v2::CurrencyPair,
     >,
     #[prost(message, optional, tag = "2")]
-    pub price: ::core::option::Option<super::super::primitive::v1::Uint128>,
+    pub price: ::core::option::Option<super::super::primitive::v1::Int128>,
     #[prost(uint64, tag = "3")]
     pub decimals: u64,
 }

--- a/crates/astria-core/src/primitive/v1/i128.rs
+++ b/crates/astria-core/src/primitive/v1/i128.rs
@@ -1,0 +1,53 @@
+//! Transformations of compiled protobuf types to other types.
+
+use crate::generated::astria::primitive::v1::Int128;
+impl From<i128> for Int128 {
+    fn from(primitive: i128) -> Self {
+        let [h0, h1, h2, h3, h4, h5, h6, h7, l0, l1, l2, l3, l4, l5, l6, l7] =
+            primitive.to_be_bytes();
+        let lo = u64::from_be_bytes([l0, l1, l2, l3, l4, l5, l6, l7]);
+        let hi = u64::from_be_bytes([h0, h1, h2, h3, h4, h5, h6, h7]);
+        Self {
+            lo,
+            hi,
+        }
+    }
+}
+
+impl From<Int128> for i128 {
+    fn from(pb: Int128) -> i128 {
+        let [l0, l1, l2, l3, l4, l5, l6, l7] = pb.lo.to_be_bytes();
+        let [h0, h1, h2, h3, h4, h5, h6, h7] = pb.hi.to_be_bytes();
+        i128::from_be_bytes([
+            h0, h1, h2, h3, h4, h5, h6, h7, l0, l1, l2, l3, l4, l5, l6, l7,
+        ])
+    }
+}
+
+impl<'a> From<&'a i128> for Int128 {
+    fn from(primitive: &'a i128) -> Self {
+        (*primitive).into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Int128;
+
+    #[track_caller]
+    fn i128_roundtrip_check(expected: i128) {
+        let pb: Int128 = expected.into();
+        let actual: i128 = pb.into();
+        assert_eq!(expected, actual);
+    }
+    #[test]
+    fn i128_roundtrips_work() {
+        i128_roundtrip_check(0i128);
+        i128_roundtrip_check(1i128);
+        i128_roundtrip_check(i128::from(u64::MAX));
+        i128_roundtrip_check(i128::from(u64::MAX) + 1i128);
+        i128_roundtrip_check(1i128 << 127);
+        i128_roundtrip_check((1i128 << 127) + (1i128 << 63));
+        i128_roundtrip_check(i128::MAX);
+    }
+}

--- a/crates/astria-core/src/primitive/v1/mod.rs
+++ b/crates/astria-core/src/primitive/v1/mod.rs
@@ -1,4 +1,5 @@
 pub mod asset;
+pub mod i128;
 pub mod u128;
 
 pub use astria_core_address::{

--- a/crates/astria-core/src/protocol/genesis/v1.rs
+++ b/crates/astria-core/src/protocol/genesis/v1.rs
@@ -1147,7 +1147,7 @@ mod tests {
                             id: CurrencyPairId::new(1),
                             nonce: CurrencyPairNonce::new(0),
                             currency_pair_price: Some(QuotePrice {
-                                price: Price::new(3_138_872_234_u128),
+                                price: Price::new(3_138_872_234_i128),
                                 block_height: 0,
                                 block_timestamp: pbjson_types::Timestamp {
                                     seconds: 1_720_122_395,

--- a/crates/astria-sequencer-utils/src/blob_parser.rs
+++ b/crates/astria-sequencer-utils/src/blob_parser.rs
@@ -570,7 +570,7 @@ impl Display for PrintableDeposit {
 
 #[derive(Serialize, Debug)]
 struct PrintableOracleData {
-    prices: Vec<(String, u128, u64)>,
+    prices: Vec<(String, i128, u64)>,
 }
 
 impl TryFrom<&RawOracleData> for PrintableOracleData {

--- a/crates/astria-sequencer/src/connect/oracle/storage/values/currency_pair_state.rs
+++ b/crates/astria-sequencer/src/connect/oracle/storage/values/currency_pair_state.rs
@@ -50,7 +50,7 @@ impl From<Timestamp> for DomainTimestamp {
 
 #[derive(Debug, BorshSerialize, BorshDeserialize)]
 struct QuotePrice {
-    price: u128,
+    price: i128,
     block_timestamp: Timestamp,
     block_height: u64,
 }

--- a/proto/primitives/astria/primitive/v1/types.proto
+++ b/proto/primitives/astria/primitive/v1/types.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package astria.primitive.v1;
 
-// A 128 bit unsigned integer encoded in protobuf.,
+// A 128 bit unsigned integer encoded in protobuf.
 //
 // Protobuf does not support integers larger than 64 bits,
 // so this message encodes a u128 by splitting it into its
@@ -14,6 +14,22 @@ package astria.primitive.v1;
 //
 // x = (hi as u128) << 64 + (lo as u128)
 message Uint128 {
+  uint64 lo = 1;
+  uint64 hi = 2;
+}
+
+// A 128 bit signed integer encoded in protobuf.
+//
+// Protobuf does not support integers larger than 64 bits,
+// so this message encodes a i128 by splitting it into its
+// upper 64 and lower 64 bits, each encoded as a uint64.
+//
+// A native i128 x can then be constructed by casting both
+// integers to i128, left shifting hi by 64 positions and
+// adding lo:
+//
+// x = (hi as i128) << 64 + (lo as i128)
+message Int128 {
   uint64 lo = 1;
   uint64 hi = 2;
 }

--- a/proto/sequencerblockapis/astria/sequencerblock/v1/block.proto
+++ b/proto/sequencerblockapis/astria/sequencerblock/v1/block.proto
@@ -157,6 +157,6 @@ message OracleData {
 
 message Price {
   connect.types.v2.CurrencyPair currency_pair = 1;
-  astria.primitive.v1.Uint128 price = 2;
+  astria.primitive.v1.Int128 price = 2;
   uint64 decimals = 3;
 }


### PR DESCRIPTION
## Summary
it's theoretically possible for the price of an asset to become negative, although rare. in the case where a price became negative, the oracle would be unable to decode the price from the sidecar.

## Background
resolves issue 3.2 "Price can become negative" in the zellic audit of the sequencer-side oracle implementation.

## Changes
- implement `Int128` proto type, similar to our existing primitive `Uint128`
- change `Price` in core to be `i128` internally, instead of `u128`

## Testing
unit tests
