### PR TITLE
ci: freeze test fix

### DIFF
--- a/.github/code-freeze-filter.yaml
+++ b/.github/code-freeze-filter.yaml
@@ -6,12 +6,10 @@
 # Example entry for `conductor` commented out below:
 
 # # Frozen for audit.
-# conductor: &conductor
-#   - crates/astria-conductor/src/**
+freeze_file: &freeze_file
+  - .github/workflows/code-freeze.yml
 
 # if new components are added above update the list below to get better
 # gh pr level visibility into which files are frozen.
-# Example entry for `conductor` commented out below:
-
-# changed:
-#   - *conductor
+changed:
+  - *freeze_file

--- a/.github/workflows/code-freeze.yml
+++ b/.github/workflows/code-freeze.yml
@@ -1,6 +1,6 @@
 name: Code Freeze
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - synchronize


### PR DESCRIPTION
## Summary
We don't have anything under code freeze right now but this breaks the freeze test. Instead we should consider the freeze file itself frozen and require override to update.
