### PR TITLE
(chore): unfreeze conductor and relayer

### DIFF
--- a/.github/code-freeze-filter.yaml
+++ b/.github/code-freeze-filter.yaml
@@ -3,16 +3,15 @@
 # in order to put an error on the given file if it is changed.
 
 # Please provide a reasoning for each component that is frozen.
+# Example entry for `conductor` commented out below:
 
-# Frozen for audit.
-conductor: &conductor
-  - crates/astria-conductor/src/**
-# Frozen for audit.
-sequencer-relayer: &sequencer-relayer
-  - crates/astria-sequencer-relayer/src/**
+# # Frozen for audit.
+# conductor: &conductor
+#   - crates/astria-conductor/src/**
 
 # if new components are added above update the list below to get better
 # gh pr level visibility into which files are frozen.
-changed:
-  - *conductor
-  - *sequencer-relayer
+# Example entry for `conductor` commented out below:
+
+# changed:
+#   - *conductor


### PR DESCRIPTION
## Summary
This removes the code-freeze on conductor and sequencer-relayer.

## Background
They were frozen for an audit, which is now complete.

## Changes
- Removed conductor and relayer entries from the freeze filter file.

## Testing
N/A

## Changelogs
No updates required.
