### PR TITLE
chore(conductor): fix flaky test

### DIFF
--- a/crates/astria-conductor/tests/blackbox/soft_and_firm.rs
+++ b/crates/astria-conductor/tests/blackbox/soft_and_firm.rs
@@ -99,7 +99,7 @@ async fn executes_soft_first_then_updates_firm() {
     );
 
     timeout(
-        Duration::from_millis(500),
+        Duration::from_millis(1000),
         join(
             execute_block.wait_until_satisfied(),
             update_commitment_state_soft.wait_until_satisfied(),
@@ -108,7 +108,7 @@ async fn executes_soft_first_then_updates_firm() {
     .await
     .expect(
         "Conductor should have executed the block and updated the soft commitment state within \
-         500ms",
+         1000ms",
     );
 
     mount_celestia_blobs!(


### PR DESCRIPTION
## Summary
Raises timeout time for flaky test.

## Background
Previously, `conductor::soft_and_firm::executes_soft_first_then_updates_firm` was failing frequently when running locally for me. Raising the timeout time appears to have fixed this issue.

## Changes
- Raised timeout for soft commitment from 500ms to 1000ms.

## Testing
Passing consistently now.

## Changelogs
No updates required.

## Related Issues
closes #2040
