### PR TITLE
release(conductor): 2.0.0-rc.1 with execution api v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "astria-auctioneer"
-version = "0.0.2"
+version = "0.0.1"
 dependencies = [
  "astria-build-info",
  "astria-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "astria-auctioneer"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "astria-build-info",
  "astria-config",
@@ -675,7 +675,7 @@ dependencies = [
 
 [[package]]
 name = "astria-conductor"
-version = "1.1.0"
+version = "2.0.0-rc.1"
 dependencies = [
  "astria-build-info",
  "astria-config",

--- a/crates/astria-auctioneer/Cargo.toml
+++ b/crates/astria-auctioneer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astria-auctioneer"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 rust-version = "1.81"
 license = "MIT OR Apache-2.0"

--- a/crates/astria-auctioneer/Cargo.toml
+++ b/crates/astria-auctioneer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astria-auctioneer"
-version = "0.0.2"
+version = "0.0.1"
 edition = "2021"
 rust-version = "1.81"
 license = "MIT OR Apache-2.0"

--- a/crates/astria-conductor/CHANGELOG.md
+++ b/crates/astria-conductor/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   provides it [#2085](https://github.com/astriaorg/astria/pull/2085).
 
 ### Changed
+
 - Upgrade to `astria.execution.v2` APIs, implement execution sessions, remove env
   vars for setting chain IDs [#2006](https://github.com/astriaorg/astria/pull/2006).
 

--- a/crates/astria-conductor/CHANGELOG.md
+++ b/crates/astria-conductor/CHANGELOG.md
@@ -9,10 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-rc.1] - 2025-04-22
+
 ### Added
 
 - Include price feed oracle data in transactions when sequencer network
   provides it [#2085](https://github.com/astriaorg/astria/pull/2085).
+
+### Changed
+- Upgrade to `astria.execution.v2` APIs, implement execution sessions, remove env
+  vars for setting chain IDs [#2006](https://github.com/astriaorg/astria/pull/2006).
 
 ### Fixed
 
@@ -24,8 +30,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update `idna` dependency to resolve cargo audit warning [#1869](https://github.com/astriaorg/astria/pull/1869).
 - Remove panic source on shutdown [#1919](https://github.com/astriaorg/astria/pull/1919).
-- Upgrade to `astria.execution.v2` APIs, implement execution sessions, remove env
-vars for setting chain IDs [#2006](https://github.com/astriaorg/astria/pull/2006).
 
 ### Added
 
@@ -375,7 +379,8 @@ address [#721](https://github.com/astriaorg/astria/pull/721).
 
 - Initial release.
 
-[unreleased]: https://github.com/astriaorg/astria/compare/conductor-v1.0.0...HEAD
+[unreleased]: https://github.com/astriaorg/astria/compare/conductor-v2.0.0-rc.1...HEAD
+[2.0.0-rc.1]: https://github.com/astriaorg/astria/compare/conductor-v1.1.0...conductor-v2.0.0-rc.1
 [1.1.0]: https://github.com/astriaorg/astria/compare/conductor-v1.0.0...conductor-v1.1.0
 [1.0.0]: https://github.com/astriaorg/astria/compare/conductor-v1.0.0-rc.2...conductor-v1.0.0
 [1.0.0-rc.2]: https://github.com/astriaorg/astria/compare/conductor-v1.0.0-rc.1...conductor-v1.0.0-rc.2

--- a/crates/astria-conductor/Cargo.toml
+++ b/crates/astria-conductor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astria-conductor"
-version = "1.1.0"
+version = "2.0.0-rc.1"
 edition = "2021"
 rust-version = "1.83.0"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary
Cuts release candidate of conductor 2.0.0

## Changelogs
Changelogs updated.
