### PR TITLE
fix(charts): incorrect image version, path support

### DIFF
--- a/charts/evm-bridge-withdrawer/Chart.yaml
+++ b/charts/evm-bridge-withdrawer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.4
+version: 1.0.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/evm-bridge-withdrawer/values.yaml
+++ b/charts/evm-bridge-withdrawer/values.yaml
@@ -13,7 +13,7 @@ images:
   evmBridgeWithdrawer:
     repo: ghcr.io/astriaorg/evm-bridge-withdrawer
     pullPolicy: IfNotPresent
-    tag: 1.0.3
+    tag: 1.0.2
     devTag: latest
 
 config:

--- a/charts/evm-stack/Chart.lock
+++ b/charts/evm-stack/Chart.lock
@@ -19,12 +19,12 @@ dependencies:
   version: 0.1.4
 - name: evm-bridge-withdrawer
   repository: file://../evm-bridge-withdrawer
-  version: 1.0.4
+  version: 1.0.5
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 15.2.4
 - name: blockscout-stack
   repository: https://blockscout.github.io/helm-charts
   version: 1.6.8
-digest: sha256:14d268d749db0add1ffc91d076d5bd16824dce2788266750430e54c4a0c305d4
-generated: "2025-04-09T10:32:10.256679874+01:00"
+digest: sha256:0b8965e6d08432c9fdde6302ff874da51cc23e3b3d423c4da76f4352e0d1b2f4
+generated: "2025-04-18T11:54:02.956592-07:00"

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -43,7 +43,7 @@ dependencies:
     repository: "file://../evm-faucet"
     condition: evm-faucet.enabled
   - name: evm-bridge-withdrawer
-    version: 1.0.4
+    version: 1.0.5
     repository: "file://../evm-bridge-withdrawer"
     condition: evm-bridge-withdrawer.enabled
   - name: postgresql

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.0
+version: 1.2.1
 
 dependencies:
   - name: celestia-node

--- a/charts/external-ingress/Chart.yaml
+++ b/charts/external-ingress/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/external-ingress/templates/ingress.yaml
+++ b/charts/external-ingress/templates/ingress.yaml
@@ -1,19 +1,15 @@
 {{- $ingressApiIsStable := eq (include "external-ingress.isStable" .) "true" -}}
 {{- $ingressSupportsIngressClassName := eq (include "external-ingress.supportsIngressClassName" .) "true" -}}
 {{- $ingressSupportsPathType := eq (include "external-ingress.supportsPathType" .) "true" -}}
-
 {{- range $name, $ingress := .Values.ingress }}
 {{- $serviceName := $ingress.service -}}
 {{- $_ := hasKey $.Values.services $serviceName | required "ingress.service must be one of the chart services" -}}
 {{- $servicePort := $ingress.port -}}
 {{- $ingressPath := default "/" $ingress.path -}}
 {{- $ingressPathType := default "Prefix" $ingress.pathType -}}
-{{- $extraPaths := $ingress.extraPaths -}}
+{{- $specificPaths := $ingress.paths -}}
 {{- $ingressClassName := default "nginx" $ingress.className }}
-{{- $servicePort := $ingress.port -}}
-{{- $ingressPath := default "/" $ingress.path -}}
-{{- $ingressPathType := default "Prefix" $ingress.pathType -}}
-{{- $extraPaths := $ingress.extraPaths -}}
+{{- $paths := default (list (dict "path" "/" "pathType" "Prefix")) $ingress.paths -}}
 {{- $ingressClassName := default "nginx" $ingress.className }}
 apiVersion: {{ include "external-ingress.apiVersion" $ }}
 kind: Ingress
@@ -48,12 +44,10 @@ spec:
     - host: {{ tpl $host $ }}
       http:
         paths:
-          {{- with $extraPaths }}
-          {{- toYaml . | nindent 10 }}
-          {{- end }}
-          - path: {{ $ingressPath }}
+          {{- range $path := $paths }}
+          - path: {{ $path.path }}
             {{- if $ingressSupportsPathType }}
-            pathType: {{ $ingressPathType }}
+            pathType: {{ $path.pathType }}
             {{- end }}
             backend:
               {{- if $ingressApiIsStable }}
@@ -65,6 +59,7 @@ spec:
               serviceName: {{ tpl $serviceName $ }}
               servicePort: {{ tpl $servicePort $ }}
               {{- end }}
+          {{- end }}
     {{- end }}
   {{- end }}
   {{- if $ingress.tls }}


### PR DESCRIPTION
## Summary
Fixes two issues found while deploying the evm-cluster test app. The version in the current evm-withdrawer application is non existent, and the support for paths does not fully exist in the external ingress app.

## Changes
- Rollback the version image tag on bridge withdrawer chart
- External ingress now supports full paths setup with same default.

## Testing
Tested the external ingress chart using values generated from evm-cluster app.

## Changelogs
No updates required.
