### PR TITLE
release(sequencer, charts): cut sequencer v2.0.0-rc.2 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -856,7 +856,7 @@ dependencies = [
 
 [[package]]
 name = "astria-sequencer"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 dependencies = [
  "assert-json-diff",
  "astria-build-info",

--- a/charts/sequencer/Chart.yaml
+++ b/charts/sequencer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.1
+version: 1.1.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/sequencer/templates/_helpers.tpl
+++ b/charts/sequencer/templates/_helpers.tpl
@@ -8,8 +8,8 @@ Namepsace to deploy elements into.
 {{- define "sequencer.imageTag" -}}
 {{- if or (eq .Values.global.network "custom") (eq .Values.global.dev true) }}{{ .Values.images.sequencer.tag }}
 {{- else if eq .Values.global.network "mainnet" }}1.0.0
-{{- else if eq .Values.global.network "dawn-1" }}2.0.0-rc.1
-{{- else if eq .Values.global.network "dusk-11" }}2.0.0-rc.1
+{{- else if eq .Values.global.network "dawn-1" }}2.0.0-rc.2
+{{- else if eq .Values.global.network "dusk-11" }}2.0.0-rc.2
 {{- end }}
 {{- end }}
 

--- a/crates/astria-sequencer/CHANGELOG.md
+++ b/crates/astria-sequencer/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-rc.2]
+
 ### Fixed
 
 - Support distributed signers as validators [#2024](https://github.com/astriaorg/astria/pull/2024)
@@ -476,7 +478,8 @@ address [#721](https://github.com/astriaorg/astria/pull/721).
 
 - Initial release.
 
-[unreleased]: https://github.com/astriaorg/astria/compare/sequencer-v2.0.0-rc.1...HEAD
+[unreleased]: https://github.com/astriaorg/astria/compare/sequencer-v2.0.0-rc.2...HEAD
+[2.0.0-rc.1]: https://github.com/astriaorg/astria/compare/sequencer-v2.0.0-rc.1...sequencer-v2.0.0-rc.2
 [2.0.0-rc.1]: https://github.com/astriaorg/astria/compare/sequencer-v1.0.0...sequencer-v2.0.0-rc.1
 [1.0.0]: https://github.com/astriaorg/astria/compare/sequencer-v1.0.0-rc.2...sequencer-v1.0.0
 [1.0.0-rc.2]: https://github.com/astriaorg/astria/compare/sequencer-v1.0.0-rc.1...sequencer-v1.0.0-rc.2

--- a/crates/astria-sequencer/CHANGELOG.md
+++ b/crates/astria-sequencer/CHANGELOG.md
@@ -479,7 +479,7 @@ address [#721](https://github.com/astriaorg/astria/pull/721).
 - Initial release.
 
 [unreleased]: https://github.com/astriaorg/astria/compare/sequencer-v2.0.0-rc.2...HEAD
-[2.0.0-rc.1]: https://github.com/astriaorg/astria/compare/sequencer-v2.0.0-rc.1...sequencer-v2.0.0-rc.2
+[2.0.0-rc.2]: https://github.com/astriaorg/astria/compare/sequencer-v2.0.0-rc.1...sequencer-v2.0.0-rc.2
 [2.0.0-rc.1]: https://github.com/astriaorg/astria/compare/sequencer-v1.0.0...sequencer-v2.0.0-rc.1
 [1.0.0]: https://github.com/astriaorg/astria/compare/sequencer-v1.0.0-rc.2...sequencer-v1.0.0
 [1.0.0-rc.2]: https://github.com/astriaorg/astria/compare/sequencer-v1.0.0-rc.1...sequencer-v1.0.0-rc.2

--- a/crates/astria-sequencer/Cargo.toml
+++ b/crates/astria-sequencer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astria-sequencer"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 rust-version = "1.83.0"


### PR DESCRIPTION
## Summary
Create a new release of sequencer & supporting charts utilizing new release.
