### PR TITLE
chore(conductor): v2.0.0-rc.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -694,7 +694,7 @@ dependencies = [
 
 [[package]]
 name = "astria-conductor"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 dependencies = [
  "astria-build-info",
  "astria-config",

--- a/crates/astria-conductor/CHANGELOG.md
+++ b/crates/astria-conductor/CHANGELOG.md
@@ -7,7 +7,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.0-rc.1] - 2025-05-08
+## [Unreleased]
+
+## [2.0.0-rc.2] - 2025-05-08
 
 ### Fixed
 
@@ -384,7 +386,8 @@ address [#721](https://github.com/astriaorg/astria/pull/721).
 
 - Initial release.
 
-[unreleased]: https://github.com/astriaorg/astria/compare/conductor-v2.0.0-rc.1...HEAD
+[unreleased]: https://github.com/astriaorg/astria/compare/conductor-v2.0.0-rc.2...HEAD
+[2.0.0-rc.2]: https://github.com/astriaorg/astria/compare/conductor-v2.0.0-rc.1...conductor-v2.0.0-rc.2
 [2.0.0-rc.1]: https://github.com/astriaorg/astria/compare/conductor-v1.1.0...conductor-v2.0.0-rc.1
 [1.1.0]: https://github.com/astriaorg/astria/compare/conductor-v1.0.0...conductor-v1.1.0
 [1.0.0]: https://github.com/astriaorg/astria/compare/conductor-v1.0.0-rc.2...conductor-v1.0.0

--- a/crates/astria-conductor/CHANGELOG.md
+++ b/crates/astria-conductor/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.0.0-rc.1] - 2025-05-08
 
 ### Fixed
 

--- a/crates/astria-conductor/Cargo.toml
+++ b/crates/astria-conductor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astria-conductor"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 edition = "2021"
 rust-version = "1.83.0"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary
Tag Conductor with v2.0.0-rc.2 that contains TLS fixes.

## Background
Contains https://github.com/astriaorg/astria/pull/2140