### PR TITLE
fix(ci): update tagging in EVM rollup restart test

### DIFF
--- a/charts/just/deploy.just
+++ b/charts/just/deploy.just
@@ -301,7 +301,7 @@ evm-rollup-restart-test tag=defaultTag:
     -n astria-validator-single single-sequencer-chart charts/sequencer \
     -f dev/values/validators/all.yml \
     -f dev/values/validators/single.yml \
-    {{ if tag != '' { replace('--set images.sequencer.devTag=# --set sequencer-relayer.images.sequencerRelayer.devTag=#', '#', tag) } else { '' } }} \
+    {{ if tag != '' { replace('--set images.sequencer.tag=# --set sequencer-relayer.images.sequencerRelayer.tag=#', '#', tag) } else { '' } }} \
     --create-namespace > /dev/null
   @just wait-for sequencer
   @echo "Starting EVM rollup..." && helm install -n astria-dev-cluster astria-chain-chart charts/evm-stack -f dev/values/rollup/evm-restart-test.yaml \


### PR DESCRIPTION
## Summary
Changes `devTag` to `tag` in `just::deploy::evm-rollup-restart-test`.

## Background
#1990 added sequencer defaults for networks, and changed instances of `devTag` for sequencer and relayer in smoke tests to `tag`. The `evm-rollup-restart-test` still uses `devTag`, and hence will not pull the correct image.

## Changes
- Changed `sequencer.images.devTag` and `sequencerRelayer.images.devTag` to each to `tag`.

## Testing
Smoke tests passing

## Changelogs
No updates required.

## Related Issues
closes #2128
