### PR TITLE
feat(account-monitor): initial account monitor service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,6 +499,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "astria-account-monitor"
+version = "0.1.0"
+dependencies = [
+ "astria-build-info",
+ "astria-config",
+ "astria-core",
+ "astria-eyre",
+ "astria-sequencer-client",
+ "astria-telemetry",
+ "futures",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
 name = "astria-auctioneer"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 exclude = ["tools/protobuf-compiler", "tools/solidity-compiler"]
 
 members = [
+  "crates/astria-account-monitor",
   "crates/astria-auctioneer",
   "crates/astria-bridge-contracts",
   "crates/astria-bridge-withdrawer",
@@ -30,6 +31,7 @@ members = [
 # Specify default members so that cargo invocations in github actions will
 # not act on lints
 default-members = [
+  "crates/astria-account-monitor",
   "crates/astria-auctioneer",
   "crates/astria-bridge-contracts",
   "crates/astria-bridge-withdrawer",

--- a/crates/astria-account-monitor/CHANGELOG.md
+++ b/crates/astria-account-monitor/CHANGELOG.md
@@ -1,0 +1,8 @@
+<!-- markdownlint-disable no-duplicate-heading -->
+
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/crates/astria-account-monitor/Cargo.toml
+++ b/crates/astria-account-monitor/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "astria-account-monitor"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+astria-build-info = { path = "../astria-build-info", features = ["runtime"] }
+astria-core = { path = "../astria-core", features = [
+  "serde",
+  "server",
+  "client",
+] }
+astria-eyre = { path = "../astria-eyre" }
+config = { package = "astria-config", path = "../astria-config" }
+sequencer-client = { package = "astria-sequencer-client", path = "../astria-sequencer-client", features = [
+  "default",
+] }
+telemetry = { package = "astria-telemetry", path = "../astria-telemetry", features = [
+  "display",
+] }
+
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+tracing = { workspace = true, features = ["attributes"] }
+tonic = { workspace = true }
+futures = { workspace = true }
+tokio = { workspace = true, features = [
+  "macros",
+  "rt-multi-thread",
+  "sync",
+  "time",
+  "signal",
+] }
+tokio-util = { workspace = true, features = ["rt"] }
+
+[dev-dependencies]
+config = { package = "astria-config", path = "../astria-config", features = [
+  "tests",
+] }
+
+[build-dependencies]
+astria-build-info = { path = "../astria-build-info", features = ["build"] }

--- a/crates/astria-account-monitor/README.md
+++ b/crates/astria-account-monitor/README.md
@@ -1,0 +1,34 @@
+# Astria Account Monitor
+
+The Account Monitor service continuously tracks account states on the Astria Shared Sequencer. It monitors:
+
+- Regular account balances and nonces 
+- Bridge account transaction heights
+
+The service runs a simple loop that periodically queries account information and updates metrics. This allows for real-time monitoring of account activity and health checks on the network.
+
+## Running Account Monitor
+
+### Dependencies
+
+We use [just](https://just.systems/man/en/chapter_4.html) for convenient project-specific commands.
+
+### Configuration
+
+Account Monitor is configured via environment variables. An example configuration can be seen in `local.env.example`.
+
+To copy a configuration to your `.env` file run:
+
+```sh
+# By default will copy `local.env.example`
+just copy-env
+```
+
+### Running locally
+
+After creating a `.env` file either manually or by copying as above, `just` will
+load it and run locally:
+
+```bash
+just run
+```

--- a/crates/astria-account-monitor/build.rs
+++ b/crates/astria-account-monitor/build.rs
@@ -1,0 +1,4 @@
+pub fn main() -> Result<(), Box<dyn std::error::Error>> {
+    astria_build_info::emit("account-monitor-v")?;
+    Ok(())
+}

--- a/crates/astria-account-monitor/justfile
+++ b/crates/astria-account-monitor/justfile
@@ -1,0 +1,12 @@
+default:
+  @just --list
+
+set dotenv-load
+set fallback
+
+default_env := 'local'
+copy-env type=default_env:
+  cp {{ type }}.env.example .env
+
+run:
+  cargo run

--- a/crates/astria-account-monitor/local.env.example
+++ b/crates/astria-account-monitor/local.env.example
@@ -1,0 +1,62 @@
+# Configuration options of Astria Account Monitor.
+
+# Log level. One of debug, info, warn, or error
+ASTRIA_ACCOUNT_MONITOR_LOG="astria_account_monitor=info"
+
+# If true disables writing to the opentelemetry OTLP endpoint.
+ASTRIA_ACCOUNT_MONITOR_NO_OTEL=false
+
+# If true disables tty detection and forces writing telemetry to stdout.
+# If false span data is written to stdout only if it is connected to a tty.
+ASTRIA_ACCOUNT_MONITOR_FORCE_STDOUT=false
+
+# If set to any non-empty value removes ANSI escape characters from the pretty
+# printed output.
+NO_COLOR=
+
+# Address of the ABCI server for the sequencer chain  
+ASTRIA_ACCOUNT_MONITOR_SEQUENCER_ABCI_ENDPOINT="http://127.0.0.1:26657"
+
+# Chain ID of the sequencer chain which transactions are submitted to.
+ASTRIA_ACCOUNT_MONITOR_SEQUENCER_CHAIN_ID="astria-dev-1"
+
+# The prefix that will be used to construct bech32m sequencer addresses.
+ASTRIA_ACCOUNT_MONITOR_SEQUENCER_ADDRESS_PREFIX=astria
+
+# The sequencer asset for balance monitoring.
+ASTRIA_ACCOUNT_MONITOR_SEQUENCER_ASSET="nria"
+
+# A list of sequencer accounts to monitor the balance of in the format.
+# "address1,address2,..."
+ASTRIA_ACCOUNT_MONITOR_SEQUENCER_ACCOUNTS=""
+
+# A list of sequencer bridge account to keep track of last submission height.
+# expected to follow the format of "address1,address2,..."
+ASTRIA_ACCOUNT_MONITOR_SEQUENCER_BRIDGE_ACCOUNTS=""
+
+# The duration in milliseconds that monitor waits between query requests.
+ASTRIA_ACCOUNT_MONITOR_QUERY_INTERVAL_MS=2000
+
+# Set to true to enable prometheus metrics.
+ASTRIA_ACCOUNT_MONITOR_NO_METRICS=true
+
+# The address at which the prometheus HTTP listener will bind if enabled.
+ASTRIA_ACCOUNT_MONITOR_METRICS_HTTP_LISTENER_ADDR="127.0.0.1:9000"
+
+# The OTEL specific config options follow the OpenTelemetry Protocol Exporter v1
+# specification as defined here:
+# https://github.com/open-telemetry/opentelemetry-specification/blob/e94af89e3d0c01de30127a0f423e912f6cda7bed/specification/protocol/exporter.md
+
+# Sets the general OTLP endpoint.
+OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317"
+# Sets the OTLP endpoint for trace data. This takes precedence over `OTEL_EXPORTER_OTLP_ENDPOINT` if set.
+OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="http://localhost:4317/v1/traces"
+# The duration in seconds that the OTEL exporter will wait for each batch export.
+OTEL_EXPORTER_OTLP_TRACES_TIMEOUT=10
+# The compression format to use for exporting. Only `"gzip"` is supported.
+# Don't set the env var if no compression is required.
+OTEL_EXPORTER_OTLP_TRACES_COMPRESSION="gzip"
+# The HTTP headers that will be set when sending gRPC requests.
+OTEL_EXPORTER_OTLP_HEADERS="key1=value1,key2=value2"
+# The HTTP headers that will be set when sending gRPC requests. This takes precedence over `OTEL_EXPORTER_OTLP_HEADERS` if set.
+OTEL_EXPORTER_OTLP_TRACE_HEADERS="key1=value1,key2=value2"

--- a/crates/astria-account-monitor/src/account_monitor/mod.rs
+++ b/crates/astria-account-monitor/src/account_monitor/mod.rs
@@ -1,0 +1,221 @@
+use std::{
+    str::FromStr,
+    time::Duration,
+};
+
+use astria_core::{
+    primitive::v1::{
+        Address,
+        asset::Denom,
+    },
+    protocol::account::v1::AssetBalance,
+};
+use astria_eyre::eyre::{
+    self,
+    OptionExt,
+    WrapErr as _,
+};
+use sequencer_client::{
+    Client,
+    SequencerClientExt as _,
+    tendermint::{
+        Hash,
+        hash::Algorithm,
+    },
+};
+use tokio::time::interval;
+use tokio_util::sync::CancellationToken;
+use tracing::{
+    debug,
+    info,
+    instrument,
+};
+
+use crate::{
+    config::Config,
+    metrics::Metrics,
+};
+
+pub struct AccountMonitor {
+    shutdown_token: ShutdownHandle,
+    sequencer_abci_client: sequencer_client::HttpClient,
+    accounts: Vec<Address>,
+    bridge_accounts: Vec<Address>,
+    sequencer_asset: Denom,
+    metrics: &'static Metrics,
+    interval: Duration,
+    // fields omitted
+}
+
+impl AccountMonitor {
+    pub fn new(cfg: Config, metrics: &'static Metrics) -> eyre::Result<Self> {
+        let shutdown_handle = ShutdownHandle::new();
+
+        let accounts = cfg.parse_accounts()?;
+        let bridge_accounts = cfg.parse_bridge_accounts()?;
+
+        let Config {
+            sequencer_abci_endpoint,
+            sequencer_asset,
+            ..
+        } = cfg;
+
+        let sequencer_cometbft_client =
+            sequencer_client::HttpClient::new(&*sequencer_abci_endpoint)
+                .wrap_err("failed constructing cometbft http client")?;
+
+        let sequencer_asset = Denom::from_str(sequencer_asset.as_str())
+            .map_err(|e| eyre::eyre!("failed to parse asset: {e}"))?;
+
+        let interval = Duration::from_millis(cfg.block_time_ms);
+        Ok(Self {
+            shutdown_token: shutdown_handle,
+            sequencer_abci_client: sequencer_cometbft_client,
+            accounts,
+            bridge_accounts,
+            sequencer_asset,
+            metrics,
+            interval,
+        })
+    }
+
+    pub async fn run_until_stopped(&self) -> eyre::Result<()> {
+        info!("starting account monitor");
+
+        let mut poll_timer = interval(self.interval);
+
+        loop {
+            // Check if shutdown signal has been received
+            if self.shutdown_token.token.is_cancelled() {
+                info!("received shutdown signal");
+                break;
+            }
+
+            // Wait for the next poll interval
+            poll_timer.tick().await;
+
+            for account in self.bridge_accounts.iter() {
+                let account = account.clone();
+                let last_tx_hash = self
+                    .sequencer_abci_client
+                    .get_bridge_account_last_transaction_hash(account)
+                    .await
+                    .wrap_err("failed to get last transaction hash")?
+                    .tx_hash;
+
+                if let Some(tx_hash) = last_tx_hash {
+                    let last_tx_height = self
+                        .sequencer_abci_client
+                        .tx(Hash::from_bytes(Algorithm::Sha256, &tx_hash)?, false)
+                        .await
+                        .wrap_err("failed query bridge tx by hash")?
+                        .height;
+
+                    self.metrics.set_bridge_last_transaction_height(
+                        account.to_string().as_str(),
+                        last_tx_height.into(),
+                    );
+                }
+            }
+
+            // Process regular accounts
+            for account in self.accounts.iter() {
+                let account = account.clone();
+
+                // Get latest nonce
+                self.metrics.increment_nonce_fetch_count();
+                match get_latest_nonce(&self.sequencer_abci_client, account).await {
+                    Ok(nonce) => {
+                        self.metrics
+                            .set_account_nonce(account.to_string().as_str(), nonce);
+                    }
+                    Err(e) => {
+                        debug!("failed to get latest nonce: {e}");
+                        self.metrics.increment_nonce_fetch_failure_count();
+                    }
+                };
+
+                // Get latest balance
+                self.metrics.increment_balance_fetch_count();
+                match get_latest_balance(
+                    &self.sequencer_abci_client,
+                    account,
+                    self.sequencer_asset.clone(),
+                )
+                .await
+                {
+                    Ok(balance) => {
+                        self.metrics
+                            .set_account_balance(account.to_string().as_str(), balance.balance);
+                    }
+                    Err(e) => {
+                        debug!("failed to get latest balance: {e}");
+                        self.metrics.increment_balance_fetch_failure_count();
+                    }
+                };
+            }
+        }
+
+        Ok(())
+    }
+}
+
+async fn get_latest_balance(
+    client: &sequencer_client::HttpClient,
+    account: Address,
+    asset: Denom,
+) -> eyre::Result<AssetBalance> {
+    let balances = client.get_latest_balance(account).await?;
+    balances
+        .balances
+        .into_iter()
+        .find(|b| b.denom == asset)
+        .ok_or_eyre("failed to find asset balance")
+}
+
+async fn get_latest_nonce(
+    client: &sequencer_client::HttpClient,
+    account: Address,
+) -> eyre::Result<u32> {
+    let nonce = client.get_latest_nonce(account).await?;
+    Ok(nonce.nonce)
+}
+
+/// A handle for instructing the [`Service`] to shut down.
+///
+/// It is returned along with its related `Service` from [`Service::new`].  The
+/// `Service` will begin to shut down as soon as [`ShutdownHandle::shutdown`] is called or
+/// when the `ShutdownHandle` is dropped.
+pub struct ShutdownHandle {
+    token: CancellationToken,
+}
+
+impl ShutdownHandle {
+    #[must_use]
+    fn new() -> Self {
+        Self {
+            token: CancellationToken::new(),
+        }
+    }
+
+    /// Returns a clone of the wrapped cancellation token.
+    #[must_use]
+    pub fn token(&self) -> CancellationToken {
+        self.token.clone()
+    }
+
+    /// Consumes `self` and cancels the wrapped cancellation token.
+    pub fn shutdown(self) {
+        self.token.cancel();
+    }
+}
+
+impl Drop for ShutdownHandle {
+    #[instrument(skip_all)]
+    fn drop(&mut self) {
+        if !self.token.is_cancelled() {
+            info!("shutdown handle dropped, issuing shutdown to all services");
+        }
+        self.token.cancel();
+    }
+}

--- a/crates/astria-account-monitor/src/build_info.rs
+++ b/crates/astria-account-monitor/src/build_info.rs
@@ -1,0 +1,3 @@
+use astria_build_info::BuildInfo;
+
+pub const BUILD_INFO: BuildInfo = astria_build_info::get!();

--- a/crates/astria-account-monitor/src/config.rs
+++ b/crates/astria-account-monitor/src/config.rs
@@ -1,0 +1,95 @@
+use astria_eyre::eyre;
+use sequencer_client::Address;
+use serde::{
+    Deserialize,
+    Serialize,
+};
+
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "this is a config, may have many boolean values"
+)]
+#[derive(Debug, Deserialize, Serialize)]
+/// The high-level config for creating an astria-account-monitor service.
+pub struct Config {
+    /// Log level. One of debug, info, warn, or error
+    pub log: String,
+
+    /// Address of the ABCI server for the sequencer chain
+    pub sequencer_abci_endpoint: String,
+
+    /// The chain ID of the sequencer chain
+    pub sequencer_chain_id: String,
+
+    /// The address prefix to use when constructing sequencer addresses using the signing key.
+    pub sequencer_address_prefix: String,
+
+    /// The addresses of the sequencer chain to monitor.
+    pub sequencer_accounts: String,
+
+    pub sequencer_bridge_accounts: String,
+    /// The asset ID of the sequencer chain to monitor.
+    pub sequencer_asset: String,
+
+    /// Sequencer block time in milliseconds
+    #[serde(alias = "query_interval_ms")]
+    pub block_time_ms: u64,
+
+    /// Forces writing trace data to stdout no matter if connected to a tty or not.
+    pub force_stdout: bool,
+
+    /// Disables writing trace data to an opentelemetry endpoint.
+    pub no_otel: bool,
+
+    /// Set to true to disable the metrics server
+    pub no_metrics: bool,
+
+    /// The endpoint which will be listened on for serving prometheus metrics
+    pub metrics_http_listener_addr: String,
+
+    /// Writes a human readable format to stdout instead of JSON formatted OTEL trace data.
+    pub pretty_print: bool,
+}
+
+impl config::Config for Config {
+    const PREFIX: &'static str = "ASTRIA_ACCOUNT_MONITOR_";
+}
+
+impl Config {
+    pub fn parse_account(&self, account: &str) -> eyre::Result<Address> {
+        let address = account
+            .parse()
+            .map_err(|e| eyre::eyre!("failed to parse account address: {e}"))?;
+        Ok(address)
+    }
+
+    pub fn parse_accounts(&self) -> eyre::Result<Vec<Address>> {
+        let accounts = self
+            .sequencer_accounts
+            .split(',')
+            .map(|account| self.parse_account(account))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(accounts)
+    }
+
+    pub fn parse_bridge_accounts(&self) -> eyre::Result<Vec<Address>> {
+        let accounts = self
+            .sequencer_bridge_accounts
+            .split(',')
+            .map(|account| self.parse_account(account))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(accounts)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Config;
+
+    const EXAMPLE_ENV: &str = include_str!("../local.env.example");
+
+    #[test]
+    fn example_env_config_is_up_to_date() {
+        config::tests::example_env_config_is_up_to_date::<Config>(EXAMPLE_ENV);
+    }
+}

--- a/crates/astria-account-monitor/src/lib.rs
+++ b/crates/astria-account-monitor/src/lib.rs
@@ -1,0 +1,52 @@
+//! Astria's account monitor tracks account information on Astria's sequencer.
+//!
+//! The account monitor periodically polls the Astria Shared Sequencer to retrieve and track
+//! information about accounts. It monitors two types of accounts:
+//!
+//! 1. Regular accounts: Tracks nonces and balances
+//! 2. Bridge accounts: Tracks transaction history and heights
+//!
+//! Account data is exposed through metrics for monitoring and alerting purposes.
+//! The polling interval is configurable, and the service continues until it receives
+//! a shutdown signal.
+//!
+//! [`AccountMonitor`] is configured using a [`Config`] and started with
+//! [`AccountMonitor::run_until_stopped`].
+//!
+//!
+//! # Examples
+//!
+//! ```no_run
+//! # use astria_account_monitor::{
+//! #     AccountMonitor,
+//! #     Config,
+//! #     telemetry,
+//! # };
+//! # use tracing::info;
+//! # tokio_test::block_on(async {
+//! let cfg: Config = config::get().expect("failed to read configuration");
+//! let cfg_ser = serde_json::to_string(&cfg)
+//!     .expect("the json serializer should never fail when serializing to a string");
+//! eprintln!("config:\n{cfg_ser}");
+//!
+//! let (metrics, _telemetry_guard) = telemetry::configure()
+//!     .set_filter_directives(&cfg.log)
+//!     .try_init(&cfg)
+//!     .expect("failed to setup telemetry");
+//! info!(config = cfg_ser, "initializing account monitor",);
+//!
+//! let monitor = AccountMonitor::from_config(&cfg, metrics)
+//!     .await
+//!     .expect("failed creating account monitor");
+//! let _ = monitor.run_until_stopped().await;
+//! # })
+//! ```
+
+pub mod account_monitor;
+mod build_info;
+pub mod config;
+pub(crate) mod metrics;
+pub use account_monitor::AccountMonitor;
+pub use build_info::BUILD_INFO;
+use config::Config;
+pub use metrics::Metrics;

--- a/crates/astria-account-monitor/src/main.rs
+++ b/crates/astria-account-monitor/src/main.rs
@@ -1,0 +1,64 @@
+use std::process::ExitCode;
+
+use astria_account_monitor::{
+    config::Config,
+    AccountMonitor,
+    BUILD_INFO,
+};
+use astria_eyre::eyre::WrapErr as _;
+use tracing::{
+    error,
+    info,
+};
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    astria_eyre::install().expect("astria eyre hook must be the first hook installed");
+
+    eprintln!(
+        "{}",
+        serde_json::to_string(&BUILD_INFO)
+            .expect("build info is serializable because it contains only unicode fields")
+    );
+
+    let cfg: Config = config::get().expect("failed to read configuration");
+
+    let mut telemetry_conf = telemetry::configure()
+        .set_no_otel(cfg.no_otel)
+        .set_force_stdout(cfg.force_stdout)
+        .set_filter_directives(&cfg.log);
+
+    if !cfg.no_metrics {
+        telemetry_conf =
+            telemetry_conf.set_metrics(&cfg.metrics_http_listener_addr, env!("CARGO_PKG_NAME"));
+    }
+
+    let (metrics, _telemetry_guard) = match telemetry_conf
+        .try_init(&cfg)
+        .wrap_err("failed to setup telemetry")
+    {
+        Err(e) => {
+            eprintln!("initializing account monitor failed:\n{e:?}");
+            return ExitCode::FAILURE;
+        }
+        Ok(metrics_and_guard) => metrics_and_guard,
+    };
+
+    let account_monitor = match AccountMonitor::new(cfg, metrics) {
+        Ok(account_monitor) => account_monitor,
+        Err(e) => {
+            error!(%e, "failed initializing AccountMonitor");
+            return ExitCode::FAILURE;
+        }
+    };
+    return match account_monitor.run_until_stopped().await {
+        Ok(()) => {
+            info!("Account monitor stopped");
+            ExitCode::SUCCESS
+        }
+        Err(error) => {
+            error!(%error, "Account monitor exited with error");
+            ExitCode::FAILURE
+        }
+    };
+}

--- a/crates/astria-account-monitor/src/metrics.rs
+++ b/crates/astria-account-monitor/src/metrics.rs
@@ -1,0 +1,174 @@
+use std::collections::HashMap;
+
+use telemetry::{
+    metric_names,
+    metrics::{
+        Counter,
+        Error,
+        Gauge,
+        RegisteringBuilder,
+    },
+};
+use tracing::error;
+
+pub struct Metrics {
+    nonce_fetch_count: Counter,
+    nonce_fetch_failure_count: Counter,
+    balance_fetch_count: Counter,
+    balance_fetch_failure_count: Counter,
+    account_nonce: HashMap<String, Gauge>,
+    account_balance: HashMap<String, Gauge>,
+    bridge_last_transaction_height: HashMap<String, Gauge>,
+}
+
+impl Metrics {
+    pub(crate) fn increment_nonce_fetch_count(&self) {
+        self.nonce_fetch_count.increment(1);
+    }
+
+    pub(crate) fn increment_nonce_fetch_failure_count(&self) {
+        self.nonce_fetch_failure_count.increment(1);
+    }
+
+    pub fn set_account_nonce(&self, account: &str, nonce: u32) {
+        if let Some(gauge) = self.account_nonce.get(account) {
+            gauge.set(nonce);
+        } else {
+            error!("No gauge found for account nonce: {}", account);
+        }
+    }
+
+    pub fn set_account_balance(&self, account: &str, balance: u128) {
+        if let Some(gauge) = self.account_balance.get(account) {
+            gauge.set(balance);
+        } else {
+            error!("No gauge found for account balance: {}", account);
+        }
+    }
+
+    pub fn increment_balance_fetch_count(&self) {
+        self.balance_fetch_count.increment(1);
+    }
+
+    pub fn increment_balance_fetch_failure_count(&self) {
+        self.balance_fetch_failure_count.increment(1);
+    }
+
+    pub fn set_bridge_last_transaction_height(&self, account: &str, height: u64) {
+        if let Some(gauge) = self.bridge_last_transaction_height.get(account) {
+            gauge.set(height);
+        } else {
+            error!(
+                "No gauge found for bridge last transaction height: {}",
+                account
+            );
+        }
+    }
+}
+
+impl telemetry::Metrics for Metrics {
+    type Config = crate::Config;
+
+    fn register(builder: &mut RegisteringBuilder, config: &Self::Config) -> Result<Self, Error>
+    where
+        Self: Sized,
+    {
+        let accounts = config
+            .parse_accounts()
+            .map_err(|e| {
+                error!("Failed to parse accounts: {e}");
+            })
+            .unwrap();
+        let bridge_accounts = config
+            .parse_bridge_accounts()
+            .map_err(|e| {
+                error!("Failed to parse bridge accounts: {e}");
+            })
+            .unwrap();
+
+        let nonce_fetch_count = builder
+            .new_counter_factory(
+                NONCE_FETCH_COUNT,
+                "The number of times we have attempted to fetch the nonce",
+            )?
+            .register()?;
+
+        let nonce_fetch_failure_count = builder
+            .new_counter_factory(
+                NONCE_FETCH_FAILURE_COUNT,
+                "The number of times we have failed to fetch the nonce",
+            )?
+            .register()?;
+
+        let balance_fetch_count = builder
+            .new_counter_factory(
+                BALANCE_FETCH_COUNT,
+                "The number of times we have attempted to fetch the balance",
+            )?
+            .register()?;
+
+        let balance_fetch_failure_count = builder
+            .new_counter_factory(
+                BALANCE_FETCH_FAILURE_COUNT,
+                "The number of times we have failed to fetch the balance",
+            )?
+            .register()?;
+
+        let mut bridge_factory = builder.new_gauge_factory(
+            BRIDGE_LAST_TRANSACTION_HEIGHT,
+            "The last transaction height for the bridge account",
+        )?;
+        // Register account-specific metrics
+        let mut account_nonce = HashMap::new();
+        let mut account_balance = HashMap::new();
+        let mut bridge_last_transaction_height = HashMap::new();
+        for account in bridge_accounts {
+            // Register account nonce gauge
+            let bridge_gauge =
+                bridge_factory.register_with_labels(&[(ACCOUNT_LABEL, account.to_string())])?;
+            bridge_last_transaction_height.insert(account.to_string().clone(), bridge_gauge);
+        }
+        let mut nonce_factory =
+            builder.new_gauge_factory(ACCOUNT_NONCE, "The current nonce for a specific account")?;
+
+        for account in accounts.clone() {
+            // Register account nonce gauge
+
+            let nonce_gauge =
+                nonce_factory.register_with_labels(&[(ACCOUNT_LABEL, account.to_string())])?;
+            account_nonce.insert(account.to_string().clone(), nonce_gauge);
+        }
+
+        let mut balance_factory = builder.new_gauge_factory(
+            ACCOUNT_BALANCE,
+            "The current balance for a specific account",
+        )?;
+        for account in accounts {
+            let balance_gauge =
+                balance_factory.register_with_labels(&[(ACCOUNT_LABEL, account.to_string())])?;
+            account_balance.insert(account.to_string().clone(), balance_gauge);
+        }
+
+        Ok(Self {
+            nonce_fetch_count,
+            nonce_fetch_failure_count,
+            balance_fetch_count,
+            balance_fetch_failure_count,
+            account_nonce,
+            account_balance,
+            bridge_last_transaction_height,
+        })
+    }
+}
+
+metric_names!(pub const METRICS_NAMES:
+    NONCE_FETCH_COUNT,
+    NONCE_FETCH_FAILURE_COUNT,
+    BALANCE_FETCH_COUNT,
+    BALANCE_FETCH_FAILURE_COUNT,
+    CURRENT_NONCE,
+    ACCOUNT_NONCE,
+    ACCOUNT_LABEL,
+    ACCOUNT_BALANCE,
+    BRIDGE_LAST_TRANSACTION_HEIGHT,
+);


### PR DESCRIPTION
## Summary
Implements account monitor service to continuously track account states on the sequencer network.

## Background
Current monitoring stack lacks the ability to continuously monitor account balances and create alerts based on such metrics. The binary queries a sequencer node using `astria-sequencer-client` for configured accounts information.

## Changes
- implements the new account monitor service

## Testing
Tested locally by running against a mainnet public rpc endpoint. Instructions can be found in the crate README.

## Metrics
- nonce_fetch_count: Counter,
- nonce_fetch_failure_count: Counter,
- balance_fetch_count: Counter,
- balance_fetch_failure_count: Counter,
- account_nonce: HashMap<String, Gauge>,
- account_balance: HashMap<String, Gauge>,
- bridge_last_transaction_height: HashMap<String, Gauge>,
