### PR TITLE
(chore): replace `humantime` crate with `jiff`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -514,7 +514,6 @@ dependencies = [
  "hex",
  "http 0.2.12",
  "http-body 0.4.6",
- "humantime",
  "hyper 0.14.32",
  "itertools 0.12.1",
  "pbjson-types",
@@ -567,7 +566,6 @@ dependencies = [
  "futures",
  "hex",
  "http 0.2.12",
- "humantime",
  "hyper 0.14.32",
  "ibc-types",
  "pin-project-lite",
@@ -610,8 +608,8 @@ dependencies = [
  "frost-ed25519",
  "futures",
  "hex",
- "humantime",
  "ibc-types",
+ "jiff",
  "pbjson-types",
  "prost",
  "rand 0.8.5",
@@ -645,7 +643,6 @@ dependencies = [
  "ethers",
  "futures",
  "hex",
- "humantime",
  "hyper 0.14.32",
  "insta",
  "itertools 0.12.1",
@@ -695,7 +692,6 @@ dependencies = [
  "futures-bounded",
  "hex",
  "http 0.2.12",
- "humantime",
  "indexmap 2.7.1",
  "insta",
  "itertools 0.12.1",
@@ -915,7 +911,6 @@ dependencies = [
  "futures-util",
  "hex",
  "hex-literal",
- "humantime",
  "prost",
  "regex",
  "serde",
@@ -955,12 +950,11 @@ dependencies = [
  "futures",
  "hex",
  "http 0.2.12",
- "humantime",
- "humantime-serde",
  "hyper 0.14.32",
  "isahc",
  "itertools 0.12.1",
  "itoa",
+ "jiff",
  "k256",
  "pbjson-types",
  "pin-project-lite",
@@ -1018,6 +1012,7 @@ dependencies = [
  "base64-serde",
  "const_format",
  "itertools 0.12.1",
+ "jiff",
  "metrics 0.23.0",
  "metrics-exporter-prometheus",
  "opentelemetry",
@@ -2443,7 +2438,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18e4fdb82bd54a12e42fb58a800dcae6b9e13982238ce2296dc3570b92148e1f"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2963,14 +2958,14 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.6"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcaee3d8e3cfc3fd92428d477bc97fc29ec8716d180c0d74c643bb26166660e0"
+checksum = "c3716d7a920fb4fac5d84e9d4bce8ceb321e9414b4409da61b07b75c1e3d0697"
 dependencies = [
  "anstream",
  "anstyle",
  "env_filter",
- "humantime",
+ "jiff",
  "log",
 ]
 
@@ -3006,7 +3001,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4079,22 +4074,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
-name = "humantime-serde"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
-dependencies = [
- "humantime",
- "serde",
-]
-
-[[package]]
 name = "hyper"
 version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4813,7 +4792,7 @@ checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
 dependencies = [
  "hermit-abi 0.4.0",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4892,6 +4871,47 @@ name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+
+[[package]]
+name = "jiff"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d699bc6dfc879fb1bf9bdff0d4c56f0884fc6f0d0eb0fba397a6d00cd9a6b85e"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d16e75759ee0aa64c57a56acbf43916987b20c77373cb7e808979e02b93c9f9"
+dependencies = [
+ "proc-macro2 1.0.93",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "962e1dfe9b2d75a84536cf5bf5eaaa4319aa7906c7160134a22883ac316d5f31"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a63c62e404e7b92979d2792352d885a7f8f83fd1d0d31eea582d77b2ceca697e"
+dependencies = [
+ "jiff-tzdb",
+]
 
 [[package]]
 name = "jmt"
@@ -6416,6 +6436,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "poseidon-parameters"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7160,7 +7189,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7944,7 +7973,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9181,7 +9210,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,13 +73,13 @@ ethers = { version = "2.0.11", default-features = false }
 futures = "0.3"
 hex = "0.4"
 hex-literal = "0.4.1"
-humantime = "2.1.0"
 hyper = "0.14"
 ibc-types = "0.12"
 indexmap = "2.1.0"
 insta = "1.36.1"
 itertools = "0.12.1"
 itoa = "1.0.10"
+jiff = "0.2.4"
 jsonrpsee = { version = "0.20" }
 pbjson-types = "0.6"
 # Note that when updating the penumbra versions, vendored types in `proto/sequencerapis/astria_vendored` may need to be updated as well.

--- a/crates/astria-auctioneer/Cargo.toml
+++ b/crates/astria-auctioneer/Cargo.toml
@@ -20,7 +20,6 @@ base64 = { workspace = true }
 bytes = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }
-humantime = { workspace = true }
 hyper = { workspace = true }
 itertools = { workspace = true }
 pbjson-types = { workspace = true }

--- a/crates/astria-auctioneer/src/auctioneer/auction/worker.rs
+++ b/crates/astria-auctioneer/src/auctioneer/auction/worker.rs
@@ -256,7 +256,7 @@ impl Worker {
                         *self.sequencer_key.address(),
                     ).in_current_span()));
                     info!(
-                        duration = %humantime::format_duration(self.latency_margin),
+                        duration = %astria_telemetry::display::format_duration(self.latency_margin),
                         "started auction timer and request for latest nonce",
                     );
                 }
@@ -288,7 +288,7 @@ pub(in crate::auctioneer) enum Error {
     NonceFetchPanicked { source: tokio::task::JoinError },
     #[error(
         "submission of winner to Sequencer elapsed after {}",
-        humantime::format_duration(SUBMISSION_TIMEOUT)
+        astria_telemetry::display::format_duration(SUBMISSION_TIMEOUT)
     )]
     SubmissionElapsed { source: tokio::time::error::Elapsed },
     #[error("encountered an error when sending the winning bid to Sequencer")]

--- a/crates/astria-auctioneer/src/auctioneer/mod.rs
+++ b/crates/astria-auctioneer/src/auctioneer/mod.rs
@@ -339,7 +339,7 @@ impl Auctioneer {
 
         let message = format!(
             "waiting {} for all constituent tasks to shutdown before aborting",
-            humantime::format_duration(WAIT_BEFORE_ABORT),
+            astria_telemetry::display::format_duration(WAIT_BEFORE_ABORT),
         );
         match &reason {
             Ok(reason) => info!(%reason, message),

--- a/crates/astria-bridge-withdrawer/Cargo.toml
+++ b/crates/astria-bridge-withdrawer/Cargo.toml
@@ -16,7 +16,6 @@ futures = { workspace = true }
 hex = { workspace = true }
 ethers = { workspace = true, features = ["ws"] }
 hyper = { workspace = true }
-humantime = { workspace = true }
 ibc-types = { workspace = true }
 pin-project-lite = { workspace = true }
 prost = { workspace = true }

--- a/crates/astria-bridge-withdrawer/src/bridge_withdrawer/ethereum/watcher.rs
+++ b/crates/astria-bridge-withdrawer/src/bridge_withdrawer/ethereum/watcher.rs
@@ -180,7 +180,7 @@ impl Watcher {
             .on_retry(
                 |attempt, next_delay: Option<Duration>, error: &ProviderError| {
                     let wait_duration = next_delay
-                        .map(humantime::format_duration)
+                        .map(telemetry::display::format_duration)
                         .map(tracing::field::display);
                     warn!(
                         attempt,

--- a/crates/astria-bridge-withdrawer/src/bridge_withdrawer/startup.rs
+++ b/crates/astria-bridge-withdrawer/src/bridge_withdrawer/startup.rs
@@ -400,7 +400,7 @@ async fn wait_for_empty_mempool(
         .on_retry(
             |attempt: u32, next_delay: Option<Duration>, error: &eyre::Report| {
                 let wait_duration = next_delay
-                    .map(humantime::format_duration)
+                    .map(telemetry::display::format_duration)
                     .map(tracing::field::display);
                 warn!(
                     error = error.as_ref() as &dyn std::error::Error,
@@ -562,7 +562,7 @@ async fn get_latest_nonce(
                 state.set_sequencer_connected(false);
 
                 let wait_duration = next_delay
-                    .map(humantime::format_duration)
+                    .map(telemetry::display::format_duration)
                     .map(tracing::field::display);
                 warn!(
                     parent: span.clone(),
@@ -600,7 +600,7 @@ fn make_cometbft_retry_config(
         .on_retry(
             move |attempt: u32, next_delay: Option<Duration>, error: &tendermint_rpc::Error| {
                 let wait_duration = next_delay
-                    .map(humantime::format_duration)
+                    .map(telemetry::display::format_duration)
                     .map(tracing::field::display);
                 warn!(
                     attempt,
@@ -631,7 +631,7 @@ fn make_cometbft_ext_retry_config(
                   next_delay: Option<Duration>,
                   error: &sequencer_client::extension_trait::Error| {
                 let wait_duration = next_delay
-                    .map(humantime::format_duration)
+                    .map(telemetry::display::format_duration)
                     .map(tracing::field::display);
                 warn!(
                     attempt,

--- a/crates/astria-bridge-withdrawer/src/bridge_withdrawer/submitter/mod.rs
+++ b/crates/astria-bridge-withdrawer/src/bridge_withdrawer/submitter/mod.rs
@@ -266,7 +266,7 @@ async fn submit_tx(
                 state.set_sequencer_connected(false);
 
                 let wait_duration = next_delay
-                    .map(humantime::format_duration)
+                    .map(telemetry::display::format_duration)
                     .map(tracing::field::display);
                 warn!(
                     parent: span.clone(),
@@ -327,7 +327,7 @@ pub(crate) async fn get_pending_nonce(
                 state.set_sequencer_connected(false);
 
                 let wait_duration = next_delay
-                    .map(humantime::format_duration)
+                    .map(telemetry::display::format_duration)
                     .map(tracing::field::display);
                 warn!(
                     error = err as &dyn std::error::Error,

--- a/crates/astria-cli/Cargo.toml
+++ b/crates/astria-cli/Cargo.toml
@@ -38,7 +38,7 @@ tendermint = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros", "signal"] }
 tracing = { workspace = true }
 which = { workspace = true }
-humantime.workspace = true
+jiff.workspace = true
 tryhard.workspace = true
 serde_json.workspace = true
 futures.workspace = true

--- a/crates/astria-cli/src/bridge/collect.rs
+++ b/crates/astria-cli/src/bridge/collect.rs
@@ -269,8 +269,8 @@ async fn connect_to_rollup(rollup_endpoint: &str) -> eyre::Result<Arc<Provider<W
         .on_retry(
             |attempt, next_delay: Option<Duration>, error: &ProviderError| {
                 let wait_duration = next_delay
-                    .map(humantime::format_duration)
-                    .map(tracing::field::display);
+                    .and_then(|delay| jiff::SignedDuration::try_from(delay).ok())
+                    .map(|signed_duration| tracing::field::display(format!("{signed_duration:#}")));
                 warn!(
                     attempt,
                     wait_duration,

--- a/crates/astria-composer/Cargo.toml
+++ b/crates/astria-composer/Cargo.toml
@@ -27,7 +27,6 @@ async-trait = { workspace = true }
 axum = { workspace = true }
 ethers = { workspace = true, features = ["ws"] }
 futures = { workspace = true }
-humantime = { workspace = true }
 hyper = { workspace = true }
 hex = { workspace = true }
 itertools = { workspace = true }

--- a/crates/astria-composer/src/collectors/geth.rs
+++ b/crates/astria-composer/src/collectors/geth.rs
@@ -316,7 +316,7 @@ async fn connect_to_geth_node(url: String) -> eyre::Result<Provider<Ws>> {
         .on_retry(
             |attempt, next_delay: Option<Duration>, error: &ProviderError| {
                 let wait_duration = next_delay
-                    .map(humantime::format_duration)
+                    .map(telemetry::display::format_duration)
                     .map(tracing::field::display);
                 warn!(
                     attempt,

--- a/crates/astria-composer/src/executor/mod.rs
+++ b/crates/astria-composer/src/executor/mod.rs
@@ -377,7 +377,7 @@ impl Executor {
                  next_delay: Option<Duration>,
                  error: &sequencer_client::tendermint_rpc::Error| {
                     let wait_duration = next_delay
-                        .map(humantime::format_duration)
+                        .map(telemetry::display::format_duration)
                         .map(tracing::field::display);
                     warn!(
                         attempt,
@@ -491,7 +491,7 @@ async fn get_pending_nonce(
                 metrics.increment_nonce_fetch_failure_count();
 
                 let wait_duration = next_delay
-                    .map(humantime::format_duration)
+                    .map(telemetry::display::format_duration)
                     .map(tracing::field::display);
                 warn!(
                     parent: span.clone(),
@@ -558,7 +558,7 @@ async fn submit_tx(
                 metrics.increment_sequencer_submission_failure_count();
 
                 let wait_duration = next_delay
-                    .map(humantime::format_duration)
+                    .map(telemetry::display::format_duration)
                     .map(tracing::field::display);
                 warn!(
                     parent: span.clone(),

--- a/crates/astria-conductor/Cargo.toml
+++ b/crates/astria-conductor/Cargo.toml
@@ -30,7 +30,6 @@ base64 = { workspace = true }
 bytes = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }
-humantime = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
 itoa = { workspace = true }

--- a/crates/astria-conductor/src/celestia/fetch.rs
+++ b/crates/astria-conductor/src/celestia/fetch.rs
@@ -103,7 +103,7 @@ async fn fetch_blobs_with_retry(
             |attempt: u32, next_delay: Option<Duration>, error: &jsonrpsee::core::Error| {
                 number_attempts.store(attempt, std::sync::atomic::Ordering::Relaxed);
                 let wait_duration = next_delay
-                    .map(humantime::format_duration)
+                    .map(telemetry::display::format_duration)
                     .map(tracing::field::display);
                 warn!(
                     attempt,

--- a/crates/astria-conductor/src/celestia/mod.rs
+++ b/crates/astria-conductor/src/celestia/mod.rs
@@ -226,7 +226,7 @@ async fn get_celestia_chain_id(
         .on_retry(
             |attempt: u32, next_delay: Option<Duration>, error: &jsonrpsee::core::Error| {
                 let wait_duration = next_delay
-                    .map(humantime::format_duration)
+                    .map(telemetry::display::format_duration)
                     .map(tracing::field::display);
                 warn!(
                     attempt,
@@ -675,7 +675,7 @@ async fn get_sequencer_chain_id(client: SequencerClient) -> eyre::Result<tenderm
         .on_retry(
             |attempt: u32, next_delay: Option<Duration>, error: &tendermint_rpc::Error| {
                 let wait_duration = next_delay
-                    .map(humantime::format_duration)
+                    .map(telemetry::display::format_duration)
                     .map(tracing::field::display);
                 warn!(
                     attempt,

--- a/crates/astria-conductor/src/celestia/verify.rs
+++ b/crates/astria-conductor/src/celestia/verify.rs
@@ -307,7 +307,7 @@ async fn fetch_commit_with_retry(
         .on_retry(
             |attempt: u32, next_delay: Option<Duration>, error: &tendermint_rpc::Error| {
                 let wait_duration = next_delay
-                    .map(humantime::format_duration)
+                    .map(telemetry::display::format_duration)
                     .map(tracing::field::display);
                 warn!(
                     attempt,
@@ -343,7 +343,7 @@ async fn fetch_validators_with_retry(
         .on_retry(
             |attempt: u32, next_delay: Option<Duration>, error: &tendermint_rpc::Error| {
                 let wait_duration = next_delay
-                    .map(humantime::format_duration)
+                    .map(telemetry::display::format_duration)
                     .map(tracing::field::display);
                 warn!(
                     attempt,

--- a/crates/astria-conductor/src/conductor/inner.rs
+++ b/crates/astria-conductor/src/conductor/inner.rs
@@ -136,7 +136,7 @@ impl Inner {
             if timeout(wait_until_timeout, &mut executor).await.is_err() {
                 warn!(
                     "waited `{}` for executor start to respond to shutdown signal; aborting",
-                    humantime::format_duration(wait_until_timeout)
+                    telemetry::display::format_duration(wait_until_timeout)
                 );
                 executor.abort();
             } else {

--- a/crates/astria-conductor/src/executor/client.rs
+++ b/crates/astria-conductor/src/executor/client.rs
@@ -233,7 +233,7 @@ impl tryhard::OnRetry<tonic::Status> for OnRetry {
         previous_error: &tonic::Status,
     ) -> Self::Future {
         let wait_duration = next_delay
-            .map(humantime::format_duration)
+            .map(telemetry::display::format_duration)
             .map(tracing::field::display);
         warn!(
             parent: self.parent.id(),

--- a/crates/astria-conductor/src/sequencer/client.rs
+++ b/crates/astria-conductor/src/sequencer/client.rs
@@ -74,7 +74,7 @@ impl SequencerGrpcClient {
             .on_retry(
                 |attempt: u32, next_delay: Option<Duration>, error: &tonic::Status| {
                     let wait_duration = next_delay
-                        .map(humantime::format_duration)
+                        .map(telemetry::display::format_duration)
                         .map(tracing::field::display);
                     warn!(
                         parent: &span,

--- a/crates/astria-conductor/src/sequencer/mod.rs
+++ b/crates/astria-conductor/src/sequencer/mod.rs
@@ -315,7 +315,7 @@ async fn get_sequencer_chain_id(
         .on_retry(
             |attempt: u32, next_delay: Option<Duration>, error: &tendermint_rpc::Error| {
                 let wait_duration = next_delay
-                    .map(humantime::format_duration)
+                    .map(telemetry::display::format_duration)
                     .map(tracing::field::display);
                 warn!(
                     attempt,

--- a/crates/astria-sequencer-client/Cargo.toml
+++ b/crates/astria-sequencer-client/Cargo.toml
@@ -14,7 +14,6 @@ astria-eyre = { path = "../astria-eyre" }
 async-trait = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }
-humantime = { workspace = true }
 prost = { workspace = true }
 tendermint = { workspace = true }
 tendermint-proto = { workspace = true }

--- a/crates/astria-sequencer-relayer/Cargo.toml
+++ b/crates/astria-sequencer-relayer/Cargo.toml
@@ -21,10 +21,9 @@ celestia-types = { workspace = true }
 const_format = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true, features = ["serde"] }
-humantime = { workspace = true }
-humantime-serde = "1.1.1"
 hyper = { workspace = true }
 itoa = { workspace = true }
+jiff = { workspace = true, features = ["serde"] }
 pbjson-types = { workspace = true }
 pin-project-lite = { workspace = true }
 prost = { workspace = true }

--- a/crates/astria-sequencer-relayer/src/relayer/mod.rs
+++ b/crates/astria-sequencer-relayer/src/relayer/mod.rs
@@ -327,7 +327,7 @@ async fn confirm_sequencer_chain_id(
         .on_retry(
             |attempt: u32, next_delay: Option<Duration>, error: &tendermint_rpc::Error| {
                 let wait_duration = next_delay
-                    .map(humantime::format_duration)
+                    .map(telemetry::display::format_duration)
                     .map(tracing::field::display);
                 warn!(
                     parent: &span,

--- a/crates/astria-sequencer-relayer/src/relayer/read.rs
+++ b/crates/astria-sequencer-relayer/src/relayer/read.rs
@@ -205,7 +205,7 @@ async fn fetch_block(
                 state.set_sequencer_connected(false);
 
                 let wait_duration = next_delay
-                    .map(humantime::format_duration)
+                    .map(telemetry::display::format_duration)
                     .map(tracing::field::display);
 
                 warn!(

--- a/crates/astria-sequencer-relayer/src/relayer/write/mod.rs
+++ b/crates/astria-sequencer-relayer/src/relayer/write/mod.rs
@@ -436,7 +436,7 @@ async fn init_with_retry(client_builder: CelestiaClientBuilder) -> eyre::Result<
         .on_retry(
             |attempt: u32, next_delay: Option<Duration>, error: &BuilderError| {
                 let wait_duration = next_delay
-                    .map(humantime::format_duration)
+                    .map(telemetry::display::format_duration)
                     .map(tracing::field::display);
                 warn!(
                     parent: &span,
@@ -508,7 +508,7 @@ async fn submit_with_retry(
                 let _ = last_error_sender.send(Some(error.clone()));
 
                 let wait_duration = next_delay
-                    .map(humantime::format_duration)
+                    .map(telemetry::display::format_duration)
                     .map(tracing::field::display);
 
                 warn!(

--- a/crates/astria-telemetry/Cargo.toml
+++ b/crates/astria-telemetry/Cargo.toml
@@ -15,6 +15,7 @@ base64 = { workspace = true, optional = true }
 base64-serde = { workspace = true, optional = true }
 const_format = { workspace = true }
 itertools = { workspace = true }
+jiff = { workspace = true, optional = true }
 
 metrics = "0.23.0"
 metrics-exporter-prometheus = { version = "0.15.0", default-features = false, features = [
@@ -47,4 +48,5 @@ display = [
   "dep:serde_json",
   "dep:base64-serde",
   "dep:serde_with",
+  "dep:jiff",
 ]

--- a/crates/astria-telemetry/src/display.rs
+++ b/crates/astria-telemetry/src/display.rs
@@ -162,7 +162,7 @@ impl Display for FormattedDuration {
                 .print_duration(&signed_duration, StdFmtWrite(f))
                 .map_err(|_| fmt::Error),
             Err(_) => {
-                write!(f, "duration greater than {:#}", SignedDuration::MAX)
+                write!(f, "<duration greater than {:#}>", SignedDuration::MAX)
             }
         }
     }

--- a/crates/astria-telemetry/src/display.rs
+++ b/crates/astria-telemetry/src/display.rs
@@ -8,6 +8,7 @@ use std::{
     },
     io,
     str,
+    time::Duration,
 };
 
 use base64_serde::base64_serde_type;
@@ -132,5 +133,37 @@ where
             inner: f,
         };
         serde_json::to_writer(&mut wr, self.0).map_err(|_| fmt::Error)
+    }
+}
+
+/// Format `duration` using human-readable format.
+///
+/// See the [`base64::engine::general_purpose::STANDARD`] for the formatting definition.
+#[must_use]
+pub fn format_duration(duration: Duration) -> FormattedDuration {
+    FormattedDuration(duration)
+}
+
+pub struct FormattedDuration(Duration);
+
+impl Display for FormattedDuration {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        use jiff::{
+            fmt::{
+                friendly::SpanPrinter,
+                StdFmtWrite,
+            },
+            SignedDuration,
+        };
+
+        static PRINTER: SpanPrinter = SpanPrinter::new();
+        match SignedDuration::try_from(self.0) {
+            Ok(signed_duration) => PRINTER
+                .print_duration(&signed_duration, StdFmtWrite(f))
+                .map_err(|_| fmt::Error),
+            Err(_) => {
+                write!(f, "duration greater than {:#}", SignedDuration::MAX)
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
Fix for a new cargo audit warning advising that `humantime` is unmaintained.

## Background
This was triggered by the warning [RUSTSEC-2025-0014](https://rustsec.org/advisories/RUSTSEC-2025-0014.html).

## Changes
- Replaced our direct usage of `humantime` with the compatible functionality provided by [`jiff`](https://github.com/BurntSushi/jiff) as mentioned as a possible alternative in the advisory.
- Ran `cargo update env_logger` to remove the final dependency on `humantime`.

## Testing
No new tests required.

## Changelogs
No updates required - these changes are invisible to consumers.

## Related Issues
Closes #2029.