### PR TITLE
release(sequencer): v2.0.0 major release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -856,7 +856,7 @@ dependencies = [
 
 [[package]]
 name = "astria-sequencer"
-version = "2.0.0-rc.2"
+version = "2.0.0"
 dependencies = [
  "assert-json-diff",
  "astria-build-info",

--- a/charts/sequencer/Chart.yaml
+++ b/charts/sequencer/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.2
+version: 2.0.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.0.0"
+appVersion: "2.0.0"
 
 dependencies:
   - name: sequencer-relayer

--- a/charts/sequencer/templates/_helpers.tpl
+++ b/charts/sequencer/templates/_helpers.tpl
@@ -7,9 +7,9 @@ Namepsace to deploy elements into.
 
 {{- define "sequencer.imageTag" -}}
 {{- if or (eq .Values.global.network "custom") (eq .Values.global.dev true) }}{{ .Values.images.sequencer.tag }}
-{{- else if eq .Values.global.network "mainnet" }}1.0.0
-{{- else if eq .Values.global.network "dawn-1" }}2.0.0-rc.2
-{{- else if eq .Values.global.network "dusk-11" }}2.0.0-rc.2
+{{- else if eq .Values.global.network "mainnet" }}2.0.0
+{{- else if eq .Values.global.network "dawn-1" }}2.0.0
+{{- else if eq .Values.global.network "dusk-11" }}2.0.0
 {{- end }}
 {{- end }}
 
@@ -156,7 +156,7 @@ name: {{ .Values.moniker }}-sequencer-metrics
 {{- end }}
 
 {{- define "sequencer.abci_url" -}}
-{{- if and .Values.global.dev .Values.sequencer.abciUDS -}}
+{{- if .Values.sequencer.abciUDS -}}
 unix://{{- include "sequencer.socket_directory" . }}abci.sock
 {{- else -}}
 tcp://127.0.0.1:{{ .Values.ports.sequencerABCI }}

--- a/charts/sequencer/templates/configmaps.yaml
+++ b/charts/sequencer/templates/configmaps.yaml
@@ -57,8 +57,10 @@ data:
   ASTRIA_SEQUENCER_LOG: "info"
   ASTRIA_SEQUENCER_DB_FILEPATH: "/sequencer/penumbra.db"
   ASTRIA_SEQUENCER_MEMPOOL_PARKED_MAX_TX_COUNT: "{{ .Values.sequencer.mempool.parked.maxTxCount }}"
+  ASTRIA_SEQUENCER_ABCI_LISTEN_URL: "{{ include "sequencer.abci_url" . }}"
   # Socket address for GRPC server
   ASTRIA_SEQUENCER_GRPC_ADDR: "0.0.0.0:{{ .Values.ports.sequencerGrpc }}"
+  ASTRIA_SEQUENCER_NO_OPTIMISTIC_BLOCKS: "{{ not .Values.sequencer.optimisticBlockApis.enabled }}"
   ASTRIA_SEQUENCER_NO_METRICS: "{{ not .Values.sequencer.metrics.enabled }}"
   ASTRIA_SEQUENCER_METRICS_HTTP_LISTENER_ADDR: "0.0.0.0:{{ .Values.ports.sequencerMetrics }}"
   ASTRIA_SEQUENCER_FORCE_STDOUT: "{{ .Values.global.useTTY }}"
@@ -76,10 +78,7 @@ data:
   # any image other than the current release version. These are generally
   # variables which are being deleted in the future.
   {{- if not (or .Values.global.dev (ne (include "sequencer.imageTag" .) .Chart.AppVersion)) }}
-  ASTRIA_SEQUENCER_LISTEN_ADDR: "127.0.0.1:{{ .Values.ports.sequencerABCI }}"
   # These are variables which are added in newer releases and are not present in the current release.
   {{- else }}
-  ASTRIA_SEQUENCER_ABCI_LISTEN_URL: "{{ include "sequencer.abci_url" . }}"
-  ASTRIA_SEQUENCER_NO_OPTIMISTIC_BLOCKS: "{{ not .Values.sequencer.optimisticBlockApis.enabled }}"
   {{- end }}
 ---

--- a/crates/astria-sequencer/CHANGELOG.md
+++ b/crates/astria-sequencer/CHANGELOG.md
@@ -9,10 +9,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0]
+
 ### Fixed
 
 - Increase mempool removal cache size to be greater than default CometBFT
   mempool size [#1969](https://github.com/astriaorg/astria/pull/1969).
+- Support distributed signers as validators [#2024](https://github.com/astriaorg/astria/pull/2024)
+- Direct fetching of consensus state in `RecoverIbcClient` action [#2037](https://github.com/astriaorg/astria/pull/2037)
+- Ensure getPendingNonce gRPC returns the correct nonce [#2012](https://github.com/astriaorg/astria/pull/2012).
+
+### Added
+
+- Implement `astria.sequencerblock.optimistic.v1alpha1.OptimisticBlockService` [#1839](https://github.com/astriaorg/astria/pull/1839).
+- Add ASTRIA_SEQUENCER_ABCI_LISTEN_URL config variable [#1877](https://github.com/astriaorg/astria/pull/1877)
+
+### Changed
+
+- Bump MSRV to 1.83.0 [#1857](https://github.com/astriaorg/astria/pull/1857).
+- Index all event attributes [#1786](https://github.com/astriaorg/astria/pull/1786).
+- Consolidate action handling to single module [#1759](https://github.com/astriaorg/astria/pull/1759).
+- Ensure all deposit assets are trace prefixed [#1807](https://github.com/astriaorg/astria/pull/1807).
+- Update `idna` dependency to resolve cargo audit warning [#1869](https://github.com/astriaorg/astria/pull/1869).
+- Remove events reporting on state storage creation [#1892](https://github.com/astriaorg/astria/pull/1892).
+- Use bridge address to determine asset in bridge unlock cost estimation instead
+  of signer [#1905](https://github.com/astriaorg/astria/pull/1905).
+- Add more thorough unit tests for all actions [#1916](https://github.com/astriaorg/astria/pull/1916).
+- Implement `BridgeTransfer` action [#1934](https://github.com/astriaorg/astria/pull/1934).
+- Implement `RecoverIbcClient` action [#2008](https://github.com/astriaorg/astria/pull/2008).
+
+### Removed
+
+- Remove ASTRIA_SEQUENCER_LISTEN_ADDR config variable [#1877](https://github.com/astriaorg/astria/pull/1877)
 
 ## [2.0.0-rc.2]
 
@@ -484,6 +512,7 @@ address [#721](https://github.com/astriaorg/astria/pull/721).
 - Initial release.
 
 [unreleased]: https://github.com/astriaorg/astria/compare/sequencer-v2.0.0-rc.2...HEAD
+[2.0.0]: https://github.com/astriaorg/astria/compare/sequencer-v1.0.0...sequencer-v2.0.0
 [2.0.0-rc.2]: https://github.com/astriaorg/astria/compare/sequencer-v2.0.0-rc.1...sequencer-v2.0.0-rc.2
 [2.0.0-rc.1]: https://github.com/astriaorg/astria/compare/sequencer-v1.0.0...sequencer-v2.0.0-rc.1
 [1.0.0]: https://github.com/astriaorg/astria/compare/sequencer-v1.0.0-rc.2...sequencer-v1.0.0

--- a/crates/astria-sequencer/Cargo.toml
+++ b/crates/astria-sequencer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astria-sequencer"
-version = "2.0.0-rc.2"
+version = "2.0.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 rust-version = "1.83.0"


### PR DESCRIPTION
## Summary
Cuts official 2.0 release of Sequencer, and chart update to ship it. 
