### PR TITLE
fix(conductor): add explicit TLS config

### DIFF
--- a/crates/astria-conductor/CHANGELOG.md
+++ b/crates/astria-conductor/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix TLS errors when connecting to remote seqeuncer networks [#2140](https://github.com/astriaorg/astria/pull/2140).
+
 ## [2.0.0-rc.1] - 2025-04-22
 
 ### Added

--- a/crates/astria-conductor/Cargo.toml
+++ b/crates/astria-conductor/Cargo.toml
@@ -45,7 +45,7 @@ tendermint-rpc = { workspace = true, features = ["http-client"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal"] }
 tokio-util = { workspace = true, features = ["rt"] }
-tonic = { workspace = true, features = ["tls", "tls-roots"] }
+tonic = { workspace = true, features = ["tls", "tls-native-roots"] }
 tower = { workspace = true, features = ["buffer", "limit"] }
 tracing = { workspace = true, features = ["valuable"] }
 tryhard = { workspace = true }

--- a/crates/astria-conductor/src/sequencer/client.rs
+++ b/crates/astria-conductor/src/sequencer/client.rs
@@ -39,10 +39,9 @@ impl SequencerGrpcClient {
         let uri: Uri = sequencer_uri
             .parse()
             .wrap_err("failed parsing provided string as Uri")?;
-        let mut endpoint = Endpoint::from(uri.clone());
-        if uri.scheme() == Some(&http::uri::Scheme::HTTPS) {
-            endpoint = endpoint.tls_config(ClientTlsConfig::new().with_enabled_roots())?;
-        }
+        let endpoint = Endpoint::from(uri.clone())
+            .tls_config(ClientTlsConfig::new().with_enabled_roots())
+            .wrap_err("failed to configure TLS for sequencer client")?;
         let inner = SequencerServiceClient::new(endpoint.connect_lazy());
         Ok(Self {
             inner,

--- a/crates/astria-conductor/src/sequencer/client.rs
+++ b/crates/astria-conductor/src/sequencer/client.rs
@@ -16,6 +16,7 @@ use astria_eyre::eyre::{
 };
 use tonic::transport::{
     Channel,
+    ClientTlsConfig,
     Endpoint,
     Uri,
 };
@@ -38,7 +39,10 @@ impl SequencerGrpcClient {
         let uri: Uri = sequencer_uri
             .parse()
             .wrap_err("failed parsing provided string as Uri")?;
-        let endpoint = Endpoint::from(uri.clone());
+        let mut endpoint = Endpoint::from(uri.clone());
+        if uri.scheme() == Some(&http::uri::Scheme::HTTPS) {
+            endpoint = endpoint.tls_config(ClientTlsConfig::new().with_enabled_roots())?;
+        }
         let inner = SequencerServiceClient::new(endpoint.connect_lazy());
         Ok(Self {
             inner,


### PR DESCRIPTION
## Summary
Add explicit TLS config for conductor when the sequencer url is https

## Background
Tonic [removed implicit TLS configs](https://github.com/hyperium/tonic/pull/1731) in v0.12.0 which now causes TLS errors when conductor tries to connect to a remote sequencer network over TLS.
