### PR TITLE
fix(core): change decimals to be u8 natively

### DIFF
--- a/crates/astria-sequencer-utils/src/blob_parser.rs
+++ b/crates/astria-sequencer-utils/src/blob_parser.rs
@@ -570,7 +570,7 @@ impl Display for PrintableDeposit {
 
 #[derive(Serialize, Debug)]
 struct PrintableOracleData {
-    prices: Vec<(String, i128, u64)>,
+    prices: Vec<(String, i128, u8)>,
 }
 
 impl TryFrom<&RawOracleData> for PrintableOracleData {

--- a/crates/astria-sequencer/src/connect/market_map/storage/values/market_map.rs
+++ b/crates/astria-sequencer/src/connect/market_map/storage/values/market_map.rs
@@ -51,7 +51,7 @@ impl<'a> From<CurrencyPair<'a>> for DomainCurrencyPair {
 #[derive(Debug, BorshSerialize, BorshDeserialize)]
 struct Ticker<'a> {
     currency_pair: CurrencyPair<'a>,
-    decimals: u64,
+    decimals: u8,
     min_provider_count: u64,
     enabled: bool,
     metadata_json: Cow<'a, str>,

--- a/crates/astria-sequencer/src/grpc/connect.rs
+++ b/crates/astria-sequencer/src/grpc/connect.rs
@@ -232,7 +232,7 @@ impl OracleService for SequencerServer {
                 .map(astria_core::connect::oracle::v2::QuotePrice::into_raw),
             nonce: state.nonce.get(),
             id: state.id.get(),
-            decimals: market.ticker.decimals,
+            decimals: market.ticker.decimals.into(),
         }))
     }
 
@@ -288,7 +288,7 @@ impl OracleService for SequencerServer {
                     .map(astria_core::connect::oracle::v2::QuotePrice::into_raw),
                 nonce: state.nonce.get(),
                 id: state.id.get(),
-                decimals: market.ticker.decimals,
+                decimals: market.ticker.decimals.into(),
             });
         }
         Ok(Response::new(GetPricesResponse {


### PR DESCRIPTION
## Summary
change decimals to be represented as u8 instead of u64 in native types. this is because geth uses u8 for decimals, so u64 could have resulted in truncation issues. decimals shouldn't be larger than u8 anyways.

## Background
fixes zellic audit issue 3.1 "Truncation and precision-loss issue between Astria and Geth during data transfer".

## Changes
- change decimals to be represented as u8 instead of u64 in native types

## Testing
code logic is unchanged.

