### PR TITLE
fix(charts): geth logLevel

### DIFF
--- a/charts/evm-rollup/Chart.yaml
+++ b/charts/evm-rollup/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.1
+version: 1.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/evm-rollup/templates/_helpers.tpl
+++ b/charts/evm-rollup/templates/_helpers.tpl
@@ -35,15 +35,15 @@ app: {{ include "rollup.appName" . }}
 The log level represented as a number
 */}}
 {{- define "rollup.logLevelNum" -}}
-{{- if eq .Values.config.logLevel "error" }}
+{{- if eq .Values.config.logLevel "error" -}}
 1
-{{- else if eq .Values.config.logLevel "warn" }}
+{{- else if eq .Values.config.logLevel "warn" -}}
 2
-{{- else if eq .Values.config.logLevel "info" }}
+{{- else if eq .Values.config.logLevel "info" -}}
 3
-{{- else if eq .Values.config.logLevel "debug" }}
+{{- else if eq .Values.config.logLevel "debug" -}}
 4
-{{- else if eq .Values.config.logLevel "trace" }}
+{{- else if eq .Values.config.logLevel "trace" -}}
 5
 {{- end }}
 {{- end }}

--- a/charts/evm-rollup/templates/statefulsets.yaml
+++ b/charts/evm-rollup/templates/statefulsets.yaml
@@ -72,6 +72,7 @@ spec:
             - --{{ $arg.name }}{{ if $arg.value }}={{ tpl $arg.value $ }}{{ end }}
             {{- end }}
             {{- end }}
+            - --verbosity={{ printf "%s" (include "rollup.logLevelNum" .) }}
           image: {{ include "rollup.image" . }}
           imagePullPolicy: {{ .Values.images.geth.pullPolicy }}
           volumeMounts:

--- a/charts/evm-stack/Chart.lock
+++ b/charts/evm-stack/Chart.lock
@@ -4,10 +4,10 @@ dependencies:
   version: 0.4.0
 - name: evm-rollup
   repository: file://../evm-rollup
-  version: 1.2.1
+  version: 1.2.2
 - name: flame-rollup
   repository: file://../flame-rollup
-  version: 0.1.1
+  version: 0.1.2
 - name: composer
   repository: file://../composer
   version: 1.0.1
@@ -26,5 +26,5 @@ dependencies:
 - name: blockscout-stack
   repository: https://blockscout.github.io/helm-charts
   version: 1.6.8
-digest: sha256:0bd21b95a497d1de9b8431aabd012ea2b9bd76b5e24ddd8606ecf87dcca17c95
-generated: "2025-03-14T17:18:03.426459-07:00"
+digest: sha256:5c3d53344f0af533ebcd284ebc8220e31a7ee0ae035155456e8b5be53c4c9d27
+generated: "2025-03-19T17:40:07.628692+02:00"

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -15,18 +15,18 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.1
+version: 1.1.2
 dependencies:
   - name: celestia-node
     version: 0.4.0
     repository: "file://../celestia-node"
     condition: celestia-node.enabled
   - name: evm-rollup
-    version: 1.2.1
+    version: 1.2.2
     repository: "file://../evm-rollup"
     condition: evm-rollup.enabled
   - name: flame-rollup
-    version: 0.1.1
+    version: 0.1.2
     repository: "file://../flame-rollup"
     condition: flame-rollup.enabled
   - name: composer

--- a/charts/flame-rollup/Chart.yaml
+++ b/charts/flame-rollup/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.1.1
+version: 0.1.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/flame-rollup/templates/_helpers.tpl
+++ b/charts/flame-rollup/templates/_helpers.tpl
@@ -35,15 +35,15 @@ app: {{ include "rollup.appName" . }}
 The log level represented as a number
 */}}
 {{- define "rollup.logLevelNum" -}}
-{{- if eq .Values.config.logLevel "error" }}
+{{- if eq .Values.config.logLevel "error" -}}
 1
-{{- else if eq .Values.config.logLevel "warn" }}
+{{- else if eq .Values.config.logLevel "warn" -}}
 2
-{{- else if eq .Values.config.logLevel "info" }}
+{{- else if eq .Values.config.logLevel "info" -}}
 3
-{{- else if eq .Values.config.logLevel "debug" }}
+{{- else if eq .Values.config.logLevel "debug" -}}
 4
-{{- else if eq .Values.config.logLevel "trace" }}
+{{- else if eq .Values.config.logLevel "trace" -}}
 5
 {{- end }}
 {{- end }}

--- a/charts/flame-rollup/templates/statefulsets.yaml
+++ b/charts/flame-rollup/templates/statefulsets.yaml
@@ -56,6 +56,7 @@ spec:
             - --{{ $arg.name }}{{ if $arg.value }}={{ tpl $arg.value $ }}{{ end }}
             {{- end }}
             {{- end }}
+            - --verbosity={{ printf "%s" (include "rollup.logLevelNum" .) }}
           image: {{ include "rollup.image" . }}
           imagePullPolicy: {{ .Values.images.geth.pullPolicy }}
           volumeMounts:


### PR DESCRIPTION
## Summary
adds verbosity flag to geth statefulset. The log level is set based on config.logLevel entry.
alternative approaches:
- Setting config.logLevel to a numeric value (as expected by Geth) with documentation for users. This keeps the configuration simple and consistent with other flags but diverges from our other charts.
- Templating the config value directly in values.yaml, which works but is not an ideal approach for maintainability.

## Changes
- adds a new flag configuring geth log level.

## Testing
Tested against a local cluster

## Changelogs
No updates required.
