### PR TITLE
chore(chart): update genesis for dusk-11 cancun

### DIFF
--- a/charts/evm-rollup/Chart.yaml
+++ b/charts/evm-rollup/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.0
+version: 2.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/evm-rollup/files/genesis/flame-devnet.genesis.json
+++ b/charts/evm-rollup/files/genesis/flame-devnet.genesis.json
@@ -12,6 +12,7 @@
     "berlinBlock": 0,
     "londonBlock": 0,
     "shanghaiTime": 0,
+    "cancunTime": 1746055000,
     "terminalTotalDifficulty": 0,
     "terminalTotalDifficultyPassed": true,
     "ethash": {},

--- a/charts/evm-stack/Chart.lock
+++ b/charts/evm-stack/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.4.0
 - name: evm-rollup
   repository: file://../evm-rollup
-  version: 2.0.0
+  version: 2.0.1
 - name: flame-rollup
   repository: file://../flame-rollup
   version: 0.1.2
@@ -26,5 +26,5 @@ dependencies:
 - name: blockscout-stack
   repository: https://blockscout.github.io/helm-charts
   version: 1.6.8
-digest: sha256:ad3d62ebd0f17a54b3d6c59323ffc73c8f328a8f819ee8ad10df44699d03a49e
-generated: "2025-04-22T12:53:40.229083-07:00"
+digest: sha256:80bcb24ef1228abe79a4c8772a2eb3a46b1690a3c46e4ea1195a75351c8ea566
+generated: "2025-04-30T16:05:28.595583-07:00"

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.0
+version: 2.0.1
 
 dependencies:
   - name: celestia-node
@@ -23,7 +23,7 @@ dependencies:
     repository: "file://../celestia-node"
     condition: celestia-node.enabled
   - name: evm-rollup
-    version: 2.0.0
+    version: 2.0.1
     repository: "file://../evm-rollup"
     condition: evm-rollup.enabled
   - name: flame-rollup


### PR DESCRIPTION
- Adds a cancun time for `dusk-11` genesis
- This time is already configured on running nodes to activate, updating charts to keep inline with deployment
