### PR TITLE
fix: tendermint-rs 0.40.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1908,9 +1908,9 @@ dependencies = [
 
 [[package]]
 name = "cnidarium-component"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d17527afe566e456b8ed3b5cd4dc9c98638da0edb4db50919c3083553ff7b605"
+checksum = "c2ac28071ab0685e67a3bc530d678ac9bd1ea1cf3a7873f0962d588f6265f135"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2457,9 +2457,9 @@ dependencies = [
 
 [[package]]
 name = "decaf377-fmd"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aadf326dfd26ff2a4311e7fd4acd54cff961bbf05bdda20117d89a47f5dc1b11"
+checksum = "7b2ce8acf5eae0289e94f1e57be2d831eec63b32a6f5862c1b23c9e737f09a70"
 dependencies = [
  "ark-ff 0.4.2",
  "ark-serialize 0.4.2",
@@ -2472,9 +2472,9 @@ dependencies = [
 
 [[package]]
 name = "decaf377-ka"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd220f7baa6f841cbfed5d6b5102d7937b145fe538f821df7692ebb76b35878c"
+checksum = "de42d6d8472201809d873ccd06e0a28ddcddd3fa2154463636a0d0f814ae6ec0"
 dependencies = [
  "ark-ff 0.4.2",
  "decaf377",
@@ -4191,9 +4191,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd68e32f5bd94849131670d34e21b0fb66057e91bee8e451e7f4e216e71616d2"
+checksum = "2370a3055f69d9dfe7382080a509560d2dd412d9f9f2a44e3a68945e5ec46955"
 dependencies = [
  "ibc-types-core-channel",
  "ibc-types-core-client",
@@ -4209,9 +4209,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-core-channel"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c57da64f7e945e7443035275cc279e0176c988ea625968c2526706aafcff1766"
+checksum = "06058daf96374a50364aac20de8dbf78e493a775dc10b8584830b59f71fc8522"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4242,9 +4242,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-core-client"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "108a89f64ffa39e04a7e29de9d9824523c3164f8518927716be870ad8a7aedf9"
+checksum = "f44e3d3c92c22dacd2c8ca0a88af6241c15826a09aa234aa194c93c877a7c62a"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4269,9 +4269,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-core-commitment"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8949e33fbb9c3f1ae49588f4829977e80439f3dfc1491b5a69492f5e4a036949"
+checksum = "f410ddb6af18ec45b05817cd31458566954bf7277172522514be6d8205b5361b"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4304,9 +4304,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-core-connection"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63035288d11e5830daf20fd99507a671ab1cc03fa04752d75ef1c75e2786543"
+checksum = "eb38f6cbfad8ccad7b7549dff3ef741b81881963708e959429dbe31273f8421d"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4334,9 +4334,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-domain-type"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2c543a23a77a5d814e0aeffd5a918964468a8b213f664897bc3f8c50cc7d5c1"
+checksum = "2dd7cacffb213747dfb9ab0e6cc3be15a8650310d424375518d780e1750ab92d"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4345,9 +4345,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-identifier"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ed2d7f06055bb2548564bf02c8c4b47561134f282adae61dc5c6ed722e1cde"
+checksum = "a5d6f619f4e7ccaf76140c907ca994a70f220ee6ad4b60e2dc12403cf4250ace"
 dependencies = [
  "displaydoc",
  "serde",
@@ -4356,9 +4356,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-lightclients-tendermint"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00fd846b7eedca1dfbb7babeb55e0d74fb0d09a7db63da93737d54a581a96371"
+checksum = "84c5f0e9ae4354c692476d527432f9157c499ff25b528e008e7d353b3d49f473"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4393,9 +4393,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-path"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f4da80e010427aff50f227920cdc8f7879469ce2db181cbcf92dc228172a334"
+checksum = "753ca9e6a7c27356e4ed0ce6b290abd1c3d01645803d825b98f992ebd8bd6964"
 dependencies = [
  "bytes",
  "derive_more 0.99.19",
@@ -4416,9 +4416,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-timestamp"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "748b2fbebe30ca799d31f6fc220d705b5180a608db842e29a3722671411d81a6"
+checksum = "0f024a20672250555fa537bf8fef31aba6f4ab8f86b272e8025338cc004c3edb"
 dependencies = [
  "bytes",
  "displaydoc",
@@ -4435,9 +4435,9 @@ dependencies = [
 
 [[package]]
 name = "ibc-types-transfer"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcb46fe34a87db49bc9bb20918d7f882871a20d741d866d217c52a5dbe16a72"
+checksum = "6684f2e9a5f0fc723e22a185852a22a02d3c6d20d8bf863c37fe5c814be5f7ef"
 dependencies = [
  "displaydoc",
  "serde",
@@ -6054,9 +6054,9 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-asset"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cf62e3affc3d42f1cab60832f5efe44996abbc8e528574aeb7fbef1c3cefec"
+checksum = "4b60b830c66aabb6f8044f937a875e109e1a384e7d5be3f73490e715b092679e"
 dependencies = [
  "anyhow",
  "ark-ff 0.4.2",
@@ -6094,9 +6094,9 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-ibc"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5cde493bf59daa8f4f0bbafea8f3bdc5288f904e968ebf5d91745cd8efdd7d7"
+checksum = "60aded2acb1c1eaa829af09505c4f51cb504019462d316fbcf63b6d960624fce"
 dependencies = [
  "anyhow",
  "ark-ff 0.4.2",
@@ -6132,9 +6132,9 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-keys"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948eea8e50cec1acffbb9f56a72da59c145492d698de5623b4e23c4802f9a65"
+checksum = "bf0edd598f5309f831246d37534434c34ca908fa0cb1322e8a1e07bddd1ec1f7"
 dependencies = [
  "aes",
  "anyhow",
@@ -6177,9 +6177,9 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-num"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f45e092ce34fd4aa7b788baf01d52f55c8e3f6d4f4bd47edef20ebfcd536557b"
+checksum = "2601a1cadab5b166418dfaf9df3b7acb57ec4cd2417fc49a48b252e6bc2daff6"
 dependencies = [
  "anyhow",
  "ark-ff 0.4.2",
@@ -6214,9 +6214,9 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-proto"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb28b919573834a8fdf2418d50c7ee1f2da652d0a0adc4949483ce4cd0d31d7b"
+checksum = "0b67dcd74aef4a76b98de43af9303dbe954b83af9651d2142b3c37f47d3ff94e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6244,9 +6244,9 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-sct"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f948f61ddac61c392f8c1065593fbbf4471bb86305cab24d2f376db0f3d42fe"
+checksum = "fc15d66f813ac8359931be3e06df3eed51fe08133a8e49fcc67a78d7b4794569"
 dependencies = [
  "anyhow",
  "ark-ff 0.4.2",
@@ -6281,9 +6281,9 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-tct"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef108e9092df830f5a0dfccf225ee936707cbc4a29f28eb4200e69b535c7d870"
+checksum = "69aa442e703953fded3003858da7e893fdd22445857ae92392212da3bfe8c59a"
 dependencies = [
  "ark-ed-on-bls12-377",
  "ark-ff 0.4.2",
@@ -6311,9 +6311,9 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-tower-trace"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02042407967610df1c4e5a04d33841f47affab70d191c3f681ef670817a29d39"
+checksum = "1a5dfea2c1b26c63a4351c7a9eb7a0cee0e64aecc8c262eef396f83450012979"
 dependencies = [
  "futures",
  "hex",
@@ -6334,9 +6334,9 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sdk-txhash"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6595b93214de81b1b8cf46b5b4941e443749bf136710785d60a26153a0fffa8d"
+checksum = "ef69f62fb25a65bec2b7ff914bf5d34031f04f7c54398f1352f478a84092da95"
 dependencies = [
  "anyhow",
  "blake2b_simd 1.0.3",
@@ -8266,9 +8266,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint"
-version = "0.40.2"
+version = "0.40.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bed57bd840305efef8e83b752dd63dde3bb0fc1c35b6490f0a4de3a0ffd8dd9"
+checksum = "ab2972a56891bc9173eaebdd51290bc848e448aa281881f3a4712bd8fe1899b3"
 dependencies = [
  "bytes",
  "digest 0.10.7",
@@ -8296,9 +8296,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-config"
-version = "0.40.2"
+version = "0.40.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38aeb44e9e275b3afe31a4f3302dfc5aa1e0aa488a22abb7577634b22b144a22"
+checksum = "651cb680d41e586bb688cc17ab0b6dfe2e62a959c5742d1351fe0b084cd75d59"
 dependencies = [
  "flex-error",
  "serde",
@@ -8310,9 +8310,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-light-client-verifier"
-version = "0.40.2"
+version = "0.40.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92f2fd222980465e4aa2e04d6218014658461ae934aa5697a16ded5cf7a33492"
+checksum = "58dc3c4ebd336efaf0b831b0cd4d2aca24ac624875fa514e18fe636da9ea98d5"
 dependencies = [
  "derive_more 0.99.19",
  "flex-error",
@@ -8323,9 +8323,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-proto"
-version = "0.40.2"
+version = "0.40.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a218320a6e92ac731ac094169cb742e3203a3ab24d30417b72cfdaab5d50c67"
+checksum = "ca44b9eaaa98e8440fbafe5593b8a32a1c395c094ac566b3eb50497f8bd2bee0"
 dependencies = [
  "bytes",
  "flex-error",
@@ -8338,9 +8338,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-rpc"
-version = "0.40.2"
+version = "0.40.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ffcf862b519894f8afa79e5be73e376c3367cbd2bbe0eaf9c653ab01cd8b20"
+checksum = "9367678af1a9fc6c064fab8b5d05f03c0fc243fe411581c00c7eed83f8ced380"
 dependencies = [
  "async-trait",
  "async-tungstenite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,8 +84,8 @@ jsonrpsee = "0.24.8"
 pbjson-types = "0.7.0"
 
 # Note that when updating the penumbra versions, vendored types in `proto/sequencerapis/astria_vendored` may need to be updated as well.
-penumbra-ibc = { package = "penumbra-sdk-ibc", version = "1.3.1", default-features = false }
-penumbra-proto = { package = "penumbra-sdk-proto", version = "1.3.1" }
+penumbra-ibc = { package = "penumbra-sdk-ibc", version = "1.4.0", default-features = false }
+penumbra-proto = { package = "penumbra-sdk-proto", version = "1.4.0" }
 
 pin-project-lite = "0.2.13"
 prost = "0.13.4"
@@ -100,10 +100,10 @@ serde = "1"
 serde_json = "1"
 sha2 = "0.10"
 tempfile = "3.6.0"
-tendermint = "0.40.2"
-tendermint-config = "0.40.2"
-tendermint-proto = "0.40.2"
-tendermint-rpc = "0.40.2"
+tendermint = "0.40.3"
+tendermint-config = "0.40.3"
+tendermint-proto = "0.40.3"
+tendermint-rpc = "0.40.3"
 thiserror = "1"
 tokio = { version = "1.44.2", default-features = false }
 tokio-stream = { version = "0.1.17" }

--- a/crates/astria-sequencer/CHANGELOG.md
+++ b/crates/astria-sequencer/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
+### Security
 
 - Update to tendermint 0.40.3 for security patch to ISA-2025-003 [#2099](https://github.com/astriaorg/astria/pull/2099)
 

--- a/crates/astria-sequencer/CHANGELOG.md
+++ b/crates/astria-sequencer/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Update to tendermint 0.40.3 for security patch to ISA-2025-003 [#2099](https://github.com/astriaorg/astria/pull/2099)
+
 ## [2.0.0]
 
 ### Fixed

--- a/crates/astria-sequencer/Cargo.toml
+++ b/crates/astria-sequencer/Cargo.toml
@@ -36,7 +36,7 @@ borsh = { version = "1.5.1", features = ["bytes", "derive"] }
 cnidarium = { version = "0.83.0", features = ["metrics"] }
 ibc-proto = { version = "0.51.1", features = ["server"] }
 matchit = "0.7.2"
-penumbra-tower-trace = { package = "penumbra-sdk-tower-trace", version = "1.3.1" }
+penumbra-tower-trace = { package = "penumbra-sdk-tower-trace", version = "1.4.0" }
 tower = { workspace = true }
 tower-abci = "0.19.0"
 tower-actor = "0.1.0"


### PR DESCRIPTION
## Summary
Updates tendermint-rs to 0.40.3 and all penumbra dependencies to 1.40.0.

## Background
Light client verification patch fix made in tendermint-rs for [ISA-2025-003](https://github.com/informalsystems/tendermint-rs/security/advisories/GHSA-6jrf-4jv4-r9mw).

Penumbra has cut new releases that update their dependency on tendermint-rs.

## Changelogs
Changelogs updated.
