### PR TITLE
feat(composer, sequencer): grpc-web via tonic-web

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -526,7 +526,7 @@ dependencies = [
  "tokio-util",
  "tonic",
  "tower 0.5.2",
- "tower-http",
+ "tower-http 0.6.2",
  "tracing",
  "tryhard",
 ]
@@ -668,6 +668,7 @@ dependencies = [
  "tokio-util",
  "tonic",
  "tonic-health",
+ "tonic-web",
  "tracing",
  "tryhard",
  "wiremock",
@@ -899,10 +900,11 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tonic",
+ "tonic-web",
  "tower 0.5.2",
  "tower-abci",
  "tower-actor",
- "tower-http",
+ "tower-http 0.6.2",
  "tracing",
  "tryhard",
  "url",
@@ -8805,6 +8807,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic-web"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5299dd20801ad736dccb4a5ea0da7376e59cd98f213bf1c3d478cf53f4834b58"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project",
+ "tokio-stream",
+ "tonic",
+ "tower-http 0.5.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8874,6 +8896,22 @@ dependencies = [
  "tokio-util",
  "tower 0.4.13",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+dependencies = [
+ "bitflags 2.8.0",
+ "bytes",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,7 @@ tokio-stream = { version = "0.1.17" }
 tokio-test = "0.4.4"
 tokio-util = "0.7.14"
 tonic = "0.12.3"
+tonic-web = "0.12.3"
 tower = { version = "0.5.2", default-features = false }
 tower-http = { version = "0.6.2", default-features = false }
 tracing = "0.1"

--- a/crates/astria-composer/CHANGELOG.md
+++ b/crates/astria-composer/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for gRPC Web [#2124](https://github.com/astriaorg/astria/pull/2124).
+
 ## [1.0.1] - 2025-03-06
 
 ### Changed

--- a/crates/astria-composer/Cargo.toml
+++ b/crates/astria-composer/Cargo.toml
@@ -51,6 +51,7 @@ tokio-util = { workspace = true, features = ["rt"] }
 tracing = { workspace = true, features = ["attributes"] }
 tryhard = { workspace = true }
 tonic = { workspace = true }
+tonic-web = { workspace = true }
 tokio-stream = { workspace = true, features = ["net"] }
 
 [dependencies.sequencer-client]

--- a/crates/astria-composer/src/grpc.rs
+++ b/crates/astria-composer/src/grpc.rs
@@ -84,6 +84,7 @@ impl GrpcServer {
 
         let composer_service = GrpcCollectorServiceServer::new(self.grpc_collector);
         let grpc_server = tonic::transport::Server::builder()
+            .layer(tonic_web::GrpcWebLayer::new())
             .add_service(health_service)
             .add_service(composer_service);
 

--- a/crates/astria-sequencer/CHANGELOG.md
+++ b/crates/astria-sequencer/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for gRPC Web [#2124](https://github.com/astriaorg/astria/pull/2124).
+
 ## [3.0.0-rc.1]
 
 ### Added

--- a/crates/astria-sequencer/Cargo.toml
+++ b/crates/astria-sequencer/Cargo.toml
@@ -69,6 +69,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt", "tracing"] }
 tokio-util = { workspace = true, features = ["rt"] }
 tonic = { workspace = true }
+tonic-web = { workspace = true }
 tracing = { workspace = true }
 tryhard = { workspace = true }
 

--- a/crates/astria-sequencer/src/grpc/mod.rs
+++ b/crates/astria-sequencer/src/grpc/mod.rs
@@ -148,6 +148,7 @@ pub(crate) async fn serve(
         // (from Penumbra) Add permissive CORS headers, so pd's gRPC services are accessible
         // from arbitrary web contexts, including from localhost.
         .layer(cors_layer)
+        .layer(tonic_web::GrpcWebLayer::new())
         .add_service(ClientQueryServer::new(ibc.clone()))
         .add_service(ChannelQueryServer::new(ibc.clone()))
         .add_service(ConnectionQueryServer::new(ibc.clone()))

--- a/crates/astria-sequencer/src/grpc/mod.rs
+++ b/crates/astria-sequencer/src/grpc/mod.rs
@@ -116,7 +116,9 @@ pub(crate) async fn serve(
     let sequencer_api = SequencerServer::new(storage.clone(), mempool, upgrades);
     let market_map_api = price_feed::SequencerServer::new(storage.clone());
     let oracle_api = price_feed::SequencerServer::new(storage.clone());
-    let cors_layer: CorsLayer = CorsLayer::permissive();
+    // Using very permissive here reflects the origin allowed headers back to the client
+    // this is required for buf studio to work.
+    let cors_layer: CorsLayer = CorsLayer::very_permissive();
 
     let mut background_tasks = BackgroundTasks::new();
     let optimistic_block_service = if no_optimistic_blocks {


### PR DESCRIPTION
## Summary
Add gRPC web support grpc servers.

## Background
gRPC web enables making requests through a browser and makes it much easier to test gprc endpoints. This introduces `tonic-web` to support it and does it using the methods which are still supported in `0.13` making upgrading when possible simple.

## Changes
-  Add tonic-web to both composer & sequencer

## Testing
CI/CD + local run with buf studio to test.

## Changelogs
Changelogs updated.
