### PR TITLE
chore(charts,hermes): bump hermes version

### DIFF
--- a/charts/hermes/Chart.yaml
+++ b/charts/hermes/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.1
+version: 0.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hermes/Chart.yaml
+++ b/charts/hermes/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.6.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.4.0"
+appVersion: "0.4.1"
 
 maintainers:
   - name: wafflesvonmaple

--- a/charts/hermes/Chart.yaml
+++ b/charts/hermes/Chart.yaml
@@ -21,7 +21,7 @@ version: 0.6.1
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.4.1"
+appVersion: "0.5.0"
 
 maintainers:
   - name: wafflesvonmaple

--- a/charts/hermes/values.yaml
+++ b/charts/hermes/values.yaml
@@ -3,7 +3,7 @@ global:
   replicaCount: 1
   logLevel: debug
 
-image: ghcr.io/astriaorg/hermes:0.4.1
+image: ghcr.io/astriaorg/hermes:0.5.0
 imagePullPolicy: IfNotPresent
 
 fullnameOverride: ""

--- a/charts/hermes/values.yaml
+++ b/charts/hermes/values.yaml
@@ -3,7 +3,7 @@ global:
   replicaCount: 1
   logLevel: debug
 
-image: ghcr.io/astriaorg/hermes:0.4.0
+image: ghcr.io/astriaorg/hermes:0.4.1
 imagePullPolicy: IfNotPresent
 
 fullnameOverride: ""


### PR DESCRIPTION
## Summary
bumps hermes image to use [pr-31 ](https://github.com/astriaorg/hermes/pull/31)

## Changes
- bumps default hermes image

## Testing
against a local cluster

## Changelogs
No updates required.
