### PR TITLE
chore(bridge-withdrawer, sequencer-client, cli): move retry logic for `wait_for_tx_invlusion` to calling components

### DIFF
--- a/crates/astria-cli/src/bridge/submit.rs
+++ b/crates/astria-cli/src/bridge/submit.rs
@@ -28,6 +28,8 @@ use tracing::{
     warn,
 };
 
+use crate::utils::wait_for_tx_inclusion;
+
 #[derive(clap::Args, Debug)]
 pub(crate) struct Command {
     /// Path to the file containing the actions to submit
@@ -144,7 +146,9 @@ async fn submit_transaction(
         .await
         .wrap_err("failed to submit transaction")?;
 
-    let tx_response = client.wait_for_tx_inclusion(res.hash).await;
+    let tx_response = wait_for_tx_inclusion(client, res.hash)
+        .await
+        .wrap_err("failed waiting for tx inclusion")?;
 
     ensure!(res.code.is_ok(), "failed to check tx: {}", res.log);
     ensure!(

--- a/crates/astria-cli/src/sequencer/submit.rs
+++ b/crates/astria-cli/src/sequencer/submit.rs
@@ -14,6 +14,8 @@ use color_eyre::eyre::{
     WrapErr as _,
 };
 
+use crate::utils::wait_for_tx_inclusion;
+
 #[derive(clap::Args, Debug)]
 pub(super) struct Command {
     /// The URL at which the Sequencer node is listening for ABCI commands.
@@ -41,7 +43,9 @@ impl Command {
 
         ensure!(res.code.is_ok(), "failed to check tx: {}", res.log);
 
-        let tx_response = sequencer_client.wait_for_tx_inclusion(res.hash).await;
+        let tx_response = wait_for_tx_inclusion(sequencer_client, res.hash)
+            .await
+            .wrap_err("failed waiting for tx inclusion")?;
 
         ensure!(
             tx_response.tx_result.code.is_ok(),

--- a/crates/astria-cli/src/utils.rs
+++ b/crates/astria-cli/src/utils.rs
@@ -17,6 +17,16 @@ use color_eyre::eyre::{
     eyre,
     WrapErr as _,
 };
+use tokio::time::{
+    timeout,
+    Duration,
+    Instant,
+};
+use tracing::{
+    debug,
+    instrument,
+    warn,
+};
 
 pub(crate) async fn submit_transaction(
     sequencer_url: &str,
@@ -52,7 +62,9 @@ pub(crate) async fn submit_transaction(
 
     ensure!(res.code.is_ok(), "failed to check tx: {}", res.log);
 
-    let tx_response = sequencer_client.wait_for_tx_inclusion(res.hash).await;
+    let tx_response = wait_for_tx_inclusion(sequencer_client, res.hash)
+        .await
+        .wrap_err("failed waiting for tx inclusion")?;
 
     ensure!(
         tx_response.tx_result.code.is_ok(),
@@ -86,4 +98,65 @@ pub(crate) fn address_from_signing_key(
 
     // Return the generated address
     Ok(from_address)
+}
+
+#[instrument(skip_all)]
+pub(crate) async fn wait_for_tx_inclusion(
+    client: HttpClient,
+    tx_hash: tendermint::hash::Hash,
+) -> eyre::Result<Response> {
+    use astria_sequencer_client::extension_trait::Error;
+
+    // The min seconds to sleep after receiving a GetTx response and sending the next request.
+    const MIN_POLL_INTERVAL_MILLIS: u64 = 100;
+    // The max seconds to sleep after receiving a GetTx response and sending the next request.
+    const MAX_POLL_INTERVAL_MILLIS: u64 = 2000;
+    // How long to wait after starting `confirm_submission` before starting to log at the warn
+    // level.
+    const START_WARNING_DELAY: Duration = Duration::from_millis(2000);
+    // The minimum duration between logging errors.
+    const LOG_ERROR_INTERVAL: Duration = Duration::from_millis(2000);
+
+    let start = Instant::now();
+    let mut logged_at = start;
+
+    let mut log_if_due = |error: Error| {
+        if logged_at.elapsed() <= LOG_ERROR_INTERVAL {
+            return;
+        }
+        if start.elapsed() < START_WARNING_DELAY {
+            debug! {
+                %error,
+                %tx_hash,
+                elapsed_seconds = start.elapsed().as_secs_f32(),
+                "waiting to confirm transaction inclusion"
+            }
+        } else {
+            warn!(
+                %error,
+                %tx_hash,
+                elapsed_seconds = start.elapsed().as_secs_f32(),
+                "waiting to confirm transaction inclusion"
+            );
+        }
+        logged_at = Instant::now();
+    };
+
+    let mut sleep_millis = MIN_POLL_INTERVAL_MILLIS;
+    let tx_fut = || async move {
+        loop {
+            tokio::time::sleep(Duration::from_millis(sleep_millis)).await;
+            match client.get_tx(tx_hash).await {
+                Ok(tx) => return tx,
+                Err(error) => {
+                    sleep_millis =
+                        std::cmp::min(sleep_millis.saturating_mul(2), MAX_POLL_INTERVAL_MILLIS);
+                    log_if_due(error);
+                }
+            }
+        }
+    };
+    timeout(Duration::from_secs(240), tx_fut())
+        .await
+        .wrap_err("timed out waiting for tx inclusion")
 }

--- a/crates/astria-sequencer-client/src/extension_trait.rs
+++ b/crates/astria-sequencer-client/src/extension_trait.rs
@@ -76,10 +76,7 @@ use tendermint_rpc::{
     Client,
     SubscriptionClient,
 };
-use tracing::{
-    instrument,
-    warn,
-};
+use tracing::instrument;
 
 #[cfg(feature = "http")]
 impl SequencerClientExt for HttpClient {}
@@ -663,58 +660,21 @@ pub trait SequencerClientExt: Client {
             .map_err(|e| Error::tendermint_rpc("broadcast_tx_sync", e))
     }
 
-    /// Probes the sequencer for a transaction of given hash with a backoff.
+    /// Attempts to obtain the given transaction from the Sequencer node by its hash.
     ///
     /// # Errors
     ///
-    /// - If the transaction is not found.
-    /// - If the transaction execution failed.
-    /// - If the transaction proof is missing.
+    /// - If the transaction was not failed. This can happen for one of 3 reasons:
+    ///   - The transaction is pending.
+    ///   - The transaction failed execution.
+    ///   - The transaction failed to be submitted.
     #[instrument(skip_all)]
-    async fn wait_for_tx_inclusion(
+    async fn get_tx(
         &self,
         tx_hash: tendermint::hash::Hash,
-    ) -> tendermint_rpc::endpoint::tx::Response {
-        use std::time::Duration;
-
-        use tokio::time::Instant;
-
-        // The min seconds to sleep after receiving a GetTx response and sending the next request.
-        const MIN_POLL_INTERVAL_MILLIS: u64 = 100;
-        // The max seconds to sleep after receiving a GetTx response and sending the next request.
-        const MAX_POLL_INTERVAL_MILLIS: u64 = 2000;
-        // How long to wait after starting `confirm_submission` before starting to log errors.
-        const START_LOGGING_DELAY: Duration = Duration::from_millis(2000);
-        // The minimum duration between logging errors.
-        const LOG_ERROR_INTERVAL: Duration = Duration::from_millis(2000);
-
-        let start = Instant::now();
-        let mut logged_at = start;
-
-        let mut log_if_due = |error: tendermint_rpc::Error| {
-            if start.elapsed() <= START_LOGGING_DELAY || logged_at.elapsed() <= LOG_ERROR_INTERVAL {
-                return;
-            }
-            warn!(
-                %error,
-                %tx_hash,
-                elapsed_seconds = start.elapsed().as_secs_f32(),
-                "waiting to confirm transaction inclusion"
-            );
-            logged_at = Instant::now();
-        };
-
-        let mut sleep_millis = MIN_POLL_INTERVAL_MILLIS;
-        loop {
-            tokio::time::sleep(Duration::from_millis(sleep_millis)).await;
-            match self.tx(tx_hash, false).await {
-                Ok(tx) => return tx,
-                Err(error) => {
-                    sleep_millis =
-                        std::cmp::min(sleep_millis.saturating_mul(2), MAX_POLL_INTERVAL_MILLIS);
-                    log_if_due(error);
-                }
-            }
-        }
+    ) -> Result<tendermint_rpc::endpoint::tx::Response, Error> {
+        self.tx(tx_hash, false)
+            .await
+            .map_err(|e| Error::tendermint_rpc("tx", e))
     }
 }

--- a/crates/astria-sequencer-client/src/tests/http.rs
+++ b/crates/astria-sequencer-client/src/tests/http.rs
@@ -374,7 +374,7 @@ async fn submit_tx_sync() {
 }
 
 #[tokio::test]
-async fn wait_for_tx_inclusion() {
+async fn get_tx() {
     let MockSequencer {
         server,
         client,
@@ -410,11 +410,12 @@ async fn wait_for_tx_inclusion() {
 
     let _tx_response_guard = register_tx_response(&server, tx_server_response.clone()).await;
 
-    let response = client.wait_for_tx_inclusion(tx_server_response.hash);
+    let response = client.get_tx(tx_server_response.hash);
 
     let response = timeout(Duration::from_millis(1000), response)
         .await
-        .expect("should have received a transaction response within 1000ms");
+        .expect("should have received a transaction response within 1000ms")
+        .unwrap();
 
     assert_eq!(response.tx_result.code, tx_server_response.tx_result.code);
     assert_eq!(response.tx_result.data, tx_server_response.tx_result.data);


### PR DESCRIPTION
## Summary
Moves retry and logging handling of the `tx` RPC and its calling `SequencerClientExt::get_tx()` to its calling components.

## Background
Having the retry and logging logic in the `SequencerClientExt` trait didn't match the precedent set by the rest of the trait, which provides more direct access to the sequencer RPCs as opposed to implementing its own retry logic. This should be left up to the caller of the method.

Additionally, a timeout needed to be added to this functionality, since a failed transaction for any reason would result in the called components (bridge withdrawer and CLI) halting.

## Changes
- Renamed `SequencerClientExt::wait_for_tx_inclusion()` to `get_tx()`.
- Removed retry and logging logic from `SequencerClientExt::get_tx()` and placed it in helper functions in both `astria-bridge-withdrawer` and `astria-sequencer-cli`
- Added timeouts to `get_tx()` calls.

## Testing
- Updated `astria_sequencer_client::tests::http::wait_for_tx_inclusion` accordingly.

## Changelogs
No updates required

## Metrics
- List out metrics added by PR, delete section if none. 

## Breaking Changelist
- Bulleted list of breaking changes, any notes on migration. Delete section if none.

## Related Issues
closes #1949
