### PR TITLE
chore(bridge-withdrawer): change batch value metric to a histogram

### DIFF
--- a/crates/astria-bridge-withdrawer/CHANGELOG.md
+++ b/crates/astria-bridge-withdrawer/CHANGELOG.md
@@ -9,10 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Histogram etric `batch_settled_value` now a histogram [#2016](https://github.com/astriaorg/astria/pull/2016).
+
 ### Changed
 
 - Update `idna` dependency to resolve cargo audit warning [#1869](https://github.com/astriaorg/astria/pull/1869).
-- Metric `batch_total_settled_value` now a histogram
+
+### Removed
+
+- Metric `batch_total_settled_value` removed in favor of `batch_settled_value` [#2016](https://github.com/astriaorg/astria/pull/2016).
 
 ## [1.0.1] - 2024-11-01
 

--- a/crates/astria-bridge-withdrawer/CHANGELOG.md
+++ b/crates/astria-bridge-withdrawer/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Histogram etric `batch_settled_value` now a histogram [#2016](https://github.com/astriaorg/astria/pull/2016).
+- Histogram metric `batch_settled_value` [#2016](https://github.com/astriaorg/astria/pull/2016).
 
 ### Changed
 
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- Metric `batch_total_settled_value` removed in favor of `batch_settled_value` [#2016](https://github.com/astriaorg/astria/pull/2016).
+- Gauage metric `batch_total_settled_value`  [#2016](https://github.com/astriaorg/astria/pull/2016).
 
 ## [1.0.1] - 2024-11-01
 

--- a/crates/astria-bridge-withdrawer/CHANGELOG.md
+++ b/crates/astria-bridge-withdrawer/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update `idna` dependency to resolve cargo audit warning [#1869](https://github.com/astriaorg/astria/pull/1869).
+- Metric `batch_total_settled_value` now a histogram
 
 ## [1.0.1] - 2024-11-01
 

--- a/crates/astria-bridge-withdrawer/src/bridge_withdrawer/submitter/mod.rs
+++ b/crates/astria-bridge-withdrawer/src/bridge_withdrawer/submitter/mod.rs
@@ -145,7 +145,7 @@ impl Submitter {
         } = self;
 
         if actions.is_empty() {
-            metrics.record_batch_total_settled_value(0);
+            metrics.record_batch_settled_value(0);
 
             return Ok(());
         }
@@ -213,7 +213,7 @@ impl Submitter {
                 batch.value = total_value,
                 "withdraw batch successfully executed."
             );
-            metrics.record_batch_total_settled_value(total_value);
+            metrics.record_batch_settled_value(total_value);
             state.set_last_rollup_height_submitted(rollup_height);
             state.set_last_sequencer_height(tx_response.height.value());
             state.set_last_sequencer_tx_hash(tx_response.hash);

--- a/crates/astria-bridge-withdrawer/src/bridge_withdrawer/submitter/mod.rs
+++ b/crates/astria-bridge-withdrawer/src/bridge_withdrawer/submitter/mod.rs
@@ -145,7 +145,7 @@ impl Submitter {
         } = self;
 
         if actions.is_empty() {
-            metrics.set_batch_total_settled_value(0);
+            metrics.record_batch_total_settled_value(0);
 
             return Ok(());
         }
@@ -213,7 +213,7 @@ impl Submitter {
                 batch.value = total_value,
                 "withdraw batch successfully executed."
             );
-            metrics.set_batch_total_settled_value(total_value);
+            metrics.record_batch_total_settled_value(total_value);
             state.set_last_rollup_height_submitted(rollup_height);
             state.set_last_sequencer_height(tx_response.height.value());
             state.set_last_sequencer_tx_hash(tx_response.hash);

--- a/crates/astria-bridge-withdrawer/src/main.rs
+++ b/crates/astria-bridge-withdrawer/src/main.rs
@@ -37,7 +37,7 @@ async fn main() -> ExitCode {
     }
 
     let (metrics, _telemetry_guard) = match telemetry_conf
-        .try_init(&())
+        .try_init(&cfg)
         .wrap_err("failed to setup telemetry")
     {
         Err(e) => {

--- a/crates/astria-bridge-withdrawer/src/metrics.rs
+++ b/crates/astria-bridge-withdrawer/src/metrics.rs
@@ -18,7 +18,7 @@ pub struct Metrics {
     nonce_fetch_latency: Histogram,
     sequencer_submission_failure_count: Counter,
     sequencer_submission_latency: Histogram,
-    batch_total_settled_value: Gauge,
+    batch_total_settled_value: Histogram,
 }
 
 impl Metrics {
@@ -46,8 +46,8 @@ impl Metrics {
         self.sequencer_submission_failure_count.increment(1);
     }
 
-    pub(crate) fn set_batch_total_settled_value(&self, value: u128) {
-        self.batch_total_settled_value.set(value);
+    pub(crate) fn record_batch_total_settled_value(&self, value: u128) {
+        self.batch_total_settled_value.record(value);
     }
 }
 
@@ -98,7 +98,7 @@ impl metrics::Metrics for Metrics {
             .register()?;
 
         let batch_total_settled_value = builder
-            .new_gauge_factory(
+            .new_histogram_factory(
                 BATCH_TOTAL_SETTLED_VALUE,
                 "Total value of withdrawals settled in a given sequencer block",
             )?

--- a/crates/astria-bridge-withdrawer/src/metrics.rs
+++ b/crates/astria-bridge-withdrawer/src/metrics.rs
@@ -1,4 +1,5 @@
 use std::time::Duration;
+
 use telemetry::{
     metric_names,
     metrics::{

--- a/crates/astria-bridge-withdrawer/tests/blackbox/helpers/test_bridge_withdrawer.rs
+++ b/crates/astria-bridge-withdrawer/tests/blackbox/helpers/test_bridge_withdrawer.rs
@@ -73,7 +73,6 @@ pub(crate) const DEFAULT_IBC_DENOM: &str = "transfer/channel-0/utia";
 pub(crate) const SEQUENCER_CHAIN_ID: &str = "test-sequencer";
 const ASTRIA_ADDRESS_PREFIX: &str = "astria";
 
-
 pub struct TestBridgeWithdrawer {
     /// The address of the public API server (health, ready).
     pub api_address: SocketAddr,


### PR DESCRIPTION
## Summary
Replaces the `batch_total_settled_value` gauge with `batch_settled_value` histogram.

## Background
The existing metric `batch_total_settled_value` has not been useful, because gauges aren't very good for fast data points information. Histograms are generally better for this data as we can grab aggregate percentage data on what is happening per batch, as well as a total sum for measuring increase over time. 

## Changes
- Replace the `batch_total_settled_value` gauge with `batch_settled_value` histogram
- Added label for metric based on the denom

## Testing
How are these changes tested?

## Changelogs
Changelogs Updated.

## Metrics
- `batch_settled_value` histogram added.

## Breaking Changes
While adding and removing a metric could be considered a breaking change, we are the only consumers here and stopped using the metric because it pretty simply did not work. 
