### PR TITLE
fix: update crossbeam-channel dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2217,9 +2217,9 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/crates/astria-conductor/CHANGELOG.md
+++ b/crates/astria-conductor/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Include price feed oracle data in transactions when sequencer network
   provides it [#2085](https://github.com/astriaorg/astria/pull/2085).
 
+### Fixed
+
+- Update `crossbeam-channel` dependency to resolve cargo audit warning [#2106](https://github.com/astriaorg/astria/pull/2106).
+
 ## [1.1.0] - 2025-03-06
 
 ### Changed


### PR DESCRIPTION
## Summary
Fixes for a new `cargo audit` warning.

We get a warning when running `cargo audit` for [RUSTSEC-2025-0024](https://rustsec.org/advisories/RUSTSEC-2025-0024).  This is for `crossbeam-channel@0.5.14`.

<details><summary>cargo audit output</summary><p>

```
Crate:     crossbeam-channel
Version:   0.5.14
Title:     crossbeam-channel: double free on Drop
Date:      2025-04-08
ID:        RUSTSEC-2025-0024
URL:       https://rustsec.org/advisories/RUSTSEC-2025-0024
Solution:  Upgrade to >=0.5.15
Dependency tree:
crossbeam-channel 0.5.14
└── moka 0.12.10
    └── astria-conductor 1.1.0

Crate:     crossbeam-channel
Version:   0.5.14
Warning:   yanked

error: 1 vulnerability found!
warning: 1 allowed warning found
```

</p></details>

## Changes
- Ran `cargo update -p crossbeam-channel`.

## Testing
Ran `cargo audit` locally.

## Changelogs
Conductor changelog updated.