### PR TITLE
chore(ci): add `mempool-apis` and `upgrades` to proto lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -61,6 +61,18 @@ jobs:
         with:
           input: "proto/composerapis"
           against: "buf.build/astria/composer-apis"
+      - uses: bufbuild/buf-breaking-action@v1
+        if: always()
+        continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'allow-breaking-proto') }}
+        with:
+          input: "proto/mempoolapis"
+          against: "buf.build/astria/mempool-apis"
+      - uses: bufbuild/buf-breaking-action@v1
+        if: always()
+        continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'allow-breaking-proto') }}
+        with:
+          input: "proto/upgrades"
+          against: "buf.build/astria/upgrades"
 
   rust:
     runs-on: ubuntu-22.04

--- a/.github/workflows/reusable-run-checker.yml
+++ b/.github/workflows/reusable-run-checker.yml
@@ -90,6 +90,7 @@ jobs:
             proto:
               - 'proto/composerapis/**'
               - 'proto/executionapis/**'
+              - 'proto/mempoolapis/**'
               - 'proto/primitives/**'
               - 'proto/protocolapis/**'
               - 'proto/sequencerblockapis/**'


### PR DESCRIPTION
## Summary
Adds the `mempool-apis` and `upgrades` proto packages to the `proto` job in the `lint` workflow. 

## Background
The `mempool-apis` and `upgrades` packages were added recently, but neither have been added to the lint since they were not yet added in BUF. Now that they are, this adds these packages to the breaking changes lint.

## Changes
- Adds `mempoolapis` and `upgrades` to the `lint/proto` job.

## Testing
CI passing.

## Changelogs
No updates required.

## Related Issues
Closes #2145 
