### PR TITLE
test(conductor)!: use v1alpha1 sequencerblock api

### DIFF
--- a/charts/just/deploy.just
+++ b/charts/just/deploy.just
@@ -301,7 +301,7 @@ evm-rollup-restart-test tag=defaultTag:
     -n astria-validator-single single-sequencer-chart charts/sequencer \
     -f dev/values/validators/all.yml \
     -f dev/values/validators/single.yml \
-    {{ if tag != '' { replace('--set images.sequencer.devTag=# --set sequencer-relayer.images.sequencerRelayer.devTag=#', '#', tag) } else { '' } }} \
+    {{ if tag != '' { replace('--set images.sequencer.tag=# --set sequencer-relayer.images.sequencerRelayer.tag=#', '#', tag) } else { '' } }} \
     --create-namespace > /dev/null
   @just wait-for sequencer
   @echo "Starting EVM rollup..." && helm install -n astria-dev-cluster astria-chain-chart charts/evm-stack -f dev/values/rollup/evm-restart-test.yaml \

--- a/charts/sequencer/Chart.yaml
+++ b/charts/sequencer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.0
+version: 2.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sequencer/Chart.yaml
+++ b/charts/sequencer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.1
+version: 2.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sequencer/values.yaml
+++ b/charts/sequencer/values.yaml
@@ -41,7 +41,7 @@ images:
   sequencer:
     repo: ghcr.io/astriaorg/sequencer
     pullPolicy: IfNotPresent
-    tag: latest
+    tag: 0.13.3
   priceFeed:
     repo: ghcr.io/skip-mev/connect-sidecar
     pullPolicy: IfNotPresent

