### PR TITLE
feat(sequencer): add recently included tx cache to mempool

### DIFF
--- a/crates/astria-core/src/generated/astria.mempool.v1.rs
+++ b/crates/astria-core/src/generated/astria.mempool.v1.rs
@@ -101,11 +101,85 @@ pub mod transaction_status {
     }
     /// Status representing a transaction which has been executed and is no longer
     /// in the Astria Sequencer's mempool.
-    #[derive(Clone, Copy, PartialEq, ::prost::Message)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Executed {
         /// The height of the block in which the transaction was included.
         #[prost(uint64, tag = "1")]
         pub height: u64,
+        /// The transaction result.
+        #[prost(message, optional, tag = "2")]
+        pub result: ::core::option::Option<executed::ExecTxResult>,
+    }
+    /// Nested message and enum types in `Executed`.
+    pub mod executed {
+        /// EventAttribute is a single key-value pair, associated with an event.
+        #[derive(Clone, PartialEq, ::prost::Message)]
+        pub struct EventAttribute {
+            #[prost(string, tag = "1")]
+            pub key: ::prost::alloc::string::String,
+            #[prost(string, tag = "2")]
+            pub value: ::prost::alloc::string::String,
+            #[prost(bool, tag = "3")]
+            pub index: bool,
+        }
+        impl ::prost::Name for EventAttribute {
+            const NAME: &'static str = "EventAttribute";
+            const PACKAGE: &'static str = "astria.mempool.v1";
+            fn full_name() -> ::prost::alloc::string::String {
+                "astria.mempool.v1.TransactionStatus.Executed.EventAttribute".into()
+            }
+            fn type_url() -> ::prost::alloc::string::String {
+                "/astria.mempool.v1.TransactionStatus.Executed.EventAttribute".into()
+            }
+        }
+        /// A record of an event which occurred during transaction execution.
+        #[derive(Clone, PartialEq, ::prost::Message)]
+        pub struct Event {
+            #[prost(string, tag = "1")]
+            pub kind: ::prost::alloc::string::String,
+            #[prost(message, repeated, tag = "2")]
+            pub attributes: ::prost::alloc::vec::Vec<EventAttribute>,
+        }
+        impl ::prost::Name for Event {
+            const NAME: &'static str = "Event";
+            const PACKAGE: &'static str = "astria.mempool.v1";
+            fn full_name() -> ::prost::alloc::string::String {
+                "astria.mempool.v1.TransactionStatus.Executed.Event".into()
+            }
+            fn type_url() -> ::prost::alloc::string::String {
+                "/astria.mempool.v1.TransactionStatus.Executed.Event".into()
+            }
+        }
+        /// The result of transaction execution.
+        #[derive(Clone, PartialEq, ::prost::Message)]
+        pub struct ExecTxResult {
+            #[prost(uint32, tag = "1")]
+            pub code: u32,
+            #[prost(bytes = "bytes", tag = "2")]
+            pub data: ::prost::bytes::Bytes,
+            #[prost(string, tag = "3")]
+            pub log: ::prost::alloc::string::String,
+            #[prost(string, tag = "4")]
+            pub info: ::prost::alloc::string::String,
+            #[prost(int64, tag = "5")]
+            pub gas_wanted: i64,
+            #[prost(int64, tag = "6")]
+            pub gas_used: i64,
+            #[prost(message, repeated, tag = "7")]
+            pub events: ::prost::alloc::vec::Vec<Event>,
+            #[prost(string, tag = "8")]
+            pub codespace: ::prost::alloc::string::String,
+        }
+        impl ::prost::Name for ExecTxResult {
+            const NAME: &'static str = "ExecTxResult";
+            const PACKAGE: &'static str = "astria.mempool.v1";
+            fn full_name() -> ::prost::alloc::string::String {
+                "astria.mempool.v1.TransactionStatus.Executed.ExecTxResult".into()
+            }
+            fn type_url() -> ::prost::alloc::string::String {
+                "/astria.mempool.v1.TransactionStatus.Executed.ExecTxResult".into()
+            }
+        }
     }
     impl ::prost::Name for Executed {
         const NAME: &'static str = "Executed";

--- a/crates/astria-core/src/generated/astria.mempool.v1.serde.rs
+++ b/crates/astria-core/src/generated/astria.mempool.v1.serde.rs
@@ -461,11 +461,17 @@ impl serde::Serialize for transaction_status::Executed {
         if self.height != 0 {
             len += 1;
         }
+        if self.result.is_some() {
+            len += 1;
+        }
         let mut struct_ser = serializer.serialize_struct("astria.mempool.v1.TransactionStatus.Executed", len)?;
         if self.height != 0 {
             #[allow(clippy::needless_borrow)]
             #[allow(clippy::needless_borrows_for_generic_args)]
             struct_ser.serialize_field("height", ToString::to_string(&self.height).as_str())?;
+        }
+        if let Some(v) = self.result.as_ref() {
+            struct_ser.serialize_field("result", v)?;
         }
         struct_ser.end()
     }
@@ -478,11 +484,13 @@ impl<'de> serde::Deserialize<'de> for transaction_status::Executed {
     {
         const FIELDS: &[&str] = &[
             "height",
+            "result",
         ];
 
         #[allow(clippy::enum_variant_names)]
         enum GeneratedField {
             Height,
+            Result,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -505,6 +513,7 @@ impl<'de> serde::Deserialize<'de> for transaction_status::Executed {
                     {
                         match value {
                             "height" => Ok(GeneratedField::Height),
+                            "result" => Ok(GeneratedField::Result),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -525,6 +534,7 @@ impl<'de> serde::Deserialize<'de> for transaction_status::Executed {
                     V: serde::de::MapAccess<'de>,
             {
                 let mut height__ = None;
+                let mut result__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
                         GeneratedField::Height => {
@@ -535,14 +545,480 @@ impl<'de> serde::Deserialize<'de> for transaction_status::Executed {
                                 Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
                             ;
                         }
+                        GeneratedField::Result => {
+                            if result__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("result"));
+                            }
+                            result__ = map_.next_value()?;
+                        }
                     }
                 }
                 Ok(transaction_status::Executed {
                     height: height__.unwrap_or_default(),
+                    result: result__,
                 })
             }
         }
         deserializer.deserialize_struct("astria.mempool.v1.TransactionStatus.Executed", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for transaction_status::executed::Event {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.kind.is_empty() {
+            len += 1;
+        }
+        if !self.attributes.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.mempool.v1.TransactionStatus.Executed.Event", len)?;
+        if !self.kind.is_empty() {
+            struct_ser.serialize_field("kind", &self.kind)?;
+        }
+        if !self.attributes.is_empty() {
+            struct_ser.serialize_field("attributes", &self.attributes)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for transaction_status::executed::Event {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "kind",
+            "attributes",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Kind,
+            Attributes,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "kind" => Ok(GeneratedField::Kind),
+                            "attributes" => Ok(GeneratedField::Attributes),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = transaction_status::executed::Event;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.mempool.v1.TransactionStatus.Executed.Event")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<transaction_status::executed::Event, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut kind__ = None;
+                let mut attributes__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Kind => {
+                            if kind__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("kind"));
+                            }
+                            kind__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Attributes => {
+                            if attributes__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("attributes"));
+                            }
+                            attributes__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(transaction_status::executed::Event {
+                    kind: kind__.unwrap_or_default(),
+                    attributes: attributes__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.mempool.v1.TransactionStatus.Executed.Event", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for transaction_status::executed::EventAttribute {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.key.is_empty() {
+            len += 1;
+        }
+        if !self.value.is_empty() {
+            len += 1;
+        }
+        if self.index {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.mempool.v1.TransactionStatus.Executed.EventAttribute", len)?;
+        if !self.key.is_empty() {
+            struct_ser.serialize_field("key", &self.key)?;
+        }
+        if !self.value.is_empty() {
+            struct_ser.serialize_field("value", &self.value)?;
+        }
+        if self.index {
+            struct_ser.serialize_field("index", &self.index)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for transaction_status::executed::EventAttribute {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "key",
+            "value",
+            "index",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Key,
+            Value,
+            Index,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "key" => Ok(GeneratedField::Key),
+                            "value" => Ok(GeneratedField::Value),
+                            "index" => Ok(GeneratedField::Index),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = transaction_status::executed::EventAttribute;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.mempool.v1.TransactionStatus.Executed.EventAttribute")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<transaction_status::executed::EventAttribute, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut key__ = None;
+                let mut value__ = None;
+                let mut index__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Key => {
+                            if key__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("key"));
+                            }
+                            key__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Value => {
+                            if value__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("value"));
+                            }
+                            value__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Index => {
+                            if index__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("index"));
+                            }
+                            index__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(transaction_status::executed::EventAttribute {
+                    key: key__.unwrap_or_default(),
+                    value: value__.unwrap_or_default(),
+                    index: index__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.mempool.v1.TransactionStatus.Executed.EventAttribute", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for transaction_status::executed::ExecTxResult {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.code != 0 {
+            len += 1;
+        }
+        if !self.data.is_empty() {
+            len += 1;
+        }
+        if !self.log.is_empty() {
+            len += 1;
+        }
+        if !self.info.is_empty() {
+            len += 1;
+        }
+        if self.gas_wanted != 0 {
+            len += 1;
+        }
+        if self.gas_used != 0 {
+            len += 1;
+        }
+        if !self.events.is_empty() {
+            len += 1;
+        }
+        if !self.codespace.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("astria.mempool.v1.TransactionStatus.Executed.ExecTxResult", len)?;
+        if self.code != 0 {
+            struct_ser.serialize_field("code", &self.code)?;
+        }
+        if !self.data.is_empty() {
+            #[allow(clippy::needless_borrow)]
+            #[allow(clippy::needless_borrows_for_generic_args)]
+            struct_ser.serialize_field("data", pbjson::private::base64::encode(&self.data).as_str())?;
+        }
+        if !self.log.is_empty() {
+            struct_ser.serialize_field("log", &self.log)?;
+        }
+        if !self.info.is_empty() {
+            struct_ser.serialize_field("info", &self.info)?;
+        }
+        if self.gas_wanted != 0 {
+            #[allow(clippy::needless_borrow)]
+            #[allow(clippy::needless_borrows_for_generic_args)]
+            struct_ser.serialize_field("gasWanted", ToString::to_string(&self.gas_wanted).as_str())?;
+        }
+        if self.gas_used != 0 {
+            #[allow(clippy::needless_borrow)]
+            #[allow(clippy::needless_borrows_for_generic_args)]
+            struct_ser.serialize_field("gasUsed", ToString::to_string(&self.gas_used).as_str())?;
+        }
+        if !self.events.is_empty() {
+            struct_ser.serialize_field("events", &self.events)?;
+        }
+        if !self.codespace.is_empty() {
+            struct_ser.serialize_field("codespace", &self.codespace)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for transaction_status::executed::ExecTxResult {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "code",
+            "data",
+            "log",
+            "info",
+            "gas_wanted",
+            "gasWanted",
+            "gas_used",
+            "gasUsed",
+            "events",
+            "codespace",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Code,
+            Data,
+            Log,
+            Info,
+            GasWanted,
+            GasUsed,
+            Events,
+            Codespace,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "code" => Ok(GeneratedField::Code),
+                            "data" => Ok(GeneratedField::Data),
+                            "log" => Ok(GeneratedField::Log),
+                            "info" => Ok(GeneratedField::Info),
+                            "gasWanted" | "gas_wanted" => Ok(GeneratedField::GasWanted),
+                            "gasUsed" | "gas_used" => Ok(GeneratedField::GasUsed),
+                            "events" => Ok(GeneratedField::Events),
+                            "codespace" => Ok(GeneratedField::Codespace),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = transaction_status::executed::ExecTxResult;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct astria.mempool.v1.TransactionStatus.Executed.ExecTxResult")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<transaction_status::executed::ExecTxResult, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut code__ = None;
+                let mut data__ = None;
+                let mut log__ = None;
+                let mut info__ = None;
+                let mut gas_wanted__ = None;
+                let mut gas_used__ = None;
+                let mut events__ = None;
+                let mut codespace__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Code => {
+                            if code__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("code"));
+                            }
+                            code__ = 
+                                Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::Data => {
+                            if data__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("data"));
+                            }
+                            data__ = 
+                                Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::Log => {
+                            if log__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("log"));
+                            }
+                            log__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Info => {
+                            if info__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("info"));
+                            }
+                            info__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::GasWanted => {
+                            if gas_wanted__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("gasWanted"));
+                            }
+                            gas_wanted__ = 
+                                Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::GasUsed => {
+                            if gas_used__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("gasUsed"));
+                            }
+                            gas_used__ = 
+                                Some(map_.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::Events => {
+                            if events__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("events"));
+                            }
+                            events__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Codespace => {
+                            if codespace__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("codespace"));
+                            }
+                            codespace__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(transaction_status::executed::ExecTxResult {
+                    code: code__.unwrap_or_default(),
+                    data: data__.unwrap_or_default(),
+                    log: log__.unwrap_or_default(),
+                    info: info__.unwrap_or_default(),
+                    gas_wanted: gas_wanted__.unwrap_or_default(),
+                    gas_used: gas_used__.unwrap_or_default(),
+                    events: events__.unwrap_or_default(),
+                    codespace: codespace__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("astria.mempool.v1.TransactionStatus.Executed.ExecTxResult", FIELDS, GeneratedVisitor)
     }
 }
 impl serde::Serialize for transaction_status::Parked {

--- a/crates/astria-core/src/lib.rs
+++ b/crates/astria-core/src/lib.rs
@@ -15,6 +15,7 @@ compile_error!(
 )]
 pub mod generated;
 pub mod execution;
+pub mod mempool;
 pub mod oracles;
 pub mod primitive;
 pub mod protocol;

--- a/crates/astria-core/src/mempool/mod.rs
+++ b/crates/astria-core/src/mempool/mod.rs
@@ -1,0 +1,1 @@
+pub mod v1;

--- a/crates/astria-core/src/mempool/v1/mod.rs
+++ b/crates/astria-core/src/mempool/v1/mod.rs
@@ -1,0 +1,1 @@
+pub mod transaction_status;

--- a/crates/astria-core/src/mempool/v1/transaction_status/executed/mod.rs
+++ b/crates/astria-core/src/mempool/v1/transaction_status/executed/mod.rs
@@ -1,0 +1,283 @@
+use base64::{
+    engine::general_purpose::STANDARD,
+    Engine,
+};
+use tendermint::abci::{
+    types::ExecTxResult,
+    v0_34,
+    v0_37,
+    Event,
+    EventAttribute,
+};
+
+use crate::{
+    generated::mempool::v1::transaction_status::executed as Raw,
+    Protobuf,
+};
+
+pub enum ExecTxResultError {}
+
+impl Protobuf for ExecTxResult {
+    type Error = ExecTxResultError;
+    type Raw = Raw::ExecTxResult;
+
+    fn try_from_raw_ref(raw: &Self::Raw) -> Result<Self, Self::Error> {
+        let Self::Raw {
+            code,
+            data,
+            log,
+            info,
+            gas_wanted,
+            gas_used,
+            events,
+            codespace,
+        } = raw;
+
+        let events = events
+            .iter()
+            .map(Event::try_from_raw_ref)
+            .collect::<Result<Vec<_>, _>>()
+            .expect("Failed to convert raw event(an infallible process)");
+        let result = ExecTxResult {
+            code: (*code).into(),
+            data: data.clone(),
+            log: log.clone(),
+            info: info.clone(),
+            gas_wanted: *gas_wanted,
+            gas_used: *gas_used,
+            events,
+            codespace: codespace.clone(),
+        };
+        Ok(result)
+    }
+
+    fn try_from_raw(raw: Self::Raw) -> Result<Self, Self::Error> {
+        let Self::Raw {
+            code,
+            data,
+            log,
+            info,
+            gas_wanted,
+            gas_used,
+            events,
+            codespace,
+        } = raw;
+
+        let events = events
+            .into_iter()
+            .map(Event::try_from_raw)
+            .collect::<Result<Vec<_>, _>>()
+            .expect("Failed to convert raw event(an infallible process)");
+        let result = ExecTxResult {
+            code: code.into(),
+            data,
+            log,
+            info,
+            gas_wanted,
+            gas_used,
+            events,
+            codespace,
+        };
+        Ok(result)
+    }
+
+    fn to_raw(&self) -> Self::Raw {
+        let Self {
+            code,
+            data,
+            log,
+            info,
+            gas_wanted,
+            gas_used,
+            events,
+            codespace,
+        } = self;
+        let events = events.iter().map(Event::to_raw).collect::<Vec<_>>();
+        Raw::ExecTxResult {
+            code: (*code).into(),
+            data: data.clone(),
+            log: log.clone(),
+            info: info.clone(),
+            gas_wanted: *gas_wanted,
+            gas_used: *gas_used,
+            events,
+            codespace: codespace.clone(),
+        }
+    }
+
+    fn into_raw(self) -> Self::Raw {
+        let Self {
+            code,
+            data,
+            log,
+            info,
+            gas_wanted,
+            gas_used,
+            events,
+            codespace,
+        } = self;
+        let events = events.into_iter().map(Event::into_raw).collect::<Vec<_>>();
+        Raw::ExecTxResult {
+            code: code.into(),
+            data,
+            log,
+            info,
+            gas_wanted,
+            gas_used,
+            events,
+            codespace,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct EventError {}
+
+impl Protobuf for Event {
+    type Error = EventError;
+    type Raw = Raw::Event;
+
+    fn try_from_raw_ref(raw: &Self::Raw) -> Result<Self, Self::Error> {
+        let Self::Raw {
+            kind,
+            attributes,
+        } = raw;
+        let attributes = attributes
+            .iter()
+            .map(EventAttribute::try_from_raw_ref)
+            .collect::<Result<Vec<_>, _>>()
+            .expect("Failed to convert raw attribute(an infallible process)");
+        Ok(Event {
+            kind: kind.clone(),
+            attributes,
+        })
+    }
+
+    fn try_from_raw(raw: Self::Raw) -> Result<Self, Self::Error> {
+        let Self::Raw {
+            kind,
+            attributes,
+        } = raw;
+        let attributes = attributes
+            .into_iter()
+            .map(EventAttribute::try_from_raw)
+            .collect::<Result<Vec<_>, _>>()
+            .expect("Failed to convert raw attribute (an infallible process)");
+        Ok(Event {
+            kind,
+            attributes,
+        })
+    }
+
+    fn to_raw(&self) -> Self::Raw {
+        let Self {
+            kind,
+            attributes,
+        } = self;
+        let attributes = attributes
+            .iter()
+            .map(EventAttribute::to_raw)
+            .collect::<Vec<_>>();
+        Raw::Event {
+            kind: kind.clone(),
+            attributes,
+        }
+    }
+
+    fn into_raw(self) -> Self::Raw {
+        let Self {
+            kind,
+            attributes,
+        } = self;
+        let attributes = attributes
+            .into_iter()
+            .map(EventAttribute::into_raw)
+            .collect::<Vec<_>>();
+        Raw::Event {
+            kind,
+            attributes,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct EventAttributeError {}
+
+impl Protobuf for EventAttribute {
+    type Error = EventAttributeError;
+    type Raw = Raw::EventAttribute;
+
+    fn try_from_raw_ref(raw: &Self::Raw) -> Result<Self, Self::Error> {
+        let Self::Raw {
+            key,
+            value,
+            index,
+        } = raw;
+
+        Ok(EventAttribute::V037(v0_37::EventAttribute {
+            key: key.clone(),
+            value: value.clone(),
+            index: *index,
+        }))
+    }
+
+    fn try_from_raw(raw: Self::Raw) -> Result<Self, Self::Error> {
+        let Self::Raw {
+            key,
+            value,
+            index,
+        } = raw;
+
+        Ok(EventAttribute::V037(v0_37::EventAttribute {
+            key,
+            value,
+            index,
+        }))
+    }
+
+    fn to_raw(&self) -> Self::Raw {
+        match self {
+            EventAttribute::V037(v0_37::EventAttribute {
+                key,
+                value,
+                index,
+            }) => Raw::EventAttribute {
+                key: key.clone(),
+                value: value.clone(),
+                index: *index,
+            },
+            EventAttribute::V034(v0_34::EventAttribute {
+                key,
+                value,
+                index,
+            }) => Raw::EventAttribute {
+                key: STANDARD.encode(key),
+                value: STANDARD.encode(value),
+                index: *index,
+            },
+        }
+    }
+
+    fn into_raw(self) -> Self::Raw {
+        match self {
+            EventAttribute::V037(v0_37::EventAttribute {
+                key,
+                value,
+                index,
+            }) => Raw::EventAttribute {
+                key,
+                value,
+                index,
+            },
+            EventAttribute::V034(v0_34::EventAttribute {
+                key,
+                value,
+                index,
+            }) => Raw::EventAttribute {
+                key: STANDARD.encode(key),
+                value: STANDARD.encode(value),
+                index,
+            },
+        }
+    }
+}

--- a/crates/astria-core/src/mempool/v1/transaction_status/mod.rs
+++ b/crates/astria-core/src/mempool/v1/transaction_status/mod.rs
@@ -1,0 +1,1 @@
+pub mod executed;

--- a/crates/astria-sequencer/CHANGELOG.md
+++ b/crates/astria-sequencer/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `astria_sequencer_extend_vote_failure_count` and
   `astria_sequencer_verify_vote_extension_failure_count` [#2085](https://github.com/astriaorg/astria/pull/2085).
 - Add mempool gRPC service [#2133](https://github.com/astriaorg/astria/pull/2133).
+- Add tx result to `Executed` transaction status [#2159](https://github.com/astriaorg/astria/pull/2159).
 
 ## [2.0.1]
 

--- a/crates/astria-sequencer/src/app/tests_app/mod.rs
+++ b/crates/astria-sequencer/src/app/tests_app/mod.rs
@@ -253,7 +253,7 @@ async fn app_commit() {
     }
 
     // commit should write the changes to the underlying storage
-    app.prepare_commit(storage.clone(), HashSet::new())
+    app.prepare_commit(storage.clone(), Vec::new())
         .await
         .unwrap();
     app.commit(storage.clone()).await.unwrap();
@@ -376,7 +376,7 @@ async fn app_create_sequencer_block_with_sequenced_data_and_deposits() {
         )
         .unwrap();
     app.apply(state_tx);
-    app.prepare_commit(storage.clone(), HashSet::new())
+    app.prepare_commit(storage.clone(), Vec::new())
         .await
         .unwrap();
     app.commit(storage.clone()).await.unwrap();
@@ -478,7 +478,7 @@ async fn app_execution_results_match_proposal_vs_after_proposal() {
         .put_bridge_account_ibc_asset(&bridge_address, &asset)
         .unwrap();
     app.apply(state_tx);
-    app.prepare_commit(storage.clone(), HashSet::new())
+    app.prepare_commit(storage.clone(), Vec::new())
         .await
         .unwrap();
     app.commit(storage.clone()).await.unwrap();
@@ -573,7 +573,7 @@ async fn app_execution_results_match_proposal_vs_after_proposal() {
     assert_eq!(prepare_proposal_result.txs, finalize_block.txs);
 
     app.mempool
-        .run_maintenance(&app.state, false, HashSet::new(), 0)
+        .run_maintenance(&app.state, false, HashMap::new(), 0)
         .await;
 
     assert_eq!(app.mempool.len().await, 0);
@@ -696,7 +696,7 @@ async fn app_prepare_proposal_cometbft_max_bytes_overflow_ok() {
 
     // run maintence to clear out transactions
     app.mempool
-        .run_maintenance(&app.state, false, HashSet::new(), 0)
+        .run_maintenance(&app.state, false, HashMap::new(), 0)
         .await;
 
     // see only first tx made it in
@@ -785,7 +785,7 @@ async fn app_prepare_proposal_sequencer_max_bytes_overflow_ok() {
 
     // run maintence to clear out transactions
     app.mempool
-        .run_maintenance(&app.state, false, HashSet::new(), 0)
+        .run_maintenance(&app.state, false, HashMap::new(), 0)
         .await;
 
     // see only first tx made it in
@@ -998,7 +998,7 @@ async fn app_proposal_fingerprint_triggers_update() {
         .put_bridge_account_ibc_asset(&bridge_address, &asset)
         .unwrap();
     app.apply(state_tx);
-    app.prepare_commit(storage.clone(), HashSet::new())
+    app.prepare_commit(storage.clone(), Vec::new())
         .await
         .unwrap();
     app.commit(storage.clone()).await.unwrap();
@@ -1202,7 +1202,7 @@ async fn app_oracle_price_update_events_in_finalize_block() {
         .put_currency_pair_state(currency_pair.clone(), currency_pair_state)
         .unwrap();
     app.apply(state_tx);
-    app.prepare_commit(storage.clone(), HashSet::new())
+    app.prepare_commit(storage.clone(), Vec::new())
         .await
         .unwrap();
     app.commit(storage.clone()).await.unwrap();

--- a/crates/astria-sequencer/src/app/tests_block_ordering.rs
+++ b/crates/astria-sequencer/src/app/tests_block_ordering.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::HashMap;
 
 use astria_core::{
     protocol::transaction::v1::action::{
@@ -202,7 +202,7 @@ async fn app_prepare_proposal_account_block_misordering_ok() {
     );
 
     app.mempool
-        .run_maintenance(&app.state, false, HashSet::new(), 0)
+        .run_maintenance(&app.state, false, HashMap::new(), 0)
         .await;
     assert_eq!(
         app.mempool.len().await,
@@ -211,7 +211,7 @@ async fn app_prepare_proposal_account_block_misordering_ok() {
     );
 
     // commit state for next prepare proposal
-    app.prepare_commit(storage.clone(), HashSet::new())
+    app.prepare_commit(storage.clone(), Vec::new())
         .await
         .unwrap();
     app.commit(storage.clone()).await.unwrap();
@@ -241,7 +241,7 @@ async fn app_prepare_proposal_account_block_misordering_ok() {
     );
 
     app.mempool
-        .run_maintenance(&app.state, false, HashSet::new(), 0)
+        .run_maintenance(&app.state, false, HashMap::new(), 0)
         .await;
     assert_eq!(app.mempool.len().await, 0, "mempool should be empty");
 }

--- a/crates/astria-sequencer/src/app/tests_breaking_changes.rs
+++ b/crates/astria-sequencer/src/app/tests_breaking_changes.rs
@@ -10,10 +10,7 @@
 //! If changes are made to the execution results of these actions, manual testing is required.
 
 use std::{
-    collections::{
-        HashMap,
-        HashSet,
-    },
+    collections::HashMap,
     str::FromStr as _,
     sync::Arc,
 };
@@ -119,7 +116,7 @@ async fn app_finalize_block_snapshot() {
 
     // the state changes must be committed, as `finalize_block` will execute the
     // changes on the latest snapshot, not the app's `StateDelta`.
-    app.prepare_commit(storage.clone(), HashSet::new())
+    app.prepare_commit(storage.clone(), Vec::new())
         .await
         .unwrap();
     app.commit(storage.clone()).await.unwrap();
@@ -419,7 +416,7 @@ async fn app_execute_transaction_with_every_action_snapshot() {
     let sudo_address = app.state.get_sudo_address().await.unwrap();
     app.end_block(height.value(), &sudo_address).await.unwrap();
 
-    app.prepare_commit(storage.clone(), HashSet::new())
+    app.prepare_commit(storage.clone(), Vec::new())
         .await
         .unwrap();
     app.commit(storage.clone()).await.unwrap();

--- a/crates/astria-sequencer/src/mempool/benchmarks.rs
+++ b/crates/astria-sequencer/src/mempool/benchmarks.rs
@@ -5,7 +5,7 @@
 #![expect(non_camel_case_types, reason = "for benchmark")]
 
 use std::{
-    collections::HashSet,
+    collections::HashMap,
     sync::Arc,
     time::Duration,
 };
@@ -301,7 +301,7 @@ fn run_maintenance<T: MempoolSize>(bencher: divan::Bencher) {
         .bench_values(move |mempool| {
             runtime.block_on(async {
                 mempool
-                    .run_maintenance(&mock_state, false, HashSet::new(), 1)
+                    .run_maintenance(&mock_state, false, HashMap::new(), 1)
                     .await;
             });
         });
@@ -345,7 +345,7 @@ fn run_maintenance_tx_recosting<T: MempoolSize>(bencher: divan::Bencher) {
         .bench_values(move |mempool| {
             runtime.block_on(async {
                 mempool
-                    .run_maintenance(&mock_state, true, HashSet::new(), 1)
+                    .run_maintenance(&mock_state, true, HashMap::new(), 1)
                     .await;
             });
         });

--- a/crates/astria-sequencer/src/mempool/recently_included_transactions.rs
+++ b/crates/astria-sequencer/src/mempool/recently_included_transactions.rs
@@ -1,0 +1,422 @@
+use std::collections::{
+    HashMap,
+    VecDeque,
+};
+
+use astria_core::primitive::v1::TransactionId;
+use tendermint::abci::types::ExecTxResult;
+use tokio::time::Instant;
+
+/// The maximum number of transactions that can be stored in the [`RecentlyIncludedTransactions`]
+/// cache. This number is calculated based on an assumed timeout time of 1 minute and a maximum
+/// throughput of 1000 transactions per second.
+const MAX_RECENTLY_INCLUDED_TRANSACTIONS: usize = 60_000;
+/// The timeout time for the transactions in the [`RecentlyIncludedTransactions`] cache.
+const MAX_TIME_RECENTLY_INCLUDED_TRANSACTIONS_SECS: u64 = 60;
+
+pub(super) struct IncludedTransactionMetadata {
+    height: u64,
+    result: ExecTxResult,
+}
+
+impl IncludedTransactionMetadata {
+    pub(super) fn height(&self) -> u64 {
+        self.height
+    }
+
+    pub(super) fn result(&self) -> &ExecTxResult {
+        &self.result
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, thiserror::Error)]
+pub(super) enum IncludedTransactionError {
+    #[error("Transaction ID {0} already exists in the cache")]
+    IdAlreadyExists(TransactionId),
+    #[error("Transaction insertion failed due to an internal error")]
+    InsertionInternalError,
+}
+
+/// A cache of transaction data for transactions which were recently included in a block. The cache
+/// has a maximum size of [`MAX_RECENTLY_INCLUDED_TRANSACTIONS`] transactions. Transactions are
+/// cleared from the cache after [`MAX_TIME_RECENTLY_INCLUDED_TRANSACTIONS_SECS`] seconds if the
+/// cache is not full.
+///
+/// Supports O(1) lookups by transaction ID while maintaining O(1) insertion and removal of oldest
+/// element. Worst case time complexity for cleaning stale transactions is O(n), where n is the
+/// number of transactions in the cache.
+pub(super) struct RecentlyIncludedTransactions {
+    /// Transaction IDs in chronological order (oldest first)
+    timestamped_ids: VecDeque<(TransactionId, Instant)>,
+    /// Hash map containing transaction metadata, keyed by transaction ID
+    transactions: HashMap<TransactionId, IncludedTransactionMetadata>,
+}
+
+impl RecentlyIncludedTransactions {
+    pub(super) fn new() -> Self {
+        Self {
+            timestamped_ids: VecDeque::new(),
+            transactions: HashMap::new(),
+        }
+    }
+
+    /// Looks up transaction metadata by its transaction ID, returning
+    /// `Some(IncludedTransactionMetadata)` if found, or `None` if not found.
+    pub(super) fn get_by_tx_id(
+        &self,
+        tx_id: &TransactionId,
+    ) -> Option<&IncludedTransactionMetadata> {
+        self.transactions.get(tx_id)
+    }
+
+    /// Adds new transaction data to the cache. Cleans stale transactions before attempting to add
+    /// the new transaction. If the cache is full, removes the oldest transaction until the cache
+    /// is not full. Returns an error if the transaction ID already exists in the cache.
+    pub(super) fn add_transaction(
+        &mut self,
+        tx_id: TransactionId,
+        height: u64,
+        result: ExecTxResult,
+    ) -> Result<(), IncludedTransactionError> {
+        // If the cache is full, remove the oldest transaction until the cache is not full.
+        while self.timestamped_ids.len() >= MAX_RECENTLY_INCLUDED_TRANSACTIONS {
+            let (oldest_tx_id, _) = self
+                .timestamped_ids
+                .pop_front()
+                .ok_or(IncludedTransactionError::InsertionInternalError)?;
+            self.transactions.remove(&oldest_tx_id);
+        }
+
+        // Check if the transaction ID already exists in the cache.
+        if self.transactions.contains_key(&tx_id) {
+            return Err(IncludedTransactionError::IdAlreadyExists(tx_id));
+        }
+
+        // Clean any stale transactions before adding a new one.
+        self.clean_stale();
+
+        // Add new transaction to the cache and push to the back of the ID vec.
+        self.timestamped_ids.push_back((tx_id, Instant::now()));
+        self.transactions.insert(
+            tx_id,
+            IncludedTransactionMetadata {
+                height,
+                result,
+            },
+        );
+        Ok(())
+    }
+
+    /// Removes all transactions from the cache that are older than
+    /// [`MAX_TIME_RECENTLY_INCLUDED_TRANSACTIONS_SECS`] seconds.
+    pub(super) fn clean_stale(&mut self) {
+        let now = Instant::now();
+        let mut split_index = 0;
+
+        while split_index < self.transactions.len() {
+            let (tx_id, timestamp) = &self.timestamped_ids[split_index];
+            if now.duration_since(*timestamp).as_secs()
+                < MAX_TIME_RECENTLY_INCLUDED_TRANSACTIONS_SECS
+            {
+                break;
+            }
+            // Remove the transaction from the hash map
+            self.transactions.remove(tx_id);
+            split_index = split_index.saturating_add(1);
+        }
+
+        // Remove from the vector
+        self.timestamped_ids.drain(0..split_index);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use astria_core::primitive::v1::TRANSACTION_ID_LEN;
+    use tokio::time;
+
+    use super::*;
+
+    // Helper function for creating unique transaction IDs for all seeds in the range of
+    // 0..u64::MAX.
+    fn dummy_tx_id(seed: u64) -> TransactionId {
+        let bytes = seed.to_be_bytes();
+        let mut destination = [0u8; TRANSACTION_ID_LEN];
+
+        let n = 8;
+        destination[..n].copy_from_slice(&bytes[..n]);
+        TransactionId::new(destination)
+    }
+
+    #[test]
+    fn construct_add_and_get_work_as_expected() {
+        let mut cache = RecentlyIncludedTransactions::new();
+
+        let tx_id_1 = dummy_tx_id(0);
+        let tx_height_1 = 1;
+        let tx_result_1 = ExecTxResult::default();
+
+        cache
+            .add_transaction(tx_id_1, tx_height_1, tx_result_1.clone())
+            .unwrap();
+        assert_eq!(cache.timestamped_ids.len(), 1);
+        assert_eq!(cache.transactions.len(), 1);
+        let transaction_1 = cache.get_by_tx_id(&cache.timestamped_ids[0].0).unwrap();
+        assert_eq!(transaction_1.height, tx_height_1);
+        assert_eq!(transaction_1.result, tx_result_1);
+
+        let tx_id_2 = dummy_tx_id(1);
+        let tx_height_2 = 2;
+        let tx_result_2 = ExecTxResult {
+            log: "transaction 2".to_string(),
+            ..ExecTxResult::default()
+        };
+        assert_ne!(tx_id_1, tx_id_2);
+        assert_ne!(tx_height_1, tx_height_2);
+        assert_ne!(tx_result_1, tx_result_2);
+
+        cache
+            .add_transaction(tx_id_2, tx_height_2, tx_result_2.clone())
+            .unwrap();
+        assert_eq!(cache.timestamped_ids.len(), 2);
+        assert_eq!(cache.transactions.len(), 2);
+        let transaction_2 = cache.get_by_tx_id(&cache.timestamped_ids[1].0).unwrap();
+        assert_eq!(transaction_2.height, tx_height_2);
+        assert_eq!(transaction_2.result, tx_result_2);
+
+        // Test lookup of non-existent tx
+        let non_existent_tx_id = dummy_tx_id(99);
+        assert_ne!(tx_id_1, non_existent_tx_id);
+        assert_ne!(tx_id_2, non_existent_tx_id);
+        assert!(cache.get_by_tx_id(&non_existent_tx_id).is_none());
+    }
+
+    #[tokio::test]
+    async fn clean_stale_works_as_expected() {
+        let mut cache = RecentlyIncludedTransactions::new();
+        let tx_id_1 = dummy_tx_id(0);
+        let tx_height_1 = 1;
+        let tx_result_1 = ExecTxResult::default();
+
+        cache
+            .add_transaction(tx_id_1, tx_height_1, tx_result_1.clone())
+            .unwrap();
+        assert_eq!(cache.timestamped_ids.len(), 1);
+        assert_eq!(cache.transactions.len(), 1);
+        assert!(cache.get_by_tx_id(&tx_id_1).is_some());
+
+        time::pause();
+        time::advance(time::Duration::from_secs(61)).await;
+        cache.clean_stale();
+        assert_eq!(cache.timestamped_ids.len(), 0);
+        assert_eq!(cache.transactions.len(), 0);
+        assert!(cache.get_by_tx_id(&tx_id_1).is_none());
+    }
+
+    #[tokio::test]
+    async fn add_transaction_clears_stale() {
+        let mut cache = RecentlyIncludedTransactions::new();
+        let tx_id_for_removal = dummy_tx_id(0);
+        let tx_height_for_removal = 1;
+        let tx_result_for_removal = ExecTxResult::default();
+
+        cache
+            .add_transaction(
+                tx_id_for_removal,
+                tx_height_for_removal,
+                tx_result_for_removal.clone(),
+            )
+            .unwrap();
+        assert_eq!(cache.timestamped_ids.len(), 1);
+        assert_eq!(cache.transactions.len(), 1);
+        let transaction_for_removal = cache.get_by_tx_id(&cache.timestamped_ids[0].0).unwrap();
+        assert_eq!(transaction_for_removal.height, tx_height_for_removal);
+        assert_eq!(transaction_for_removal.result, tx_result_for_removal);
+
+        time::pause();
+        time::advance(time::Duration::from_secs(61)).await;
+
+        let tx_id_2 = dummy_tx_id(1);
+        let tx_height_2 = 2;
+        let tx_result_2 = ExecTxResult {
+            log: "transaction 2".to_string(),
+            ..ExecTxResult::default()
+        };
+
+        // Should remove the old transaction and add the new one
+        cache
+            .add_transaction(tx_id_2, tx_height_2, tx_result_2.clone())
+            .unwrap();
+
+        assert_eq!(cache.timestamped_ids.len(), 1);
+        assert_eq!(cache.transactions.len(), 1);
+        let transaction_2 = cache.get_by_tx_id(&cache.timestamped_ids[0].0).unwrap();
+        assert_eq!(transaction_2.height, tx_height_2);
+        assert_eq!(transaction_2.result, tx_result_2);
+    }
+
+    #[test]
+    fn add_transaction_removes_oldest_when_full() {
+        let mut cache = RecentlyIncludedTransactions::new();
+        for i in 0..MAX_RECENTLY_INCLUDED_TRANSACTIONS {
+            let tx_id = dummy_tx_id(i as u64);
+            let tx_height = i as u64;
+            let tx_result = ExecTxResult {
+                log: format!("transaction {i}"),
+                ..ExecTxResult::default()
+            };
+            cache.add_transaction(tx_id, tx_height, tx_result).unwrap();
+        }
+
+        // Check that the cache is full and that first transaction is the oldest one.
+        assert_eq!(cache.transactions.len(), MAX_RECENTLY_INCLUDED_TRANSACTIONS);
+        assert_eq!(
+            cache.timestamped_ids.len(),
+            MAX_RECENTLY_INCLUDED_TRANSACTIONS
+        );
+        let pre_clean_first_tx = cache.get_by_tx_id(&cache.timestamped_ids[0].0).unwrap();
+        assert_eq!(pre_clean_first_tx.height, 0);
+        assert_eq!(
+            pre_clean_first_tx.result,
+            ExecTxResult {
+                log: "transaction 0".to_string(),
+                ..ExecTxResult::default()
+            }
+        );
+
+        // Add one more transaction to trigger the removal of the oldest transaction.
+        let tx_id_to_add = dummy_tx_id(0);
+        let tx_height_to_add = 1_234_567_890;
+        let tx_result_to_add = ExecTxResult {
+            log: "ethan_was here".to_string(),
+            ..ExecTxResult::default()
+        };
+        cache
+            .add_transaction(tx_id_to_add, tx_height_to_add, tx_result_to_add.clone())
+            .unwrap();
+
+        // Check that cache is still full and that the oldest transaction was removed.
+        assert_eq!(cache.transactions.len(), MAX_RECENTLY_INCLUDED_TRANSACTIONS);
+        assert_eq!(
+            cache.timestamped_ids.len(),
+            MAX_RECENTLY_INCLUDED_TRANSACTIONS
+        );
+        let post_clean_first_tx = cache.get_by_tx_id(&cache.timestamped_ids[0].0).unwrap();
+        assert_eq!(post_clean_first_tx.height, 1);
+        assert_eq!(
+            post_clean_first_tx.result,
+            ExecTxResult {
+                log: "transaction 1".to_string(),
+                ..ExecTxResult::default()
+            }
+        );
+
+        // If removal failed, this should grab the first transaction in the cache since they share
+        // the same ID.
+        let post_clean_last_tx = cache
+            .get_by_tx_id(&cache.timestamped_ids[MAX_RECENTLY_INCLUDED_TRANSACTIONS - 1].0)
+            .unwrap();
+
+        // Check that the last transaction is the one we just added.
+        assert_eq!(post_clean_last_tx.height, tx_height_to_add);
+        assert_eq!(post_clean_last_tx.result, tx_result_to_add);
+    }
+
+    #[test]
+    fn add_duplicate_transaction_returns_error() {
+        let mut cache = RecentlyIncludedTransactions::new();
+        let tx_id = dummy_tx_id(0);
+        let tx_height = 1;
+        let tx_result = ExecTxResult::default();
+
+        // First addition should succeed
+        let result = cache.add_transaction(tx_id, tx_height, tx_result.clone());
+        assert!(result.is_ok());
+        assert_eq!(cache.timestamped_ids.len(), 1);
+        assert_eq!(cache.transactions.len(), 1);
+
+        // Second addition with same tx_id should fail
+        let err = cache
+            .add_transaction(tx_id, tx_height + 1, tx_result.clone())
+            .unwrap_err();
+        assert_eq!(err, IncludedTransactionError::IdAlreadyExists(tx_id));
+
+        // Cache state should remain unchanged
+        assert_eq!(cache.timestamped_ids.len(), 1);
+        assert_eq!(cache.transactions.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn clean_stale_handles_mixed_ages() {
+        let mut cache = RecentlyIncludedTransactions::new();
+
+        // Add transactions with different timestamps
+        time::pause();
+
+        // Add old transaction
+        let tx_id_old = dummy_tx_id(0);
+        let tx_height_old = 1;
+        let tx_result_old = ExecTxResult::default();
+        cache
+            .add_transaction(tx_id_old, tx_height_old, tx_result_old.clone())
+            .unwrap();
+
+        // Advance time to make sure both transactions aren't invalidated at the same time
+        time::advance(time::Duration::from_secs(30)).await;
+
+        // Add fresh transaction
+        let tx_id_fresh = dummy_tx_id(1);
+        let tx_height_fresh = 2;
+        let tx_result_fresh = ExecTxResult {
+            log: "fresh transaction".to_string(),
+            ..ExecTxResult::default()
+        };
+        cache
+            .add_transaction(tx_id_fresh, tx_height_fresh, tx_result_fresh.clone())
+            .unwrap();
+
+        // Advance time to make sure the old transaction is stale
+        time::advance(time::Duration::from_secs(31)).await;
+
+        // Clean stale entries
+        cache.clean_stale();
+
+        // Check that only the old transaction was removed
+        assert_eq!(cache.timestamped_ids.len(), 1);
+        assert_eq!(cache.transactions.len(), 1);
+        assert!(cache.get_by_tx_id(&tx_id_old).is_none());
+        assert!(cache.get_by_tx_id(&tx_id_fresh).is_some());
+
+        let remaining_tx = cache.get_by_tx_id(&tx_id_fresh).unwrap();
+        assert_eq!(remaining_tx.height, tx_height_fresh);
+        assert_eq!(remaining_tx.result, tx_result_fresh);
+    }
+
+    #[tokio::test]
+    async fn clean_stale_with_empty_cache() {
+        let mut cache = RecentlyIncludedTransactions::new();
+
+        // Clean stale entries on empty cache should not crash
+        cache.clean_stale();
+
+        assert_eq!(cache.timestamped_ids.len(), 0);
+        assert_eq!(cache.transactions.len(), 0);
+    }
+
+    #[test]
+    fn transaction_metadata_accessors() {
+        let height = 42;
+        let result = ExecTxResult {
+            log: "test result".to_string(),
+            ..ExecTxResult::default()
+        };
+
+        let metadata = IncludedTransactionMetadata {
+            height,
+            result: result.clone(),
+        };
+
+        assert_eq!(metadata.height(), height);
+        assert_eq!(metadata.result(), &result);
+    }
+}

--- a/crates/astria-sequencer/src/service/mempool/into_check_tx_response.rs
+++ b/crates/astria-sequencer/src/service/mempool/into_check_tx_response.rs
@@ -45,12 +45,15 @@ impl IntoCheckTxResponse for RemovalReason {
                     .into(),
                 ..response::CheckTx::default()
             },
-            RemovalReason::IncludedInBlock(height) => response::CheckTx {
+            RemovalReason::IncludedInBlock {
+                height,
+                result,
+            } => response::CheckTx {
                 code: Code::Err(AbciErrorCode::TRANSACTION_INCLUDED_IN_BLOCK.value()),
                 info: AbciErrorCode::TRANSACTION_INCLUDED_IN_BLOCK.to_string(),
                 log: format!(
                     "transaction removed from app mempool because it was included in block \
-                     {height}"
+                     {height} with result: {result:?}"
                 ),
                 ..response::CheckTx::default()
             },

--- a/proto/mempoolapis/astria/mempool/v1/transaction_status.proto
+++ b/proto/mempoolapis/astria/mempool/v1/transaction_status.proto
@@ -41,5 +41,33 @@ message TransactionStatus {
   message Executed {
     // The height of the block in which the transaction was included.
     uint64 height = 1;
+
+    // The transaction result.
+    ExecTxResult result = 2;
+
+    // EventAttribute is a single key-value pair, associated with an event.
+    message EventAttribute {
+      string key = 1;
+      string value = 2;
+      bool index = 3;
+    }
+
+    // A record of an event which occurred during transaction execution.
+    message Event {
+      string kind = 1;
+      repeated EventAttribute attributes = 2;
+    }
+
+    // The result of transaction execution.
+    message ExecTxResult {
+      uint32 code = 1;
+      bytes data = 2;
+      string log = 3;
+      string info = 4;
+      int64 gas_wanted = 5;
+      int64 gas_used = 6;
+      repeated Event events = 7;
+      string codespace = 8;
+    }
   }
 }


### PR DESCRIPTION
## Summary
Adds a cache of recently included transactions to the mempool.

## Background
#2133 added support for getting a transaction's status from the mempool. When CometBFT calls `CheckTx`, however, transactions are removed from the removal cache. So, transactions which have been included in a block have an extremely limited amount of time to be observed as "included" before they disappear from the mempool completely. This is bad UX, and these changes aim to address that.

## Changes
- Adds `RecentlyIncludedTransactions` cache to mempool with a timeout of 1 minute and a maximum of 60,000 transactions included.

## Testing
- Added unit tests for `RecentlyIncludedTransactions`
- Added unit tests in mempool to ensure `transaction_status` correctly grabs the status from `recently_included_transactions`.

## Changelogs
Ensure all relevant changelog files are updated as necessary. See
[keepachangelog](https://keepachangelog.com/en/1.1.0/#how) for change
categories. Replace this text with e.g. "Changelogs updated." or "No updates
required." to acknowledge changelogs have been considered.

## Related Issues
closes #2147
