### PR TITLE
fix: update `ring` dependency and update audit ignore list

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -12,4 +12,8 @@ ignore = [
   # `derivative` is Unmaintained. It is a transient dependency of many crates including several
   # penumbra ones, so cannot easily be replaced.
   "RUSTSEC-2024-0388",
+  # `ring@0.16.20`: Some AES functions may panic when overflow checking is enabled. It is a
+  # transient dependency of the deprecated `ethers`. We should replace our usage of `ethers` with
+  # `alloy` to resolve this. See https://github.com/astriaorg/astria/issues/2020.
+  "RUSTSEC-2025-0009",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2443,7 +2443,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18e4fdb82bd54a12e42fb58a800dcae6b9e13982238ce2296dc3570b92148e1f"
 dependencies = [
  "data-encoding",
- "syn 2.0.98",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5154,7 +5154,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -6966,9 +6966,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.11"
+version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da5349ae27d3887ca812fb375b45a4fbb36d8d12d2df394968cd86e35683fe73"
+checksum = "70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee"
 dependencies = [
  "cc",
  "cfg-if",
@@ -7170,7 +7170,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
- "ring 0.17.11",
+ "ring 0.17.13",
  "rustls-webpki",
  "sct",
 ]
@@ -7202,7 +7202,7 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring 0.17.11",
+ "ring 0.17.13",
  "untrusted 0.9.0",
 ]
 
@@ -7346,7 +7346,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring 0.17.11",
+ "ring 0.17.13",
  "untrusted 0.9.0",
 ]
 


### PR DESCRIPTION
## Summary
Fixes for two new `cargo audit` warnings.