--- a/crates/astria-conductor/Cargo.toml
+++ b/crates/astria-conductor/Cargo.toml
@@ -45,7 +45,7 @@ tendermint-rpc = { workspace = true, features = ["http-client"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal"] }
 tokio-util = { workspace = true, features = ["rt"] }
-tonic = { workspace = true, features = ["tls", "tls-roots"] }
+tonic = { workspace = true, features = ["tls", "tls-native-roots"] }
 tower = { workspace = true, features = ["buffer", "limit"] }
 tracing = { workspace = true, features = ["valuable"] }
 tryhard = { workspace = true }

--- a/crates/astria-conductor/src/block_cache.rs
+++ b/crates/astria-conductor/src/block_cache.rs
@@ -4,7 +4,7 @@ use std::{
     future::Future,
 };
 
-use astria_core::sequencerblock::v1::{
+use astria_core::sequencerblock::v1alpha1::{
     block::FilteredSequencerBlock,
     SubmittedMetadata,
 };

--- a/crates/astria-conductor/src/celestia/block_verifier.rs
+++ b/crates/astria-conductor/src/celestia/block_verifier.rs
@@ -221,14 +221,10 @@ mod tests {
     use std::collections::BTreeMap;
 
     use astria_core::{
-        generated::astria::sequencerblock::v1::SequencerBlockHeader as RawSequencerBlockHeader,
+        generated::astria::sequencerblock::v1alpha1::SequencerBlockHeader as RawSequencerBlockHeader,
         primitive::v1::RollupId,
-        sequencerblock::v1::{
-            block::{
-                self,
-                ExtendedCommitInfoWithProof,
-                SequencerBlockHeader,
-            },
+        sequencerblock::v1alpha1::{
+            block::SequencerBlockHeader,
             celestia::UncheckedSubmittedMetadata,
         },
     };
@@ -351,11 +347,6 @@ mod tests {
         let data_hash = tree.root();
         let rollup_transactions_proof = tree.construct_proof(0).unwrap();
         let rollup_ids_proof = tree.construct_proof(1).unwrap();
-        let extended_commit_info_proof = tree.construct_proof(2).unwrap();
-        let extended_commit_info_with_proof = ExtendedCommitInfoWithProof::unchecked_from_parts(
-            extended_commit_info.into(),
-            extended_commit_info_proof,
-        );
 
         let (validator_set, proposer_address, commit) =
             make_test_validator_set_and_commit(1, "test-chain".try_into().unwrap());
@@ -374,13 +365,11 @@ mod tests {
         let header = SequencerBlockHeader::try_from_raw(header).unwrap();
 
         let sequencer_blob = UncheckedSubmittedMetadata {
-            block_hash: block::Hash::new([0u8; 32]),
+            block_hash: [0u8; 32],
             header,
             rollup_ids: vec![],
             rollup_transactions_proof,
             rollup_ids_proof,
-            upgrade_change_hashes: vec![],
-            extended_commit_info_with_proof: Some(extended_commit_info_with_proof),
         }
         .try_into_celestia_sequencer_blob()
         .unwrap();
@@ -408,12 +397,6 @@ mod tests {
         let data_hash = tree.root();
         let rollup_transactions_proof = tree.construct_proof(0).unwrap();
         let rollup_ids_proof = tree.construct_proof(1).unwrap();
-        let extended_commit_info_proof = tree.construct_proof(2).unwrap();
-        let extended_commit_info_with_proof = ExtendedCommitInfoWithProof::unchecked_from_parts(
-            extended_commit_info.into(),
-            extended_commit_info_proof,
-        );
-
         let (validator_set, proposer_address, commit) =
             make_test_validator_set_and_commit(1, "test-chain".try_into().unwrap());
 
@@ -431,13 +414,11 @@ mod tests {
         let header = SequencerBlockHeader::try_from_raw(header).unwrap();
 
         let sequencer_blob = UncheckedSubmittedMetadata {
-            block_hash: block::Hash::new([0u8; 32]),
+            block_hash: [0u8; 32],
             header,
             rollup_ids: vec![rollup_id],
             rollup_transactions_proof,
             rollup_ids_proof,
-            upgrade_change_hashes: vec![],
-            extended_commit_info_with_proof: Some(extended_commit_info_with_proof),
         }
         .try_into_celestia_sequencer_blob()
         .unwrap();

--- a/crates/astria-conductor/src/celestia/convert.rs
+++ b/crates/astria-conductor/src/celestia/convert.rs
@@ -1,10 +1,10 @@
 use astria_core::{
     brotli::decompress_bytes,
-    generated::astria::sequencerblock::v1::{
+    generated::astria::sequencerblock::v1alpha1::{
         SubmittedMetadataList,
         SubmittedRollupDataList,
     },
-    sequencerblock::v1::{
+    sequencerblock::v1alpha1::{
         celestia::{
             SubmittedMetadataError,
             SubmittedRollupDataError,

--- a/crates/astria-conductor/src/celestia/mod.rs
+++ b/crates/astria-conductor/src/celestia/mod.rs
@@ -6,11 +6,7 @@ use std::{
 
 use astria_core::{
     primitive::v1::RollupId,
-    protocol::price_feed::v1::ExtendedCommitInfoWithCurrencyPairMapping,
-    sequencerblock::v1::block::{
-        self,
-        SequencerBlockHeader,
-    },
+    sequencerblock::v1alpha1::block::SequencerBlockHeader,
 };
 use astria_eyre::eyre::{
     self,
@@ -101,14 +97,13 @@ use crate::block_cache::BlockCache;
 #[derive(Clone, Debug)]
 pub(crate) struct ReconstructedBlock {
     pub(crate) celestia_height: u64,
-    pub(crate) block_hash: block::Hash,
+    pub(crate) block_hash: [u8; 32],
     pub(crate) header: SequencerBlockHeader,
     pub(crate) transactions: Vec<Bytes>,
-    pub(crate) extended_commit_info: Option<ExtendedCommitInfoWithCurrencyPairMapping>,
 }
 
 impl ReconstructedBlock {
-    pub(crate) fn block_hash(&self) -> &block::Hash {
+    pub(crate) fn block_hash(&self) -> &[u8; 32] {
         &self.block_hash
     }
 
@@ -473,7 +468,7 @@ impl RunningReader {
                     error = %eyre::Report::new(e),
                     source_celestia_height = celestia_height,
                     sequencer_height,
-                    block_hash = %block_hash,
+                    block_hash = %hex::encode(block_hash),
                     "failed pushing reconstructed block into sequential cache; dropping it",
                 );
             }

--- a/crates/astria-conductor/src/celestia/reporting.rs
+++ b/crates/astria-conductor/src/celestia/reporting.rs
@@ -52,7 +52,10 @@ impl Serialize for ReportReconstructedBlock<'_> {
         ];
         let mut state = serializer.serialize_struct("ReconstructedBlockInfo", FIELDS.len())?;
         state.serialize_field(FIELDS[0], &self.0.celestia_height)?;
-        state.serialize_field(FIELDS[1], &SerializeDisplay(&self.0.block_hash))?;
+        state.serialize_field(
+            FIELDS[1],
+            &SerializeDisplay(&hex::encode(self.0.block_hash)),
+        )?;
         state.serialize_field(FIELDS[2], &self.0.transactions.len())?;
         state.serialize_field(FIELDS[3], &self.0.celestia_height)?;
         state.end()

--- a/crates/astria-conductor/src/executor/client.rs
+++ b/crates/astria-conductor/src/executor/client.rs
@@ -11,9 +11,8 @@ use astria_core::{
             self as raw,
             execution_service_client::ExecutionServiceClient,
         },
-        sequencerblock::v1::RollupData,
+        sequencerblock::v1alpha1::RollupData,
     },
-    sequencerblock::v1::block::Hash,
     Protobuf as _,
 };
 use astria_eyre::eyre::{
@@ -129,7 +128,7 @@ impl Client {
         parent_hash: String,
         transactions: Vec<Bytes>,
         timestamp: Timestamp,
-        sequencer_block_hash: Hash,
+        sequencer_block_hash: [u8; 32],
     ) -> eyre::Result<ExecutedBlockMetadata> {
         use prost::Message;
 
@@ -144,7 +143,7 @@ impl Client {
             parent_hash,
             transactions,
             timestamp: Some(timestamp),
-            sequencer_block_hash: sequencer_block_hash.to_string(),
+            sequencer_block_hash: hex::encode(sequencer_block_hash).to_string(),
         };
         let response = tryhard::retry_fn(|| {
             let mut client = self.inner.clone();

--- a/crates/astria-conductor/src/executor/tests.rs
+++ b/crates/astria-conductor/src/executor/tests.rs
@@ -5,22 +5,7 @@ use astria_core::{
         ExecutionSession,
     },
     generated::astria::execution::v2 as raw,
-    protocol::price_feed::v1::ExtendedCommitInfoWithCurrencyPairMapping,
     Protobuf as _,
-};
-use bytes::Bytes;
-use indexmap::IndexMap;
-use tendermint::{
-    abci::types::{
-        BlockSignatureInfo,
-        ExtendedCommitInfo,
-        ExtendedVoteInfo,
-        Validator,
-    },
-    block::{
-        BlockIdFlag,
-        Round,
-    },
 };
 
 use super::{
@@ -222,54 +207,4 @@ fn should_execute_firm() {
         "firm-and-soft-mode conductors should not execute firm blocks if soft and firm numbers \
          don't match"
     );
-}
-
-#[test]
-fn should_prepend_valid_price_feed_data_to_txs() {
-    let tx = Bytes::from(vec![1; 1]);
-    let txs = vec![tx.clone(); 1];
-    let extended_commit_info = ExtendedCommitInfoWithCurrencyPairMapping {
-        extended_commit_info: ExtendedCommitInfo {
-            round: Round::default(),
-            votes: vec![],
-        },
-        id_to_currency_pair: IndexMap::new(),
-    };
-    let bytes =
-        super::prepend_transactions_by_price_feed_if_exists(txs, Some(extended_commit_info));
-    assert_eq!(bytes.len(), 2);
-    assert_eq!(bytes[1], tx);
-}
-
-#[test]
-fn should_not_prepend_invalid_price_feed_data_to_txs() {
-    let txs = vec![Bytes::from(vec![1; 1])];
-    let invalid_extended_vote_info = ExtendedVoteInfo {
-        validator: Validator {
-            address: [1; 20],
-            power: 10_u8.into(),
-        },
-        sig_info: BlockSignatureInfo::Flag(BlockIdFlag::Commit),
-        vote_extension: Bytes::from(vec![100]), // this fails to decode as a vote extension
-        extension_signature: None,
-    };
-    let extended_commit_info = ExtendedCommitInfoWithCurrencyPairMapping {
-        extended_commit_info: ExtendedCommitInfo {
-            round: Round::default(),
-            votes: vec![invalid_extended_vote_info],
-        },
-        id_to_currency_pair: IndexMap::new(),
-    };
-    let bytes = super::prepend_transactions_by_price_feed_if_exists(
-        txs.clone(),
-        Some(extended_commit_info),
-    );
-    assert_eq!(bytes, txs);
-}
-
-#[test]
-fn should_not_prepend_missing_price_feed_data_to_txs() {
-    let txs = vec![Bytes::from(vec![1; 1])];
-    let bytes = super::prepend_transactions_by_price_feed_if_exists(txs.clone(), None);
-    assert_eq!(bytes, txs);
 }

--- a/crates/astria-conductor/src/sequencer/block_stream.rs
+++ b/crates/astria-conductor/src/sequencer/block_stream.rs
@@ -7,7 +7,7 @@ use std::{
 
 use astria_core::{
     primitive::v1::RollupId,
-    sequencerblock::v1::block::FilteredSequencerBlock,
+    sequencerblock::v1alpha1::block::FilteredSequencerBlock,
 };
 use astria_eyre::eyre::{
     self,

--- a/crates/astria-conductor/src/sequencer/builder.rs
+++ b/crates/astria-conductor/src/sequencer/builder.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use astria_core::sequencerblock::v1::block::FilteredSequencerBlock;
+use astria_core::sequencerblock::v1alpha1::block::FilteredSequencerBlock;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 

--- a/crates/astria-conductor/src/sequencer/client.rs
+++ b/crates/astria-conductor/src/sequencer/client.rs
@@ -16,6 +16,7 @@ use astria_eyre::eyre::{
 };
 use tonic::transport::{
     Channel,
+    ClientTlsConfig,
     Endpoint,
     Uri,
 };
@@ -38,7 +39,9 @@ impl SequencerGrpcClient {
         let uri: Uri = sequencer_uri
             .parse()
             .wrap_err("failed parsing provided string as Uri")?;
-        let endpoint = Endpoint::from(uri.clone());
+        let endpoint = Endpoint::from(uri.clone())
+            .tls_config(ClientTlsConfig::new().with_enabled_roots())
+            .wrap_err("failed to configure TLS for sequencer client")?;
         let inner = SequencerServiceClient::new(endpoint.connect_lazy());
         Ok(Self {
             inner,

--- a/crates/astria-conductor/src/sequencer/client.rs
+++ b/crates/astria-conductor/src/sequencer/client.rs
@@ -3,12 +3,12 @@
 use std::time::Duration;
 
 use astria_core::{
-    generated::astria::sequencerblock::v1::{
+    generated::astria::sequencerblock::v1alpha1::{
         sequencer_service_client::SequencerServiceClient,
         GetFilteredSequencerBlockRequest,
     },
     primitive::v1::RollupId,
-    sequencerblock::v1::block::FilteredSequencerBlock,
+    sequencerblock::v1alpha1::block::FilteredSequencerBlock,
 };
 use astria_eyre::eyre::{
     self,

--- a/crates/astria-conductor/src/sequencer/mod.rs
+++ b/crates/astria-conductor/src/sequencer/mod.rs
@@ -2,7 +2,7 @@
 
 use std::time::Duration;
 
-use astria_core::sequencerblock::v1::block::FilteredSequencerBlock;
+use astria_core::sequencerblock::v1alpha1::block::FilteredSequencerBlock;
 use astria_eyre::eyre::{
     self,
     bail,

--- a/crates/astria-conductor/src/sequencer/reporting.rs
+++ b/crates/astria-conductor/src/sequencer/reporting.rs
@@ -1,6 +1,6 @@
 use astria_core::{
     primitive::v1::RollupId,
-    sequencerblock::v1::block::{
+    sequencerblock::v1alpha1::block::{
         FilteredSequencerBlock,
         RollupTransactions,
     },
@@ -37,46 +37,5 @@ impl Serialize for ReportRollups<'_> {
             map.serialize_entry(id, &txes.transactions().len())?;
         }
         map.end()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use astria_core::{
-        primitive::v1::RollupId,
-        protocol::test_utils::ConfigureSequencerBlock,
-        sequencerblock::v1::block::FilteredSequencerBlock,
-    };
-    use insta::assert_json_snapshot;
-
-    use crate::sequencer::reporting::{
-        ReportFilteredSequencerBlock,
-        ReportRollups,
-    };
-
-    const ROLLUP_42: RollupId = RollupId::new([42u8; 32]);
-    const ROLLUP_69: RollupId = RollupId::new([69u8; 32]);
-
-    fn snapshot_block() -> FilteredSequencerBlock {
-        let block = ConfigureSequencerBlock {
-            height: 100,
-            sequence_data: vec![
-                (ROLLUP_42, b"hello".to_vec()),
-                (ROLLUP_42, b"hello world".to_vec()),
-                (ROLLUP_69, b"hello world".to_vec()),
-            ],
-            ..Default::default()
-        }
-        .make();
-
-        block.into_filtered_block([ROLLUP_42, ROLLUP_69])
-    }
-
-    #[test]
-    fn snapshots() {
-        let block = snapshot_block();
-
-        assert_json_snapshot!(ReportRollups(block.rollup_transactions()));
-        assert_json_snapshot!(ReportFilteredSequencerBlock(&block));
     }
 }

--- a/crates/astria-conductor/tests/blackbox/helpers/macros.rs
+++ b/crates/astria-conductor/tests/blackbox/helpers/macros.rs
@@ -53,7 +53,7 @@ macro_rules! celestia_network_head {
 #[macro_export]
 macro_rules! filtered_sequencer_block {
     (sequencer_height: $height:expr) => {{
-        let block = ::astria_core::protocol::test_utils::ConfigureSequencerBlock {
+        let block = ::astria_core::protocol::test_utils::ConfigureV1Alpha1SequencerBlock {
             height: $height,
             sequence_data: vec![($crate::ROLLUP_ID, $crate::helpers::data())],
             ..Default::default()
@@ -262,7 +262,6 @@ macro_rules! mount_execute_block {
                 "sessionId": $crate::helpers::EXECUTION_SESSION_ID,
                 "parentHash": $parent,
                 "transactions": [
-                    {"priceFeedData": {}},
                     {"sequencedData": BASE64_STANDARD.encode($crate::helpers::data())}
                 ],
             }),
@@ -312,7 +311,7 @@ macro_rules! mount_get_filtered_sequencer_block {
     ($test_env:ident, sequencer_height: $height:expr, delay: $delay:expr $(,)?) => {
         $test_env
             .mount_get_filtered_sequencer_block(
-                ::astria_core::generated::astria::sequencerblock::v1::GetFilteredSequencerBlockRequest {
+                ::astria_core::generated::astria::sequencerblock::v1alpha1::GetFilteredSequencerBlockRequest {
                     height: $height,
                     rollup_ids: vec![$crate::ROLLUP_ID.to_raw()],
                 },
@@ -498,7 +497,6 @@ macro_rules! mount_execute_block_tonic_code {
                 "sessionId": $crate::helpers::EXECUTION_SESSION_ID,
                 "parentHash": $parent,
                 "transactions": [
-                    {"priceFeedData": {}},
                     {"sequencedData": BASE64_STANDARD.encode($crate::helpers::data())}
                 ],
             }),

--- a/crates/astria-conductor/tests/blackbox/helpers/mock_grpc.rs
+++ b/crates/astria-conductor/tests/blackbox/helpers/mock_grpc.rs
@@ -3,40 +3,32 @@ use std::{
     sync::Arc,
 };
 
-use astria_core::generated::{
-    astria::{
-        execution::v2::{
-            execution_service_server::{
-                ExecutionService,
-                ExecutionServiceServer,
-            },
-            CommitmentState,
-            CreateExecutionSessionRequest,
-            ExecuteBlockRequest,
-            ExecuteBlockResponse,
-            ExecutedBlockMetadata,
-            ExecutionSession,
-            GetExecutedBlockMetadataRequest,
-            UpdateCommitmentStateRequest,
+use astria_core::generated::astria::{
+    execution::v2::{
+        execution_service_server::{
+            ExecutionService,
+            ExecutionServiceServer,
         },
-        sequencerblock::v1::{
-            sequencer_service_server::{
-                SequencerService,
-                SequencerServiceServer,
-            },
-            FilteredSequencerBlock,
-            GetFilteredSequencerBlockRequest,
-            GetPendingNonceRequest,
-            GetPendingNonceResponse,
-            GetSequencerBlockRequest,
-            SequencerBlock,
-        },
+        CommitmentState,
+        CreateExecutionSessionRequest,
+        ExecuteBlockRequest,
+        ExecuteBlockResponse,
+        ExecutedBlockMetadata,
+        ExecutionSession,
+        GetExecutedBlockMetadataRequest,
+        UpdateCommitmentStateRequest,
     },
-    sequencerblock::v1::{
-        GetUpgradesInfoRequest,
-        GetUpgradesInfoResponse,
-        GetValidatorNameRequest,
-        GetValidatorNameResponse,
+    sequencerblock::v1alpha1::{
+        sequencer_service_server::{
+            SequencerService,
+            SequencerServiceServer,
+        },
+        FilteredSequencerBlock,
+        GetFilteredSequencerBlockRequest,
+        GetPendingNonceRequest,
+        GetPendingNonceResponse,
+        GetSequencerBlockRequest,
+        SequencerBlock,
     },
 };
 use astria_eyre::eyre::{
@@ -123,20 +115,6 @@ impl SequencerService for SequencerServiceImpl {
         self: Arc<Self>,
         _request: Request<GetPendingNonceRequest>,
     ) -> tonic::Result<Response<GetPendingNonceResponse>> {
-        unimplemented!()
-    }
-
-    async fn get_upgrades_info(
-        self: Arc<Self>,
-        _request: Request<GetUpgradesInfoRequest>,
-    ) -> tonic::Result<Response<GetUpgradesInfoResponse>> {
-        unimplemented!()
-    }
-
-    async fn get_validator_name(
-        self: Arc<Self>,
-        _request: Request<GetValidatorNameRequest>,
-    ) -> tonic::Result<Response<GetValidatorNameResponse>> {
         unimplemented!()
     }
 }

--- a/crates/astria-core/src/generated/astria.execution.v2.rs
+++ b/crates/astria-core/src/generated/astria.execution.v2.rs
@@ -101,7 +101,7 @@ pub struct ExecuteBlockRequest {
     /// List of transactions to include in the new block.
     #[prost(message, repeated, tag = "3")]
     pub transactions: ::prost::alloc::vec::Vec<
-        super::super::sequencerblock::v1::RollupData,
+        super::super::sequencerblock::v1alpha1::RollupData,
     >,
     /// Timestamp to be used for new block.
     #[prost(message, optional, tag = "4")]

--- a/crates/astria-core/src/generated/astria.sequencerblock.v1alpha1.rs
+++ b/crates/astria-core/src/generated/astria.sequencerblock.v1alpha1.rs
@@ -179,8 +179,8 @@ pub struct FilteredSequencerBlock {
     /// and is extracted from `astria.SequencerBlock.rollup_transactions`.
     /// Note that these are all the rollup IDs in the sequencer block, not merely those in
     /// `rollup_transactions` field. This is necessary to prove that no rollup IDs were omitted.
-    #[prost(message, repeated, tag = "5")]
-    pub all_rollup_ids: ::prost::alloc::vec::Vec<super::super::primitive::v1::RollupId>,
+    #[prost(bytes = "bytes", repeated, tag = "5")]
+    pub all_rollup_ids: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
     /// The proof that the `rollup_ids` are included
     /// in the CometBFT block this sequencer block is derived form.
     ///

--- a/crates/astria-core/src/generated/astria.sequencerblock.v1alpha1.serde.rs
+++ b/crates/astria-core/src/generated/astria.sequencerblock.v1alpha1.serde.rs
@@ -242,7 +242,7 @@ impl serde::Serialize for FilteredSequencerBlock {
             struct_ser.serialize_field("rollupTransactionsProof", v)?;
         }
         if !self.all_rollup_ids.is_empty() {
-            struct_ser.serialize_field("allRollupIds", &self.all_rollup_ids)?;
+            struct_ser.serialize_field("allRollupIds", &self.all_rollup_ids.iter().map(pbjson::private::base64::encode).collect::<Vec<_>>())?;
         }
         if let Some(v) = self.rollup_ids_proof.as_ref() {
             struct_ser.serialize_field("rollupIdsProof", v)?;
@@ -362,7 +362,10 @@ impl<'de> serde::Deserialize<'de> for FilteredSequencerBlock {
                             if all_rollup_ids__.is_some() {
                                 return Err(serde::de::Error::duplicate_field("allRollupIds"));
                             }
-                            all_rollup_ids__ = Some(map_.next_value()?);
+                            all_rollup_ids__ = 
+                                Some(map_.next_value::<Vec<::pbjson::private::BytesDeserialize<_>>>()?
+                                    .into_iter().map(|x| x.0).collect())
+                            ;
                         }
                         GeneratedField::RollupIdsProof => {
                             if rollup_ids_proof__.is_some() {

--- a/crates/astria-core/src/protocol/test_utils.rs
+++ b/crates/astria-core/src/protocol/test_utils.rs
@@ -278,3 +278,140 @@ pub fn minimal_extended_commit_info_bytes() -> Bytes {
     )
     .encode()
 }
+
+/// Allows configuring a Comet BFT block setting the height, signing key and
+/// proposer address.
+///
+/// If the proposer address is not set it will be generated from the signing key.
+#[derive(Default)]
+pub struct ConfigureV1Alpha1SequencerBlock {
+    pub block_hash: Option<[u8; 32]>,
+    pub chain_id: Option<String>,
+    pub height: u32,
+    pub proposer_address: Option<tendermint::account::Id>,
+    pub signing_key: Option<SigningKey>,
+    pub sequence_data: Vec<(RollupId, Vec<u8>)>,
+    pub deposits: Vec<crate::sequencerblock::v1alpha1::block::Deposit>,
+    pub unix_timestamp: UnixTimeStamp,
+}
+
+impl ConfigureV1Alpha1SequencerBlock {
+    /// Construct a [`SequencerBlock`] with the configured parameters.
+    #[must_use]
+    #[expect(
+        clippy::missing_panics_doc,
+        clippy::too_many_lines,
+        reason = "This should only be used in tests, so everything here is unwrapped"
+    )]
+    pub fn make(self) -> crate::sequencerblock::v1alpha1::SequencerBlock {
+        use tendermint::Time;
+
+        use crate::{
+            protocol::transaction::v1::Action,
+            sequencerblock::v1alpha1::block::{
+                Deposit,
+                RollupData,
+            },
+        };
+
+        let Self {
+            block_hash,
+            chain_id,
+            height,
+            signing_key,
+            proposer_address,
+            sequence_data,
+            unix_timestamp,
+            deposits,
+        } = self;
+
+        let block_hash = block_hash.unwrap_or([0; 32]);
+        let chain_id = chain_id.unwrap_or_else(|| "test".to_string());
+
+        let signing_key = signing_key.unwrap_or_else(|| SigningKey::new(rand::rngs::OsRng));
+
+        let proposer_address = proposer_address.unwrap_or_else(|| {
+            let public_key: tendermint::crypto::ed25519::VerificationKey =
+                signing_key.verification_key().as_ref().try_into().unwrap();
+            tendermint::account::Id::from(public_key)
+        });
+
+        let actions: Vec<Action> = sequence_data
+            .into_iter()
+            .map(|(rollup_id, data)| {
+                RollupDataSubmission {
+                    rollup_id,
+                    data: data.into(),
+                    fee_asset: "nria".parse().unwrap(),
+                }
+                .into()
+            })
+            .collect();
+        let txs = if actions.is_empty() {
+            vec![]
+        } else {
+            let body = TransactionBody::builder()
+                .actions(actions)
+                .chain_id(chain_id.clone())
+                .nonce(1)
+                .try_build()
+                .expect(
+                    "should be able to build transaction body since only rollup data submission \
+                     actions are contained",
+                );
+            vec![body.sign(&signing_key)]
+        };
+        let mut deposits_map: HashMap<RollupId, Vec<Deposit>> = HashMap::new();
+        for deposit in deposits {
+            if let Some(entry) = deposits_map.get_mut(&deposit.rollup_id) {
+                entry.push(deposit);
+            } else {
+                deposits_map.insert(deposit.rollup_id, vec![deposit]);
+            }
+        }
+
+        let mut rollup_transactions =
+            group_rollup_data_submissions_in_signed_transaction_transactions_by_rollup_id(
+                txs.iter()
+                    .map(|tx| Arc::new(tx.clone()))
+                    .collect::<Vec<_>>()
+                    .as_slice(),
+            );
+        for (rollup_id, deposit) in deposits_map.clone() {
+            rollup_transactions
+                .entry(rollup_id)
+                .or_default()
+                .extend(deposit.into_iter().map(|deposit| {
+                    RollupData::Deposit(Box::new(deposit))
+                        .into_raw()
+                        .encode_to_vec()
+                        .into()
+                }));
+        }
+        rollup_transactions.sort_unstable_keys();
+        let rollup_transactions_tree = derive_merkle_tree_from_rollup_txs(&rollup_transactions);
+
+        let rollup_ids_root = merkle::Tree::from_leaves(
+            rollup_transactions
+                .keys()
+                .map(|rollup_id| rollup_id.as_ref().to_vec()),
+        )
+        .root();
+        let mut data = vec![
+            rollup_transactions_tree.root().to_vec(),
+            rollup_ids_root.to_vec(),
+        ];
+        data.extend(txs.into_iter().map(|tx| tx.into_raw().encode_to_vec()));
+        let data = data.into_iter().map(Bytes::from).collect();
+        crate::sequencerblock::v1alpha1::SequencerBlock::try_from_block_info_and_data(
+            block_hash,
+            chain_id.try_into().unwrap(),
+            height.into(),
+            Time::from_unix_timestamp(unix_timestamp.secs, unix_timestamp.nanos).unwrap(),
+            proposer_address,
+            data,
+            deposits_map,
+        )
+        .unwrap()
+    }
+}

--- a/crates/astria-core/src/sequencerblock/mod.rs
+++ b/crates/astria-core/src/sequencerblock/mod.rs
@@ -1,2 +1,3 @@
 pub mod optimistic;
 pub mod v1;
+pub mod v1alpha1;

--- a/crates/astria-core/src/sequencerblock/v1alpha1/block.rs
+++ b/crates/astria-core/src/sequencerblock/v1alpha1/block.rs
@@ -1360,8 +1360,12 @@ impl FilteredSequencerBlockError {
 ///
 /// A [`Deposit`] is constructed whenever a [`BridgeLockAction`] is executed
 /// and stored as part of the block's events.
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
-#[serde(into = "crate::generated::astria::sequencerblock::v1alpha1::Deposit")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize),
+    serde(into = "crate::generated::astria::sequencerblock::v1alpha1::Deposit")
+)]
 pub struct Deposit {
     // the address on the sequencer to which the funds were sent to.
     pub bridge_address: Address,

--- a/crates/astria-core/src/sequencerblock/v1alpha1/block.rs
+++ b/crates/astria-core/src/sequencerblock/v1alpha1/block.rs
@@ -1,0 +1,1568 @@
+use std::{
+    collections::HashMap,
+    vec::IntoIter,
+};
+
+use bytes::Bytes;
+use indexmap::IndexMap;
+use sha2::Sha256;
+use tendermint::{
+    account,
+    Time,
+};
+
+use super::{
+    are_rollup_ids_included,
+    are_rollup_txs_included,
+    celestia::{
+        self,
+        SubmittedMetadata,
+        SubmittedRollupData,
+    },
+    raw,
+};
+use crate::{
+    primitive::v1::{
+        asset,
+        derive_merkle_tree_from_rollup_txs,
+        Address,
+        AddressError,
+        IncorrectRollupIdLength,
+        RollupId,
+        TransactionId,
+        TransactionIdError,
+    },
+    protocol::transaction::v1::{
+        action,
+        Transaction,
+        TransactionError,
+    },
+    Protobuf as _,
+};
+
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub struct RollupTransactionsError(RollupTransactionsErrorKind);
+
+impl RollupTransactionsError {
+    fn rollup_id(source: IncorrectRollupIdLength) -> Self {
+        Self(RollupTransactionsErrorKind::RollupId(source))
+    }
+
+    fn field_not_set(field: &'static str) -> Self {
+        Self(RollupTransactionsErrorKind::FieldNotSet(field))
+    }
+
+    fn proof_invalid(source: merkle::audit::InvalidProof) -> Self {
+        Self(RollupTransactionsErrorKind::ProofInvalid(source))
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum RollupTransactionsErrorKind {
+    #[error("`id` field is invalid")]
+    RollupId(#[source] IncorrectRollupIdLength),
+    #[error("the expected field in the raw source type was not set: `{0}`")]
+    FieldNotSet(&'static str),
+    #[error("failed constructing a proof from the raw protobuf `proof` field")]
+    ProofInvalid(#[source] merkle::audit::InvalidProof),
+}
+
+/// The individual parts that make up a [`RollupTransactions`] type.
+///
+/// Provides convenient access to the fields of [`RollupTransactions`].
+#[derive(Clone, Debug, PartialEq)]
+pub struct RollupTransactionsParts {
+    pub rollup_id: RollupId,
+    pub transactions: Vec<Bytes>,
+    pub proof: merkle::Proof,
+}
+
+/// The opaque transactions belonging to a rollup identified by its rollup ID.
+#[derive(Clone, Debug, PartialEq)]
+pub struct RollupTransactions {
+    /// The 32 bytes identifying a rollup. Usually the sha256 hash of a plain rollup name.
+    rollup_id: RollupId,
+    /// The block data for this rollup in the form of encoded [`RollupData`].
+    transactions: Vec<Bytes>,
+    /// Proof that this set of transactions belongs in the rollup datas merkle tree
+    proof: merkle::Proof,
+}
+
+impl RollupTransactions {
+    /// Returns the [`RollupId`] identifying the rollup these transactions belong to.
+    #[must_use]
+    pub fn rollup_id(&self) -> &RollupId {
+        &self.rollup_id
+    }
+
+    /// Returns the block data for this rollup.
+    #[must_use]
+    pub fn transactions(&self) -> &[Bytes] {
+        &self.transactions
+    }
+
+    /// Returns the merkle proof that these transactions were included
+    /// in the `action_tree_commitment`.
+    #[must_use]
+    pub fn proof(&self) -> &merkle::Proof {
+        &self.proof
+    }
+
+    /// Transforms these rollup transactions into their raw representation, which can in turn be
+    /// encoded as protobuf.
+    #[must_use]
+    pub fn into_raw(self) -> raw::RollupTransactions {
+        let Self {
+            rollup_id,
+            transactions,
+            proof,
+        } = self;
+        let transactions = transactions.into_iter().map(Into::into).collect();
+        raw::RollupTransactions {
+            rollup_id: Some(rollup_id.into_raw()),
+            transactions,
+            proof: Some(proof.into_raw()),
+        }
+    }
+
+    /// Attempts to transform the rollup transactions from their raw representation.
+    ///
+    /// # Errors
+    /// Returns an error if the rollup ID bytes could not be turned into a [`RollupId`].
+    pub fn try_from_raw(raw: raw::RollupTransactions) -> Result<Self, RollupTransactionsError> {
+        let raw::RollupTransactions {
+            rollup_id,
+            transactions,
+            proof,
+        } = raw;
+        let Some(rollup_id) = rollup_id else {
+            return Err(RollupTransactionsError::field_not_set("rollup_id"));
+        };
+        let rollup_id =
+            RollupId::try_from_raw(rollup_id).map_err(RollupTransactionsError::rollup_id)?;
+        let proof = 'proof: {
+            let Some(proof) = proof else {
+                break 'proof Err(RollupTransactionsError::field_not_set("proof"));
+            };
+            merkle::Proof::try_from_raw(proof).map_err(RollupTransactionsError::proof_invalid)
+        }?;
+        let transactions = transactions.into_iter().map(Into::into).collect();
+        Ok(Self {
+            rollup_id,
+            transactions,
+            proof,
+        })
+    }
+
+    /// Convert [`RollupTransactions`] into [`RollupTransactionsParts`].
+    #[must_use]
+    pub fn into_parts(self) -> RollupTransactionsParts {
+        let Self {
+            rollup_id,
+            transactions,
+            proof,
+        } = self;
+        RollupTransactionsParts {
+            rollup_id,
+            transactions,
+            proof,
+        }
+    }
+
+    /// This should only be used where `parts` has been provided by a trusted entity, e.g. read from
+    /// our own state store.
+    ///
+    /// Note that this function is not considered part of the public API and is subject to breaking
+    /// change at any time.
+    #[cfg(feature = "unchecked-constructors")]
+    #[doc(hidden)]
+    #[must_use]
+    pub fn unchecked_from_parts(parts: RollupTransactionsParts) -> Self {
+        let RollupTransactionsParts {
+            rollup_id,
+            transactions,
+            proof,
+        } = parts;
+        Self {
+            rollup_id,
+            transactions,
+            proof,
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub struct SequencerBlockError(SequencerBlockErrorKind);
+
+impl SequencerBlockError {
+    fn invalid_block_hash(length: usize) -> Self {
+        Self(SequencerBlockErrorKind::InvalidBlockHash(length))
+    }
+
+    fn field_not_set(field: &'static str) -> Self {
+        Self(SequencerBlockErrorKind::FieldNotSet(field))
+    }
+
+    fn header(source: SequencerBlockHeaderError) -> Self {
+        Self(SequencerBlockErrorKind::Header(source))
+    }
+
+    fn parse_rollup_transactions(source: RollupTransactionsError) -> Self {
+        Self(SequencerBlockErrorKind::ParseRollupTransactions(source))
+    }
+
+    fn transaction_proof_invalid(source: merkle::audit::InvalidProof) -> Self {
+        Self(SequencerBlockErrorKind::TransactionProofInvalid(source))
+    }
+
+    fn id_proof_invalid(source: merkle::audit::InvalidProof) -> Self {
+        Self(SequencerBlockErrorKind::IdProofInvalid(source))
+    }
+
+    fn no_rollup_transactions_root() -> Self {
+        Self(SequencerBlockErrorKind::NoRollupTransactionsRoot)
+    }
+
+    fn incorrect_rollup_transactions_root_length(len: usize) -> Self {
+        Self(SequencerBlockErrorKind::IncorrectRollupTransactionsRootLength(len))
+    }
+
+    fn no_rollup_ids_root() -> Self {
+        Self(SequencerBlockErrorKind::NoRollupIdsRoot)
+    }
+
+    fn incorrect_rollup_ids_root_length(len: usize) -> Self {
+        Self(SequencerBlockErrorKind::IncorrectRollupIdsRootLength(len))
+    }
+
+    fn rollup_transactions_not_in_sequencer_block() -> Self {
+        Self(SequencerBlockErrorKind::RollupTransactionsNotInSequencerBlock)
+    }
+
+    fn rollup_ids_not_in_sequencer_block() -> Self {
+        Self(SequencerBlockErrorKind::RollupIdsNotInSequencerBlock)
+    }
+
+    fn transaction_protobuf_decode(source: prost::DecodeError) -> Self {
+        Self(SequencerBlockErrorKind::TransactionProtobufDecode(source))
+    }
+
+    fn raw_signed_transaction_conversion(source: TransactionError) -> Self {
+        Self(SequencerBlockErrorKind::RawTransactionConversion(source))
+    }
+
+    fn rollup_transactions_root_does_not_match_reconstructed() -> Self {
+        Self(SequencerBlockErrorKind::RollupTransactionsRootDoesNotMatchReconstructed)
+    }
+
+    fn rollup_ids_root_does_not_match_reconstructed() -> Self {
+        Self(SequencerBlockErrorKind::RollupIdsRootDoesNotMatchReconstructed)
+    }
+
+    fn invalid_rollup_transactions_root() -> Self {
+        Self(SequencerBlockErrorKind::InvalidRollupTransactionsRoot)
+    }
+
+    fn invalid_rollup_ids_proof() -> Self {
+        Self(SequencerBlockErrorKind::InvalidRollupIdsProof)
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum SequencerBlockErrorKind {
+    #[error("the block hash was expected to be 32 bytes long, but was actually `{0}`")]
+    InvalidBlockHash(usize),
+    #[error("the expected field in the raw source type was not set: `{0}`")]
+    FieldNotSet(&'static str),
+    #[error("failed constructing a sequencer block header from the raw protobuf header")]
+    Header(#[source] SequencerBlockHeaderError),
+    #[error(
+        "failed parsing a raw protobuf rollup transaction because it contained an invalid rollup \
+         ID"
+    )]
+    ParseRollupTransactions(#[source] RollupTransactionsError),
+    #[error("failed constructing a transaction proof from the raw protobuf transaction proof")]
+    TransactionProofInvalid(#[source] merkle::audit::InvalidProof),
+    #[error("failed constructing a rollup ID proof from the raw protobuf rollup ID proof")]
+    IdProofInvalid(#[source] merkle::audit::InvalidProof),
+    #[error(
+        "the cometbft block.data field was too short and did not contain the rollup transaction \
+         root"
+    )]
+    NoRollupTransactionsRoot,
+    #[error(
+        "the rollup transaction root in the cometbft block.data field was expected to be 32 bytes \
+         long, but was actually `{0}`"
+    )]
+    IncorrectRollupTransactionsRootLength(usize),
+    #[error("the cometbft block.data field was too short and did not contain the rollup ID root")]
+    NoRollupIdsRoot,
+    #[error(
+        "the rollup ID root in the cometbft block.data field was expected to be 32 bytes long, \
+         but was actually `{0}`"
+    )]
+    IncorrectRollupIdsRootLength(usize),
+    #[error(
+        "the Merkle Tree Hash derived from the rollup transactions recorded in the raw protobuf \
+         sequencer block could not be verified against their proof and the block's data hash"
+    )]
+    RollupTransactionsNotInSequencerBlock,
+    #[error(
+        "the Merkle Tree Hash derived from the rollup IDs recorded in the raw protobuf sequencer \
+         block could not be verified against their proof and the block's data hash"
+    )]
+    RollupIdsNotInSequencerBlock,
+    #[error(
+        "failed decoding an entry in the cometbft block.data field as a protobuf astria \
+         transaction"
+    )]
+    TransactionProtobufDecode(#[source] prost::DecodeError),
+    #[error(
+        "failed converting a raw protobuf transaction decoded from the cometbft block.data
+        field to a native astria transaction"
+    )]
+    RawTransactionConversion(#[source] TransactionError),
+    #[error(
+        "the root derived from the rollup transactions in the cometbft block.data field did not \
+         match the root stored in the same block.data field"
+    )]
+    RollupTransactionsRootDoesNotMatchReconstructed,
+    #[error(
+        "the root derived from the rollup IDs in the cometbft block.data field did not match the \
+         root stored in the same block.data field"
+    )]
+    RollupIdsRootDoesNotMatchReconstructed,
+    #[error(
+        "the rollup transactions root in the header did not verify against data_hash given the \
+         rollup transactions proof"
+    )]
+    InvalidRollupTransactionsRoot,
+    #[error(
+        "the rollup IDs root constructed from the block's rollup IDs did not verify against \
+         data_hash given the rollup IDs proof"
+    )]
+    InvalidRollupIdsProof,
+}
+
+/// The individual parts that make up a [`SequencerBlockHeader`].
+///
+/// This type exists to provide convenient access to the fields of
+/// a `[SequencerBlockHeader]`.
+#[derive(Debug, PartialEq)]
+pub struct SequencerBlockHeaderParts {
+    pub chain_id: tendermint::chain::Id,
+    pub height: tendermint::block::Height,
+    pub time: Time,
+    pub rollup_transactions_root: [u8; 32],
+    pub data_hash: [u8; 32],
+    pub proposer_address: account::Id,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SequencerBlockHeader {
+    chain_id: tendermint::chain::Id,
+    height: tendermint::block::Height,
+    time: Time,
+    // the 32-byte merkle root of all the rollup transactions in the block
+    rollup_transactions_root: [u8; 32],
+    data_hash: [u8; 32],
+    proposer_address: account::Id,
+}
+
+impl SequencerBlockHeader {
+    #[must_use]
+    pub fn chain_id(&self) -> &tendermint::chain::Id {
+        &self.chain_id
+    }
+
+    #[must_use]
+    pub fn height(&self) -> tendermint::block::Height {
+        self.height
+    }
+
+    #[must_use]
+    pub fn time(&self) -> Time {
+        self.time
+    }
+
+    #[must_use]
+    pub fn rollup_transactions_root(&self) -> &[u8; 32] {
+        &self.rollup_transactions_root
+    }
+
+    #[must_use]
+    pub fn data_hash(&self) -> &[u8; 32] {
+        &self.data_hash
+    }
+
+    #[must_use]
+    pub fn proposer_address(&self) -> &account::Id {
+        &self.proposer_address
+    }
+
+    /// Convert [`SequencerBlockHeader`] into its [`SequencerBlockHeaderParts`].
+    #[must_use]
+    pub fn into_parts(self) -> SequencerBlockHeaderParts {
+        let Self {
+            chain_id,
+            height,
+            time,
+            rollup_transactions_root,
+            data_hash,
+            proposer_address,
+        } = self;
+        SequencerBlockHeaderParts {
+            chain_id,
+            height,
+            time,
+            rollup_transactions_root,
+            data_hash,
+            proposer_address,
+        }
+    }
+
+    #[must_use]
+    pub fn into_raw(self) -> raw::SequencerBlockHeader {
+        let time: tendermint_proto::google::protobuf::Timestamp = self.time.into();
+        raw::SequencerBlockHeader {
+            chain_id: self.chain_id.to_string(),
+            height: self.height.value(),
+            time: Some(pbjson_types::Timestamp {
+                seconds: time.seconds,
+                nanos: time.nanos,
+            }),
+            rollup_transactions_root: Bytes::copy_from_slice(&self.rollup_transactions_root),
+            data_hash: Bytes::copy_from_slice(&self.data_hash),
+            proposer_address: Bytes::copy_from_slice(self.proposer_address.as_bytes()),
+        }
+    }
+
+    /// Attempts to transform the sequencer block header from its raw representation.
+    ///
+    /// # Errors
+    ///
+    /// - If the `cometbft_header` field is not set.
+    /// - If the `cometbft_header` field cannot be converted.
+    /// - If the `rollup_transactions_root` field is not 32 bytes long.
+    pub fn try_from_raw(raw: raw::SequencerBlockHeader) -> Result<Self, SequencerBlockHeaderError> {
+        let raw::SequencerBlockHeader {
+            chain_id,
+            height,
+            time,
+            rollup_transactions_root,
+            data_hash,
+            proposer_address,
+            ..
+        } = raw;
+
+        let chain_id = tendermint::chain::Id::try_from(chain_id)
+            .map_err(SequencerBlockHeaderError::invalid_chain_id)?;
+
+        let height = tendermint::block::Height::try_from(height)
+            .map_err(SequencerBlockHeaderError::invalid_height)?;
+
+        let Some(time) = time else {
+            return Err(SequencerBlockHeaderError::field_not_set("time"));
+        };
+        let time = Time::try_from(tendermint_proto::google::protobuf::Timestamp {
+            seconds: time.seconds,
+            nanos: time.nanos,
+        })
+        .map_err(SequencerBlockHeaderError::time)?;
+
+        let rollup_transactions_root =
+            rollup_transactions_root.as_ref().try_into().map_err(|_| {
+                SequencerBlockHeaderError::incorrect_rollup_transactions_root_length(
+                    rollup_transactions_root.len(),
+                )
+            })?;
+
+        let data_hash = data_hash.as_ref().try_into().map_err(|_| {
+            SequencerBlockHeaderError::incorrect_rollup_transactions_root_length(data_hash.len())
+        })?;
+
+        let proposer_address = account::Id::try_from(proposer_address)
+            .map_err(SequencerBlockHeaderError::proposer_address)?;
+
+        Ok(Self {
+            chain_id,
+            height,
+            time,
+            rollup_transactions_root,
+            data_hash,
+            proposer_address,
+        })
+    }
+
+    /// This should only be used where `parts` has been provided by a trusted entity, e.g. read from
+    /// our own state store.
+    ///
+    /// Note that this function is not considered part of the public API and is subject to breaking
+    /// change at any time.
+    #[cfg(feature = "unchecked-constructors")]
+    #[doc(hidden)]
+    #[must_use]
+    pub fn unchecked_from_parts(parts: SequencerBlockHeaderParts) -> Self {
+        let SequencerBlockHeaderParts {
+            chain_id,
+            height,
+            time,
+            rollup_transactions_root,
+            data_hash,
+            proposer_address,
+        } = parts;
+        Self {
+            chain_id,
+            height,
+            time,
+            rollup_transactions_root,
+            data_hash,
+            proposer_address,
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub struct SequencerBlockHeaderError(SequencerBlockHeaderErrorKind);
+
+impl SequencerBlockHeaderError {
+    fn invalid_chain_id(source: tendermint::Error) -> Self {
+        Self(SequencerBlockHeaderErrorKind::InvalidChainId(source))
+    }
+
+    fn invalid_height(source: tendermint::Error) -> Self {
+        Self(SequencerBlockHeaderErrorKind::InvalidHeight(source))
+    }
+
+    fn field_not_set(field: &'static str) -> Self {
+        Self(SequencerBlockHeaderErrorKind::FieldNotSet(field))
+    }
+
+    fn time(source: tendermint::Error) -> Self {
+        Self(SequencerBlockHeaderErrorKind::Time(source))
+    }
+
+    fn incorrect_rollup_transactions_root_length(len: usize) -> Self {
+        Self(SequencerBlockHeaderErrorKind::IncorrectRollupTransactionsRootLength(len))
+    }
+
+    fn proposer_address(source: tendermint::Error) -> Self {
+        Self(SequencerBlockHeaderErrorKind::ProposerAddress(source))
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum SequencerBlockHeaderErrorKind {
+    #[error("the chain ID in the raw protobuf sequencer block header was invalid")]
+    InvalidChainId(#[source] tendermint::Error),
+    #[error("the height in the raw protobuf sequencer block header was invalid")]
+    InvalidHeight(#[source] tendermint::Error),
+    #[error("the expected field in the raw source type was not set: `{0}`")]
+    FieldNotSet(&'static str),
+    #[error("failed to create a tendermint time from the raw protobuf time")]
+    Time(#[source] tendermint::Error),
+    #[error(
+        "the rollup transaction root in the cometbft block.data field was expected to be 32 bytes \
+         long, but was actually `{0}`"
+    )]
+    IncorrectRollupTransactionsRootLength(usize),
+    #[error(
+        "the proposer address in the raw protobuf sequencer block header was not 20 bytes long"
+    )]
+    ProposerAddress(#[source] tendermint::Error),
+}
+
+/// The individual parts that make up a [`SequencerBlock`].
+///
+/// Exists to provide convenient access to fields of a [`SequencerBlock`].
+#[derive(Clone, Debug, PartialEq)]
+pub struct SequencerBlockParts {
+    pub block_hash: [u8; 32],
+    pub header: SequencerBlockHeader,
+    pub rollup_transactions: IndexMap<RollupId, RollupTransactions>,
+    pub rollup_transactions_proof: merkle::Proof,
+    pub rollup_ids_proof: merkle::Proof,
+}
+
+/// `SequencerBlock` is constructed from a tendermint/cometbft block by
+/// converting its opaque `data` bytes into sequencer specific types.
+#[derive(Clone, Debug, PartialEq)]
+#[expect(
+    clippy::module_name_repetitions,
+    reason = "we want consistent and specific naming"
+)]
+pub struct SequencerBlock {
+    /// The result of hashing the cometbft header. Guaranteed to not be `None` as compared to
+    /// the cometbft/tendermint-rs return type.
+    block_hash: [u8; 32],
+    /// the block header, which contains the cometbft header and additional sequencer-specific
+    /// commitments.
+    header: SequencerBlockHeader,
+    /// The collection of rollup transactions that were included in this block.
+    rollup_transactions: IndexMap<RollupId, RollupTransactions>,
+    /// The proof that the rollup transactions are included in the `CometBFT` block this
+    /// sequencer block is derived form. This proof together with
+    /// `Sha256(MTH(rollup_transactions))` must match `header.data_hash`.
+    /// `MTH(rollup_transactions)` is the Merkle Tree Hash derived from the
+    /// rollup transactions.
+    rollup_transactions_proof: merkle::Proof,
+    /// The proof that the rollup IDs listed in `rollup_transactions` are included
+    /// in the `CometBFT` block this sequencer block is derived form. This proof together
+    /// with `Sha256(MTH(rollup_ids))` must match `header.data_hash`.
+    /// `MTH(rollup_ids)` is the Merkle Tree Hash derived from the rollup IDs listed in
+    /// the rollup transactions.
+    rollup_ids_proof: merkle::Proof,
+}
+
+impl SequencerBlock {
+    /// Returns the hash of the `CometBFT` block this sequencer block is derived from.
+    ///
+    /// This is done by hashing the `CometBFT` header stored in this block.
+    #[must_use]
+    pub fn block_hash(&self) -> &[u8; 32] {
+        &self.block_hash
+    }
+
+    #[must_use]
+    pub fn header(&self) -> &SequencerBlockHeader {
+        &self.header
+    }
+
+    /// The height stored in this sequencer block.
+    #[must_use]
+    pub fn height(&self) -> tendermint::block::Height {
+        self.header.height
+    }
+
+    #[must_use]
+    pub fn rollup_transactions(&self) -> &IndexMap<RollupId, RollupTransactions> {
+        &self.rollup_transactions
+    }
+
+    #[must_use]
+    pub fn rollup_transactions_proof(&self) -> &merkle::Proof {
+        &self.rollup_transactions_proof
+    }
+
+    #[must_use]
+    pub fn rollup_ids_proof(&self) -> &merkle::Proof {
+        &self.rollup_ids_proof
+    }
+
+    /// Converts a [`SequencerBlock`] into its [`SequencerBlockParts`].
+    #[must_use]
+    pub fn into_parts(self) -> SequencerBlockParts {
+        let Self {
+            block_hash,
+            header,
+            rollup_transactions,
+            rollup_transactions_proof,
+            rollup_ids_proof,
+        } = self;
+        SequencerBlockParts {
+            block_hash,
+            header,
+            rollup_transactions,
+            rollup_transactions_proof,
+            rollup_ids_proof,
+        }
+    }
+
+    /// Returns the map of rollup transactions, consuming `self`.
+    #[must_use]
+    pub fn into_rollup_transactions(self) -> IndexMap<RollupId, RollupTransactions> {
+        self.rollup_transactions
+    }
+
+    #[must_use]
+    pub fn into_raw(self) -> raw::SequencerBlock {
+        let Self {
+            block_hash,
+            header,
+            rollup_transactions,
+            rollup_transactions_proof,
+            rollup_ids_proof,
+        } = self;
+        raw::SequencerBlock {
+            block_hash: Bytes::copy_from_slice(&block_hash),
+            header: Some(header.into_raw()),
+            rollup_transactions: rollup_transactions
+                .into_values()
+                .map(RollupTransactions::into_raw)
+                .collect(),
+            rollup_transactions_proof: Some(rollup_transactions_proof.into_raw()),
+            rollup_ids_proof: Some(rollup_ids_proof.into_raw()),
+        }
+    }
+
+    #[must_use]
+    pub fn into_filtered_block<I, R>(mut self, rollup_ids: I) -> FilteredSequencerBlock
+    where
+        I: IntoIterator<Item = R>,
+        RollupId: From<R>,
+    {
+        let all_rollup_ids: Vec<RollupId> = self.rollup_transactions.keys().copied().collect();
+
+        let mut filtered_rollup_transactions = IndexMap::new();
+        for id in rollup_ids {
+            let id = id.into();
+            if let Some(rollup_transactions) = self.rollup_transactions.shift_remove(&id) {
+                filtered_rollup_transactions.insert(id, rollup_transactions);
+            };
+        }
+
+        FilteredSequencerBlock {
+            block_hash: self.block_hash,
+            header: self.header,
+            rollup_transactions: filtered_rollup_transactions,
+            rollup_transactions_proof: self.rollup_transactions_proof,
+            all_rollup_ids,
+            rollup_ids_proof: self.rollup_ids_proof,
+        }
+    }
+
+    #[must_use]
+    pub fn to_filtered_block<I, R>(&self, rollup_ids: I) -> FilteredSequencerBlock
+    where
+        I: IntoIterator<Item = R>,
+        RollupId: From<R>,
+    {
+        let all_rollup_ids: Vec<RollupId> = self.rollup_transactions.keys().copied().collect();
+
+        let mut filtered_rollup_transactions = IndexMap::new();
+        for id in rollup_ids {
+            let id = id.into();
+            if let Some(rollup_transactions) = self.rollup_transactions.get(&id).cloned() {
+                filtered_rollup_transactions.insert(id, rollup_transactions);
+            };
+        }
+
+        FilteredSequencerBlock {
+            block_hash: self.block_hash,
+            header: self.header.clone(),
+            rollup_transactions: filtered_rollup_transactions,
+            rollup_transactions_proof: self.rollup_transactions_proof.clone(),
+            all_rollup_ids,
+            rollup_ids_proof: self.rollup_ids_proof.clone(),
+        }
+    }
+
+    /// Turn the sequencer block into a [`SubmittedMetadata`] and list of [`SubmittedRollupData`].
+    #[must_use]
+    pub fn split_for_celestia(self) -> (SubmittedMetadata, Vec<SubmittedRollupData>) {
+        celestia::PreparedBlock::from_sequencer_block(self).into_parts()
+    }
+
+    /// Converts from relevant header fields and the block data.
+    ///
+    /// # Errors
+    /// TODO(https://github.com/astriaorg/astria/issues/612)
+    ///
+    /// # Panics
+    ///
+    /// - if a rollup data merkle proof cannot be constructed.
+    pub fn try_from_block_info_and_data(
+        block_hash: [u8; 32],
+        chain_id: tendermint::chain::Id,
+        height: tendermint::block::Height,
+        time: Time,
+        proposer_address: account::Id,
+        data: Vec<Bytes>,
+        deposits: HashMap<RollupId, Vec<Deposit>>,
+    ) -> Result<Self, SequencerBlockError> {
+        use prost::Message as _;
+
+        let tree = merkle_tree_from_data(&data);
+        let data_hash = tree.root();
+
+        let mut data_list = data.into_iter();
+        let (rollup_transactions_root, rollup_ids_root) =
+            rollup_transactions_and_ids_root_from_data(&mut data_list)?;
+
+        let mut rollup_datas = IndexMap::new();
+        for elem in data_list {
+            let raw_tx =
+                crate::generated::astria::protocol::transaction::v1::Transaction::decode(&*elem)
+                    .map_err(SequencerBlockError::transaction_protobuf_decode)?;
+            let tx = Transaction::try_from_raw(raw_tx)
+                .map_err(SequencerBlockError::raw_signed_transaction_conversion)?;
+            for action in tx.into_unsigned().into_actions() {
+                // XXX: The fee asset is dropped. We shjould explain why that's ok.
+                if let action::Action::RollupDataSubmission(action::RollupDataSubmission {
+                    rollup_id,
+                    data,
+                    fee_asset: _,
+                }) = action
+                {
+                    let elem = rollup_datas.entry(rollup_id).or_insert(vec![]);
+                    let data = RollupData::SequencedData(data)
+                        .into_raw()
+                        .encode_to_vec()
+                        .into();
+                    elem.push(data);
+                }
+            }
+        }
+        for (id, deposits) in deposits {
+            rollup_datas
+                .entry(id)
+                .or_default()
+                .extend(deposits.into_iter().map(|deposit| {
+                    RollupData::Deposit(Box::new(deposit))
+                        .into_raw()
+                        .encode_to_vec()
+                        .into()
+                }));
+        }
+
+        // XXX: The rollup data must be sorted by its keys before constructing the merkle tree.
+        // Since it's constructed from non-deterministically ordered sources, there is otherwise no
+        // guarantee that the same data will give the root.
+        rollup_datas.sort_unstable_keys();
+
+        // ensure the rollup IDs commitment matches the one calculated from the rollup data
+        if rollup_ids_root != merkle::Tree::from_leaves(rollup_datas.keys()).root() {
+            return Err(SequencerBlockError::rollup_ids_root_does_not_match_reconstructed());
+        }
+
+        let rollup_transaction_tree = derive_merkle_tree_from_rollup_txs(&rollup_datas);
+        if rollup_transactions_root != rollup_transaction_tree.root() {
+            return Err(
+                SequencerBlockError::rollup_transactions_root_does_not_match_reconstructed(),
+            );
+        }
+
+        let mut rollup_transactions = IndexMap::new();
+        for (i, (rollup_id, data)) in rollup_datas.into_iter().enumerate() {
+            let proof = rollup_transaction_tree
+                .construct_proof(i)
+                .expect("the proof must exist because the tree was derived with the same leaf");
+            rollup_transactions.insert(
+                rollup_id,
+                RollupTransactions {
+                    rollup_id,
+                    transactions: data, // TODO: rename this field?
+                    proof,
+                },
+            );
+        }
+        rollup_transactions.sort_unstable_keys();
+
+        // action tree root is always the first tx in a block
+        let rollup_transactions_proof = tree.construct_proof(0).expect(
+            "the tree has at least one leaf; if this line is reached and `construct_proof` \
+             returns None it means that the short circuiting checks above it have been removed",
+        );
+
+        let rollup_ids_proof = tree.construct_proof(1).expect(
+            "the tree has at least two leaves; if this line is reached and `construct_proof` \
+             returns None it means that the short circuiting checks above it have been removed",
+        );
+
+        Ok(Self {
+            block_hash,
+            header: SequencerBlockHeader {
+                chain_id,
+                height,
+                time,
+                rollup_transactions_root,
+                data_hash,
+                proposer_address,
+            },
+            rollup_transactions,
+            rollup_transactions_proof,
+            rollup_ids_proof,
+        })
+    }
+
+    /// Converts from the raw decoded protobuf representation of this type.
+    ///
+    /// # Errors
+    /// TODO(https://github.com/astriaorg/astria/issues/612)
+    pub fn try_from_raw(raw: raw::SequencerBlock) -> Result<Self, SequencerBlockError> {
+        use sha2::Digest as _;
+
+        fn rollup_txs_to_tuple(
+            raw: raw::RollupTransactions,
+        ) -> Result<(RollupId, RollupTransactions), RollupTransactionsError> {
+            let rollup_transactions = RollupTransactions::try_from_raw(raw)?;
+            Ok((rollup_transactions.rollup_id, rollup_transactions))
+        }
+
+        let raw::SequencerBlock {
+            block_hash,
+            header,
+            rollup_transactions,
+            rollup_transactions_proof,
+            rollup_ids_proof,
+        } = raw;
+
+        let block_hash = block_hash
+            .as_ref()
+            .try_into()
+            .map_err(|_| SequencerBlockError::invalid_block_hash(block_hash.len()))?;
+
+        let rollup_transactions_proof = 'proof: {
+            let Some(rollup_transactions_proof) = rollup_transactions_proof else {
+                break 'proof Err(SequencerBlockError::field_not_set(
+                    "rollup_transactions_proof",
+                ));
+            };
+            merkle::Proof::try_from_raw(rollup_transactions_proof)
+                .map_err(SequencerBlockError::transaction_proof_invalid)
+        }?;
+        let rollup_ids_proof = 'proof: {
+            let Some(rollup_ids_proof) = rollup_ids_proof else {
+                break 'proof Err(SequencerBlockError::field_not_set("rollup_ids_proof"));
+            };
+            merkle::Proof::try_from_raw(rollup_ids_proof)
+                .map_err(SequencerBlockError::id_proof_invalid)
+        }?;
+        let header = 'header: {
+            let Some(header) = header else {
+                break 'header Err(SequencerBlockError::field_not_set("header"));
+            };
+            SequencerBlockHeader::try_from_raw(header).map_err(SequencerBlockError::header)
+        }?;
+
+        let rollup_transactions: IndexMap<RollupId, RollupTransactions> = rollup_transactions
+            .into_iter()
+            .map(rollup_txs_to_tuple)
+            .collect::<Result<_, _>>()
+            .map_err(SequencerBlockError::parse_rollup_transactions)?;
+
+        let data_hash = header.data_hash;
+
+        if !rollup_transactions_proof
+            .verify(&Sha256::digest(header.rollup_transactions_root), data_hash)
+        {
+            return Err(SequencerBlockError::invalid_rollup_transactions_root());
+        };
+
+        let rollup_ids_root = merkle::Tree::from_leaves(rollup_transactions.keys()).root();
+        if !rollup_ids_proof.verify(&Sha256::digest(rollup_ids_root), data_hash) {
+            return Err(SequencerBlockError::invalid_rollup_ids_proof());
+        };
+
+        if !are_rollup_txs_included(&rollup_transactions, &rollup_transactions_proof, data_hash) {
+            return Err(SequencerBlockError::rollup_transactions_not_in_sequencer_block());
+        }
+        if !are_rollup_ids_included(
+            rollup_transactions.keys().copied(),
+            &rollup_ids_proof,
+            data_hash,
+        ) {
+            return Err(SequencerBlockError::rollup_ids_not_in_sequencer_block());
+        }
+
+        Ok(Self {
+            block_hash,
+            header,
+            rollup_transactions,
+            rollup_transactions_proof,
+            rollup_ids_proof,
+        })
+    }
+
+    /// This should only be used where `parts` has been provided by a trusted entity, e.g. read from
+    /// our own state store.
+    ///
+    /// Note that this function is not considered part of the public API and is subject to breaking
+    /// change at any time.
+    #[cfg(feature = "unchecked-constructors")]
+    #[doc(hidden)]
+    #[must_use]
+    pub fn unchecked_from_parts(parts: SequencerBlockParts) -> Self {
+        let SequencerBlockParts {
+            block_hash,
+            header,
+            rollup_transactions,
+            rollup_transactions_proof,
+            rollup_ids_proof,
+        } = parts;
+        Self {
+            block_hash,
+            header,
+            rollup_transactions,
+            rollup_transactions_proof,
+            rollup_ids_proof,
+        }
+    }
+}
+
+fn rollup_transactions_and_ids_root_from_data(
+    data_list: &mut IntoIter<Bytes>,
+) -> Result<([u8; 32], [u8; 32]), SequencerBlockError> {
+    let rollup_transactions_root: [u8; 32] = data_list
+        .next()
+        .ok_or(SequencerBlockError::no_rollup_transactions_root())?
+        .as_ref()
+        .try_into()
+        .map_err(|_| {
+            SequencerBlockError::incorrect_rollup_transactions_root_length(data_list.len())
+        })?;
+    let rollup_ids_root: [u8; 32] = data_list
+        .next()
+        .ok_or(SequencerBlockError::no_rollup_ids_root())?
+        .as_ref()
+        .try_into()
+        .map_err(|_| SequencerBlockError::incorrect_rollup_ids_root_length(data_list.len()))?;
+    Ok((rollup_transactions_root, rollup_ids_root))
+}
+
+/// Constructs a `[merkle::Tree]` from an iterator yielding byte slices.
+///
+/// This hashes each item before pushing it into the Merkle Tree, which
+/// effectively causes a double hashing. The leaf hash of an item `d_i`
+/// is then `MTH(d_i) = SHA256(0x00 || SHA256(d_i))`.
+pub fn merkle_tree_from_data<I, B>(iter: I) -> merkle::Tree
+where
+    I: IntoIterator<Item = B>,
+    B: AsRef<[u8]>,
+{
+    use sha2::Digest as _;
+    merkle::Tree::from_leaves(iter.into_iter().map(|item| Sha256::digest(&item)))
+}
+
+/// The individual parts that make up a [`FilteredSequencerBlock`].
+///
+/// Exists to provide convenient access to fields of a [`FilteredSequencerBlock`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct FilteredSequencerBlockParts {
+    pub block_hash: [u8; 32],
+    pub header: SequencerBlockHeader,
+    // filtered set of rollup transactions
+    pub rollup_transactions: IndexMap<RollupId, RollupTransactions>,
+    // proof that `rollup_transactions_root` is included in `data_hash`
+    pub rollup_transactions_proof: merkle::Proof,
+    // all rollup ids in the sequencer block
+    pub all_rollup_ids: Vec<RollupId>,
+    // proof that `rollup_ids` is included in `data_hash`
+    pub rollup_ids_proof: merkle::Proof,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[expect(
+    clippy::module_name_repetitions,
+    reason = "we want consistent and specific naming"
+)]
+pub struct FilteredSequencerBlock {
+    block_hash: [u8; 32],
+    header: SequencerBlockHeader,
+    // filtered set of rollup transactions
+    rollup_transactions: IndexMap<RollupId, RollupTransactions>,
+    // proof that `rollup_transactions_root` is included in `data_hash`
+    rollup_transactions_proof: merkle::Proof,
+    // all rollup ids in the sequencer block
+    all_rollup_ids: Vec<RollupId>,
+    // proof that `rollup_ids` is included in `data_hash`
+    rollup_ids_proof: merkle::Proof,
+}
+
+impl FilteredSequencerBlock {
+    #[must_use]
+    pub fn block_hash(&self) -> &[u8; 32] {
+        &self.block_hash
+    }
+
+    #[must_use]
+    pub fn header(&self) -> &SequencerBlockHeader {
+        &self.header
+    }
+
+    #[must_use]
+    pub fn height(&self) -> tendermint::block::Height {
+        self.header.height
+    }
+
+    #[must_use]
+    pub fn rollup_transactions(&self) -> &IndexMap<RollupId, RollupTransactions> {
+        &self.rollup_transactions
+    }
+
+    #[must_use]
+    pub fn rollup_transactions_root(&self) -> &[u8; 32] {
+        &self.header.rollup_transactions_root
+    }
+
+    #[must_use]
+    pub fn rollup_transactions_proof(&self) -> &merkle::Proof {
+        &self.rollup_transactions_proof
+    }
+
+    #[must_use]
+    pub fn all_rollup_ids(&self) -> &[RollupId] {
+        &self.all_rollup_ids
+    }
+
+    #[must_use]
+    pub fn rollup_ids_proof(&self) -> &merkle::Proof {
+        &self.rollup_ids_proof
+    }
+
+    #[must_use]
+    pub fn into_raw(self) -> raw::FilteredSequencerBlock {
+        let Self {
+            block_hash,
+            header,
+            rollup_transactions,
+            rollup_transactions_proof,
+            rollup_ids_proof,
+            ..
+        } = self;
+        raw::FilteredSequencerBlock {
+            block_hash: Bytes::copy_from_slice(&block_hash),
+            header: Some(header.into_raw()),
+            rollup_transactions: rollup_transactions
+                .into_values()
+                .map(RollupTransactions::into_raw)
+                .collect(),
+            rollup_transactions_proof: Some(rollup_transactions_proof.into_raw()),
+            all_rollup_ids: self.all_rollup_ids.iter().map(RollupId::to_raw).collect(),
+            rollup_ids_proof: Some(rollup_ids_proof.into_raw()),
+        }
+    }
+
+    /// Converts from the raw decoded protobuf representation of this type.
+    ///
+    /// # Errors
+    ///
+    /// - if the rollup transactions proof is not set
+    /// - if the rollup IDs proof is not set
+    /// - if the rollup transactions proof cannot be constructed from the raw protobuf
+    /// - if the rollup IDs proof cannot be constructed from the raw protobuf
+    /// - if the cometbft header is not set
+    /// - if the cometbft header cannot be constructed from the raw protobuf
+    /// - if the cometbft block hash is None
+    /// - if the data hash is None
+    /// - if the rollup transactions cannot be parsed
+    /// - if the rollup transactions root is not 32 bytes
+    /// - if the rollup transactions are not included in the sequencer block
+    /// - if the rollup IDs root is not 32 bytes
+    /// - if the rollup IDs are not included in the sequencer block
+    pub fn try_from_raw(
+        raw: raw::FilteredSequencerBlock,
+    ) -> Result<Self, FilteredSequencerBlockError> {
+        use sha2::Digest as _;
+
+        fn rollup_txs_to_tuple(
+            raw: raw::RollupTransactions,
+        ) -> Result<(RollupId, RollupTransactions), RollupTransactionsError> {
+            let rollup_transactions = RollupTransactions::try_from_raw(raw)?;
+            Ok((rollup_transactions.rollup_id, rollup_transactions))
+        }
+
+        let raw::FilteredSequencerBlock {
+            block_hash,
+            header,
+            rollup_transactions,
+            rollup_transactions_proof,
+            all_rollup_ids,
+            rollup_ids_proof,
+            ..
+        } = raw;
+
+        let block_hash = block_hash
+            .as_ref()
+            .try_into()
+            .map_err(|_| FilteredSequencerBlockError::invalid_block_hash(block_hash.len()))?;
+
+        let rollup_transactions_proof = {
+            let Some(rollup_transactions_proof) = rollup_transactions_proof else {
+                return Err(FilteredSequencerBlockError::field_not_set(
+                    "rollup_transactions_proof",
+                ));
+            };
+            merkle::Proof::try_from_raw(rollup_transactions_proof)
+                .map_err(FilteredSequencerBlockError::transaction_proof_invalid)
+        }?;
+        let rollup_ids_proof = {
+            let Some(rollup_ids_proof) = rollup_ids_proof else {
+                return Err(FilteredSequencerBlockError::field_not_set(
+                    "rollup_ids_proof",
+                ));
+            };
+            merkle::Proof::try_from_raw(rollup_ids_proof)
+                .map_err(FilteredSequencerBlockError::id_proof_invalid)
+        }?;
+        let header = {
+            let Some(header) = header else {
+                return Err(FilteredSequencerBlockError::field_not_set("header"));
+            };
+            SequencerBlockHeader::try_from_raw(header)
+                .map_err(FilteredSequencerBlockError::invalid_header)
+        }?;
+
+        // XXX: These rollup transactions are not sorted compared to those used for
+        // deriving the rollup transactions merkle tree in `SequencerBlock`.
+        let rollup_transactions = rollup_transactions
+            .into_iter()
+            .map(rollup_txs_to_tuple)
+            .collect::<Result<IndexMap<_, _>, _>>()
+            .map_err(FilteredSequencerBlockError::parse_rollup_transactions)?;
+
+        let all_rollup_ids: Vec<RollupId> = all_rollup_ids
+            .into_iter()
+            .map(RollupId::try_from_raw)
+            .collect::<Result<_, _>>()
+            .map_err(FilteredSequencerBlockError::invalid_rollup_id)?;
+
+        if !rollup_transactions_proof.verify(
+            &Sha256::digest(header.rollup_transactions_root),
+            header.data_hash,
+        ) {
+            return Err(FilteredSequencerBlockError::rollup_transactions_not_in_sequencer_block());
+        }
+
+        for rollup_transactions in rollup_transactions.values() {
+            if !super::do_rollup_transaction_match_root(
+                rollup_transactions,
+                header.rollup_transactions_root,
+            ) {
+                return Err(
+                    FilteredSequencerBlockError::rollup_transaction_for_id_not_in_sequencer_block(
+                        *rollup_transactions.rollup_id(),
+                    ),
+                );
+            }
+        }
+
+        if !are_rollup_ids_included(
+            all_rollup_ids.iter().copied(),
+            &rollup_ids_proof,
+            header.data_hash,
+        ) {
+            return Err(FilteredSequencerBlockError::rollup_ids_not_in_sequencer_block());
+        }
+
+        Ok(Self {
+            block_hash,
+            header,
+            rollup_transactions,
+            rollup_transactions_proof,
+            all_rollup_ids,
+            rollup_ids_proof,
+        })
+    }
+
+    /// Transforms the filtered blocks into its constituent parts.
+    #[must_use]
+    pub fn into_parts(self) -> FilteredSequencerBlockParts {
+        let Self {
+            block_hash,
+            header,
+            rollup_transactions,
+            rollup_transactions_proof,
+            all_rollup_ids,
+            rollup_ids_proof,
+        } = self;
+        FilteredSequencerBlockParts {
+            block_hash,
+            header,
+            rollup_transactions,
+            rollup_transactions_proof,
+            all_rollup_ids,
+            rollup_ids_proof,
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub struct FilteredSequencerBlockError(FilteredSequencerBlockErrorKind);
+
+#[derive(Debug, thiserror::Error)]
+enum FilteredSequencerBlockErrorKind {
+    #[error(
+        "the block hash in the raw protobuf filtered sequencer block was expected to be 32 bytes \
+         long, but was actually `{0}`"
+    )]
+    InvalidBlockHash(usize),
+    #[error("failed to create a sequencer block header from the raw protobuf header")]
+    InvalidHeader(SequencerBlockHeaderError),
+    #[error("the rollup ID in the raw protobuf rollup transaction was not 32 bytes long")]
+    InvalidRollupId(IncorrectRollupIdLength),
+    #[error("the expected field in the raw source type was not set: `{0}`")]
+    FieldNotSet(&'static str),
+    #[error("failed parsing a raw protobuf rollup transaction")]
+    ParseRollupTransactions(RollupTransactionsError),
+    #[error(
+        "the rollup transactions in the sequencer block were not included in the block's data hash"
+    )]
+    RollupTransactionsNotInSequencerBlock,
+    #[error(
+        "the rollup transaction for rollup ID `{id}` contained in the filtered sequencer block \
+         could not be verified against the rollup transactions root"
+    )]
+    RollupTransactionForIdNotInSequencerBlock { id: RollupId },
+    #[error("the rollup IDs in the sequencer block were not included in the block's data hash")]
+    RollupIdsNotInSequencerBlock,
+    #[error("failed constructing a transaction proof from the raw protobuf transaction proof")]
+    TransactionProofInvalid(merkle::audit::InvalidProof),
+    #[error("failed constructing a rollup ID proof from the raw protobuf rollup ID proof")]
+    IdProofInvalid(merkle::audit::InvalidProof),
+}
+
+impl FilteredSequencerBlockError {
+    fn invalid_block_hash(len: usize) -> Self {
+        Self(FilteredSequencerBlockErrorKind::InvalidBlockHash(len))
+    }
+
+    fn invalid_header(source: SequencerBlockHeaderError) -> Self {
+        Self(FilteredSequencerBlockErrorKind::InvalidHeader(source))
+    }
+
+    fn invalid_rollup_id(source: IncorrectRollupIdLength) -> Self {
+        Self(FilteredSequencerBlockErrorKind::InvalidRollupId(source))
+    }
+
+    fn field_not_set(field: &'static str) -> Self {
+        Self(FilteredSequencerBlockErrorKind::FieldNotSet(field))
+    }
+
+    fn parse_rollup_transactions(source: RollupTransactionsError) -> Self {
+        Self(FilteredSequencerBlockErrorKind::ParseRollupTransactions(
+            source,
+        ))
+    }
+
+    fn rollup_transactions_not_in_sequencer_block() -> Self {
+        Self(FilteredSequencerBlockErrorKind::RollupTransactionsNotInSequencerBlock)
+    }
+
+    fn rollup_transaction_for_id_not_in_sequencer_block(id: RollupId) -> Self {
+        Self(
+            FilteredSequencerBlockErrorKind::RollupTransactionForIdNotInSequencerBlock {
+                id,
+            },
+        )
+    }
+
+    fn rollup_ids_not_in_sequencer_block() -> Self {
+        Self(FilteredSequencerBlockErrorKind::RollupIdsNotInSequencerBlock)
+    }
+
+    fn transaction_proof_invalid(source: merkle::audit::InvalidProof) -> Self {
+        Self(FilteredSequencerBlockErrorKind::TransactionProofInvalid(
+            source,
+        ))
+    }
+
+    fn id_proof_invalid(source: merkle::audit::InvalidProof) -> Self {
+        Self(FilteredSequencerBlockErrorKind::IdProofInvalid(source))
+    }
+}
+
+/// [`Deposit`] represents a deposit from the sequencer to a rollup.
+///
+/// A [`Deposit`] is constructed whenever a [`BridgeLockAction`] is executed
+/// and stored as part of the block's events.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+#[serde(into = "crate::generated::astria::sequencerblock::v1alpha1::Deposit")]
+pub struct Deposit {
+    // the address on the sequencer to which the funds were sent to.
+    pub bridge_address: Address,
+    // the rollup ID registered to the `bridge_address`
+    pub rollup_id: RollupId,
+    // the amount that was transferred to `bridge_address`
+    pub amount: u128,
+    // the IBC ICS20 denom of the asset that was transferred
+    pub asset: asset::Denom,
+    // the address on the destination chain (rollup) which to send the bridged funds to
+    pub destination_chain_address: String,
+    // the transaction ID of the source action for the deposit, consisting
+    // of the transaction hash.
+    pub source_transaction_id: TransactionId,
+    // index of the deposit's source action within its transaction
+    pub source_action_index: u64,
+}
+
+impl Deposit {
+    #[must_use]
+    pub fn into_raw(self) -> raw::Deposit {
+        let Self {
+            bridge_address,
+            rollup_id,
+            amount,
+            asset,
+            destination_chain_address,
+            source_transaction_id,
+            source_action_index,
+        } = self;
+        raw::Deposit {
+            bridge_address: Some(bridge_address.into_raw()),
+            rollup_id: Some(rollup_id.into_raw()),
+            amount: Some(amount.into()),
+            asset: asset.to_string(),
+            destination_chain_address,
+            source_transaction_id: Some(source_transaction_id.into_raw()),
+            source_action_index,
+        }
+    }
+
+    /// Attempts to transform the deposit from its raw representation.
+    ///
+    /// # Errors
+    ///
+    /// - if the bridge address is invalid
+    /// - if the amount is unset
+    /// - if the rollup ID is invalid
+    /// - if the asset ID is invalid
+    pub fn try_from_raw(raw: raw::Deposit) -> Result<Self, DepositError> {
+        let raw::Deposit {
+            bridge_address,
+            rollup_id,
+            amount,
+            asset,
+            destination_chain_address,
+            source_transaction_id,
+            source_action_index,
+        } = raw;
+        let Some(bridge_address) = bridge_address else {
+            return Err(DepositError::field_not_set("bridge_address"));
+        };
+        let bridge_address =
+            Address::try_from_raw(bridge_address).map_err(DepositError::address)?;
+        let amount = amount.ok_or(DepositError::field_not_set("amount"))?.into();
+        let Some(rollup_id) = rollup_id else {
+            return Err(DepositError::field_not_set("rollup_id"));
+        };
+        let rollup_id =
+            RollupId::try_from_raw(rollup_id).map_err(DepositError::incorrect_rollup_id_length)?;
+        let asset = asset.parse().map_err(DepositError::incorrect_asset)?;
+        let Some(source_transaction_id) = source_transaction_id else {
+            return Err(DepositError::field_not_set("transaction_id"));
+        };
+        let source_transaction_id = TransactionId::try_from_raw_ref(&source_transaction_id)
+            .map_err(DepositError::transaction_id_error)?;
+        Ok(Self {
+            bridge_address,
+            rollup_id,
+            amount,
+            asset,
+            destination_chain_address,
+            source_transaction_id,
+            source_action_index,
+        })
+    }
+}
+
+impl From<Deposit> for raw::Deposit {
+    fn from(deposit: Deposit) -> Self {
+        deposit.into_raw()
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub struct DepositError(DepositErrorKind);
+
+impl DepositError {
+    fn address(source: AddressError) -> Self {
+        Self(DepositErrorKind::Address {
+            source,
+        })
+    }
+
+    fn field_not_set(field: &'static str) -> Self {
+        Self(DepositErrorKind::FieldNotSet(field))
+    }
+
+    fn incorrect_rollup_id_length(source: IncorrectRollupIdLength) -> Self {
+        Self(DepositErrorKind::IncorrectRollupIdLength(source))
+    }
+
+    fn incorrect_asset(source: asset::ParseDenomError) -> Self {
+        Self(DepositErrorKind::IncorrectAsset(source))
+    }
+
+    fn transaction_id_error(source: TransactionIdError) -> Self {
+        Self(DepositErrorKind::TransactionIdError(source))
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum DepositErrorKind {
+    #[error("the address is invalid")]
+    Address { source: AddressError },
+    #[error("the expected field in the raw source type was not set: `{0}`")]
+    FieldNotSet(&'static str),
+    #[error("the rollup ID length is not 32 bytes")]
+    IncorrectRollupIdLength(#[source] IncorrectRollupIdLength),
+    #[error("the `asset` field could not be parsed")]
+    IncorrectAsset(#[source] asset::ParseDenomError),
+    #[error("field `source_transaction_id` was invalid")]
+    TransactionIdError(#[source] TransactionIdError),
+}
+
+/// A piece of data that is sent to a rollup execution node.
+///
+/// The data can be either sequenced data (originating from a [`RollupDataSubmission`]
+/// action submitted by a user) or a [`Deposit`] (originating from a [`BridgeLock`] action).
+///
+/// The rollup node receives this type as opaque, protobuf-encoded bytes from conductor,
+/// and must decode it accordingly.
+#[derive(Debug, Clone, PartialEq)]
+pub enum RollupData {
+    SequencedData(Bytes),
+    Deposit(Box<Deposit>),
+}
+
+impl RollupData {
+    #[must_use]
+    pub fn into_raw(self) -> raw::RollupData {
+        match self {
+            Self::SequencedData(data) => raw::RollupData {
+                value: Some(raw::rollup_data::Value::SequencedData(data)),
+            },
+            Self::Deposit(deposit) => raw::RollupData {
+                value: Some(raw::rollup_data::Value::Deposit(deposit.into_raw())),
+            },
+        }
+    }
+
+    /// Attempts to transform the `RollupData` from its raw representation.
+    ///
+    /// # Errors
+    ///
+    /// - if the `data` field is not set
+    /// - if the variant is `Deposit` but a `Deposit` cannot be constructed from the raw proto
+    pub fn try_from_raw(raw: raw::RollupData) -> Result<Self, RollupDataError> {
+        let raw::RollupData {
+            value,
+        } = raw;
+        match value {
+            Some(raw::rollup_data::Value::SequencedData(data)) => Ok(Self::SequencedData(data)),
+            Some(raw::rollup_data::Value::Deposit(deposit)) => Deposit::try_from_raw(deposit)
+                .map(Box::new)
+                .map(Self::Deposit)
+                .map_err(RollupDataError::deposit),
+            None => Err(RollupDataError::field_not_set("data")),
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub struct RollupDataError(RollupDataErrorKind);
+
+impl RollupDataError {
+    fn field_not_set(field: &'static str) -> Self {
+        Self(RollupDataErrorKind::FieldNotSet(field))
+    }
+
+    fn deposit(source: DepositError) -> Self {
+        Self(RollupDataErrorKind::Deposit(source))
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum RollupDataErrorKind {
+    #[error("the expected field in the raw source type was not set: `{0}`")]
+    FieldNotSet(&'static str),
+    #[error("failed to validate `deposit` field")]
+    Deposit(#[source] DepositError),
+}

--- a/crates/astria-core/src/sequencerblock/v1alpha1/block.rs
+++ b/crates/astria-core/src/sequencerblock/v1alpha1/block.rs
@@ -1121,7 +1121,11 @@ impl FilteredSequencerBlock {
                 .map(RollupTransactions::into_raw)
                 .collect(),
             rollup_transactions_proof: Some(rollup_transactions_proof.into_raw()),
-            all_rollup_ids: self.all_rollup_ids.iter().map(RollupId::to_raw).collect(),
+            all_rollup_ids: self
+                .all_rollup_ids
+                .iter()
+                .map(|id| Bytes::copy_from_slice(id.as_ref()))
+                .collect(),
             rollup_ids_proof: Some(rollup_ids_proof.into_raw()),
         }
     }
@@ -1206,7 +1210,7 @@ impl FilteredSequencerBlock {
 
         let all_rollup_ids: Vec<RollupId> = all_rollup_ids
             .into_iter()
-            .map(RollupId::try_from_raw)
+            .map(|bytes| RollupId::try_from_slice(&bytes))
             .collect::<Result<_, _>>()
             .map_err(FilteredSequencerBlockError::invalid_rollup_id)?;
 

--- a/crates/astria-core/src/sequencerblock/v1alpha1/celestia.rs
+++ b/crates/astria-core/src/sequencerblock/v1alpha1/celestia.rs
@@ -1,0 +1,636 @@
+use bytes::Bytes;
+use sha2::{
+    Digest as _,
+    Sha256,
+};
+
+use super::{
+    block::{
+        RollupTransactionsParts,
+        SequencerBlock,
+        SequencerBlockHeader,
+        SequencerBlockHeaderError,
+    },
+    raw,
+    IncorrectRollupIdLength,
+    RollupId,
+};
+use crate::Protobuf;
+
+/// A [`super::SequencerBlock`] split and prepared for submission to a data availability provider.
+///
+/// Consists of a head [`SubmittedMetadata`] and a tail of [`SubmittedRollupData`]s.
+pub(super) struct PreparedBlock {
+    head: SubmittedMetadata,
+    tail: Vec<SubmittedRollupData>,
+}
+
+impl PreparedBlock {
+    /// Construct a bundle of celestia blobs from a [`super::SequencerBlock`].
+    #[must_use]
+    pub(super) fn from_sequencer_block(block: SequencerBlock) -> Self {
+        let super::block::SequencerBlockParts {
+            block_hash,
+            header,
+            rollup_transactions,
+            rollup_transactions_proof,
+            rollup_ids_proof,
+        } = block.into_parts();
+
+        let head = SubmittedMetadata {
+            block_hash,
+            header,
+            rollup_ids: rollup_transactions.keys().copied().collect(),
+            rollup_transactions_proof,
+            rollup_ids_proof,
+        };
+
+        let mut tail = Vec::with_capacity(rollup_transactions.len());
+        for (rollup_id, rollup_txs) in rollup_transactions {
+            let RollupTransactionsParts {
+                transactions,
+                proof,
+                ..
+            } = rollup_txs.into_parts();
+            let transactions = transactions.into_iter().map(Bytes::into).collect();
+            tail.push(SubmittedRollupData {
+                sequencer_block_hash: block_hash,
+                rollup_id,
+                transactions,
+                proof,
+            });
+        }
+        Self {
+            head,
+            tail,
+        }
+    }
+
+    /// Returns the head and the tail of the split block, consuming it.
+    pub(super) fn into_parts(self) -> (SubmittedMetadata, Vec<SubmittedRollupData>) {
+        (self.head, self.tail)
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("failed constructing a celestia rollup blob")]
+pub struct SubmittedRollupDataError {
+    #[source]
+    kind: SubmittedRollupDataErrorKind,
+}
+
+impl SubmittedRollupDataError {
+    fn field_not_set(field: &'static str) -> Self {
+        Self {
+            kind: SubmittedRollupDataErrorKind::FieldNotSet {
+                field,
+            },
+        }
+    }
+
+    fn rollup_id(source: IncorrectRollupIdLength) -> Self {
+        Self {
+            kind: SubmittedRollupDataErrorKind::RollupId {
+                source,
+            },
+        }
+    }
+
+    fn proof(source: <merkle::Proof as Protobuf>::Error) -> Self {
+        Self {
+            kind: SubmittedRollupDataErrorKind::Proof {
+                source,
+            },
+        }
+    }
+
+    fn sequencer_block_hash(actual_len: usize) -> Self {
+        Self {
+            kind: SubmittedRollupDataErrorKind::SequencerBlockHash(actual_len),
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum SubmittedRollupDataErrorKind {
+    #[error("the expected field in the raw source type was not set: `{field}`")]
+    FieldNotSet { field: &'static str },
+    #[error("failed converting the provided bytes to Rollup ID")]
+    RollupId { source: IncorrectRollupIdLength },
+    #[error("failed constructing a Merkle Hash Tree Proof from the provided raw protobuf type")]
+    Proof {
+        source: <merkle::Proof as Protobuf>::Error,
+    },
+    #[error(
+        "the provided bytes were too short for a sequencer block hash. Expected: 32 bytes, \
+         provided: {0}"
+    )]
+    SequencerBlockHash(usize),
+}
+
+/// A shadow of [`SubmittedRollupData`] with public access to all its fields.
+///
+/// At the moment there are no invariants upheld by [`SubmittedRollupData`] so
+/// they can be converted directly into one another. This can change in the future.
+pub struct UncheckedSubmittedRollupData {
+    /// The hash of the sequencer block. Must be 32 bytes.
+    pub sequencer_block_hash: [u8; 32],
+    /// The 32 bytes identifying the rollup this blob belongs to. Matches
+    /// `astria.sequencerblock.v1.RollupTransactions.rollup_id`
+    pub rollup_id: RollupId,
+    /// A list of opaque bytes that are serialized rollup transactions.
+    pub transactions: Vec<Bytes>,
+    /// The proof that these rollup transactions are included in sequencer block.
+    pub proof: merkle::Proof,
+}
+
+impl UncheckedSubmittedRollupData {
+    #[must_use]
+    pub fn into_celestia_rollup_blob(self) -> SubmittedRollupData {
+        SubmittedRollupData::from_unchecked(self)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct SubmittedRollupData {
+    /// The hash of the sequencer block. Must be 32 bytes.
+    sequencer_block_hash: [u8; 32],
+    /// The 32 bytes identifying the rollup this blob belongs to. Matches
+    /// `astria.sequencerblock.v1.RollupTransactions.rollup_id`
+    rollup_id: RollupId,
+    /// A list of opaque bytes that are serialized rollup transactions.
+    transactions: Vec<Bytes>,
+    /// The proof that these rollup transactions are included in sequencer block.
+    proof: merkle::Proof,
+}
+
+impl SubmittedRollupData {
+    #[must_use]
+    pub fn proof(&self) -> &merkle::Proof {
+        &self.proof
+    }
+
+    #[must_use]
+    pub fn transactions(&self) -> &[Bytes] {
+        &self.transactions
+    }
+
+    #[must_use]
+    pub fn rollup_id(&self) -> RollupId {
+        self.rollup_id
+    }
+
+    #[must_use]
+    pub fn sequencer_block_hash(&self) -> &[u8; 32] {
+        &self.sequencer_block_hash
+    }
+
+    /// Converts from the unchecked representation of this type (its shadow).
+    ///
+    /// This type does not uphold any extra invariants so there are no extra checks necessary.
+    #[must_use]
+    pub fn from_unchecked(unchecked: UncheckedSubmittedRollupData) -> Self {
+        let UncheckedSubmittedRollupData {
+            sequencer_block_hash,
+            rollup_id,
+            transactions,
+            proof,
+        } = unchecked;
+        Self {
+            sequencer_block_hash,
+            rollup_id,
+            transactions,
+            proof,
+        }
+    }
+
+    /// Converts to the unchecked representation of this type (its shadow).
+    ///
+    /// Useful to get public access to the type's fields.
+    #[must_use]
+    pub fn into_unchecked(self) -> UncheckedSubmittedRollupData {
+        let Self {
+            sequencer_block_hash,
+            rollup_id,
+            transactions,
+            proof,
+        } = self;
+        UncheckedSubmittedRollupData {
+            sequencer_block_hash,
+            rollup_id,
+            transactions,
+            proof,
+        }
+    }
+
+    /// Converts to the raw decoded protobuf representation of this type.
+    ///
+    /// Useful for then encoding it as protobuf.
+    #[must_use]
+    pub fn into_raw(self) -> raw::SubmittedRollupData {
+        let Self {
+            sequencer_block_hash,
+            rollup_id,
+            transactions,
+            proof,
+        } = self;
+        raw::SubmittedRollupData {
+            sequencer_block_hash: Bytes::copy_from_slice(&sequencer_block_hash),
+            rollup_id: Some(rollup_id.to_raw()),
+            transactions,
+            proof: Some(proof.into_raw()),
+        }
+    }
+
+    /// Converts from the raw decoded protobuf representation of this type.
+    ///
+    /// # Errors
+    /// TODO(https://github.com/astriaorg/astria/issues/612)
+    pub fn try_from_raw(raw: raw::SubmittedRollupData) -> Result<Self, SubmittedRollupDataError> {
+        let raw::SubmittedRollupData {
+            sequencer_block_hash,
+            rollup_id,
+            transactions,
+            proof,
+        } = raw;
+        let Some(rollup_id) = rollup_id else {
+            return Err(SubmittedRollupDataError::field_not_set("rollup_id"));
+        };
+        let rollup_id =
+            RollupId::try_from_raw(rollup_id).map_err(SubmittedRollupDataError::rollup_id)?;
+        let sequencer_block_hash = sequencer_block_hash.as_ref().try_into().map_err(|_| {
+            SubmittedRollupDataError::sequencer_block_hash(sequencer_block_hash.len())
+        })?;
+        let proof = 'proof: {
+            let Some(proof) = proof else {
+                break 'proof Err(SubmittedRollupDataError::field_not_set("proof"));
+            };
+            merkle::Proof::try_from_raw(proof).map_err(SubmittedRollupDataError::proof)
+        }?;
+        Ok(Self {
+            sequencer_block_hash,
+            rollup_id,
+            transactions,
+            proof,
+        })
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("failed constructing a celestia sequencer blob")]
+pub struct SubmittedMetadataError {
+    #[source]
+    kind: SubmittedMetadataErrorKind,
+}
+
+impl SubmittedMetadataError {
+    fn block_hash(actual_len: usize) -> Self {
+        Self {
+            kind: SubmittedMetadataErrorKind::BlockHash(actual_len),
+        }
+    }
+
+    fn header(source: SequencerBlockHeaderError) -> Self {
+        Self {
+            kind: SubmittedMetadataErrorKind::Header {
+                source,
+            },
+        }
+    }
+
+    fn field_not_set(field: &'static str) -> Self {
+        Self {
+            kind: SubmittedMetadataErrorKind::FieldNotSet(field),
+        }
+    }
+
+    fn rollup_ids(source: IncorrectRollupIdLength) -> Self {
+        Self {
+            kind: SubmittedMetadataErrorKind::RollupIds {
+                source,
+            },
+        }
+    }
+
+    fn rollup_transactions_proof(source: <merkle::Proof as Protobuf>::Error) -> Self {
+        Self {
+            kind: SubmittedMetadataErrorKind::RollupTransactionsProof {
+                source,
+            },
+        }
+    }
+
+    fn rollup_ids_proof(source: <merkle::Proof as Protobuf>::Error) -> Self {
+        Self {
+            kind: SubmittedMetadataErrorKind::RollupIdsProof {
+                source,
+            },
+        }
+    }
+
+    fn rollup_transactions_not_in_cometbft_block() -> Self {
+        Self {
+            kind: SubmittedMetadataErrorKind::RollupTransactionsNotInCometBftBlock,
+        }
+    }
+
+    fn rollup_ids_not_in_cometbft_block() -> Self {
+        Self {
+            kind: SubmittedMetadataErrorKind::RollupIdsNotInCometBftBlock,
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum SubmittedMetadataErrorKind {
+    #[error(
+        "the provided bytes were too short for a block hash; expected: 32 bytes, actual: {0} bytes"
+    )]
+    BlockHash(usize),
+    #[error("failed constructing the sequencer block header from its raw source value")]
+    Header { source: SequencerBlockHeaderError },
+    #[error("the field of the raw source value was not set: `{0}`")]
+    FieldNotSet(&'static str),
+    #[error("one of the rollup IDs in the raw source value was invalid")]
+    RollupIds { source: IncorrectRollupIdLength },
+    #[error(
+        "failed constructing a Merkle Hash Tree Proof for the rollup transactions from the raw \
+         raw source type"
+    )]
+    RollupTransactionsProof {
+        source: <merkle::Proof as Protobuf>::Error,
+    },
+    #[error(
+        "failed constructing a Merkle Hash Tree Proof for the rollup IDs from the raw raw source \
+         type"
+    )]
+    RollupIdsProof {
+        source: <merkle::Proof as Protobuf>::Error,
+    },
+    #[error(
+        "the Merkle Tree Hash of the rollup transactions was not a leaf in the sequencer block \
+         data"
+    )]
+    RollupTransactionsNotInCometBftBlock,
+    #[error("the Merkle Tree Hash of the rollup IDs was not a leaf in the sequencer block data")]
+    RollupIdsNotInCometBftBlock,
+}
+
+/// A shadow of [`SubmittedMetadata`] with public access to its fields.
+///
+/// This type does not guarantee any invariants and is mainly useful to get
+/// access the sequencer block's internal types.
+#[derive(Clone, Debug)]
+pub struct UncheckedSubmittedMetadata {
+    pub block_hash: [u8; 32],
+    /// The original `CometBFT` header that is the input to this blob's original sequencer block.
+    /// Corresponds to `astria.SequencerBlock.header`.
+    pub header: SequencerBlockHeader,
+    /// The rollup rollup IDs for which `SubmittedRollupData`s were submitted to celestia.
+    /// Corresponds to the `astria.sequencer.v1.RollupTransactions.id` field
+    /// and is extracted from `astria.SequencerBlock.rollup_transactions`.
+    pub rollup_ids: Vec<RollupId>,
+    /// The proof that the rollup transactions are included in sequencer block.
+    /// Corresponds to `astria.SequencerBlock.rollup_transactions_proof`.
+    pub rollup_transactions_proof: merkle::Proof,
+    /// The proof that this sequencer blob includes all rollup IDs of the original sequencer
+    /// block it was derived from. This proof together with `Sha256(MTH(rollup_ids))` (Sha256
+    /// applied to the Merkle Tree Hash of the rollup ID sequence) must be equal to
+    /// `header.data_hash` which itself must match
+    /// `astria.SequencerBlock.header.data_hash`. This field corresponds to
+    /// `astria.SequencerBlock.rollup_ids_proof`.
+    pub rollup_ids_proof: merkle::Proof,
+}
+
+impl UncheckedSubmittedMetadata {
+    /// Converts this unchecked blob into its checked [`SubmittedMetadata`] representation.
+    ///
+    /// # Errors
+    /// TODO(https://github.com/astriaorg/astria/issues/612)
+    pub fn try_into_celestia_sequencer_blob(
+        self,
+    ) -> Result<SubmittedMetadata, SubmittedMetadataError> {
+        SubmittedMetadata::try_from_unchecked(self)
+    }
+
+    /// Converts from the raw decoded protobuf representation of this type.
+    ///
+    /// # Errors
+    /// TODO(https://github.com/astriaorg/astria/issues/612)
+    pub fn try_from_raw(raw: raw::SubmittedMetadata) -> Result<Self, SubmittedMetadataError> {
+        let raw::SubmittedMetadata {
+            block_hash,
+            header,
+            rollup_ids,
+            rollup_transactions_proof,
+            rollup_ids_proof,
+            ..
+        } = raw;
+        let header = 'header: {
+            let Some(header) = header else {
+                break 'header Err(SubmittedMetadataError::field_not_set("header"));
+            };
+            SequencerBlockHeader::try_from_raw(header).map_err(SubmittedMetadataError::header)
+        }?;
+        let rollup_ids: Vec<_> = rollup_ids
+            .into_iter()
+            .map(RollupId::try_from_raw)
+            .collect::<Result<_, _>>()
+            .map_err(SubmittedMetadataError::rollup_ids)?;
+
+        let rollup_transactions_proof = 'transactions_proof: {
+            let Some(rollup_transactions_proof) = rollup_transactions_proof else {
+                break 'transactions_proof Err(SubmittedMetadataError::field_not_set(
+                    "rollup_transactions_root",
+                ));
+            };
+            merkle::Proof::try_from_raw(rollup_transactions_proof)
+                .map_err(SubmittedMetadataError::rollup_transactions_proof)
+        }?;
+
+        let rollup_ids_proof = 'ids_proof: {
+            let Some(rollup_ids_proof) = rollup_ids_proof else {
+                break 'ids_proof Err(SubmittedMetadataError::field_not_set("rollup_ids_proof"));
+            };
+            merkle::Proof::try_from_raw(rollup_ids_proof)
+                .map_err(SubmittedMetadataError::rollup_ids_proof)
+        }?;
+
+        let block_hash = block_hash
+            .as_ref()
+            .try_into()
+            .map_err(|_| SubmittedMetadataError::block_hash(block_hash.len()))?;
+
+        Ok(Self {
+            block_hash,
+            header,
+            rollup_ids,
+            rollup_transactions_proof,
+            rollup_ids_proof,
+        })
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct SubmittedMetadata {
+    /// The block hash obtained from hashing `.header`.
+    block_hash: [u8; 32],
+    /// The sequencer block header.
+    header: SequencerBlockHeader,
+    /// The rollup IDs for which `SubmittedRollupData`s were submitted to celestia.
+    /// Corresponds to the `astria.sequencer.v1.RollupTransactions.id` field
+    /// and is extracted from `astria.SequencerBlock.rollup_transactions`.
+    rollup_ids: Vec<RollupId>,
+    /// The proof that the rollup transactions are included in sequencer block.
+    /// Corresponds to `astria.SequencerBlock.rollup_transactions_proof`.
+    rollup_transactions_proof: merkle::Proof,
+    /// The proof that this sequencer blob includes all rollup IDs of the original sequencer
+    /// block it was derived from. This proof together with `Sha256(MTH(rollup_ids))` (Sha256
+    /// applied to the Merkle Tree Hash of the rollup ID sequence) must be equal to
+    /// `header.data_hash` which itself must match
+    /// `astria.SequencerBlock.header.data_hash`. This field corresponds to
+    /// `astria.SequencerBlock.rollup_ids_proof`.
+    rollup_ids_proof: merkle::Proof,
+}
+
+/// An iterator over rollup IDs.
+pub struct RollupIdIter<'a>(std::slice::Iter<'a, RollupId>);
+
+impl<'a> Iterator for RollupIdIter<'a> {
+    type Item = &'a RollupId;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
+impl SubmittedMetadata {
+    /// Returns the block hash of the tendermint header stored in this blob.
+    #[must_use]
+    pub fn block_hash(&self) -> &[u8; 32] {
+        &self.block_hash
+    }
+
+    /// Returns the sequencer's `CometBFT` chain ID.
+    #[must_use]
+    pub fn cometbft_chain_id(&self) -> &tendermint::chain::Id {
+        self.header.chain_id()
+    }
+
+    /// Returns the `CometBFT` height stored in the header of the [`SequencerBlock`] this blob was
+    /// derived from.
+    #[must_use]
+    pub fn height(&self) -> tendermint::block::Height {
+        self.header.height()
+    }
+
+    /// Returns the header of the [`SequencerBlock`] this blob was derived from.
+    #[must_use]
+    pub fn header(&self) -> &SequencerBlockHeader {
+        &self.header
+    }
+
+    /// Returns the rollup IDs.
+    #[must_use]
+    pub fn rollup_ids(&self) -> RollupIdIter {
+        RollupIdIter(self.rollup_ids.iter())
+    }
+
+    /// Returns the Merkle Tree Hash constructed from the rollup transactions of the original
+    /// [`SequencerBlock`] this blob was derived from.
+    #[must_use]
+    pub fn rollup_transactions_root(&self) -> &[u8; 32] {
+        self.header.rollup_transactions_root()
+    }
+
+    #[must_use]
+    pub fn contains_rollup_id(&self, rollup_id: RollupId) -> bool {
+        self.rollup_ids.contains(&rollup_id)
+    }
+
+    /// Converts into the unchecked representation fo this type.
+    #[must_use]
+    pub fn into_unchecked(self) -> UncheckedSubmittedMetadata {
+        let Self {
+            block_hash,
+            header,
+            rollup_ids,
+            rollup_transactions_proof,
+            rollup_ids_proof,
+        } = self;
+        UncheckedSubmittedMetadata {
+            block_hash,
+            header,
+            rollup_ids,
+            rollup_transactions_proof,
+            rollup_ids_proof,
+        }
+    }
+
+    /// Converts from the unchecked representation of this type.
+    ///
+    /// # Errors
+    /// TODO(https://github.com/astriaorg/astria/issues/612)
+    pub fn try_from_unchecked(
+        unchecked: UncheckedSubmittedMetadata,
+    ) -> Result<Self, SubmittedMetadataError> {
+        let UncheckedSubmittedMetadata {
+            block_hash,
+            header,
+            rollup_ids,
+            rollup_transactions_proof,
+            rollup_ids_proof,
+        } = unchecked;
+
+        if !rollup_transactions_proof.verify(
+            &Sha256::digest(header.rollup_transactions_root()),
+            *header.data_hash(),
+        ) {
+            return Err(SubmittedMetadataError::rollup_transactions_not_in_cometbft_block());
+        }
+
+        if !super::are_rollup_ids_included(
+            rollup_ids.iter().copied(),
+            &rollup_ids_proof,
+            *header.data_hash(),
+        ) {
+            return Err(SubmittedMetadataError::rollup_ids_not_in_cometbft_block());
+        }
+
+        Ok(Self {
+            block_hash,
+            header,
+            rollup_ids,
+            rollup_transactions_proof,
+            rollup_ids_proof,
+        })
+    }
+
+    /// Converts into the raw decoded protobuf representation of this type.
+    pub fn into_raw(self) -> raw::SubmittedMetadata {
+        let Self {
+            block_hash,
+            header,
+            rollup_ids,
+            rollup_transactions_proof,
+            rollup_ids_proof,
+            ..
+        } = self;
+        raw::SubmittedMetadata {
+            block_hash: Bytes::copy_from_slice(&block_hash),
+            header: Some(header.into_raw()),
+            rollup_ids: rollup_ids.into_iter().map(RollupId::into_raw).collect(),
+            rollup_transactions_proof: Some(rollup_transactions_proof.into_raw()),
+            rollup_ids_proof: Some(rollup_ids_proof.into_raw()),
+        }
+    }
+
+    /// Converts from the raw decoded protobuf representation of this type.
+    ///
+    /// # Errors
+    /// TODO(https://github.com/astriaorg/astria/issues/612)
+    pub fn try_from_raw(raw: raw::SubmittedMetadata) -> Result<Self, SubmittedMetadataError> {
+        UncheckedSubmittedMetadata::try_from_raw(raw)
+            .and_then(UncheckedSubmittedMetadata::try_into_celestia_sequencer_blob)
+    }
+}

--- a/crates/astria-core/src/sequencerblock/v1alpha1/mod.rs
+++ b/crates/astria-core/src/sequencerblock/v1alpha1/mod.rs
@@ -1,0 +1,67 @@
+pub mod block;
+pub mod celestia;
+
+pub use block::{
+    RollupTransactions,
+    SequencerBlock,
+};
+pub use celestia::{
+    SubmittedMetadata,
+    SubmittedRollupData,
+};
+use indexmap::IndexMap;
+use sha2::{
+    Digest as _,
+    Sha256,
+};
+
+use crate::{
+    generated::astria::sequencerblock::v1alpha1 as raw,
+    primitive::v1::{
+        derive_merkle_tree_from_rollup_txs,
+        IncorrectRollupIdLength,
+        RollupId,
+    },
+};
+
+pub(crate) fn are_rollup_ids_included<TRollupIds>(
+    ids: TRollupIds,
+    proof: &merkle::Proof,
+    data_hash: [u8; 32],
+) -> bool
+where
+    TRollupIds: IntoIterator<Item = RollupId>,
+{
+    let tree = merkle::Tree::from_leaves(ids);
+    let hash_of_root = Sha256::digest(tree.root());
+    proof.verify(&hash_of_root, data_hash)
+}
+
+pub(crate) fn are_rollup_txs_included(
+    rollup_datas: &IndexMap<RollupId, RollupTransactions>,
+    rollup_proof: &merkle::Proof,
+    data_hash: [u8; 32],
+) -> bool {
+    let rollup_datas = rollup_datas
+        .iter()
+        .map(|(rollup_id, tx_data)| (rollup_id, tx_data.transactions()));
+    let rollup_tree = derive_merkle_tree_from_rollup_txs(rollup_datas);
+    let hash_of_rollup_root = Sha256::digest(rollup_tree.root());
+    rollup_proof.verify(&hash_of_rollup_root, data_hash)
+}
+
+fn do_rollup_transaction_match_root(
+    rollup_transactions: &RollupTransactions,
+    root: [u8; 32],
+) -> bool {
+    let id = rollup_transactions.rollup_id();
+    rollup_transactions
+        .proof()
+        .audit()
+        .with_root(root)
+        .with_leaf_builder()
+        .write(id.as_ref())
+        .write(&merkle::Tree::from_leaves(rollup_transactions.transactions()).root())
+        .finish_leaf()
+        .perform()
+}

--- a/crates/astria-core/src/sequencerblock/v1alpha1/tests.rs
+++ b/crates/astria-core/src/sequencerblock/v1alpha1/tests.rs
@@ -1,0 +1,719 @@
+use astria_core_address::Address;
+use bytes::Bytes;
+use prost::Message as _;
+use sha2::Digest as _;
+
+use super::{
+    super::do_rollup_transactions_match_root,
+    *,
+};
+use crate::{
+    crypto::SigningKey,
+    generated::protocol::transaction::v1::Transaction as RawTransaction,
+    protocol::{
+        test_utils::{
+            minimal_extended_commit_info,
+            minimal_extended_commit_info_bytes,
+            upgrade_change_hashes,
+            upgrade_change_hashes_bytes,
+            ConfigureSequencerBlock,
+        },
+        transaction::v1::{
+            action::Transfer,
+            Transaction,
+            TransactionBody,
+        },
+    },
+    Protobuf as _,
+};
+
+const ROLLUP_TXS_ROOT: [u8; 32] = [1; 32];
+const ROLLUP_IDS_ROOT: [u8; 32] = [2; 32];
+
+#[test]
+fn sequencer_block_from_cometbft_block_gives_expected_merkle_proofs() {
+    let sequencer_block = ConfigureSequencerBlock::default().make();
+    let rollup_ids_root =
+        merkle::Tree::from_leaves(sequencer_block.rollup_transactions().keys()).root();
+
+    let rollup_transaction_tree = derive_merkle_tree_from_rollup_txs(
+        sequencer_block
+            .rollup_transactions()
+            .iter()
+            .map(|(id, txs)| (id, txs.transactions())),
+    );
+
+    for rollup_transactions in sequencer_block.rollup_transactions().values() {
+        assert!(
+            do_rollup_transactions_match_root(rollup_transactions, rollup_transaction_tree.root()),
+            "audit failed; rollup transaction and its proof does not evaluate to rollup \
+             transactions root",
+        );
+    }
+
+    let data_hash = *sequencer_block.header().data_hash();
+    assert!(sequencer_block
+        .rollup_transactions_proof()
+        .verify(&Sha256::digest(rollup_transaction_tree.root()), data_hash));
+    assert!(sequencer_block
+        .rollup_ids_proof()
+        .verify(&Sha256::digest(rollup_ids_root), data_hash));
+}
+
+#[test]
+fn block_to_filtered_roundtrip() {
+    let sequencer_block = ConfigureSequencerBlock::default().make();
+    let rollup_ids = sequencer_block.rollup_transactions().keys();
+    let filtered_sequencer_block = sequencer_block.to_filtered_block(rollup_ids);
+
+    let raw = filtered_sequencer_block.clone().into_raw();
+    let from_raw = FilteredSequencerBlock::try_from_raw(raw).unwrap();
+
+    assert_eq!(filtered_sequencer_block, from_raw);
+}
+
+#[test]
+fn encoded_rollup_txs_root_length_should_be_correct() {
+    assert_eq!(
+        DataItem::RollupTransactionsRoot([1; 32]).encode().len(),
+        DataItem::ENCODED_ROLLUP_TRANSACTIONS_ROOT_LENGTH
+    );
+}
+
+#[test]
+fn encoded_rollup_ids_root_length_should_be_correct() {
+    assert_eq!(
+        DataItem::RollupIdsRoot([1; 32]).encode().len(),
+        DataItem::ENCODED_ROLLUP_IDS_ROOT_LENGTH
+    );
+}
+
+fn rollup_txs_root_legacy_bytes() -> Bytes {
+    ROLLUP_TXS_ROOT.as_slice().into()
+}
+
+fn rollup_txs_root_bytes() -> Bytes {
+    DataItem::RollupTransactionsRoot(ROLLUP_TXS_ROOT).encode()
+}
+
+fn rollup_ids_root_legacy_bytes() -> Bytes {
+    ROLLUP_IDS_ROOT.as_slice().into()
+}
+
+fn rollup_ids_root_bytes() -> Bytes {
+    DataItem::RollupIdsRoot(ROLLUP_IDS_ROOT).encode()
+}
+
+fn tx(nonce: u32) -> Transaction {
+    let signing_key = SigningKey::from([
+        213, 191, 74, 63, 204, 231, 23, 176, 56, 139, 204, 39, 73, 235, 193, 72, 173, 153, 105,
+        178, 63, 69, 238, 27, 96, 95, 213, 135, 120, 87, 106, 196,
+    ]);
+
+    let transfer = Transfer {
+        to: Address::builder()
+            .array([0; 20])
+            .prefix("astria")
+            .try_build()
+            .unwrap(),
+        amount: 0,
+        asset: "nria".parse().unwrap(),
+        fee_asset: "nria".parse().unwrap(),
+    };
+
+    let body = TransactionBody::builder()
+        .actions(vec![transfer.into()])
+        .chain_id("test-1".to_string())
+        .nonce(nonce)
+        .try_build()
+        .unwrap();
+
+    body.sign(&signing_key)
+}
+
+fn tx_bytes(nonce: u32) -> Bytes {
+    tx(nonce).into_raw().encode_to_vec().into()
+}
+
+macro_rules! assert_err_matches {
+    ($expression:expr, $pattern:pat $(if $guard:expr)? $(,)?) => {
+        let pattern_str = stringify!($pattern);
+        let if_guard_str = stringify!($(if $guard)?);
+        let expected_str = if if_guard_str.is_empty() {
+            format!("`{pattern_str}`")
+        } else {
+            format!("`{pattern_str} {if_guard_str}`")
+        };
+        let expected = expected_str.replace('\n', " ");
+        assert!(
+            matches!($expression, $pattern $(if $guard)?),
+            "expected {expected}, got `SequencerBlockErrorKind::{:?}`", $expression,
+        );
+    };
+}
+
+// Tests for the `ExpandedBlockData` constructors.
+mod expanded_block_data {
+    use super::*;
+
+    #[test]
+    fn should_fail_to_parse_legacy_txs_missing_rollup_txs_root() {
+        let data = [];
+        let SequencerBlockError(error_kind) =
+            ExpandedBlockData::new_from_untyped_data(&data).unwrap_err();
+        assert_err_matches!(
+            error_kind,
+            SequencerBlockErrorKind::NoRollupTransactionsRoot
+        );
+    }
+
+    #[test]
+    fn should_fail_to_parse_legacy_txs_malformed_rollup_txs_root() {
+        let data = [vec![0; 31].into()];
+        let SequencerBlockError(error_kind) =
+            ExpandedBlockData::new_from_untyped_data(&data).unwrap_err();
+        assert_err_matches!(
+            error_kind,
+            SequencerBlockErrorKind::IncorrectRollupTransactionsRootLength
+        );
+    }
+
+    #[test]
+    fn should_fail_to_parse_legacy_txs_missing_rollup_ids_root() {
+        let data = [rollup_txs_root_legacy_bytes()];
+        let SequencerBlockError(error_kind) =
+            ExpandedBlockData::new_from_untyped_data(&data).unwrap_err();
+        assert_err_matches!(error_kind, SequencerBlockErrorKind::NoRollupIdsRoot);
+    }
+
+    #[test]
+    fn should_fail_to_parse_legacy_txs_malformed_rollup_ids_root() {
+        let data = [rollup_txs_root_legacy_bytes(), vec![0; 31].into()];
+        let SequencerBlockError(error_kind) =
+            ExpandedBlockData::new_from_untyped_data(&data).unwrap_err();
+        assert_err_matches!(
+            error_kind,
+            SequencerBlockErrorKind::IncorrectRollupIdsRootLength
+        );
+    }
+
+    #[test]
+    fn should_fail_to_parse_legacy_txs_malformed_protobuf_tx() {
+        let data = [
+            rollup_txs_root_legacy_bytes(),
+            rollup_ids_root_legacy_bytes(),
+            vec![3].into(),
+        ];
+        let SequencerBlockError(error_kind) =
+            ExpandedBlockData::new_from_untyped_data(&data).unwrap_err();
+        assert_err_matches!(
+            error_kind,
+            SequencerBlockErrorKind::TransactionProtobufDecode(_)
+        );
+    }
+
+    #[test]
+    fn should_fail_to_parse_legacy_txs_malformed_raw_tx() {
+        let bad_tx = RawTransaction {
+            signature: vec![1].into(),
+            public_key: vec![2].into(),
+            body: None,
+        };
+        let data = [
+            rollup_txs_root_legacy_bytes(),
+            rollup_ids_root_legacy_bytes(),
+            bad_tx.encode_to_vec().into(),
+        ];
+        let SequencerBlockError(error_kind) =
+            ExpandedBlockData::new_from_untyped_data(&data).unwrap_err();
+        assert_err_matches!(
+            error_kind,
+            SequencerBlockErrorKind::RawTransactionConversion(_)
+        );
+    }
+
+    #[test]
+    fn should_parse_legacy_txs_with_user_submitted_txs() {
+        let data = [
+            rollup_txs_root_legacy_bytes(),
+            rollup_ids_root_legacy_bytes(),
+            tx_bytes(0),
+            tx_bytes(1),
+            tx_bytes(2),
+        ];
+        let items = ExpandedBlockData::new_from_untyped_data(&data).unwrap();
+        assert_eq!(ROLLUP_TXS_ROOT, items.rollup_transactions_root);
+        assert_eq!(ROLLUP_IDS_ROOT, items.rollup_ids_root);
+        assert_eq!(tx(0).id(), items.user_submitted_transactions[0].id());
+        assert_eq!(tx(1).id(), items.user_submitted_transactions[1].id());
+        assert_eq!(tx(2).id(), items.user_submitted_transactions[2].id());
+    }
+
+    #[test]
+    fn should_parse_legacy_txs_with_no_user_submitted_txs() {
+        let data = [
+            rollup_txs_root_legacy_bytes(),
+            rollup_ids_root_legacy_bytes(),
+        ];
+        let items = ExpandedBlockData::new_from_untyped_data(&data).unwrap();
+        assert_eq!(ROLLUP_TXS_ROOT, items.rollup_transactions_root);
+        assert_eq!(ROLLUP_IDS_ROOT, items.rollup_ids_root);
+        assert!(items.upgrade_change_hashes.is_empty());
+        assert!(items.extended_commit_info_with_proof.is_none());
+        assert!(items.user_submitted_transactions.is_empty());
+    }
+
+    #[test]
+    fn should_fail_to_parse_data_items_missing_rollup_txs_root() {
+        let data = [];
+        let SequencerBlockError(error_kind) =
+            ExpandedBlockData::new_from_typed_data(&data, true).unwrap_err();
+        assert_err_matches!(
+            error_kind,
+            SequencerBlockErrorKind::NoRollupTransactionsRoot
+        );
+    }
+
+    #[test]
+    fn should_fail_to_parse_data_items_malformed_item() {
+        let data = [vec![0; 31].into()];
+        let SequencerBlockError(error_kind) =
+            ExpandedBlockData::new_from_typed_data(&data, true).unwrap_err();
+        assert_err_matches!(
+            error_kind,
+            SequencerBlockErrorKind::DataItem(DataItemError(DataItemErrorKind::Decode { .. }))
+        );
+    }
+
+    #[test]
+    fn should_fail_to_parse_data_items_rollup_txs_root_not_first_item() {
+        let data = [rollup_ids_root_bytes(), rollup_txs_root_bytes()];
+        let SequencerBlockError(error_kind) =
+            ExpandedBlockData::new_from_typed_data(&data, true).unwrap_err();
+        assert_err_matches!(
+            error_kind,
+            SequencerBlockErrorKind::DataItem(DataItemError(DataItemErrorKind::Mismatch { index, .. }))
+            if index == 0
+        );
+    }
+
+    #[test]
+    fn should_fail_to_parse_data_items_missing_rollup_ids_root() {
+        let data = [rollup_txs_root_bytes()];
+        let SequencerBlockError(error_kind) =
+            ExpandedBlockData::new_from_typed_data(&data, true).unwrap_err();
+        assert_err_matches!(error_kind, SequencerBlockErrorKind::NoRollupIdsRoot);
+    }
+
+    #[test]
+    fn should_fail_to_parse_data_items_rollup_ids_root_not_second_item() {
+        let data = [rollup_txs_root_bytes(), rollup_txs_root_bytes()];
+        let SequencerBlockError(error_kind) =
+            ExpandedBlockData::new_from_typed_data(&data, true).unwrap_err();
+        assert_err_matches!(
+            error_kind,
+            SequencerBlockErrorKind::DataItem(DataItemError(DataItemErrorKind::Mismatch { index, .. }))
+            if index == 1
+        );
+    }
+
+    #[test]
+    fn should_fail_to_parse_data_items_missing_required_extended_commit_info() {
+        let data = [rollup_txs_root_bytes(), rollup_ids_root_bytes()];
+        let SequencerBlockError(error_kind) =
+            ExpandedBlockData::new_from_typed_data(&data, true).unwrap_err();
+        assert_err_matches!(error_kind, SequencerBlockErrorKind::NoExtendedCommitInfo);
+    }
+
+    #[test]
+    fn should_fail_to_parse_data_items_malformed_protobuf_tx() {
+        let data = [
+            rollup_txs_root_bytes(),
+            rollup_ids_root_bytes(),
+            minimal_extended_commit_info_bytes(),
+            vec![3].into(),
+        ];
+        let SequencerBlockError(error_kind) =
+            ExpandedBlockData::new_from_typed_data(&data, true).unwrap_err();
+        assert_err_matches!(
+            error_kind,
+            SequencerBlockErrorKind::TransactionProtobufDecode(_)
+        );
+    }
+
+    #[test]
+    fn should_fail_to_parse_data_items_malformed_raw_tx() {
+        let bad_tx = RawTransaction {
+            signature: vec![1].into(),
+            public_key: vec![2].into(),
+            body: None,
+        };
+        let data = [
+            rollup_txs_root_bytes(),
+            rollup_ids_root_bytes(),
+            minimal_extended_commit_info_bytes(),
+            bad_tx.encode_to_vec().into(),
+        ];
+        let SequencerBlockError(error_kind) =
+            ExpandedBlockData::new_from_typed_data(&data, true).unwrap_err();
+        assert_err_matches!(
+            error_kind,
+            SequencerBlockErrorKind::RawTransactionConversion(_)
+        );
+    }
+
+    #[test]
+    fn should_parse_with_no_upgrade_change_hashes_no_extended_commit_info_no_user_submitted_txs() {
+        let data = [rollup_txs_root_bytes(), rollup_ids_root_bytes()];
+        let items = ExpandedBlockData::new_from_typed_data(&data, false).unwrap();
+        assert_eq!(ROLLUP_TXS_ROOT, items.rollup_transactions_root);
+        assert_eq!(ROLLUP_IDS_ROOT, items.rollup_ids_root);
+        assert!(items.upgrade_change_hashes.is_empty());
+        assert!(items.extended_commit_info_with_proof.is_none());
+        assert!(items.user_submitted_transactions.is_empty());
+    }
+
+    #[test]
+    fn should_parse_with_no_upgrade_change_hashes_no_extended_commit_info_some_user_submitted_txs()
+    {
+        let data = [
+            rollup_txs_root_bytes(),
+            rollup_ids_root_bytes(),
+            tx_bytes(0),
+            tx_bytes(1),
+            tx_bytes(2),
+        ];
+        let items = ExpandedBlockData::new_from_typed_data(&data, false).unwrap();
+        assert_eq!(ROLLUP_TXS_ROOT, items.rollup_transactions_root);
+        assert_eq!(ROLLUP_IDS_ROOT, items.rollup_ids_root);
+        assert!(items.upgrade_change_hashes.is_empty());
+        assert!(items.extended_commit_info_with_proof.is_none());
+        assert_eq!(tx(0).id(), items.user_submitted_transactions[0].id());
+        assert_eq!(tx(1).id(), items.user_submitted_transactions[1].id());
+        assert_eq!(tx(2).id(), items.user_submitted_transactions[2].id());
+    }
+
+    #[test]
+    fn should_parse_with_no_upgrade_change_hashes_some_extended_commit_info_no_user_submitted_txs()
+    {
+        let data = [
+            rollup_txs_root_bytes(),
+            rollup_ids_root_bytes(),
+            minimal_extended_commit_info_bytes(),
+        ];
+        let items = ExpandedBlockData::new_from_typed_data(&data, true).unwrap();
+        assert_eq!(ROLLUP_TXS_ROOT, items.rollup_transactions_root);
+        assert_eq!(ROLLUP_IDS_ROOT, items.rollup_ids_root);
+        assert!(items.upgrade_change_hashes.is_empty());
+        assert_eq!(
+            &minimal_extended_commit_info(),
+            items
+                .extended_commit_info_with_proof
+                .unwrap()
+                .extended_commit_info()
+        );
+        assert!(items.user_submitted_transactions.is_empty());
+    }
+
+    #[test]
+    fn should_parse_with_no_upgrade_change_hashes_some_extended_commit_info_some_user_submitted_txs(
+    ) {
+        let data = [
+            rollup_txs_root_bytes(),
+            rollup_ids_root_bytes(),
+            minimal_extended_commit_info_bytes(),
+            tx_bytes(0),
+            tx_bytes(1),
+            tx_bytes(2),
+        ];
+        let items = ExpandedBlockData::new_from_typed_data(&data, true).unwrap();
+        assert_eq!(ROLLUP_TXS_ROOT, items.rollup_transactions_root);
+        assert_eq!(ROLLUP_IDS_ROOT, items.rollup_ids_root);
+        assert!(items.upgrade_change_hashes.is_empty());
+        assert_eq!(
+            &minimal_extended_commit_info(),
+            items
+                .extended_commit_info_with_proof
+                .unwrap()
+                .extended_commit_info()
+        );
+        assert_eq!(tx(0).id(), items.user_submitted_transactions[0].id());
+        assert_eq!(tx(1).id(), items.user_submitted_transactions[1].id());
+        assert_eq!(tx(2).id(), items.user_submitted_transactions[2].id());
+    }
+
+    #[test]
+    fn should_parse_with_upgrade_change_hashes_no_extended_commit_info_no_user_submitted_txs() {
+        let data = [
+            rollup_txs_root_bytes(),
+            rollup_ids_root_bytes(),
+            upgrade_change_hashes_bytes(),
+        ];
+        let items = ExpandedBlockData::new_from_typed_data(&data, false).unwrap();
+        assert_eq!(ROLLUP_TXS_ROOT, items.rollup_transactions_root);
+        assert_eq!(ROLLUP_IDS_ROOT, items.rollup_ids_root);
+        assert_eq!(upgrade_change_hashes(), items.upgrade_change_hashes);
+        assert!(items.extended_commit_info_with_proof.is_none());
+        assert!(items.user_submitted_transactions.is_empty());
+    }
+
+    #[test]
+    fn should_parse_with_upgrade_change_hashes_no_extended_commit_info_some_user_submitted_txs() {
+        let data = [
+            rollup_txs_root_bytes(),
+            rollup_ids_root_bytes(),
+            upgrade_change_hashes_bytes(),
+            tx_bytes(0),
+            tx_bytes(1),
+            tx_bytes(2),
+        ];
+        let items = ExpandedBlockData::new_from_typed_data(&data, false).unwrap();
+        assert_eq!(ROLLUP_TXS_ROOT, items.rollup_transactions_root);
+        assert_eq!(ROLLUP_IDS_ROOT, items.rollup_ids_root);
+        assert_eq!(upgrade_change_hashes(), items.upgrade_change_hashes);
+        assert!(items.extended_commit_info_with_proof.is_none());
+        assert_eq!(tx(0).id(), items.user_submitted_transactions[0].id());
+        assert_eq!(tx(1).id(), items.user_submitted_transactions[1].id());
+        assert_eq!(tx(2).id(), items.user_submitted_transactions[2].id());
+    }
+
+    #[test]
+    fn should_parse_with_upgrade_change_hashes_some_extended_commit_info_no_user_submitted_txs() {
+        let data = [
+            rollup_txs_root_bytes(),
+            rollup_ids_root_bytes(),
+            upgrade_change_hashes_bytes(),
+            minimal_extended_commit_info_bytes(),
+        ];
+        let items = ExpandedBlockData::new_from_typed_data(&data, true).unwrap();
+        assert_eq!(ROLLUP_TXS_ROOT, items.rollup_transactions_root);
+        assert_eq!(ROLLUP_IDS_ROOT, items.rollup_ids_root);
+        assert_eq!(upgrade_change_hashes(), items.upgrade_change_hashes);
+        assert_eq!(
+            &minimal_extended_commit_info(),
+            items
+                .extended_commit_info_with_proof
+                .unwrap()
+                .extended_commit_info()
+        );
+        assert!(items.user_submitted_transactions.is_empty());
+    }
+
+    #[test]
+    fn should_parse_with_upgrade_change_hashes_some_extended_commit_info_some_user_submitted_txs() {
+        let data = [
+            rollup_txs_root_bytes(),
+            rollup_ids_root_bytes(),
+            upgrade_change_hashes_bytes(),
+            minimal_extended_commit_info_bytes(),
+            tx_bytes(0),
+            tx_bytes(1),
+            tx_bytes(2),
+        ];
+        let items = ExpandedBlockData::new_from_typed_data(&data, true).unwrap();
+        assert_eq!(ROLLUP_TXS_ROOT, items.rollup_transactions_root);
+        assert_eq!(ROLLUP_IDS_ROOT, items.rollup_ids_root);
+        assert_eq!(upgrade_change_hashes(), items.upgrade_change_hashes);
+        assert_eq!(
+            &minimal_extended_commit_info(),
+            items
+                .extended_commit_info_with_proof
+                .unwrap()
+                .extended_commit_info()
+        );
+        assert_eq!(tx(0).id(), items.user_submitted_transactions[0].id());
+        assert_eq!(tx(1).id(), items.user_submitted_transactions[1].id());
+        assert_eq!(tx(2).id(), items.user_submitted_transactions[2].id());
+    }
+}
+
+// Tests for nontrivial parts of `try_from_raw` constructors.
+mod try_from_raw {
+    use super::*;
+
+    fn rollup_1() -> RollupId {
+        RollupId::from_unhashed_bytes(b"rollup_1")
+    }
+
+    fn rollup_2() -> RollupId {
+        RollupId::from_unhashed_bytes(b"rollup_2")
+    }
+
+    /// Three txs all from rollup 1.
+    fn block_with_three_txs() -> SequencerBlock {
+        ConfigureSequencerBlock {
+            sequence_data: vec![
+                (rollup_1(), vec![1]),
+                (rollup_1(), vec![2]),
+                (rollup_1(), vec![3]),
+            ],
+            ..ConfigureSequencerBlock::default()
+        }
+        .make()
+    }
+
+    /// Three txs from rollup 1 and three from rollup 2.
+    fn block_with_six_txs() -> SequencerBlock {
+        ConfigureSequencerBlock {
+            sequence_data: vec![
+                (rollup_1(), vec![1]),
+                (rollup_1(), vec![2]),
+                (rollup_1(), vec![3]),
+                (rollup_2(), vec![4]),
+                (rollup_2(), vec![5]),
+                (rollup_2(), vec![6]),
+            ],
+            ..ConfigureSequencerBlock::default()
+        }
+        .make()
+    }
+
+    #[test]
+    fn sequencer_block_should_fail_bad_rollup_txs_proof() {
+        let mut block = block_with_six_txs().into_raw();
+        block.rollup_transactions_proof =
+            block_with_three_txs().into_raw().rollup_transactions_proof;
+        let SequencerBlockError(error_kind) = SequencerBlock::try_from_raw(block).unwrap_err();
+        assert_err_matches!(
+            error_kind,
+            SequencerBlockErrorKind::InvalidRollupTransactionsRoot
+        );
+    }
+
+    #[test]
+    fn sequencer_block_should_fail_missing_rollup_tx() {
+        let mut block = block_with_six_txs().into_raw();
+        // Pop the last tx from rollup 2's txs.
+        let _ = block
+            .rollup_transactions
+            .last_mut()
+            .unwrap()
+            .transactions
+            .pop();
+        let SequencerBlockError(error_kind) = SequencerBlock::try_from_raw(block).unwrap_err();
+        assert_err_matches!(
+            error_kind,
+            SequencerBlockErrorKind::RollupTransactionsNotInSequencerBlock
+        );
+    }
+
+    #[test]
+    fn sequencer_block_should_fail_extra_rollup_tx() {
+        let mut block = block_with_six_txs().into_raw();
+        // Push a tx to rollup 2's txs.
+        block
+            .rollup_transactions
+            .last_mut()
+            .unwrap()
+            .transactions
+            .push(vec![4].into());
+        let SequencerBlockError(error_kind) = SequencerBlock::try_from_raw(block).unwrap_err();
+        assert_err_matches!(
+            error_kind,
+            SequencerBlockErrorKind::RollupTransactionsNotInSequencerBlock
+        );
+    }
+
+    #[test]
+    fn sequencer_block_should_fail_bad_rollup_ids_proof() {
+        let mut block = block_with_six_txs().into_raw();
+        block.rollup_ids_proof = block_with_three_txs().into_raw().rollup_ids_proof;
+        let SequencerBlockError(error_kind) = SequencerBlock::try_from_raw(block).unwrap_err();
+        assert_err_matches!(error_kind, SequencerBlockErrorKind::InvalidRollupIdsProof);
+    }
+
+    #[test]
+    fn filtered_sequencer_block_should_fail_bad_rollup_txs_proof() {
+        let mut block = block_with_six_txs()
+            .into_filtered_block([rollup_1(), rollup_2()])
+            .into_raw();
+        block.rollup_transactions_proof =
+            block_with_three_txs().into_raw().rollup_transactions_proof;
+        let FilteredSequencerBlockError(error_kind) =
+            FilteredSequencerBlock::try_from_raw(block).unwrap_err();
+        assert_err_matches!(
+            error_kind,
+            FilteredSequencerBlockErrorKind::RollupTransactionsNotInSequencerBlock
+        );
+    }
+
+    #[test]
+    fn filtered_sequencer_block_should_fail_missing_rollup_tx() {
+        let mut block = block_with_six_txs()
+            .into_filtered_block([rollup_1(), rollup_2()])
+            .into_raw();
+        // Pop the last tx from rollup 2's txs.
+        let _ = block
+            .rollup_transactions
+            .last_mut()
+            .unwrap()
+            .transactions
+            .pop();
+        let FilteredSequencerBlockError(error_kind) =
+            FilteredSequencerBlock::try_from_raw(block).unwrap_err();
+        assert_err_matches!(
+            error_kind,
+            FilteredSequencerBlockErrorKind::RollupTransactionForIdNotInSequencerBlock { .. }
+        );
+    }
+
+    #[test]
+    fn filtered_sequencer_block_should_fail_extra_rollup_tx() {
+        let mut block = block_with_six_txs()
+            .into_filtered_block([rollup_1(), rollup_2()])
+            .into_raw();
+        // Push a tx to rollup 2's txs.
+        block
+            .rollup_transactions
+            .last_mut()
+            .unwrap()
+            .transactions
+            .push(vec![4].into());
+        let FilteredSequencerBlockError(error_kind) =
+            FilteredSequencerBlock::try_from_raw(block).unwrap_err();
+        assert_err_matches!(
+            error_kind,
+            FilteredSequencerBlockErrorKind::RollupTransactionForIdNotInSequencerBlock { .. }
+        );
+    }
+
+    #[test]
+    fn filtered_sequencer_block_should_fail_bad_rollup_ids_proof() {
+        let mut block = block_with_six_txs()
+            .into_filtered_block([rollup_1(), rollup_2()])
+            .into_raw();
+        block.rollup_ids_proof = block_with_three_txs().into_raw().rollup_ids_proof;
+        let FilteredSequencerBlockError(error_kind) =
+            FilteredSequencerBlock::try_from_raw(block).unwrap_err();
+        assert_err_matches!(
+            error_kind,
+            FilteredSequencerBlockErrorKind::InvalidRollupIdsProof
+        );
+    }
+
+    #[test]
+    fn extended_commit_info_with_proof_should_fail_bad_proof() {
+        let data = [
+            rollup_txs_root_bytes(),
+            rollup_ids_root_bytes(),
+            minimal_extended_commit_info_bytes(),
+        ];
+        let items = ExpandedBlockData::new_from_typed_data(&data, true).unwrap();
+        let mut extended_commit_info_with_proof =
+            items.extended_commit_info_with_proof.unwrap().into_raw();
+
+        // Change the proof to be invalid.
+        extended_commit_info_with_proof
+            .proof
+            .as_mut()
+            .unwrap()
+            .leaf_index = 0;
+
+        let ExtendedCommitInfoError(error_kind) = ExtendedCommitInfoWithProof::try_from_raw(
+            extended_commit_info_with_proof,
+            items.data_root_hash,
+        )
+        .unwrap_err();
+        assert_err_matches!(error_kind, ExtendedCommitInfoErrorKind::NotInSequencerBlock);
+    }
+}

--- a/proto/executionapis/astria/execution/v2/execute_block_request.proto
+++ b/proto/executionapis/astria/execution/v2/execute_block_request.proto
@@ -2,7 +2,7 @@ syntax = 'proto3';
 
 package astria.execution.v2;
 
-import "astria/sequencerblock/v1/block.proto";
+import "astria/sequencerblock/v1alpha1/block.proto";
 import "google/protobuf/timestamp.proto";
 
 // ExecuteBlockRequest contains all the information needed to create a new rollup
@@ -17,7 +17,7 @@ message ExecuteBlockRequest {
   // formatted in the execution node's preferred encoding.
   string parent_hash = 2;
   // List of transactions to include in the new block.
-  repeated astria.sequencerblock.v1.RollupData transactions = 3;
+  repeated astria.sequencerblock.v1alpha1.RollupData transactions = 3;
   // Timestamp to be used for new block.
   google.protobuf.Timestamp timestamp = 4;
   // The hash of the sequencer block from which the transactions and timestamp

--- a/proto/sequencerblockapis/astria/sequencerblock/v1alpha1/block.proto
+++ b/proto/sequencerblockapis/astria/sequencerblock/v1alpha1/block.proto
@@ -113,7 +113,7 @@ message FilteredSequencerBlock {
   // and is extracted from `astria.SequencerBlock.rollup_transactions`.
   // Note that these are all the rollup IDs in the sequencer block, not merely those in
   // `rollup_transactions` field. This is necessary to prove that no rollup IDs were omitted.
-  repeated astria.primitive.v1.RollupId all_rollup_ids = 5;
+  repeated bytes all_rollup_ids = 5;
   // The proof that the `rollup_ids` are included
   // in the CometBFT block this sequencer block is derived form.
   //


### PR DESCRIPTION
## Summary
Reverts Conductor to using `v1alpha1` SequencerBlock API.

## Background
Necessary to migrate Forma to dusk-5. From there, we can migrate it to testnet and mainnet.

## Changes
- List changes which were made.

## Testing
How are these changes tested?

## Changelogs
Ensure all relevant changelog files are updated as necessary. See
[keepachangelog](https://keepachangelog.com/en/1.1.0/#how) for change
categories. Replace this text with e.g. "Changelogs updated." or "No updates
required." to acknowledge changelogs have been considered.

## Metrics
- List out metrics added by PR, delete section if none. 

## Breaking Changelist
- Bulleted list of breaking changes, any notes on migration. Delete section if none.

## Related Issues
Link any issues that are related, prefer full GitHub links.

closes <!-- list any issues closed here -->
