### PR TITLE
chore(charts): add initial draft of upgrades.json files for running networks

### DIFF
--- a/charts/sequencer/Chart.yaml
+++ b/charts/sequencer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.0
+version: 2.1.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/sequencer/files/upgrades/dawn-1.upgrades.json
+++ b/charts/sequencer/files/upgrades/dawn-1.upgrades.json
@@ -1,1 +1,27 @@
-{}
+{
+  "aspen": {
+    "baseInfo": {
+      "activationHeight": "999999999",
+      "appVersion": "2"
+    },
+    "priceFeedChange": {
+      "genesis": {
+        "marketMap": {
+          "marketMap": {},
+          "params": {
+            "marketAuthorities": [
+              "astria14cxdcjk2cugk8ccknzdfye57xla5sxtsrs9g33"
+            ],
+            "admin": "astria14cxdcjk2cugk8ccknzdfye57xla5sxtsrs9g33"
+          }
+        },
+        "oracle": {
+          "currencyPairGenesis": [],
+          "nextId": "0"
+        }
+      }
+    },
+    "validatorUpdateActionChange": {},
+    "ibcAcknowledgementFailureChange": {}
+  }
+}

--- a/charts/sequencer/files/upgrades/dusk-11.upgrades.json
+++ b/charts/sequencer/files/upgrades/dusk-11.upgrades.json
@@ -1,1 +1,27 @@
-{}
+{
+  "aspen": {
+    "baseInfo": {
+      "activationHeight": "14034813",
+      "appVersion": "2"
+    },
+    "priceFeedChange": {
+      "genesis": {
+        "marketMap": {
+          "marketMap": {},
+          "params": {
+            "marketAuthorities": [
+              "astria1zx0chamzu245nz0hkreffnx32v7uxg0nljl9sx"
+            ],
+            "admin": "astria1zx0chamzu245nz0hkreffnx32v7uxg0nljl9sx"
+          }
+        },
+        "oracle": {
+          "currencyPairGenesis": [],
+          "nextId": "0"
+        }
+      }
+    },
+    "validatorUpdateActionChange": {},
+    "ibcAcknowledgementFailureChange": {}
+  }
+}

--- a/charts/sequencer/files/upgrades/mainnet.upgrades.json
+++ b/charts/sequencer/files/upgrades/mainnet.upgrades.json
@@ -1,1 +1,27 @@
-{}
+{
+  "aspen": {
+    "baseInfo": {
+      "activationHeight": "999999999",
+      "appVersion": "2"
+    },
+    "priceFeedChange": {
+      "genesis": {
+        "marketMap": {
+          "marketMap": {},
+          "params": {
+            "marketAuthorities": [
+              "astria15uanr956ekq9yhp77v4pqaa3ve06h3xv9w5lml"
+            ],
+            "admin": "astria15uanr956ekq9yhp77v4pqaa3ve06h3xv9w5lml"
+          }
+        },
+        "oracle": {
+          "currencyPairGenesis": [],
+          "nextId": "0"
+        }
+      }
+    },
+    "validatorUpdateActionChange": {},
+    "ibcAcknowledgementFailureChange": {}
+  }
+}


### PR DESCRIPTION
## Summary
Initial draft upgrades.json files

## Background
We need an upgrades.json file for each of devnet, testnet and mainnet.

## Changes
- Updated `dusk-11.upgrades.json` with an activation point estimated as 2025-04-14 16:00:00 UTC
- Updated `dawn-1.upgrades.json` with an activation point estimated as 2025-05-14 16:00:00 UTC
- Updated `mainnet.upgrades.json` with an activation point estimated as 2025-05-14 16:00:00 UTC