## Background
We get two warnings when running `cargo audit`, both for [RUSTSEC-2025-0009](https://rustsec.org/advisories/RUSTSEC-2025-0009).  One is for `ring@0.16.20` and the other `ring@0.17.11`.

<details><summary>cargo audit output</summary><p>

```
Crate:     ring
Version:   0.16.20
Title:     Some AES functions may panic when overflow checking is enabled.
Date:      2025-03-06
ID:        RUSTSEC-2025-0009
URL:       https://rustsec.org/advisories/RUSTSEC-2025-0009
Solution:  Upgrade to >=0.17.12
Dependency tree:
ring 0.16.20
└── jsonwebtoken 8.3.0
    └── ethers-providers 2.0.14
        ├── ethers-middleware 2.0.14
        │   └── ethers 2.0.14
        │       ├── astria-test-utils 0.1.0
        │       │   └── astria-composer 1.0.0
        │       ├── astria-composer 1.0.0
        │       ├── astria-cli 0.5.1
        │       ├── astria-bridge-withdrawer 1.0.1
        │       └── astria-bridge-contracts 0.1.0
        │           ├── astria-cli 0.5.1
        │           └── astria-bridge-withdrawer 1.0.1
        ├── ethers-contract 2.0.14
        │   ├── ethers-middleware 2.0.14
        │   └── ethers 2.0.14
        └── ethers 2.0.14

Crate:     ring
Version:   0.17.11
Title:     Some AES functions may panic when overflow checking is enabled.
Date:      2025-03-06
ID:        RUSTSEC-2025-0009
URL:       https://rustsec.org/advisories/RUSTSEC-2025-0009
Solution:  Upgrade to >=0.17.12
Dependency tree:
ring 0.17.11
├── sct 0.7.1
│   └── rustls 0.21.12
│       ├── tungstenite 0.20.1
│       │   ├── tokio-tungstenite 0.20.1
│       │   │   └── ethers-providers 2.0.14
│       │   │       ├── ethers-middleware 2.0.14
│       │   │       │   └── ethers 2.0.14
│       │   │       │       ├── astria-test-utils 0.1.0
│       │   │       │       │   └── astria-composer 1.0.0
│       │   │       │       ├── astria-composer 1.0.0
│       │   │       │       ├── astria-cli 0.5.1
│       │   │       │       ├── astria-bridge-withdrawer 1.0.1
│       │   │       │       └── astria-bridge-contracts 0.1.0
│       │   │       │           ├── astria-cli 0.5.1
│       │   │       │           └── astria-bridge-withdrawer 1.0.1
│       │   │       ├── ethers-contract 2.0.14
│       │   │       │   ├── ethers-middleware 2.0.14
│       │   │       │   └── ethers 2.0.14
│       │   │       └── ethers 2.0.14
│       │   └── async-tungstenite 0.23.0
│       │       └── tendermint-rpc 0.34.1
│       │           ├── astria-sequencer-relayer 1.0.0
│       │           ├── astria-sequencer-client 0.1.0
│       │           │   ├── astria-sequencer-relayer 1.0.0
│       │           │   ├── astria-conductor 1.0.0
│       │           │   ├── astria-composer 1.0.0
│       │           │   ├── astria-cli 0.5.1
│       │           │   ├── astria-bridge-withdrawer 1.0.1
│       │           │   └── astria-auctioneer 0.0.1
│       │           ├── astria-conductor 1.0.0
│       │           ├── astria-composer 1.0.0
│       │           └── astria-bridge-withdrawer 1.0.1
│       ├── tonic 0.10.2
│       │   ├── tonic-health 0.10.2
│       │   │   └── astria-composer 1.0.0
│       │   ├── penumbra-tower-trace 0.80.10
│       │   │   └── astria-sequencer 1.0.0
│       │   ├── penumbra-sct 0.80.10
│       │   │   └── penumbra-ibc 0.80.10
│       │   │       ├── astria-sequencer-utils 0.1.0
│       │   │       ├── astria-sequencer 1.0.0
│       │   │       └── astria-core 0.1.0
│       │   │           ├── astria-sequencer-utils 0.1.0
│       │   │           ├── astria-sequencer-relayer 1.0.0
│       │   │           ├── astria-sequencer-client 0.1.0
│       │   │           ├── astria-sequencer 1.0.0
│       │   │           ├── astria-core 0.1.0
│       │   │           ├── astria-conductor 1.0.0
│       │   │           ├── astria-composer 1.0.0
│       │   │           ├── astria-cli 0.5.1
│       │   │           ├── astria-bridge-withdrawer 1.0.1
│       │   │           ├── astria-bridge-contracts 0.1.0
│       │   │           └── astria-auctioneer 0.0.1
│       │   ├── penumbra-proto 0.80.10
│       │   │   ├── penumbra-txhash 0.80.10
│       │   │   │   └── penumbra-ibc 0.80.10
│       │   │   ├── penumbra-tct 0.80.10
│       │   │   │   ├── penumbra-txhash 0.80.10
│       │   │   │   ├── penumbra-sct 0.80.10
│       │   │   │   └── penumbra-keys 0.80.10
│       │   │   │       └── penumbra-sct 0.80.10
│       │   │   ├── penumbra-sct 0.80.10
│       │   │   ├── penumbra-num 0.80.10
│       │   │   │   ├── penumbra-ibc 0.80.10
│       │   │   │   └── penumbra-asset 0.80.10
│       │   │   │       ├── penumbra-keys 0.80.10
│       │   │   │       └── penumbra-ibc 0.80.10
│       │   │   ├── penumbra-keys 0.80.10
│       │   │   ├── penumbra-ibc 0.80.10
│       │   │   ├── penumbra-asset 0.80.10
│       │   │   ├── astria-sequencer 1.0.0
│       │   │   └── astria-core 0.1.0
│       │   ├── penumbra-ibc 0.80.10
│       │   ├── ibc-proto 0.41.0
│       │   │   ├── penumbra-proto 0.80.10
│       │   │   ├── penumbra-ibc 0.80.10
│       │   │   ├── ibc-types-lightclients-tendermint 0.12.1
│       │   │   │   └── ibc-types 0.12.1
│       │   │   │       ├── penumbra-proto 0.80.10
│       │   │   │       ├── penumbra-ibc 0.80.10
│       │   │   │       ├── cnidarium 0.80.10
│       │   │   │       │   ├── penumbra-sct 0.80.10
│       │   │   │       │   ├── penumbra-proto 0.80.10
│       │   │   │       │   ├── penumbra-ibc 0.80.10
│       │   │   │       │   ├── cnidarium-component 0.80.10
│       │   │   │       │   │   └── penumbra-sct 0.80.10
│       │   │   │       │   └── astria-sequencer 1.0.0
│       │   │   │       ├── astria-sequencer 1.0.0
│       │   │   │       ├── astria-core 0.1.0
│       │   │   │       ├── astria-cli 0.5.1
│       │   │   │       ├── astria-bridge-withdrawer 1.0.1
│       │   │   │       └── astria-bridge-contracts 0.1.0
│       │   │   ├── ibc-types-core-connection 0.12.1
│       │   │   │   ├── ibc-types-path 0.12.1
│       │   │   │   │   └── ibc-types 0.12.1
│       │   │   │   ├── ibc-types-lightclients-tendermint 0.12.1
│       │   │   │   ├── ibc-types-core-channel 0.12.1
│       │   │   │   │   ├── ibc-types-path 0.12.1
│       │   │   │   │   └── ibc-types 0.12.1
│       │   │   │   └── ibc-types 0.12.1
│       │   │   ├── ibc-types-core-commitment 0.12.1
│       │   │   │   ├── ibc-types-lightclients-tendermint 0.12.1
│       │   │   │   ├── ibc-types-core-connection 0.12.1
│       │   │   │   ├── ibc-types-core-channel 0.12.1
│       │   │   │   └── ibc-types 0.12.1
│       │   │   ├── ibc-types-core-client 0.12.1
│       │   │   │   ├── ibc-types-path 0.12.1
│       │   │   │   ├── ibc-types-lightclients-tendermint 0.12.1
│       │   │   │   ├── ibc-types-core-connection 0.12.1
│       │   │   │   ├── ibc-types-core-channel 0.12.1
│       │   │   │   └── ibc-types 0.12.1
│       │   │   ├── ibc-types-core-channel 0.12.1
│       │   │   └── astria-sequencer 1.0.0
│       │   ├── astria-sequencer-relayer 1.0.0
│       │   ├── astria-sequencer 1.0.0
│       │   ├── astria-grpc-mock-test 0.1.0
│       │   ├── astria-grpc-mock 0.1.0
│       │   │   ├── astria-sequencer-relayer 1.0.0
│       │   │   ├── astria-grpc-mock-test 0.1.0
│       │   │   ├── astria-conductor 1.0.0
│       │   │   ├── astria-composer 1.0.0
│       │   │   └── astria-bridge-withdrawer 1.0.1
│       │   ├── astria-core 0.1.0
│       │   ├── astria-conductor 1.0.0
│       │   ├── astria-composer 1.0.0
│       │   ├── astria-bridge-withdrawer 1.0.1
│       │   └── astria-auctioneer 0.0.1
│       ├── tokio-rustls 0.24.1
│       │   ├── tonic 0.10.2
│       │   ├── reqwest 0.11.27
│       │   │   ├── tendermint-rpc 0.34.1
│       │   │   ├── ethers-providers 2.0.14
│       │   │   ├── ethers-middleware 2.0.14
│       │   │   ├── astria-composer 1.0.0
│       │   │   └── astria-bridge-withdrawer 1.0.1
│       │   ├── jsonrpsee-client-transport 0.20.4
│       │   │   └── jsonrpsee-ws-client 0.20.4
│       │   │       └── jsonrpsee 0.20.4
│       │   │           ├── celestia-rpc 0.1.1
│       │   │           │   └── astria-conductor 1.0.0
│       │   │           ├── astria-test-utils 0.1.0
│       │   │           └── astria-conductor 1.0.0
│       │   ├── hyper-rustls 0.24.2
│       │   │   ├── reqwest 0.11.27
│       │   │   └── jsonrpsee-http-client 0.20.4
│       │   │       └── jsonrpsee 0.20.4
│       │   └── async-tungstenite 0.23.0
│       ├── reqwest 0.11.27
│       └── hyper-rustls 0.24.2
├── rustls-webpki 0.101.7
│   └── rustls 0.21.12
└── rustls 0.21.12

error: 2 vulnerabilities found!
```

</p></details>

One of these vulnerabilities can be resolved simply by running `cargo update ring@0.17.11`.  However, to resolve the one caused by `ring@0.16.20`, we need to change our own usage of `ethers` to `alloy` throughout.

For now, this is worked around by adding an entry to the ignore list.  The outstanding work is being tracked at #2020.

## Changes
- Ran `cargo update ring@0.17.11`
- Ignore RustSec warning in `.cargo/audit.toml`.

## Testing
Ran `cargo audit` locally.

## Changelogs
No updates required - nothing really fixed or updated.

## Related Issues
Closes #2018.
Closes #2019.