### PR TITLE
fix: use penumbra rev which includes `packet_acknowledgements` fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1926,7 +1926,7 @@ dependencies = [
 [[package]]
 name = "cnidarium"
 version = "0.80.10"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=686fa5b53e8ad306736d2de61d1ffb6d11722e2b#686fa5b53e8ad306736d2de61d1ffb6d11722e2b"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=ff338148adf023d28ddb1e50a8a14dc6fda23d97#ff338148adf023d28ddb1e50a8a14dc6fda23d97"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1955,7 +1955,7 @@ dependencies = [
 [[package]]
 name = "cnidarium-component"
 version = "0.80.10"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=686fa5b53e8ad306736d2de61d1ffb6d11722e2b#686fa5b53e8ad306736d2de61d1ffb6d11722e2b"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=ff338148adf023d28ddb1e50a8a14dc6fda23d97#ff338148adf023d28ddb1e50a8a14dc6fda23d97"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2500,7 +2500,7 @@ dependencies = [
 [[package]]
 name = "decaf377-fmd"
 version = "0.80.10"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=686fa5b53e8ad306736d2de61d1ffb6d11722e2b#686fa5b53e8ad306736d2de61d1ffb6d11722e2b"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=ff338148adf023d28ddb1e50a8a14dc6fda23d97#ff338148adf023d28ddb1e50a8a14dc6fda23d97"
 dependencies = [
  "ark-ff 0.4.2",
  "ark-serialize 0.4.2",
@@ -2514,7 +2514,7 @@ dependencies = [
 [[package]]
 name = "decaf377-ka"
 version = "0.80.10"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=686fa5b53e8ad306736d2de61d1ffb6d11722e2b#686fa5b53e8ad306736d2de61d1ffb6d11722e2b"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=ff338148adf023d28ddb1e50a8a14dc6fda23d97#ff338148adf023d28ddb1e50a8a14dc6fda23d97"
 dependencies = [
  "ark-ff 0.4.2",
  "decaf377",
@@ -6039,7 +6039,7 @@ dependencies = [
 [[package]]
 name = "penumbra-asset"
 version = "0.80.10"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=686fa5b53e8ad306736d2de61d1ffb6d11722e2b#686fa5b53e8ad306736d2de61d1ffb6d11722e2b"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=ff338148adf023d28ddb1e50a8a14dc6fda23d97#ff338148adf023d28ddb1e50a8a14dc6fda23d97"
 dependencies = [
  "anyhow",
  "ark-ff 0.4.2",
@@ -6078,7 +6078,7 @@ dependencies = [
 [[package]]
 name = "penumbra-ibc"
 version = "0.80.10"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=686fa5b53e8ad306736d2de61d1ffb6d11722e2b#686fa5b53e8ad306736d2de61d1ffb6d11722e2b"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=ff338148adf023d28ddb1e50a8a14dc6fda23d97#ff338148adf023d28ddb1e50a8a14dc6fda23d97"
 dependencies = [
  "anyhow",
  "ark-ff 0.4.2",
@@ -6115,7 +6115,7 @@ dependencies = [
 [[package]]
 name = "penumbra-keys"
 version = "0.80.10"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=686fa5b53e8ad306736d2de61d1ffb6d11722e2b#686fa5b53e8ad306736d2de61d1ffb6d11722e2b"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=ff338148adf023d28ddb1e50a8a14dc6fda23d97#ff338148adf023d28ddb1e50a8a14dc6fda23d97"
 dependencies = [
  "aes",
  "anyhow",
@@ -6159,7 +6159,7 @@ dependencies = [
 [[package]]
 name = "penumbra-num"
 version = "0.80.10"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=686fa5b53e8ad306736d2de61d1ffb6d11722e2b#686fa5b53e8ad306736d2de61d1ffb6d11722e2b"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=ff338148adf023d28ddb1e50a8a14dc6fda23d97#ff338148adf023d28ddb1e50a8a14dc6fda23d97"
 dependencies = [
  "anyhow",
  "ark-ff 0.4.2",
@@ -6195,7 +6195,7 @@ dependencies = [
 [[package]]
 name = "penumbra-proto"
 version = "0.80.10"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=686fa5b53e8ad306736d2de61d1ffb6d11722e2b#686fa5b53e8ad306736d2de61d1ffb6d11722e2b"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=ff338148adf023d28ddb1e50a8a14dc6fda23d97#ff338148adf023d28ddb1e50a8a14dc6fda23d97"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6224,7 +6224,7 @@ dependencies = [
 [[package]]
 name = "penumbra-sct"
 version = "0.80.10"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=686fa5b53e8ad306736d2de61d1ffb6d11722e2b#686fa5b53e8ad306736d2de61d1ffb6d11722e2b"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=ff338148adf023d28ddb1e50a8a14dc6fda23d97#ff338148adf023d28ddb1e50a8a14dc6fda23d97"
 dependencies = [
  "anyhow",
  "ark-ff 0.4.2",
@@ -6260,7 +6260,7 @@ dependencies = [
 [[package]]
 name = "penumbra-tct"
 version = "0.80.10"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=686fa5b53e8ad306736d2de61d1ffb6d11722e2b#686fa5b53e8ad306736d2de61d1ffb6d11722e2b"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=ff338148adf023d28ddb1e50a8a14dc6fda23d97#ff338148adf023d28ddb1e50a8a14dc6fda23d97"
 dependencies = [
  "ark-ed-on-bls12-377",
  "ark-ff 0.4.2",
@@ -6289,7 +6289,7 @@ dependencies = [
 [[package]]
 name = "penumbra-tower-trace"
 version = "0.80.10"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=686fa5b53e8ad306736d2de61d1ffb6d11722e2b#686fa5b53e8ad306736d2de61d1ffb6d11722e2b"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=ff338148adf023d28ddb1e50a8a14dc6fda23d97#ff338148adf023d28ddb1e50a8a14dc6fda23d97"
 dependencies = [
  "futures",
  "hex",
@@ -6311,7 +6311,7 @@ dependencies = [
 [[package]]
 name = "penumbra-txhash"
 version = "0.80.10"
-source = "git+https://github.com/penumbra-zone/penumbra.git?rev=686fa5b53e8ad306736d2de61d1ffb6d11722e2b#686fa5b53e8ad306736d2de61d1ffb6d11722e2b"
+source = "git+https://github.com/penumbra-zone/penumbra.git?rev=ff338148adf023d28ddb1e50a8a14dc6fda23d97#ff338148adf023d28ddb1e50a8a14dc6fda23d97"
 dependencies = [
  "anyhow",
  "blake2b_simd 1.0.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,9 +83,9 @@ jiff = "0.2.4"
 jsonrpsee = { version = "0.20" }
 pbjson-types = "0.6"
 # Note that when updating the penumbra versions, vendored types in `proto/sequencerapis/astria_vendored` may need to be updated as well.
-penumbra-ibc = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "686fa5b53e8ad306736d2de61d1ffb6d11722e2b", default-features = false }
-penumbra-proto = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "686fa5b53e8ad306736d2de61d1ffb6d11722e2b" }
-penumbra-tower-trace = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "686fa5b53e8ad306736d2de61d1ffb6d11722e2b" }
+penumbra-ibc = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "ff338148adf023d28ddb1e50a8a14dc6fda23d97", default-features = false }
+penumbra-proto = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "ff338148adf023d28ddb1e50a8a14dc6fda23d97" }
+penumbra-tower-trace = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "ff338148adf023d28ddb1e50a8a14dc6fda23d97" }
 pin-project-lite = "0.2.13"
 prost = "0.12"
 rand = "0.8.5"

--- a/crates/astria-sequencer/Cargo.toml
+++ b/crates/astria-sequencer/Cargo.toml
@@ -33,7 +33,7 @@ telemetry = { package = "astria-telemetry", path = "../astria-telemetry", featur
 ] }
 
 borsh = { version = "1.5.1", features = ["bytes", "derive"] }
-cnidarium = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "686fa5b53e8ad306736d2de61d1ffb6d11722e2b", features = [
+cnidarium = { git = "https://github.com/penumbra-zone/penumbra.git", rev = "ff338148adf023d28ddb1e50a8a14dc6fda23d97", features = [
   "metrics",
 ] }
 ibc-proto = { version = "0.41.0", features = ["server"] }


### PR DESCRIPTION
## Summary
see https://github.com/penumbra-zone/penumbra/compare/686fa5b53e8ad306736d2de61d1ffb6d11722e2b..ff338148adf023d28ddb1e50a8a14dc6fda23d97

this has been merged into penumbra main: https://github.com/penumbra-zone/penumbra/pull/5170 

## Background
see above

## Testing
hermes failure ack testing
