### PR TITLE
fix(sequencer): mempool pending nonce calcuations

### DIFF
--- a/crates/astria-sequencer/CHANGELOG.md
+++ b/crates/astria-sequencer/CHANGELOG.md
@@ -9,9 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Ensure getPendingNonce gRPC returns the correct nonce [#2012](https://github.com/astriaorg/astria/pull/2012).
+
 ### Added
 
 - Implement `astria.sequencerblock.optimistic.v1alpha1.OptimisticBlockService` [#1839](https://github.com/astriaorg/astria/pull/1839).
+- Add ASTRIA_SEQUENCER_ABCI_LISTEN_URL config variable [#1877](https://github.com/astriaorg/astria/pull/1877)
 
 ### Changed
 
@@ -30,10 +35,6 @@ of signer [#1905](https://github.com/astriaorg/astria/pull/1905).
 ### Removed
 
 - Remove ASTRIA_SEQUENCER_LISTEN_ADDR config variable [#1877](https://github.com/astriaorg/astria/pull/1877)
-
-### Added
-
-- Add ASTRIA_SEQUENCER_ABCI_LISTEN_URL config variable [#1877](https://github.com/astriaorg/astria/pull/1877)
 
 ## [1.0.0] - 2024-10-25
 

--- a/crates/astria-sequencer/src/app/mod.rs
+++ b/crates/astria-sequencer/src/app/mod.rs
@@ -945,13 +945,6 @@ impl App {
             .wrap_err("failed to run post execute transactions handler")?;
         }
 
-        // update the priority of any txs in the mempool based on the updated app state
-        if self.recost_mempool {
-            self.metrics.increment_mempool_recosted();
-        }
-        update_mempool_after_finalization(&mut self.mempool, &self.state, self.recost_mempool)
-            .await;
-
         let post_transaction_execution_result: PostTransactionExecutionResult = self
             .state
             .object_get(POST_TRANSACTION_EXECUTION_RESULT_KEY)
@@ -1170,6 +1163,13 @@ impl App {
 
         // Get the latest version of the state, now that we've committed it.
         self.state = Arc::new(StateDelta::new(storage.latest_snapshot()));
+
+        // update the priority of any txs in the mempool based on the updated app state
+        if self.recost_mempool {
+            self.metrics.increment_mempool_recosted();
+        }
+        update_mempool_after_finalization(&mut self.mempool, &self.state, self.recost_mempool)
+            .await;
     }
 
     // StateDelta::apply only works when the StateDelta wraps an underlying

--- a/crates/astria-sequencer/src/grpc/sequencer.rs
+++ b/crates/astria-sequencer/src/grpc/sequencer.rs
@@ -316,7 +316,7 @@ mod tests {
         };
         let request = Request::new(request);
         let response = server.get_pending_nonce(request).await.unwrap();
-        assert_eq!(response.into_inner().inner, sequential_nonce);
+        assert_eq!(response.into_inner().inner, sequential_nonce + 1);
     }
 
     #[tokio::test]

--- a/crates/astria-sequencer/src/mempool/mod.rs
+++ b/crates/astria-sequencer/src/mempool/mod.rs
@@ -417,16 +417,16 @@ impl Mempool {
 
             if demotion_txs.is_empty() {
                 // nothing to demote, check for transactions to promote
-                let highest_pending_nonce = pending
+                let pending_nonce = pending
                     .pending_nonce(address)
-                    .map_or(current_nonce, |nonce| nonce.saturating_add(1));
+                    .map_or(current_nonce, |nonce| nonce);
 
                 let remaining_balances =
                     pending.subtract_contained_costs(address, current_balances.clone());
-                let promtion_txs =
-                    parked.find_promotables(address, highest_pending_nonce, &remaining_balances);
+                let promotion_txs =
+                    parked.find_promotables(address, pending_nonce, &remaining_balances);
 
-                for tx in promtion_txs {
+                for tx in promotion_txs {
                     let tx_id = tx.id();
                     if let Err(error) = pending.add(tx, current_nonce, &current_balances) {
                         // NOTE: this shouldn't happen. Promotions should never fail. This also
@@ -999,14 +999,14 @@ mod tests {
                 .pending_nonce(astria_address_from_hex_string(ALICE_ADDRESS).as_bytes())
                 .await
                 .unwrap(),
-            1
+            2
         );
         assert_eq!(
             mempool
                 .pending_nonce(astria_address_from_hex_string(BOB_ADDRESS).as_bytes())
                 .await
                 .unwrap(),
-            101
+            102
         );
 
         // Check the pending nonce for an address with no txs is `None`.

--- a/crates/astria-sequencer/src/service/consensus.rs
+++ b/crates/astria-sequencer/src/service/consensus.rs
@@ -483,6 +483,7 @@ mod tests {
         use sha2::Digest as _;
 
         let signing_key = SigningKey::new(OsRng);
+        let address_bytes = *signing_key.verification_key().address_bytes();
         let (mut consensus_service, mempool) =
             new_consensus_service(Some(signing_key.verification_key())).await;
 
@@ -527,7 +528,15 @@ mod tests {
             .await
             .unwrap();
 
+        // Mempool should still have a transaction
+        assert_eq!(mempool.len().await, 1);
+        assert_eq!(mempool.pending_nonce(&address_bytes).await, Some(1));
+
+        let commit = ConsensusRequest::Commit {};
+        consensus_service.handle_request(commit).await.unwrap();
+
         // ensure that txs included in a block are removed from the mempool
         assert_eq!(mempool.len().await, 0);
+        assert_eq!(mempool.pending_nonce(&address_bytes).await, None);
     }
 }


### PR DESCRIPTION
## Summary
Updates when the mempool is rebalanced in order to solve for race condition in which call falls through to state before it has been written, by rebalancing after commit and updates the mempool methods to return the pending account nonce instead of the highest nonce in the pending mempool. 

## Background
Nonce is defined as the number of transactions which have been executed on the account. The pending nonce should then be the number of transactions executed + the number of transactions sitting in pending. Our API was not doing this correctly. Pending nonce on the mempool was being defined as the transaction with the highest nonce as opposed to what the account nonce will be after all pending transactions.

Additionally, our mempool was being rebalanced before state was committed, this can result in a race condition where you request the pending nonce after rebalancing has occured but before committed state has occured resulting in fetching not the pending nonce but the current nonce. 

## Changes
- Move mempool maintenance to after `commit` from finalized block
- Mempool defines pending nonce as pending account nonce instead of highest nonce in queue

## Testing
CI/CD tests, which have been updated.

## Changelogs
Changelogs updated.

## Related Issues
closes #2011 
