### PR TITLE
fix: update cargo audit ignore list

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -16,4 +16,11 @@ ignore = [
   # transient dependency of the deprecated `ethers`. We should replace our usage of `ethers` with
   # `alloy` to resolve this. See https://github.com/astriaorg/astria/issues/2020.
   "RUSTSEC-2025-0009",
+  # `ring` < 0.17 is Unmaintained. It is a transient dependency of the deprecated `ethers`. As with
+  # RUSTSEC-2025-0009 above, we should replace our usage of `ethers` with `alloy` to resolve this.
+  # See https://github.com/astriaorg/astria/issues/2020.
+  "RUSTSEC-2025-0010",
+  # `paste` is Unmaintained. It is a transient dependency of many crates including several penumbra
+  # ones, so cannot easily be replaced.
+  "RUSTSEC-2024-0436",
 ]


### PR DESCRIPTION
## Summary
Fixes for two new `cargo audit` warnings.

## Background
We get two non-critical warnings when running `cargo audit`: [RUSTSEC-2024-0436](https://rustsec.org/advisories/RUSTSEC-2024-0436) and [RUSTSEC-2025-0010](https://rustsec.org/advisories/RUSTSEC-2025-0010).

<details><summary>cargo audit output</summary><p>

```
Crate:     paste
Version:   1.0.15
Warning:   unmaintained
Title:     paste - no longer maintained
Date:      2024-10-07
ID:        RUSTSEC-2024-0436
URL:       https://rustsec.org/advisories/RUSTSEC-2024-0436
Dependency tree:
paste 1.0.15
├── flex-error 0.4.4
│   ├── tendermint-rpc 0.34.1
│   │   ├── astria-sequencer-relayer 1.0.1
│   │   ├── astria-sequencer-client 0.1.0
│   │   │   ├── astria-sequencer-relayer 1.0.1
│   │   │   ├── astria-conductor 1.1.0
│   │   │   ├── astria-composer 1.0.1
│   │   │   ├── astria-cli 0.6.0
│   │   │   ├── astria-bridge-withdrawer 1.0.2
│   │   │   └── astria-auctioneer 0.0.1
│   │   ├── astria-conductor 1.1.0
│   │   ├── astria-composer 1.0.1
│   │   └── astria-bridge-withdrawer 1.0.2
│   ├── tendermint-proto 0.34.1
│   │   ├── tower-abci 0.12.0
│   │   │   └── astria-sequencer 2.0.0-rc.1
│   │   ├── tendermint-rpc 0.34.1
│   │   ├── tendermint 0.34.1
│   │   │   ├── tower-abci 0.12.0
│   │   │   ├── tendermint-rpc 0.34.1
│   │   │   ├── tendermint-light-client-verifier 0.34.1
│   │   │   │   ├── penumbra-ibc 0.80.10
│   │   │   │   │   ├── astria-sequencer-utils 0.1.0
│   │   │   │   │   ├── astria-sequencer 2.0.0-rc.1
│   │   │   │   │   └── astria-core 0.1.0
│   │   │   │   │       ├── astria-sequencer-utils 0.1.0
│   │   │   │   │       ├── astria-sequencer-relayer 1.0.1
│   │   │   │   │       ├── astria-sequencer-client 0.1.0
│   │   │   │   │       ├── astria-sequencer 2.0.0-rc.1
│   │   │   │   │       ├── astria-core 0.1.0
│   │   │   │   │       ├── astria-conductor 1.1.0
│   │   │   │   │       ├── astria-composer 1.0.1
│   │   │   │   │       ├── astria-cli 0.6.0
│   │   │   │   │       ├── astria-bridge-withdrawer 1.0.2
│   │   │   │   │       ├── astria-bridge-contracts 0.1.0
│   │   │   │   │       │   ├── astria-cli 0.6.0
│   │   │   │   │       │   └── astria-bridge-withdrawer 1.0.2
│   │   │   │   │       └── astria-auctioneer 0.0.1
│   │   │   │   ├── ibc-types-lightclients-tendermint 0.12.1
│   │   │   │   │   └── ibc-types 0.12.1
│   │   │   │   │       ├── penumbra-proto 0.80.10
│   │   │   │   │       │   ├── penumbra-txhash 0.80.10
│   │   │   │   │       │   │   └── penumbra-ibc 0.80.10
│   │   │   │   │       │   ├── penumbra-tct 0.80.10
│   │   │   │   │       │   │   ├── penumbra-txhash 0.80.10
│   │   │   │   │       │   │   ├── penumbra-sct 0.80.10
│   │   │   │   │       │   │   │   └── penumbra-ibc 0.80.10
│   │   │   │   │       │   │   └── penumbra-keys 0.80.10
│   │   │   │   │       │   │       └── penumbra-sct 0.80.10
│   │   │   │   │       │   ├── penumbra-sct 0.80.10
│   │   │   │   │       │   ├── penumbra-num 0.80.10
│   │   │   │   │       │   │   ├── penumbra-ibc 0.80.10
│   │   │   │   │       │   │   └── penumbra-asset 0.80.10
│   │   │   │   │       │   │       ├── penumbra-keys 0.80.10
│   │   │   │   │       │   │       └── penumbra-ibc 0.80.10
│   │   │   │   │       │   ├── penumbra-keys 0.80.10
│   │   │   │   │       │   ├── penumbra-ibc 0.80.10
│   │   │   │   │       │   ├── penumbra-asset 0.80.10
│   │   │   │   │       │   ├── astria-sequencer 2.0.0-rc.1
│   │   │   │   │       │   └── astria-core 0.1.0
│   │   │   │   │       ├── penumbra-ibc 0.80.10
│   │   │   │   │       ├── cnidarium 0.80.10
│   │   │   │   │       │   ├── penumbra-sct 0.80.10
│   │   │   │   │       │   ├── penumbra-proto 0.80.10
│   │   │   │   │       │   ├── penumbra-ibc 0.80.10
│   │   │   │   │       │   ├── cnidarium-component 0.80.10
│   │   │   │   │       │   │   └── penumbra-sct 0.80.10
│   │   │   │   │       │   └── astria-sequencer 2.0.0-rc.1
│   │   │   │   │       ├── astria-sequencer 2.0.0-rc.1
│   │   │   │   │       ├── astria-core 0.1.0
│   │   │   │   │       ├── astria-cli 0.6.0
│   │   │   │   │       ├── astria-bridge-withdrawer 1.0.2
│   │   │   │   │       └── astria-bridge-contracts 0.1.0
│   │   │   │   └── ibc-types-core-commitment 0.12.1
│   │   │   │       ├── ibc-types-lightclients-tendermint 0.12.1
│   │   │   │       ├── ibc-types-core-connection 0.12.1
│   │   │   │       │   ├── ibc-types-path 0.12.1
│   │   │   │       │   │   └── ibc-types 0.12.1
│   │   │   │       │   ├── ibc-types-lightclients-tendermint 0.12.1
│   │   │   │       │   ├── ibc-types-core-channel 0.12.1
│   │   │   │       │   │   ├── ibc-types-path 0.12.1
│   │   │   │       │   │   └── ibc-types 0.12.1
│   │   │   │       │   └── ibc-types 0.12.1
│   │   │   │       ├── ibc-types-core-channel 0.12.1
│   │   │   │       └── ibc-types 0.12.1
│   │   │   ├── tendermint-config 0.34.1
│   │   │   │   ├── tendermint-rpc 0.34.1
│   │   │   │   └── astria-sequencer-relayer 1.0.1
│   │   │   ├── penumbra-tower-trace 0.80.10
│   │   │   │   └── astria-sequencer 2.0.0-rc.1
│   │   │   ├── penumbra-sct 0.80.10
│   │   │   ├── penumbra-proto 0.80.10
│   │   │   ├── penumbra-ibc 0.80.10
│   │   │   ├── ibc-types-timestamp 0.12.1
│   │   │   │   ├── ibc-types-lightclients-tendermint 0.12.1
│   │   │   │   ├── ibc-types-core-connection 0.12.1
│   │   │   │   ├── ibc-types-core-commitment 0.12.1
│   │   │   │   ├── ibc-types-core-client 0.12.1
│   │   │   │   │   ├── ibc-types-path 0.12.1
│   │   │   │   │   ├── ibc-types-lightclients-tendermint 0.12.1
│   │   │   │   │   ├── ibc-types-core-connection 0.12.1
│   │   │   │   │   ├── ibc-types-core-channel 0.12.1
│   │   │   │   │   └── ibc-types 0.12.1
│   │   │   │   ├── ibc-types-core-channel 0.12.1
│   │   │   │   └── ibc-types 0.12.1
│   │   │   ├── ibc-types-path 0.12.1
│   │   │   ├── ibc-types-lightclients-tendermint 0.12.1
│   │   │   ├── ibc-types-core-connection 0.12.1
│   │   │   ├── ibc-types-core-commitment 0.12.1
│   │   │   ├── ibc-types-core-client 0.12.1
│   │   │   ├── ibc-types-core-channel 0.12.1
│   │   │   ├── cnidarium-component 0.80.10
│   │   │   ├── cnidarium 0.80.10
│   │   │   ├── astria-sequencer-relayer 1.0.1
│   │   │   ├── astria-sequencer-client 0.1.0
│   │   │   ├── astria-sequencer 2.0.0-rc.1
│   │   │   ├── astria-core 0.1.0
│   │   │   ├── astria-conductor 1.1.0
│   │   │   ├── astria-composer 1.0.1
│   │   │   ├── astria-cli 0.6.0
│   │   │   ├── astria-bridge-withdrawer 1.0.2
│   │   │   └── astria-bridge-contracts 0.1.0
│   │   ├── penumbra-tower-trace 0.80.10
│   │   ├── ibc-types-timestamp 0.12.1
│   │   ├── ibc-types-path 0.12.1
│   │   ├── ibc-types-lightclients-tendermint 0.12.1
│   │   ├── ibc-types-core-connection 0.12.1
│   │   ├── ibc-types-core-commitment 0.12.1
│   │   ├── ibc-types-core-client 0.12.1
│   │   ├── ibc-types-core-channel 0.12.1
│   │   ├── ibc-proto 0.41.0
│   │   │   ├── penumbra-proto 0.80.10
│   │   │   ├── penumbra-ibc 0.80.10
│   │   │   ├── ibc-types-lightclients-tendermint 0.12.1
│   │   │   ├── ibc-types-core-connection 0.12.1
│   │   │   ├── ibc-types-core-commitment 0.12.1
│   │   │   ├── ibc-types-core-client 0.12.1
│   │   │   ├── ibc-types-core-channel 0.12.1
│   │   │   └── astria-sequencer 2.0.0-rc.1
│   │   ├── astria-sequencer-client 0.1.0
│   │   ├── astria-sequencer 2.0.0-rc.1
│   │   └── astria-core 0.1.0
│   ├── tendermint-light-client-verifier 0.34.1
│   ├── tendermint-config 0.34.1
│   ├── tendermint 0.34.1
│   ├── ibc-proto 0.41.0
│   ├── celestia-tendermint-proto 0.32.2
│   │   ├── celestia-types 0.1.1
│   │   │   ├── celestia-rpc 0.1.1
│   │   │   │   └── astria-conductor 1.1.0
│   │   │   ├── astria-sequencer-relayer 1.0.1
│   │   │   ├── astria-core 0.1.0
│   │   │   └── astria-conductor 1.1.0
│   │   ├── celestia-tendermint 0.32.2
│   │   │   ├── celestia-types 0.1.1
│   │   │   ├── astria-sequencer-relayer 1.0.1
│   │   │   ├── astria-core 0.1.0
│   │   │   └── astria-conductor 1.1.0
│   │   └── celestia-proto 0.1.1
│   │       └── celestia-types 0.1.1
│   └── celestia-tendermint 0.32.2
├── dylint_linting 3.3.0
│   └── tracing_debug_field 0.1.0
├── ark-ff 0.4.2
│   ├── ruint 1.13.1
│   │   └── celestia-types 0.1.1
│   ├── poseidon377 1.2.0
│   │   ├── penumbra-tct 0.80.10
│   │   ├── penumbra-sct 0.80.10
│   │   ├── penumbra-keys 0.80.10
│   │   └── penumbra-asset 0.80.10
│   ├── poseidon-permutation 1.1.0
│   │   └── poseidon377 1.2.0
│   ├── penumbra-tct 0.80.10
│   ├── penumbra-sct 0.80.10
│   ├── penumbra-num 0.80.10
│   ├── penumbra-keys 0.80.10
│   ├── penumbra-ibc 0.80.10
│   ├── penumbra-asset 0.80.10
│   ├── decaf377-rdsa 0.11.0
│   │   ├── penumbra-sct 0.80.10
│   │   ├── penumbra-proto 0.80.10
│   │   ├── penumbra-num 0.80.10
│   │   ├── penumbra-keys 0.80.10
│   │   └── penumbra-asset 0.80.10
│   ├── decaf377-ka 0.80.10
│   │   └── penumbra-keys 0.80.10
│   ├── decaf377-fmd 0.80.10
│   │   ├── penumbra-proto 0.80.10
│   │   ├── penumbra-num 0.80.10
│   │   ├── penumbra-keys 0.80.10
│   │   └── penumbra-asset 0.80.10
│   ├── decaf377 0.10.1
│   │   ├── poseidon377 1.2.0
│   │   ├── poseidon-permutation 1.1.0
│   │   ├── poseidon-parameters 1.1.0
│   │   │   ├── poseidon377 1.2.0
│   │   │   └── poseidon-permutation 1.1.0
│   │   ├── penumbra-tct 0.80.10
│   │   ├── penumbra-sct 0.80.10
│   │   ├── penumbra-num 0.80.10
│   │   ├── penumbra-keys 0.80.10
│   │   ├── penumbra-asset 0.80.10
│   │   ├── decaf377-rdsa 0.11.0
│   │   ├── decaf377-ka 0.80.10
│   │   └── decaf377-fmd 0.80.10
│   ├── ark-snark 0.4.0
│   │   ├── poseidon377 1.2.0
│   │   ├── penumbra-num 0.80.10
│   │   ├── decaf377 0.10.1
│   │   └── ark-crypto-primitives 0.4.0
│   │       └── ark-groth16 0.4.0
│   │           ├── poseidon377 1.2.0
│   │           ├── penumbra-num 0.80.10
│   │           └── decaf377 0.10.1
│   ├── ark-relations 0.4.0
│   │   ├── poseidon377 1.2.0
│   │   ├── poseidon-permutation 1.1.0
│   │   ├── penumbra-tct 0.80.10
│   │   ├── penumbra-sct 0.80.10
│   │   ├── penumbra-num 0.80.10
│   │   ├── penumbra-keys 0.80.10
│   │   ├── penumbra-asset 0.80.10
│   │   ├── decaf377 0.10.1
│   │   ├── ark-snark 0.4.0
│   │   ├── ark-r1cs-std 0.4.0
│   │   │   ├── poseidon377 1.2.0
│   │   │   ├── poseidon-permutation 1.1.0
│   │   │   ├── penumbra-tct 0.80.10
│   │   │   ├── penumbra-sct 0.80.10
│   │   │   ├── penumbra-num 0.80.10
│   │   │   ├── penumbra-keys 0.80.10
│   │   │   ├── penumbra-asset 0.80.10
│   │   │   └── decaf377 0.10.1
│   │   ├── ark-groth16 0.4.0
│   │   └── ark-crypto-primitives 0.4.0
│   ├── ark-r1cs-std 0.4.0
│   ├── ark-poly 0.4.2
│   │   ├── ark-groth16 0.4.0
│   │   └── ark-ec 0.4.2
│   │       ├── poseidon377 1.2.0
│   │       ├── decaf377 0.10.1
│   │       ├── ark-r1cs-std 0.4.0
│   │       ├── ark-groth16 0.4.0
│   │       ├── ark-ed-on-bls12-377 0.4.0
│   │       │   ├── penumbra-tct 0.80.10
│   │       │   └── decaf377 0.10.1
│   │       ├── ark-crypto-primitives 0.4.0
│   │       └── ark-bls12-377 0.4.0
│   │           ├── decaf377 0.10.1
│   │           └── ark-ed-on-bls12-377 0.4.0
│   ├── ark-groth16 0.4.0
│   ├── ark-ed-on-bls12-377 0.4.0
│   ├── ark-ec 0.4.2
│   ├── ark-crypto-primitives 0.4.0
│   └── ark-bls12-377 0.4.0
└── ark-ff 0.3.0
    └── ruint 1.13.1

Crate:     ring
Version:   0.16.20
Warning:   unmaintained
Title:     Versions of *ring* prior to 0.17 are unmaintained.
Date:      2025-03-05
ID:        RUSTSEC-2025-0010
URL:       https://rustsec.org/advisories/RUSTSEC-2025-0010
Dependency tree:
ring 0.16.20
└── jsonwebtoken 8.3.0
    └── ethers-providers 2.0.14
        ├── ethers-middleware 2.0.14
        │   └── ethers 2.0.14
        │       ├── astria-test-utils 0.1.0
        │       │   └── astria-composer 1.0.1
        │       ├── astria-composer 1.0.1
        │       ├── astria-cli 0.6.0
        │       ├── astria-bridge-withdrawer 1.0.2
        │       └── astria-bridge-contracts 0.1.0
        │           ├── astria-cli 0.6.0
        │           └── astria-bridge-withdrawer 1.0.2
        ├── ethers-contract 2.0.14
        │   ├── ethers-middleware 2.0.14
        │   └── ethers 2.0.14
        └── ethers 2.0.14

warning: 2 allowed warnings found
```

</p></details>

The first warning will be difficult to resolve by replacing `paste` as it's used in a lot of our dependencies.  As the RustSec report doesn't suggest any concrete problems with the crate, I have added the warning to the ignore list.

For the second warning, we already have a ticket to replace `ethers` at #2020, so this has been added to the ignore list in the meantime too.

## Changes
- Ignore RustSec warnings in `.cargo/audit.toml`.

## Testing
Ran `cargo audit` locally.

## Changelogs
No updates required - nothing really fixed or updated.

## Related Issues
Closes #2025.
Closes #2026.