### PR TITLE
chore(sequencer-utils): add upgrade activation height calculator to sequencer-utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1002,14 +1002,17 @@ dependencies = [
  "hex",
  "indenter",
  "itertools 0.12.1",
+ "jiff",
  "maplit",
  "pbjson-types",
  "penumbra-sdk-ibc",
  "predicates",
  "prost",
+ "reqwest 0.12.15",
  "rlp",
  "serde",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/astria-sequencer-utils/Cargo.toml
+++ b/crates/astria-sequencer-utils/Cargo.toml
@@ -20,13 +20,16 @@ colour = "2.1.0"
 ethers-core = "2.0.14"
 hex = { workspace = true }
 indenter = "0.3.3"
+reqwest = { workspace = true }
 itertools = { workspace = true }
+jiff = { workspace = true }
 pbjson-types = { workspace = true }
 penumbra-ibc = { workspace = true }
 prost = { workspace = true }
 rlp = "0.5.2"
 serde = { workspace = true }
 serde_json = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt", "time"] }
 
 astria-core = { path = "../astria-core", features = ["brotli", "serde"] }
 astria-eyre = { path = "../astria-eyre" }

--- a/crates/astria-sequencer-utils/README.md
+++ b/crates/astria-sequencer-utils/README.md
@@ -6,11 +6,12 @@
 
 ## General
 
-There are three functions provided by the tool, further described below:
+There are four functions provided by the tool, further described below:
 
 1. `generate-genesis-state`
 1. `copy-genesis-state`
 1. `parse-blob`
+1. `estimate-activation-point`
 
 ### `generate-genesis-state`: create an example sequencer genesis state
 
@@ -96,4 +97,58 @@ cargo run -- parse-blob \
 
 # input via stdin
 cargo run -- parse-blob <<< cat tests/resources/parse_blob/batched_rollup_data/input.txt
+```
+
+---
+
+<!-- markdownlint-disable line-length -->
+
+### `estimate-activation-point`: Estimate an Activation Point to Schedule an Upcoming Upgrade
+
+The subcommand estimates an activation point for a specified network's next
+upgrade.  It gets the current block height from the provided sequencer, gets
+a block previous to this (default ~24 hours previous) and estimates a mean
+block time from these. This mean is used to predict the height or block time
+of the future block.
+
+#### Usage for `estimate-activation-point`
+
+This subcommand has the following args:
+
+1. `-u`, `--sequencer-url` [required]: the sequencer RPC URL on the desired
+   network. E.g. `https://rpc.sequencer.dawn-1.astria.org` for current testnet
+
+1. Exactly one of the following three args is required:
+   1. `-d`, `--desired-duration`: desired duration until activation point. Can
+      specify days, hours, minutes by e.g. `"3d 4h 5m"`
+   1. `-i`, `--desired-instant`: desired instant of activation point, e.g.
+      `"2025-08-17 16:00:00Z"` where the `Z` suffix denotes UTC, or the same
+      instant with a -5 hour offset from UTC is `"2025-08-17 11:00:00-05:00"`
+   1. `-t`, `--predict-block-time`: height of future block for which to
+      predict block time
+
+1. `-r`, `--range` [required, default 43200]: the number of blocks to use to
+   estimate a mean block time
+1. `-v`, `--verbose` [optional]: if provided, the output contains extra info
+   including the chain name, current height, estimated height difference and
+   estimated activation instant.
+
+#### Example for `estimate-activation-point`
+
+In `crates/astria-sequencer-utils`:
+
+```sh
+cargo r -- estimate-activation-point \
+ --sequencer-url https://rpc.astria.org \
+ --desired-duration "123d 4h 5m" \
+ --verbose
+```
+
+which produces output like:
+
+```sh
+current height on `astria`: 6403702
+estimated height difference: 4805828
+estimated activation instant on `astria`: 2025-08-17T16:00:00.449856364Z
+estimated activation height on `astria`: 11209530
 ```

--- a/crates/astria-sequencer-utils/README.md
+++ b/crates/astria-sequencer-utils/README.md
@@ -107,9 +107,9 @@ cargo run -- parse-blob <<< cat tests/resources/parse_blob/batched_rollup_data/i
 
 The subcommand estimates an activation point for a specified network's next
 upgrade.  It gets the current block height from the provided sequencer, gets
-a block previous to this (default ~24 hours previous) and estimates a mean
-block time from these. This mean is used to predict the height or block time
-of the future block.
+a block previous to this (default ~24 hours previous), and estimates a mean
+block time from these. This mean is used to predict either the height or block
+timestamp of the future block.
 
 #### Usage for `estimate-activation-point`
 
@@ -127,11 +127,11 @@ This subcommand has the following args:
    1. `-t`, `--predict-block-time`: height of future block for which to
       predict block time
 
-1. `-r`, `--range` [required, default 43200]: the number of blocks to use to
-   estimate a mean block time
+1. `-s`, `--sample_size` [required, default 43200]: the number of blocks to use
+   to estimate a mean block time
 1. `-v`, `--verbose` [optional]: if provided, the output contains extra info
    including the chain name, current height, estimated height difference and
-   estimated activation instant.
+   estimated activation instant
 
 #### Example for `estimate-activation-point`
 

--- a/crates/astria-sequencer-utils/src/activation_point_estimator.rs
+++ b/crates/astria-sequencer-utils/src/activation_point_estimator.rs
@@ -1,0 +1,288 @@
+#![expect(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::cast_precision_loss,
+    clippy::arithmetic_side_effects,
+    reason = "casts between f64 and u64 will involve values where these lints are not a problem"
+)]
+
+use std::time::Duration;
+
+use astria_eyre::eyre::{
+    bail,
+    ensure,
+    eyre,
+    Result,
+    WrapErr,
+};
+use jiff::{
+    Span,
+    SpanTotal,
+    Timestamp,
+    Unit,
+};
+use serde_json::Value;
+
+#[derive(clap::Args, Debug)]
+pub struct Args {
+    /// The URL of the Sequencer node
+    #[arg(long, short = 'u', value_name = "URL")]
+    sequencer_url: String,
+
+    #[command(flatten)]
+    action: Action,
+
+    /// The number of blocks to use to estimate a mean block time.
+    #[arg(long, short = 'r', default_value = "43200", value_name = "INTEGER")]
+    range: u64,
+
+    /// Print verbose output
+    #[arg(long, short = 'v')]
+    verbose: bool,
+}
+
+#[derive(clap::Args, Debug)]
+#[group(required = true, multiple = false)]
+pub struct Action {
+    /// Estimate an activation point (block height) for the given duration in the future. Enter as
+    /// e.g. "3d 4h 5m"
+    #[arg(
+        long,
+        short = 'd',
+        value_name = "DURATION",
+        value_parser = clap::value_parser!(Span)
+    )]
+    desired_duration: Option<Span>,
+
+    /// Estimate an activation point (block height) for the given instant. Enter as e.g.
+    /// "2025-08-17 16:00:00Z" where the `Z` suffix denotes UTC, or the same instant with a -5 hour
+    /// offset from UTC is "2025-08-17 11:00:00-05:00"
+    #[arg(
+        long,
+        short = 'i',
+        value_name = "TIMESTAMP",
+        value_parser = clap::value_parser!(Timestamp)
+    )]
+    desired_instant: Option<Timestamp>,
+
+    /// Predict block time for given height
+    #[arg(long, short = 't', value_name = "BLOCK HEIGHT")]
+    predict_block_time: Option<u64>,
+}
+
+impl Args {
+    async fn get_current_height(&self) -> Result<(u64, Timestamp)> {
+        let blocking_getter = async {
+            reqwest::get(format!("{}/block", self.sequencer_url))
+                .await
+                .wrap_err("failed to get latest block")?
+                .text()
+                .await
+                .wrap_err("failed to parse block response as UTF-8 string")
+        };
+
+        let response = tokio::time::timeout(Duration::from_secs(5), blocking_getter)
+            .await
+            .wrap_err("timed out fetching block")??
+            .trim()
+            .to_string();
+        let json_rpc_response: Value = serde_json::from_str(&response)
+            .wrap_err_with(|| format!("failed to parse block response `{response}` as json"))?;
+        let header = json_rpc_response
+            .get("result")
+            .and_then(|value| value.get("block"))
+            .and_then(|value| value.get("header"))
+            .ok_or_else(|| {
+                eyre!("expected block response `{response}` to have field `result.block.header`")
+            })?;
+        let height_str = header
+            .get("height")
+            .and_then(Value::as_str)
+            .ok_or_else(|| eyre!("expected header `{header}` to have string field `height`"))?;
+        let height: u64 = height_str
+            .parse()
+            .wrap_err_with(|| format!("expected height `{height_str}` to convert to `u64`"))?;
+        let time_str = header
+            .get("time")
+            .and_then(Value::as_str)
+            .ok_or_else(|| eyre!("expected header `{header}` to have string field `time`"))?;
+        let timestamp: Timestamp = time_str
+            .parse()
+            .wrap_err_with(|| format!("expected time `{time_str}` to convert to `Timestamp`"))?;
+
+        Ok((height, timestamp))
+    }
+
+    async fn get_timestamp_at_height(&self, height: u64) -> Result<Timestamp> {
+        let blocking_getter = async {
+            reqwest::get(format!("{}/block?height={height}", self.sequencer_url))
+                .await
+                .wrap_err_with(|| format!("failed to get block at height {height}"))?
+                .text()
+                .await
+                .wrap_err("failed to parse block response as UTF-8 string")
+        };
+
+        let response = tokio::time::timeout(Duration::from_secs(5), blocking_getter)
+            .await
+            .wrap_err_with(|| format!("timed out fetching block at height {height}"))??
+            .trim()
+            .to_string();
+        let json_rpc_response: Value = serde_json::from_str(&response)
+            .wrap_err_with(|| format!("failed to parse block response `{response}` as json"))?;
+        let time_str = json_rpc_response
+            .get("result")
+            .and_then(|value| value.get("block"))
+            .and_then(|value| value.get("header"))
+            .and_then(|value| value.get("time"))
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                eyre!(
+                    "expected block response `{response}` to have string field \
+                     `result.block.header.time`"
+                )
+            })?;
+        time_str
+            .parse()
+            .wrap_err_with(|| format!("expected time `{time_str}` to convert to `Timestamp`"))
+    }
+
+    async fn get_network_name(&self) -> Result<String> {
+        let blocking_getter = async {
+            reqwest::get(format!("{}/status", self.sequencer_url))
+                .await
+                .wrap_err("failed to get status")?
+                .text()
+                .await
+                .wrap_err("failed to parse status response as UTF-8 string")
+        };
+
+        let response = tokio::time::timeout(Duration::from_secs(5), blocking_getter)
+            .await
+            .wrap_err("timed out fetching status")??
+            .trim()
+            .to_string();
+        let json_rpc_response: Value = serde_json::from_str(&response)
+            .wrap_err_with(|| format!("failed to parse status response `{response}` as json"))?;
+        Ok(json_rpc_response
+            .get("result")
+            .and_then(|value| value.get("node_info"))
+            .and_then(|value| value.get("network"))
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                eyre!(
+                    "expected status response `{response}` to have string field \
+                     `result.node_info.network`"
+                )
+            })?
+            .to_string())
+    }
+}
+
+struct Estimator {
+    current_height: u64,
+    current_timestamp: Timestamp,
+    estimated_block_time_nanoseconds: f64,
+    network_name: String,
+    verbose: bool,
+}
+
+impl Estimator {
+    async fn new(args: &Args) -> Result<Self> {
+        let (current_height, current_timestamp) = args.get_current_height().await?;
+        ensure!(
+            current_height > 1,
+            "need current height to be greater than 1"
+        );
+        let range = std::cmp::min(args.range, current_height);
+        let old_timestamp = args.get_timestamp_at_height(current_height - range).await?;
+        let network_name = args.get_network_name().await?;
+        if args.verbose {
+            println!("current height on `{network_name}`: {current_height}");
+        }
+        let time_diff_nanoseconds = (current_timestamp - old_timestamp)
+            .total(Unit::Nanosecond)
+            .wrap_err("failed to get time difference total nanoseconds")?;
+        let estimated_block_time_nanoseconds = time_diff_nanoseconds / range as f64;
+
+        Ok(Self {
+            current_height,
+            current_timestamp,
+            estimated_block_time_nanoseconds,
+            network_name,
+            verbose: args.verbose,
+        })
+    }
+
+    fn estimate_height(&self, desired_duration: Span) -> Result<()> {
+        ensure!(
+            desired_duration.is_positive(),
+            "desired activation is earlier than current block time - good luck with the time \
+             travel"
+        );
+        let duration_nanoseconds = desired_duration
+            .total(SpanTotal::from(Unit::Nanosecond).days_are_24_hours())
+            .wrap_err("failed to get duration total nanoseconds")?;
+
+        let estimated_height_diff =
+            (duration_nanoseconds / self.estimated_block_time_nanoseconds).ceil() as u64;
+        let estimated_height = self.current_height + estimated_height_diff;
+        if self.verbose {
+            println!("estimated height difference: {estimated_height_diff}");
+        }
+
+        if self.verbose {
+            println!(
+                "estimated activation instant on `{}`: {}",
+                self.network_name,
+                self.current_timestamp + Duration::from_nanos(duration_nanoseconds as u64)
+            );
+            colour::dark_green!("estimated activation height on `{}`: ", self.network_name);
+            colour::green_ln_bold!("{estimated_height}");
+        } else {
+            print!("{estimated_height}");
+        }
+        Ok(())
+    }
+
+    fn predict_block_time(&self, future_height: u64) -> Result<()> {
+        ensure!(
+            future_height > self.current_height,
+            "given height is earlier than current block height - no prediction required"
+        );
+        let height_diff = (future_height - self.current_height) as f64;
+        let estimated_instant = self.current_timestamp
+            + Duration::from_nanos((self.estimated_block_time_nanoseconds * height_diff) as u64);
+
+        if self.verbose {
+            colour::dark_green!(
+                "estimated instant on `{}` for block {future_height}: ",
+                self.network_name
+            );
+            colour::green_ln_bold!("{estimated_instant}");
+        } else {
+            print!("{estimated_instant}");
+        }
+        Ok(())
+    }
+}
+
+/// Estimates the activation height.
+///
+/// # Errors
+///
+/// Returns an error if bad stuff happens.
+pub async fn run(mut args: Args) -> Result<()> {
+    args.sequencer_url = args.sequencer_url.trim_end_matches('/').to_string();
+    let estimator = Estimator::new(&args).await?;
+
+    if let Some(desired_duration) = args.action.desired_duration {
+        estimator.estimate_height(desired_duration)
+    } else if let Some(desired_instant) = args.action.desired_instant {
+        estimator.estimate_height(desired_instant - estimator.current_timestamp)
+    } else if let Some(future_height) = args.action.predict_block_time {
+        estimator.predict_block_time(future_height)
+    } else {
+        bail!("clap should guarantee exactly one of these args is `Some`")
+    }
+}

