### PR TITLE
chore(sequencer-client): add timeout to 'wait_for_tx_inclusion'

### DIFF
--- a/crates/astria-bridge-withdrawer/src/bridge_withdrawer/submitter/mod.rs
+++ b/crates/astria-bridge-withdrawer/src/bridge_withdrawer/submitter/mod.rs
@@ -296,7 +296,10 @@ async fn submit_tx(
 
     ensure!(check_tx.code.is_ok(), "check_tx failed: {}", check_tx.log);
 
-    let tx_response = client.wait_for_tx_inclusion(check_tx.hash).await;
+    let tx_response = client
+        .wait_for_tx_inclusion(check_tx.hash)
+        .await
+        .wrap_err("failed to confirm transaction inclusion")?;
 
     ensure!(
         tx_response.tx_result.code.is_ok(),

--- a/crates/astria-cli/src/bridge/submit.rs
+++ b/crates/astria-cli/src/bridge/submit.rs
@@ -144,7 +144,10 @@ async fn submit_transaction(
         .await
         .wrap_err("failed to submit transaction")?;
 
-    let tx_response = client.wait_for_tx_inclusion(res.hash).await;
+    let tx_response = client
+        .wait_for_tx_inclusion(res.hash)
+        .await
+        .wrap_err("failed to confirm transaction inclusion")?;
 
     ensure!(res.code.is_ok(), "failed to check tx: {}", res.log);
     ensure!(

--- a/crates/astria-cli/src/sequencer/submit.rs
+++ b/crates/astria-cli/src/sequencer/submit.rs
@@ -41,7 +41,10 @@ impl Command {
 
         ensure!(res.code.is_ok(), "failed to check tx: {}", res.log);
 
-        let tx_response = sequencer_client.wait_for_tx_inclusion(res.hash).await;
+        let tx_response = sequencer_client
+            .wait_for_tx_inclusion(res.hash)
+            .await
+            .wrap_err("failed to confirm transaction inclusion")?;
 
         ensure!(
             tx_response.tx_result.code.is_ok(),

--- a/crates/astria-cli/src/utils.rs
+++ b/crates/astria-cli/src/utils.rs
@@ -52,7 +52,10 @@ pub(crate) async fn submit_transaction(
 
     ensure!(res.code.is_ok(), "failed to check tx: {}", res.log);
 
-    let tx_response = sequencer_client.wait_for_tx_inclusion(res.hash).await;
+    let tx_response = sequencer_client
+        .wait_for_tx_inclusion(res.hash)
+        .await
+        .wrap_err("failed to confirm transaction inclusion")?;
 
     ensure!(
         tx_response.tx_result.code.is_ok(),

--- a/crates/astria-sequencer-client/src/extension_trait.rs
+++ b/crates/astria-sequencer-client/src/extension_trait.rs
@@ -688,7 +688,12 @@ pub trait SequencerClientExt: Client {
         // The minimum duration between logging errors.
         const LOG_ERROR_INTERVAL: Duration = Duration::from_millis(2000);
         // The maximum amount of time to wait for a transaction to be included.
+        #[cfg(not(test))]
         const MAX_WAIT_TIME: Duration = Duration::from_secs(240);
+        #[cfg(test)]
+        const MAX_WAIT_TIME: Duration = Duration::from_secs(crate::tests::http::TX_TIMEOUT_SECS);
+
+        println!("max wait time: {}", MAX_WAIT_TIME.as_secs());
 
         let start = Instant::now();
         let mut logged_at = start;

--- a/crates/astria-sequencer-client/src/tests/http.rs
+++ b/crates/astria-sequencer-client/src/tests/http.rs
@@ -414,7 +414,8 @@ async fn wait_for_tx_inclusion() {
 
     let response = timeout(Duration::from_millis(1000), response)
         .await
-        .expect("should have received a transaction response within 1000ms");
+        .expect("should have received a transaction response within 1000ms")
+        .unwrap();
 
     assert_eq!(response.tx_result.code, tx_server_response.tx_result.code);
     assert_eq!(response.tx_result.data, tx_server_response.tx_result.data);

--- a/crates/astria-sequencer-client/src/tests/mod.rs
+++ b/crates/astria-sequencer-client/src/tests/mod.rs
@@ -1,2 +1,2 @@
 #[cfg(feature = "http")]
-mod http;
+pub(crate) mod http;


### PR DESCRIPTION
## Summary
Added a timeout of 240s to the `wait_for_tx_inclusion` method of `SequencerClient`.

## Background
The `SequencerClient` would previously poll the `tx` RPC indefinitely, so if the transaction failed for whatever reason (or even if it failed to submit), any component that calls the method `wait_for_tx_inclusion` would be halted.

## Changes
- Added timeout to `wait_for_tx_inclusion` of 240s (maximum time allowed in mempool), returning `tendermint_rpc::Error::Timeout` if it doesn't succeed within that time.

## Testing
Added unit test to ensure that the timeout returns an error correctly.

## Changelogs
No updates required

## Related Issues
closes #1949
