### PR TITLE
chore(sequencer): remove extraneous check from action

### DIFF
--- a/crates/astria-sequencer/src/action_handler/impls/currency_pairs_change.rs
+++ b/crates/astria-sequencer/src/action_handler/impls/currency_pairs_change.rs
@@ -109,10 +109,6 @@ async fn check_and_execute_currency_pairs_removal<S: StateWrite>(
         .get_num_currency_pairs()
         .await
         .wrap_err("failed to get number of currency pairs")?;
-    ensure!(
-        num_currency_pairs >= currency_pairs.len() as u64,
-        "cannot remove more currency pairs than exist",
-    );
 
     for pair in currency_pairs {
         if state


### PR DESCRIPTION
## Summary
Removed an extraneous check from the `CurrencyPairsChange` action.

## Background
The check fails if the action specifies more currency-pair removals than currently exist in storage.  However, given that removal of a non-existent pair is silently ignored, there is no point to this check.

## Changes
- Removed the check.

## Testing
No tests cover this currently.  (More extensive tests are being added as part of #1958.)

## Changelogs
No updates required.

## Breaking Changelist
- While this is technically a consensus-breaking change, the action in question has only been deployed to devnet as part of v3.0.0-rc.1, so it is relatively safe to include this without any special handling.