--- a/crates/astria-sequencer-utils/src/cli.rs
+++ b/crates/astria-sequencer-utils/src/cli.rs
@@ -35,7 +35,7 @@ pub enum Command {
     #[command(arg_required_else_help = true)]
     ParseBlob(blob_parser::Args),
 
-    /// Estimate the activation point to schedule or check an upcoming upgrade
+    /// Estimate the activation point of an upgrade to schedule or check an upcoming one
     #[command(arg_required_else_help = true)]
     EstimateActivationPoint(activation_point_estimator::Args),
 }

--- a/crates/astria-sequencer-utils/src/cli.rs
+++ b/crates/astria-sequencer-utils/src/cli.rs
@@ -4,6 +4,7 @@ use clap::{
 };
 
 use super::{
+    activation_point_estimator,
     blob_parser,
     genesis_example,
     genesis_parser,
@@ -18,6 +19,10 @@ struct Cli {
 }
 
 #[derive(Debug, Subcommand)]
+#[expect(
+    clippy::large_enum_variant,
+    reason = "this doesn't matter for this enum"
+)]
 pub enum Command {
     /// Copy genesis state to a JSON file
     #[command(arg_required_else_help = true)]
@@ -29,6 +34,10 @@ pub enum Command {
     /// Parse blob data from an arg, a file, or stdin
     #[command(arg_required_else_help = true)]
     ParseBlob(blob_parser::Args),
+
+    /// Estimate the activation point to schedule or check an upcoming upgrade
+    #[command(arg_required_else_help = true)]
+    EstimateActivationPoint(activation_point_estimator::Args),
 }
 
 #[must_use]

--- a/crates/astria-sequencer-utils/src/lib.rs
+++ b/crates/astria-sequencer-utils/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod activation_point_estimator;
 pub mod blob_parser;
 pub mod cli;
 pub mod genesis_example;

--- a/crates/astria-sequencer-utils/src/main.rs
+++ b/crates/astria-sequencer-utils/src/main.rs
@@ -1,5 +1,6 @@
 use astria_eyre::eyre::Result;
 use astria_sequencer_utils::{
+    activation_point_estimator,
     blob_parser,
     cli::{
         self,
@@ -9,12 +10,14 @@ use astria_sequencer_utils::{
     genesis_parser,
 };
 
-fn main() -> Result<()> {
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
     astria_eyre::install()
         .expect("the astria eyre install hook must be called before eyre reports are constructed");
     match cli::get() {
         Command::CopyGenesisState(args) => genesis_parser::run(args),
         Command::GenerateGenesisState(args) => genesis_example::run(&args),
         Command::ParseBlob(args) => blob_parser::run(args),
+        Command::EstimateActivationPoint(args) => activation_point_estimator::run(args).await,
     }
 }


### PR DESCRIPTION
## Summary
This adds a new subcommand to the sequencer-utils tool to help estimating activation points (i.e. future block heights) for scheduling sequencer upgrades.

## Background
This should be useful for setting upgrade activation points and also for monitoring scheduled activation points.

## Changes
- Added `estimate-activation-point` subcommand.

## Testing
Manual ad-hoc tests only.

## Changelogs
No updates required.

## Related Issues
Closes #2104.