### PR TITLE
chore(sequencer): refactor sequencer `serve()` function

### DIFF
--- a/crates/astria-sequencer/src/checked_actions/checked_action.rs
+++ b/crates/astria-sequencer/src/checked_actions/checked_action.rs
@@ -869,7 +869,6 @@ mod tests {
 
     #[tokio::test]
     async fn should_report_insufficient_funds() {
-        astria_eyre::install().unwrap();
         let mut fixture = Fixture::default_initialized().await;
         let tx_signer = [20; ADDRESS_LENGTH];
         let action = dummy_rollup_data_submission();

--- a/crates/astria-sequencer/src/sequencer.rs
+++ b/crates/astria-sequencer/src/sequencer.rs
@@ -246,16 +246,17 @@ impl Sequencer {
         // TODO(janis): need a mechanism to check and report if the grpc server setup failed.
         // right now it's fire and forget and the grpc server is only reaped if sequencer
         // itself is taken down.
-        let grpc_server_handle = tokio::spawn(crate::grpc::serve(
-            storage.clone(),
+        let grpc_server_args = crate::grpc::SequencerServerArgs {
+            storage: storage.clone(),
             mempool,
             upgrades,
             metrics,
             grpc_addr,
-            config.no_optimistic_blocks,
+            no_optimistic_blocks: config.no_optimistic_blocks,
             event_bus_subscription,
-            grpc_shutdown_rx,
-        ));
+            shutdown_rx: grpc_shutdown_rx,
+        };
+        let grpc_server_handle = tokio::spawn(crate::grpc::serve(grpc_server_args));
 
         debug!(%config.abci_listen_url, "starting sequencer");
         let consensus_cancellation_token = tokio_util::sync::CancellationToken::new();


### PR DESCRIPTION
## Summary
Refactors `serve()` arguments into helper struct.

## Background
The `serve()` function which created the gRPC server for the sequencer and ran it had too many arguments, so a refactor was needed.

## Changes
- Created helper struct `SequencerServerArgs` to cut down arg count.

## Testing
- No additional tests required.

## Changelogs
No updates required.

## Related Issues
closes <!-- list any issues closed here --> #2134 
