### PR TITLE
chore(sequencer): add app-level mempool tests for transaction inclusion

### DIFF
--- a/crates/astria-sequencer/src/app/tests_app/mempool.rs
+++ b/crates/astria-sequencer/src/app/tests_app/mempool.rs
@@ -21,8 +21,11 @@ use tendermint::{
 use super::*;
 use crate::{
     accounts::StateReadExt as _,
+    mempool::TransactionStatus,
     test_utils::{
         dummy_balances,
+        dummy_rollup_data_submission,
+        dummy_transfer,
         dummy_tx_costs,
         nria,
         Fixture,
@@ -547,5 +550,575 @@ async fn maintenance_funds_added_promotes() {
             .unwrap(),
         10,
         "transfer should've worked"
+    );
+}
+
+async fn assert_tx_in_pending(fixture: &Fixture, tx_id: &TransactionId, tx_name: &str) {
+    assert!(
+        matches!(
+            fixture.mempool().transaction_status(tx_id).await.unwrap(),
+            TransactionStatus::Pending,
+        ),
+        "{tx_name} should be in pending"
+    );
+}
+
+#[expect(clippy::too_many_lines, reason = "it's a test")]
+#[tokio::test]
+async fn proposer_flow_included_transactions_sent_to_mempool() {
+    // The flow of this test simulates a proposer gathering transactions from the builder queue in
+    // mempool and executing a full round of the consensus protocol. This includes:
+    // 1. prepare_proposal - transactions should be executed and stored in ephemeral cache with
+    //    `EXECUTION_RESULTS_KEY` key.
+    // 2. process_proposal - execution should be skipped since they already were in
+    //    "prepare_proposal". Transactions should be moved within ephemeral cache to
+    //    `POST_TRANSACTION_EXECUTION_RESULT_KEY` key.
+    // 3. finalize_block - execution should be skipped. Transactions should be moved to the write
+    //    batch.
+    // 4. commit - transactions should still be in mempool and should be in the write batch. After
+    //    execution of this method, transactions should be removed from mempool and added to the
+    //    removal cache.
+    let mut fixture = Fixture::default_initialized().await;
+    let height = fixture.block_height().await.increment();
+
+    let tx_1 = fixture
+        .checked_tx_builder()
+        .with_signer(ALICE.clone())
+        .with_action(dummy_rollup_data_submission())
+        .build()
+        .await;
+    let tx_2 = fixture
+        .checked_tx_builder()
+        .with_signer(ALICE.clone())
+        .with_action(dummy_transfer())
+        .with_nonce(1)
+        .build()
+        .await;
+
+    let tx_1_id = tx_1.id();
+    let tx_2_id = tx_2.id();
+
+    // Insert transactions into mempool
+    fixture
+        .mempool()
+        .insert(
+            tx_1.clone(),
+            0,
+            &dummy_balances(0, 0),
+            dummy_tx_costs(0, 0, 0),
+        )
+        .await
+        .unwrap();
+    fixture
+        .mempool()
+        .insert(
+            tx_2.clone(),
+            0,
+            &dummy_balances(0, 0),
+            dummy_tx_costs(0, 0, 0),
+        )
+        .await
+        .unwrap();
+
+    // Ensure transactions are in pending
+    assert_eq!(fixture.mempool().len().await, 2, "two txs in mempool");
+    assert_tx_in_pending(&fixture, tx_1_id, "tx_1").await;
+    assert_tx_in_pending(&fixture, tx_2_id, "tx_2").await;
+
+    // Submit prepare_proposal
+    fixture
+        .app
+        .prepare_proposal(
+            PrepareProposal {
+                max_tx_bytes: 200_000,
+                txs: vec![],
+                local_last_commit: Some(ExtendedCommitInfo {
+                    votes: vec![],
+                    round: 0u16.into(),
+                }),
+                misbehavior: vec![],
+                height,
+                time: Time::now(),
+                next_validators_hash: Hash::default(),
+                proposer_address: account::Id::new([1u8; 20]),
+            },
+            fixture.storage(),
+        )
+        .await
+        .unwrap();
+
+    // Ensure executed transactions are in state under EXECUTION_RESULTS_KEY
+    let (_, _, executed_tx_ids): (
+        Vec<(RollupId, Bytes)>,
+        Vec<ExecTxResult>,
+        HashSet<TransactionId>,
+    ) = fixture.state().object_get(EXECUTION_RESULTS_KEY).unwrap();
+    assert_eq!(executed_tx_ids.len(), 2, "both txs should be in state");
+    assert!(executed_tx_ids.contains(tx_1_id), "tx_1 should be in state");
+    assert!(executed_tx_ids.contains(tx_2_id), "tx_2 should be in state");
+
+    // Submit process_proposal
+    let txs = transactions_with_extended_commit_info_and_commitments(
+        height,
+        &[tx_1.clone(), tx_2.clone()],
+        None,
+    );
+    fixture
+        .app
+        .process_proposal(
+            ProcessProposal {
+                hash: Hash::try_from([99u8; 32].to_vec()).unwrap(),
+                height,
+                time: Time::now(),
+                next_validators_hash: Hash::default(),
+                proposer_address: [0u8; 20].to_vec().try_into().unwrap(),
+                txs: txs.clone(),
+                proposed_last_commit: Some(CommitInfo {
+                    votes: vec![],
+                    round: Round::default(),
+                }),
+                misbehavior: vec![],
+            },
+            fixture.storage(),
+        )
+        .await
+        .unwrap();
+
+    // Ensure executed transactions are in state
+    assert!(
+        fixture
+            .state()
+            .object_get::<(
+                Vec<(RollupId, Bytes)>,
+                Vec<ExecTxResult>,
+                HashSet<TransactionId>
+            )>(EXECUTION_RESULTS_KEY)
+            .is_none(),
+        "EXECUTION_RESULTS_KEY should be empty"
+    );
+    let post_transaction_execution_results: PostTransactionExecutionResult = fixture
+        .state()
+        .object_get(POST_TRANSACTION_EXECUTION_RESULT_KEY)
+        .unwrap();
+    assert_eq!(
+        post_transaction_execution_results.executed_tx_ids.len(),
+        2,
+        "both txs should be in state"
+    );
+    assert!(
+        post_transaction_execution_results
+            .executed_tx_ids
+            .contains(tx_1_id),
+        "tx_1 should be in state"
+    );
+    assert!(
+        post_transaction_execution_results
+            .executed_tx_ids
+            .contains(tx_2_id),
+        "tx_2 should be in state"
+    );
+
+    // Submit finalize_block
+    fixture
+        .app
+        .finalize_block(
+            FinalizeBlock {
+                hash: Hash::try_from([97u8; 32].to_vec()).unwrap(),
+                height,
+                time: Time::now(),
+                next_validators_hash: Hash::default(),
+                proposer_address: [0u8; 20].to_vec().try_into().unwrap(),
+                txs,
+                decided_last_commit: CommitInfo {
+                    votes: vec![],
+                    round: Round::default(),
+                },
+                misbehavior: vec![],
+            },
+            fixture.storage(),
+        )
+        .await
+        .unwrap();
+
+    // Ensure transactions are in write batch
+    let write_batch = fixture.app.write_batch.as_ref().unwrap();
+    assert_eq!(
+        write_batch.executed_tx_ids.len(),
+        2,
+        "both txs should be in write batch"
+    );
+    assert!(
+        write_batch.executed_tx_ids.contains(tx_1_id),
+        "tx_1 should be in write batch"
+    );
+    assert!(
+        write_batch.executed_tx_ids.contains(tx_2_id),
+        "tx_2 should be in write batch"
+    );
+
+    // Ensure transactions are still in pending
+    assert_eq!(fixture.mempool().len().await, 2, "two txs in mempool");
+    assert_tx_in_pending(&fixture, tx_1_id, "tx_1").await;
+    assert_tx_in_pending(&fixture, tx_2_id, "tx_2").await;
+
+    // Commit the block, should remove transactions from mempool
+    fixture.app.commit(fixture.storage()).await.unwrap();
+
+    // Ensure transactions are removed from mempool
+    assert_eq!(fixture.mempool().len().await, 0, "mempool should be empty");
+    assert!(
+        fixture.mempool().removal_cache().await.len() == 2,
+        "removal cache should have 2 txs"
+    );
+    let TransactionStatus::Removed(RemovalReason::IncludedInBlock(height_1)) =
+        fixture.mempool().transaction_status(tx_1_id).await.unwrap()
+    else {
+        panic!("tx_1 should be removed");
+    };
+    assert_eq!(
+        height_1,
+        height.value(),
+        "tx_1 should be removed from mempool with height {height}"
+    );
+    let TransactionStatus::Removed(RemovalReason::IncludedInBlock(height_2)) =
+        fixture.mempool().transaction_status(tx_2_id).await.unwrap()
+    else {
+        panic!("tx_2 should be removed");
+    };
+    assert_eq!(
+        height_2,
+        height.value(),
+        "tx_2 should be removed from mempool with height {height}"
+    );
+}
+
+#[expect(clippy::too_many_lines, reason = "it's a test")]
+#[tokio::test]
+async fn non_proposer_validator_flow_included_transactions_sent_to_mempool() {
+    // The flow of this test simulates a validator receiving a block from the current proposer and
+    // executing a full round of the consensus protocol. This includes:
+    // 1. process_proposal - transactions are executed and then added to the ephemeral cache under
+    //    the `POST_TRANSACTION_EXECUTION_RESULT_KEY` key.
+    // 2. finalize_block - execution should be skipped since they were already executed in
+    //    "process_proposal". Transactions should be moved to the write batch.
+    // 3. commit - transactions should still be in mempool and should be in the write batch. After
+    //    execution of this method, transactions should be removed from mempool and added to the
+    //    removal cache.
+    let mut fixture = Fixture::default_initialized().await;
+    let height = fixture.block_height().await.increment();
+
+    let tx_1 = fixture
+        .checked_tx_builder()
+        .with_signer(ALICE.clone())
+        .with_action(dummy_rollup_data_submission())
+        .build()
+        .await;
+    let tx_2 = fixture
+        .checked_tx_builder()
+        .with_signer(ALICE.clone())
+        .with_action(dummy_transfer())
+        .with_nonce(1)
+        .build()
+        .await;
+
+    let tx_1_id = tx_1.id();
+    let tx_2_id = tx_2.id();
+
+    // Insert transactions into mempool
+    fixture
+        .mempool()
+        .insert(
+            tx_1.clone(),
+            0,
+            &dummy_balances(0, 0),
+            dummy_tx_costs(0, 0, 0),
+        )
+        .await
+        .unwrap();
+    fixture
+        .mempool()
+        .insert(
+            tx_2.clone(),
+            0,
+            &dummy_balances(0, 0),
+            dummy_tx_costs(0, 0, 0),
+        )
+        .await
+        .unwrap();
+
+    // Ensure transactions are in pending
+    assert_eq!(fixture.mempool().len().await, 2, "two txs in mempool");
+    assert_tx_in_pending(&fixture, tx_1_id, "tx_1").await;
+    assert_tx_in_pending(&fixture, tx_2_id, "tx_2").await;
+
+    // Submit process_proposal
+    let txs = transactions_with_extended_commit_info_and_commitments(
+        height,
+        &[tx_1.clone(), tx_2.clone()],
+        None,
+    );
+    fixture
+        .app
+        .process_proposal(
+            ProcessProposal {
+                hash: Hash::try_from([99u8; 32].to_vec()).unwrap(),
+                height,
+                time: Time::now(),
+                next_validators_hash: Hash::default(),
+                proposer_address: [0u8; 20].to_vec().try_into().unwrap(),
+                txs: txs.clone(),
+                proposed_last_commit: Some(CommitInfo {
+                    votes: vec![],
+                    round: Round::default(),
+                }),
+                misbehavior: vec![],
+            },
+            fixture.storage(),
+        )
+        .await
+        .unwrap();
+
+    // Ensure executed transactions are in state
+    assert!(
+        fixture
+            .state()
+            .object_get::<(
+                Vec<(RollupId, Bytes)>,
+                Vec<ExecTxResult>,
+                HashSet<TransactionId>
+            )>(EXECUTION_RESULTS_KEY)
+            .is_none(),
+        "EXECUTION_RESULTS_KEY should be empty"
+    );
+    let post_transaction_execution_results: PostTransactionExecutionResult = fixture
+        .state()
+        .object_get(POST_TRANSACTION_EXECUTION_RESULT_KEY)
+        .unwrap();
+    assert_eq!(
+        post_transaction_execution_results.executed_tx_ids.len(),
+        2,
+        "both txs should be in state"
+    );
+    assert!(
+        post_transaction_execution_results
+            .executed_tx_ids
+            .contains(tx_1_id),
+        "tx_1 should be in state"
+    );
+    assert!(
+        post_transaction_execution_results
+            .executed_tx_ids
+            .contains(tx_2_id),
+        "tx_2 should be in state"
+    );
+
+    // Submit finalize_block
+    fixture
+        .app
+        .finalize_block(
+            FinalizeBlock {
+                hash: Hash::try_from([97u8; 32].to_vec()).unwrap(),
+                height,
+                time: Time::now(),
+                next_validators_hash: Hash::default(),
+                proposer_address: [0u8; 20].to_vec().try_into().unwrap(),
+                txs,
+                decided_last_commit: CommitInfo {
+                    votes: vec![],
+                    round: Round::default(),
+                },
+                misbehavior: vec![],
+            },
+            fixture.storage(),
+        )
+        .await
+        .unwrap();
+
+    // Ensure transactions are in write batch
+    let write_batch = fixture.app.write_batch.as_ref().unwrap();
+    assert_eq!(
+        write_batch.executed_tx_ids.len(),
+        2,
+        "both txs should be in write batch"
+    );
+    assert!(
+        write_batch.executed_tx_ids.contains(tx_1_id),
+        "tx_1 should be in write batch"
+    );
+    assert!(
+        write_batch.executed_tx_ids.contains(tx_2_id),
+        "tx_2 should be in write batch"
+    );
+
+    // Ensure transactions are still in pending
+    assert_eq!(fixture.mempool().len().await, 2, "two txs in mempool");
+    assert_tx_in_pending(&fixture, tx_1_id, "tx_1").await;
+    assert_tx_in_pending(&fixture, tx_2_id, "tx_2").await;
+
+    // Commit the block, should remove transactions from mempool
+    fixture.app.commit(fixture.storage()).await.unwrap();
+
+    // Ensure transactions are removed from mempool
+    assert_eq!(fixture.mempool().len().await, 0, "mempool should be empty");
+    assert!(
+        fixture.mempool().removal_cache().await.len() == 2,
+        "removal cache should have 2 txs"
+    );
+    let TransactionStatus::Removed(RemovalReason::IncludedInBlock(height_1)) =
+        fixture.mempool().transaction_status(tx_1_id).await.unwrap()
+    else {
+        panic!("tx_1 should be removed");
+    };
+    assert_eq!(
+        height_1,
+        height.value(),
+        "tx_1 should be removed from mempool with height {height}"
+    );
+    let TransactionStatus::Removed(RemovalReason::IncludedInBlock(height_2)) =
+        fixture.mempool().transaction_status(tx_2_id).await.unwrap()
+    else {
+        panic!("tx_2 should be removed");
+    };
+    assert_eq!(
+        height_2,
+        height.value(),
+        "tx_2 should be removed from mempool with height {height}"
+    );
+}
+
+#[expect(clippy::too_many_lines, reason = "it's a test")]
+#[tokio::test]
+async fn non_validator_flow_included_transactions_sent_to_mempool() {
+    // The flow of this test simulates a full node (running a mempool) that is not a validator
+    // receiving a `FinalizeBlock` from CometBFT and committing it. This includes:
+    // 1. finalize_block - transactions are executed for the first time since the node is not a
+    //    validator, then added to the write batch.
+    // 2. commit - transactions should still be in mempool and should be in the write batch. After
+    //    execution of this method, transactions should be removed from mempool and added to the
+    //    removal cache.
+    let mut fixture = Fixture::default_initialized().await;
+    let height = fixture.block_height().await.increment();
+
+    let tx_1 = fixture
+        .checked_tx_builder()
+        .with_signer(ALICE.clone())
+        .with_action(dummy_rollup_data_submission())
+        .build()
+        .await;
+    let tx_2 = fixture
+        .checked_tx_builder()
+        .with_signer(ALICE.clone())
+        .with_action(dummy_transfer())
+        .with_nonce(1)
+        .build()
+        .await;
+
+    let tx_1_id = tx_1.id();
+    let tx_2_id = tx_2.id();
+
+    // Insert transactions into mempool
+    fixture
+        .mempool()
+        .insert(
+            tx_1.clone(),
+            0,
+            &dummy_balances(0, 0),
+            dummy_tx_costs(0, 0, 0),
+        )
+        .await
+        .unwrap();
+    fixture
+        .mempool()
+        .insert(
+            tx_2.clone(),
+            0,
+            &dummy_balances(0, 0),
+            dummy_tx_costs(0, 0, 0),
+        )
+        .await
+        .unwrap();
+
+    // Ensure transactions are in pending
+    assert_eq!(fixture.mempool().len().await, 2, "two txs in mempool");
+    assert_tx_in_pending(&fixture, tx_1_id, "tx_1").await;
+    assert_tx_in_pending(&fixture, tx_2_id, "tx_2").await;
+
+    let txs = transactions_with_extended_commit_info_and_commitments(
+        height,
+        &[tx_1.clone(), tx_2.clone()],
+        None,
+    );
+
+    // Submit finalize_block
+    fixture
+        .app
+        .finalize_block(
+            FinalizeBlock {
+                hash: Hash::try_from([97u8; 32].to_vec()).unwrap(),
+                height,
+                time: Time::now(),
+                next_validators_hash: Hash::default(),
+                proposer_address: [0u8; 20].to_vec().try_into().unwrap(),
+                txs,
+                decided_last_commit: CommitInfo {
+                    votes: vec![],
+                    round: Round::default(),
+                },
+                misbehavior: vec![],
+            },
+            fixture.storage(),
+        )
+        .await
+        .unwrap();
+
+    // Ensure transactions are in write batch
+    let write_batch = fixture.app.write_batch.as_ref().unwrap();
+    assert_eq!(
+        write_batch.executed_tx_ids.len(),
+        2,
+        "both txs should be in write batch"
+    );
+    assert!(
+        write_batch.executed_tx_ids.contains(tx_1_id),
+        "tx_1 should be in write batch"
+    );
+    assert!(
+        write_batch.executed_tx_ids.contains(tx_2_id),
+        "tx_2 should be in write batch"
+    );
+
+    // Ensure transactions are still in pending
+    assert_eq!(fixture.mempool().len().await, 2, "two txs in mempool");
+    assert_tx_in_pending(&fixture, tx_1_id, "tx_1").await;
+    assert_tx_in_pending(&fixture, tx_2_id, "tx_2").await;
+
+    // Commit the block, should remove transactions from mempool
+    fixture.app.commit(fixture.storage()).await.unwrap();
+
+    // Ensure transactions are removed from mempool
+    assert_eq!(fixture.mempool().len().await, 0, "mempool should be empty");
+    assert!(
+        fixture.mempool().removal_cache().await.len() == 2,
+        "removal cache should have 2 txs"
+    );
+    let TransactionStatus::Removed(RemovalReason::IncludedInBlock(height_1)) =
+        fixture.mempool().transaction_status(tx_1_id).await.unwrap()
+    else {
+        panic!("tx_1 should be removed");
+    };
+    assert_eq!(
+        height_1,
+        height.value(),
+        "tx_1 should be removed from mempool with height {height}"
+    );
+    let TransactionStatus::Removed(RemovalReason::IncludedInBlock(height_2)) =
+        fixture.mempool().transaction_status(tx_2_id).await.unwrap()
+    else {
+        panic!("tx_2 should be removed");
+    };
+    assert_eq!(
+        height_2,
+        height.value(),
+        "tx_2 should be removed from mempool with height {height}"
     );
 }

--- a/crates/astria-sequencer/src/app/tests_app/mempool.rs
+++ b/crates/astria-sequencer/src/app/tests_app/mempool.rs
@@ -569,10 +569,10 @@ async fn proposer_flow_included_transactions_sent_to_mempool() {
     // The flow of this test simulates a proposer gathering transactions from the builder queue in
     // mempool and executing a full round of the consensus protocol. This includes:
     // 1. prepare_proposal - transactions are executed here.
-    // 2. process_proposal - transactions not executed, and should still be in pending.
-    // 3. finalize_block - transactions not executed, and should still be in pending.
-    // 4. commit - transactions should still be in mempool. After execution of this method,
-    //    transactions should be removed from mempool and added to the removal cache.
+    // 2. process_proposal - transactions not executed, and IDs should still be in pending.
+    // 3. finalize_block - transactions not executed, and IDs should still be in pending.
+    // 4. commit - transaction IDs should still be in mempool. After execution of this method, they
+    //    should be removed from mempool and added to the removal cache.
     let mut fixture = Fixture::default_initialized().await;
     let height = fixture.block_height().await.increment();
 
@@ -723,8 +723,9 @@ async fn proposer_flow_included_transactions_sent_to_mempool() {
 
     // Ensure transactions are removed from mempool
     assert_eq!(fixture.mempool().len().await, 0, "mempool should be empty");
-    assert!(
-        fixture.mempool().removal_cache().await.len() == 2,
+    assert_eq!(
+        fixture.mempool().removal_cache().await.len(),
+        2,
         "removal cache should have 2 txs"
     );
     let TransactionStatus::Removed(RemovalReason::IncludedInBlock(height_1)) =
@@ -755,9 +756,9 @@ async fn non_proposer_validator_flow_included_transactions_sent_to_mempool() {
     // The flow of this test simulates a validator receiving a block from the current proposer and
     // executing a full round of the consensus protocol. This includes:
     // 1. process_proposal - transactions are executed here.
-    // 2. finalize_block - transactions not executed, and should still be in pending.
-    // 3. commit - transactions should still be in mempool. After execution of this method,
-    //    transactions should be removed from mempool and added to the removal cache.
+    // 2. finalize_block - transactions not executed, and IDs should still be in pending.
+    // 3. commit - transaction IDs should still be in mempool. After execution of this method, they
+    //    should be removed from mempool and added to the removal cache.
     let mut fixture = Fixture::default_initialized().await;
     let height = fixture.block_height().await.increment();
 
@@ -877,8 +878,9 @@ async fn non_proposer_validator_flow_included_transactions_sent_to_mempool() {
 
     // Ensure transactions are removed from mempool
     assert_eq!(fixture.mempool().len().await, 0, "mempool should be empty");
-    assert!(
-        fixture.mempool().removal_cache().await.len() == 2,
+    assert_eq!(
+        fixture.mempool().removal_cache().await.len(),
+        2,
         "removal cache should have 2 txs"
     );
     let TransactionStatus::Removed(RemovalReason::IncludedInBlock(height_1)) =
@@ -909,8 +911,8 @@ async fn non_validator_flow_included_transactions_sent_to_mempool() {
     // receiving a `FinalizeBlock` from CometBFT and committing it. This includes:
     // 1. finalize_block - transactions are executed for the first time since the node is not a
     //    validator, then added to the write batch.
-    // 2. commit - transactions should still be in mempool. After execution of this method,
-    //    transactions should be removed from mempool and added to the removal cache.
+    // 2. commit - transaction IDs should still be in mempool. After execution of this method, they
+    //    should be removed from mempool and added to the removal cache.
     let mut fixture = Fixture::default_initialized().await;
     let height = fixture.block_height().await.increment();
 
@@ -1000,8 +1002,9 @@ async fn non_validator_flow_included_transactions_sent_to_mempool() {
 
     // Ensure transactions are removed from mempool
     assert_eq!(fixture.mempool().len().await, 0, "mempool should be empty");
-    assert!(
-        fixture.mempool().removal_cache().await.len() == 2,
+    assert_eq!(
+        fixture.mempool().removal_cache().await.len(),
+        2,
         "removal cache should have 2 txs"
     );
     let TransactionStatus::Removed(RemovalReason::IncludedInBlock(height_1)) =

--- a/crates/astria-sequencer/src/checked_actions/checked_action.rs
+++ b/crates/astria-sequencer/src/checked_actions/checked_action.rs
@@ -865,7 +865,6 @@ mod tests {
 
     #[tokio::test]
     async fn should_report_insufficient_funds() {
-        astria_eyre::install().unwrap();
         let mut fixture = Fixture::default_initialized().await;
         let tx_signer = [20; ADDRESS_LENGTH];
         let action = dummy_rollup_data_submission();


### PR DESCRIPTION
## Summary
Added app-level mempool tests to ensure that transactions are successfully removed from the mempool with an "included" status in regular execution.

## Background
#2133 added support for `TransactionStatus`es, namely creating a new `RemovalReason::IncludedInBlock`. Tests were added to ensure that transaction IDs which were passed to the mempool in `App::commit` were successfully marked as "included", but no tests were added at a higher level to ensure that transactions are successfully conveyed between the different app methods and then to mempool. This led to a silent failure when the PR was first drafted, and the tests were deemed best suited for a followup.

These changes aim to address the three possible execution flows within the app to ensure executed transaction IDs are successfully passed to the mempool in `commit` no matter when they were executed:
1. `prepare_proposal` (execution here) -> `process_proposal` -> `finalize_block` -> `commit`
2. `process_proposal` (execution here) -> `finalize_block` -> `commit`
3. `finalize_block` (execution here) -> `commit`

## Changes/Testing
- Added tests for the 3 flows listed above in `app/tests/mempool`.
- Removed an eyre hook installation that was causing failure.

## Changelogs
No updates required.

## Related Issues
closes #2146 
