### PR TITLE
chore(charts): update sequencer chart

### DIFF
--- a/charts/sequencer/Chart.yaml
+++ b/charts/sequencer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.1
+version: 2.1.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/sequencer/templates/service.yaml
+++ b/charts/sequencer/templates/service.yaml
@@ -66,7 +66,7 @@ spec:
     - name: seq-metric
       port: {{ .Values.ports.sequencerMetrics }}
       targetPort: seq-metric
-    {{- if .Values.sequencer.priceFeed.metrics.enabled }}
+    {{- if .Values.sequencer.priceFeed.enabled }}
     - name: price-fd-metric
       port: {{ .Values.ports.priceFeedMetrics }}
       targetPort: price-fd-metric

--- a/charts/sequencer/templates/servicemonitor.yaml
+++ b/charts/sequencer/templates/servicemonitor.yaml
@@ -34,7 +34,7 @@ spec:
       {{- with .Values.serviceMonitor.scrapeTimeout  }}
       scrapeTimeout: {{ . }}
       {{- end }}
-    {{- if .Values.sequencer.priceFeed.metrics.enabled }}
+    {{- if .Values.sequencer.priceFeed.enabled }}
     - port: price-fd-metric
       path: /
       {{- with .Values.serviceMonitor.interval }}

--- a/dev/values/validators/all-without-native.yml
+++ b/dev/values/validators/all-without-native.yml
@@ -27,8 +27,6 @@ sequencer:
       appVersion: 2
   priceFeed:
     enabled: true
-    metrics:
-      enabled: true
     markets:
       - name: "BTC/USD"
         providerConfigs:

--- a/dev/values/validators/all.yml
+++ b/dev/values/validators/all.yml
@@ -44,8 +44,6 @@ sequencer:
     enabled: false
   priceFeed:
     enabled: true
-    metrics:
-      enabled: true
 
 resources:
   cometbft:


### PR DESCRIPTION
## Summary
Minor change to sequencer charts to flatten the yaml slightly.

## Background
We don't need a separate value to enable/disable metrics for the price feed sidecar.  We can use the existing value of `sequencer.metrcis.enabled && sequencer.priceFeed.enabled` for this.

## Changes
- Changed `sequencer.priceFeed.metrics.enabled` to `sequencer.priceFeed.enabled` inside a block where `sequencer.metrcis.enabled` is already true.

## Testing
Ran `helm template` locally.  Will be testing via argocd later.

## Changelogs
No updates required.

## Related Issues
Part of [ZenHub issue 121](https://github.com/astriaorg/astria/issues#workspaces/astria-6792bd6513d9f600312d8b6f/issues/zh/121).
