### PR TITLE
chore(charts): disable sidecar if priceFeed is disabled

### DIFF
--- a/charts/sequencer/Chart.yaml
+++ b/charts/sequencer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.0
+version: 2.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sequencer/templates/statefulsets.yaml
+++ b/charts/sequencer/templates/statefulsets.yaml
@@ -109,6 +109,7 @@ spec:
             limits:
               cpu: {{ .Values.resources.cometbft.limits.cpu }}
               memory: {{ .Values.resources.cometbft.limits.memory }}
+        {{- if .Values.sequencer.priceFeed.enabled }}
         - name: price-feed
           image: "{{ include "priceFeed.image" . }}"
           imagePullPolicy: {{ .Values.images.priceFeed.pullPolicy }}
@@ -126,6 +127,7 @@ spec:
               name: price-feed-grpc
             - containerPort: {{ .Values.ports.priceFeedMetrics }}
               name: price-fd-metric
+        {{- end }}
       volumes:
         - name: socket-volume
           emptyDir: {}


### PR DESCRIPTION
## Summary
disable sidecar if priceFeed is disabled

## Background
Currently the price-feed sidecar runs by default, we should allow configuring this behavior.

## Changes
- sidecar runs only if price feed is enabled

## Testing
locally templating the chart with `helm template my-chart ./charts/sequencer -f ./dev/values/validators/single.yml`

## Changelogs
No updates required.
