### PR TITLE
chore(charts): update for latest geth releases

### DIFF
--- a/charts/evm-rollup/Chart.yaml
+++ b/charts/evm-rollup/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.2
+version: 1.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.0.0"
+appVersion: "1.1.0"
 
 maintainers:
   - name: wafflesvonmaple

--- a/charts/evm-rollup/values.yaml
+++ b/charts/evm-rollup/values.yaml
@@ -10,7 +10,7 @@ images:
   geth:
     repo: ghcr.io/astriaorg/astria-geth
     pullPolicy: IfNotPresent
-    tag: 1.0.0
+    tag: 1.1.0
     devTag: latest
     overrideTag: ""
   conductor:

--- a/charts/evm-stack/Chart.lock
+++ b/charts/evm-stack/Chart.lock
@@ -4,10 +4,10 @@ dependencies:
   version: 0.4.0
 - name: evm-rollup
   repository: file://../evm-rollup
-  version: 1.1.2
+  version: 1.2.0
 - name: flame-rollup
   repository: file://../flame-rollup
-  version: 0.0.2
+  version: 0.1.0
 - name: composer
   repository: file://../composer
   version: 1.0.0
@@ -26,5 +26,5 @@ dependencies:
 - name: blockscout-stack
   repository: https://blockscout.github.io/helm-charts
   version: 1.6.8
-digest: sha256:ec55e7e1427dd7af6b3764d7cedc7b5b168ec2443fa140cb3000c8ed68d711ac
-generated: "2025-02-20T10:44:04.460576+02:00"
+digest: sha256:5cb974f9b75faaecfa412898230421802160abb8df4c907482f159af9c110667
+generated: "2025-03-07T10:26:40.207281-08:00"

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -15,18 +15,18 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.12
+version: 1.1.0
 dependencies:
   - name: celestia-node
     version: 0.4.0
     repository: "file://../celestia-node"
     condition: celestia-node.enabled
   - name: evm-rollup
-    version: 1.1.2
+    version: 1.2.0
     repository: "file://../evm-rollup"
     condition: evm-rollup.enabled
   - name: flame-rollup
-    version: 0.0.2
+    version: 0.1.0
     repository: "file://../flame-rollup"
     condition: flame-rollup.enabled
   - name: composer

--- a/charts/flame-rollup/Chart.yaml
+++ b/charts/flame-rollup/Chart.yaml
@@ -16,12 +16,12 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.0.2
+version: 0.1.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.0.1"
+appVersion: "0.1.0"
 
 maintainers:
   - name: wafflesvonmaple

--- a/charts/flame-rollup/values.yaml
+++ b/charts/flame-rollup/values.yaml
@@ -10,8 +10,8 @@ images:
   geth:
     repo: ghcr.io/astriaorg/flame
     pullPolicy: IfNotPresent
-    tag: sha-457e1f9
-    devTag: sha-457e1f9
+    tag: 0.1.0
+    devTag: latest
   conductor:
     repo: ghcr.io/astriaorg/conductor
     pullPolicy: IfNotPresent

--- a/dev/values/rollup/dev.yaml
+++ b/dev/values/rollup/dev.yaml
@@ -9,9 +9,6 @@ global:
   celestiaChainId: celestia-local-0
 
 evm-rollup:
-  images:
-    geth:
-      devTag: pr-75
   genesis:
     ## These values are used to configure the genesis block of the rollup chain
     ## no defaults as they are unique to each chain

--- a/dev/values/rollup/flame-dev.yaml
+++ b/dev/values/rollup/flame-dev.yaml
@@ -13,9 +13,6 @@ evm-rollup:
 
 flame-rollup:
   enabled: true
-  images:
-    geth:
-      devTag: pr-49
   genesis:
     ## These values are used to configure the genesis block of the rollup chain
     ## no defaults as they are unique to each chain


### PR DESCRIPTION
## Summary
Updates the evm charts to use latest releases of `astria-geth` and `flame` images

## Background
New releases of geth and flame cut. 

## Changes
- Update the dev charts to use latest
- Utilize the newest release images for core charts

## Testing
CI/CD tests

## Changelogs
No updates required.
