### PR TITLE
chore(ci): update argo manifests to use github app creds

### DIFF
--- a/dev/argocd/pr-preview-envs/evm-appset.yaml
+++ b/dev/argocd/pr-preview-envs/evm-appset.yaml
@@ -25,9 +25,7 @@ spec:
       github:
         owner: astriaorg
         repo: astria
-        tokenRef:
-          key: token
-          secretName: github-pat
+        appSecretName: github-app-credentials
         labels:
         # All of the following labels are required to be set on the PR for the app to be created
         - preview

--- a/dev/argocd/pr-preview-envs/sequencer-appset.yaml
+++ b/dev/argocd/pr-preview-envs/sequencer-appset.yaml
@@ -25,9 +25,7 @@ spec:
         github:
           owner: astriaorg
           repo: astria
-          tokenRef:
-            key: token
-            secretName: github-pat
+          appSecretName: github-app-credentials
           labels:
             # ALL of the following labels are required to be set on the PR for the app to be created
             - preview


### PR DESCRIPTION
## Summary
Updates argo manifests to utilize github app credentials instead of a personal access token. 

## Background
Personal access tokens have an expiry and are set on user accounts. We have since updated things to use org-level github apps for everything else. This brings our preview-env configuration in line with the rest.

## Changes
Switched reference to k8s secret containing github PAT to a different secret containing github app credentials

## Testing
These were tested against dev environment
