### PR TITLE
fix(sequencer): simple ibc ack failure message

### DIFF
--- a/charts/sequencer/files/upgrades/custom.upgrades.json
+++ b/charts/sequencer/files/upgrades/custom.upgrades.json
@@ -75,7 +75,8 @@
         }
       }
     },
-    "validatorUpdateActionChange": {}
+    "validatorUpdateActionChange": {},
+    "ibcAcknowledgementFailureChange": {}
   }
   {{- end }}
   {{- end }}

--- a/crates/astria-core/src/generated/astria.upgrades.v1.rs
+++ b/crates/astria-core/src/generated/astria.upgrades.v1.rs
@@ -44,6 +44,10 @@ pub struct Aspen {
     pub validator_update_action_change: ::core::option::Option<
         aspen::ValidatorUpdateActionChange,
     >,
+    #[prost(message, optional, tag = "4")]
+    pub ibc_acknowledgement_failure_change: ::core::option::Option<
+        aspen::IbcAcknowledgementFailureChange,
+    >,
 }
 /// Nested message and enum types in `Aspen`.
 pub mod aspen {
@@ -68,6 +72,16 @@ pub mod aspen {
     pub struct ValidatorUpdateActionChange {}
     impl ::prost::Name for ValidatorUpdateActionChange {
         const NAME: &'static str = "ValidatorUpdateActionChange";
+        const PACKAGE: &'static str = "astria.upgrades.v1";
+        fn full_name() -> ::prost::alloc::string::String {
+            ::prost::alloc::format!("astria.upgrades.v1.Aspen.{}", Self::NAME)
+        }
+    }
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct IbcAcknowledgementFailureChange {}
+    impl ::prost::Name for IbcAcknowledgementFailureChange {
+        const NAME: &'static str = "IbcAcknowledgementFailureChange";
         const PACKAGE: &'static str = "astria.upgrades.v1";
         fn full_name() -> ::prost::alloc::string::String {
             ::prost::alloc::format!("astria.upgrades.v1.Aspen.{}", Self::NAME)

--- a/crates/astria-core/src/generated/astria.upgrades.v1.serde.rs
+++ b/crates/astria-core/src/generated/astria.upgrades.v1.serde.rs
@@ -15,6 +15,9 @@ impl serde::Serialize for Aspen {
         if self.validator_update_action_change.is_some() {
             len += 1;
         }
+        if self.ibc_acknowledgement_failure_change.is_some() {
+            len += 1;
+        }
         let mut struct_ser = serializer.serialize_struct("astria.upgrades.v1.Aspen", len)?;
         if let Some(v) = self.base_info.as_ref() {
             struct_ser.serialize_field("baseInfo", v)?;
@@ -24,6 +27,9 @@ impl serde::Serialize for Aspen {
         }
         if let Some(v) = self.validator_update_action_change.as_ref() {
             struct_ser.serialize_field("validatorUpdateActionChange", v)?;
+        }
+        if let Some(v) = self.ibc_acknowledgement_failure_change.as_ref() {
+            struct_ser.serialize_field("ibcAcknowledgementFailureChange", v)?;
         }
         struct_ser.end()
     }
@@ -41,6 +47,8 @@ impl<'de> serde::Deserialize<'de> for Aspen {
             "priceFeedChange",
             "validator_update_action_change",
             "validatorUpdateActionChange",
+            "ibc_acknowledgement_failure_change",
+            "ibcAcknowledgementFailureChange",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -48,6 +56,7 @@ impl<'de> serde::Deserialize<'de> for Aspen {
             BaseInfo,
             PriceFeedChange,
             ValidatorUpdateActionChange,
+            IbcAcknowledgementFailureChange,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -72,6 +81,7 @@ impl<'de> serde::Deserialize<'de> for Aspen {
                             "baseInfo" | "base_info" => Ok(GeneratedField::BaseInfo),
                             "priceFeedChange" | "price_feed_change" => Ok(GeneratedField::PriceFeedChange),
                             "validatorUpdateActionChange" | "validator_update_action_change" => Ok(GeneratedField::ValidatorUpdateActionChange),
+                            "ibcAcknowledgementFailureChange" | "ibc_acknowledgement_failure_change" => Ok(GeneratedField::IbcAcknowledgementFailureChange),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -94,6 +104,7 @@ impl<'de> serde::Deserialize<'de> for Aspen {
                 let mut base_info__ = None;
                 let mut price_feed_change__ = None;
                 let mut validator_update_action_change__ = None;
+                let mut ibc_acknowledgement_failure_change__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
                         GeneratedField::BaseInfo => {
@@ -114,16 +125,94 @@ impl<'de> serde::Deserialize<'de> for Aspen {
                             }
                             validator_update_action_change__ = map_.next_value()?;
                         }
+                        GeneratedField::IbcAcknowledgementFailureChange => {
+                            if ibc_acknowledgement_failure_change__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("ibcAcknowledgementFailureChange"));
+                            }
+                            ibc_acknowledgement_failure_change__ = map_.next_value()?;
+                        }
                     }
                 }
                 Ok(Aspen {
                     base_info: base_info__,
                     price_feed_change: price_feed_change__,
                     validator_update_action_change: validator_update_action_change__,
+                    ibc_acknowledgement_failure_change: ibc_acknowledgement_failure_change__,
                 })
             }
         }
         deserializer.deserialize_struct("astria.upgrades.v1.Aspen", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for aspen::IbcAcknowledgementFailureChange {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let len = 0;
+        let struct_ser = serializer.serialize_struct("astria.upgrades.v1.Aspen.IbcAcknowledgementFailureChange", len)?;
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for aspen::IbcAcknowledgementFailureChange {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                            Err(serde::de::Error::unknown_field(value, FIELDS))
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = aspen::IbcAcknowledgementFailureChange;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.upgrades.v1.Aspen.IbcAcknowledgementFailureChange")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<aspen::IbcAcknowledgementFailureChange, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                while map_.next_key::<GeneratedField>()?.is_some() {
+                    let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                }
+                Ok(aspen::IbcAcknowledgementFailureChange {
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.upgrades.v1.Aspen.IbcAcknowledgementFailureChange", FIELDS, GeneratedVisitor)
     }
 }
 impl serde::Serialize for aspen::PriceFeedChange {

--- a/crates/astria-sequencer/src/ibc/ics20_transfer.rs
+++ b/crates/astria-sequencer/src/ibc/ics20_transfer.rs
@@ -25,6 +25,10 @@ use astria_core::{
         Ics20WithdrawalFromRollup,
     },
     sequencerblock::v1::block::Deposit,
+    upgrades::v1::aspen::{
+        Aspen,
+        IbcAcknowledgementFailureChange,
+    },
 };
 use astria_eyre::{
     anyhow::{
@@ -92,6 +96,7 @@ use crate::{
         StateWriteExt as _,
     },
     transaction::StateReadExt as _,
+    upgrades::StateReadExt as _,
     utils::create_deposit_event,
 };
 
@@ -365,6 +370,12 @@ impl AppHandlerExecute for Ics20Transfer {
     ) -> anyhow::Result<()> {
         use penumbra_ibc::component::packet::WriteAcknowledgement as _;
 
+        let use_new_error_format = state
+            .get_upgrade_change_info(&Aspen::NAME, &IbcAcknowledgementFailureChange::NAME)
+            .await
+            .map_err(|err| eyre_to_anyhow(err).context("failed to read upgrade info"))?
+            .is_some();
+
         let ack = match receive_tokens(&mut state, &msg.packet).await {
             Ok(()) => TokenTransferAcknowledgement::success(),
             Err(e) => {
@@ -372,7 +383,12 @@ impl AppHandlerExecute for Ics20Transfer {
                     error = AsRef::<dyn std::error::Error>::as_ref(&e),
                     "failed to execute ics20 transfer"
                 );
-                TokenTransferAcknowledgement::Error(format!("{e:#}"))
+                let error_message = if use_new_error_format {
+                    "ics20 transfer failed".to_string()
+                } else {
+                    format!("{e:#}")
+                };
+                TokenTransferAcknowledgement::Error(error_message)
             }
         };
 

--- a/proto/upgrades/astria/upgrades/v1/upgrades.proto
+++ b/proto/upgrades/astria/upgrades/v1/upgrades.proto
@@ -28,7 +28,10 @@ message Aspen {
 
   message ValidatorUpdateActionChange {}
 
+  message IbcAcknowledgementFailureChange {}
+
   BaseUpgradeInfo base_info = 1;
   PriceFeedChange price_feed_change = 2;
   ValidatorUpdateActionChange validator_update_action_change = 3;
+  IbcAcknowledgementFailureChange ibc_acknowledgement_failure_change = 4;
 }


### PR DESCRIPTION
## Summary
After Aspen upgrade, changes to a simple ibc acknowledgement failure message which does not put sequencer error codes into consensus.

## Background
The exi

## Changes
- Changes Ics 20 transfer ack failure message to a simple string after aspen upgrade.

## Testing
CI/CD
