### PR TITLE
ci: use nip.io instead of localdev.me

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -70,49 +70,49 @@ just clean-persisted-data
 
 ### Faucet
 
-The default rollup faucet is available at <http://faucet.astria.localdev.me>.
+The default rollup faucet is available at <http://faucet.astria.127.0.0.1.nip.io>.
 
 If you deploy a custom faucet, it will be reachable at
-`http://faucet.<rollup_name>.localdev.me`.
+`http://faucet.<rollup_name>.127.0.0.1.nip.io`.
 
 By default, no account is funded during geth genesis.
 Run `just init rollup-bridge` to fund the faucet account. This account key is
 defined in `../dev/values/rollup/dev.yaml` and is identical to the key in
 `./evm-rollup/files/keys/private_key.txt`.
 
-The default sequencer faucet is available at <http://sequencer-faucet.localdev.me>.
+The default sequencer faucet is available at <http://sequencer-faucet.127.0.0.1.nip.io>.
 
 ### Blockscout
 
-The default Blockscout app is available at <http://explorer.astria.localdev.me>.
+The default Blockscout app is available at <http://explorer.astria.127.0.0.1.nip.io>.
 
 If you deploy a custom Blockscout app, it will be available at
-`http://explorer.<rollup_name>.localdev.me`.
+`http://explorer.<rollup_name>.127.0.0.1.nip.io`.
 
 ### Sequencer
 
-The default sequencer RPC is available at <http://rpc.sequencer.localdev.me/health>.
+The default sequencer RPC is available at <http://rpc.sequencer.127.0.0.1.nip.io/health>.
 
 ### EVM Rollup
 
-The default EVM rollup has an RPC endpoint available at <http://executor.astria.localdev.me>.
+The default EVM rollup has an RPC endpoint available at <http://executor.astria.127.0.0.1.nip.io>.
 
-There is also a default WSS endpoint available at <ws://ws-executor.astria.localdev.me>.
+There is also a default WSS endpoint available at <ws://ws-executor.astria.127.0.0.1.nip.io>.
 
 If you deploy a custom rollup, then the endpoints will be
-`http://executor.<rollup_name>.localdev.me` and `ws://ws-executor.<rollup_name>.localdev.me`
+`http://executor.<rollup_name>.127.0.0.1.nip.io` and `ws://ws-executor.<rollup_name>.127.0.0.1.nip.io`
 
 ### Connecting Metamask
 
 * adding the default network
   * network name: `astria`
-  * rpc url: `http://executor.astria.localdev.me`
+  * rpc url: `http://executor.astria.127.0.0.1.nip.io`
   * chain id: `1337`
   * currency symbol: `RIA`
 
 * adding a custom network
   * network name: `<rollup_name>`
-  * rpc url: `http://executor.<rollup_name>.localdev.me`
+  * rpc url: `http://executor.<rollup_name>.127.0.0.1.nip.io`
   * chain id: `<network_id>`
   * currency symbol: `RIA`
 
@@ -231,7 +231,7 @@ just clean
 # example of deploying contract w/ forge (https://github.com/foundry-rs/foundry)
 RUST_LOG=debug forge create src/Storage.sol:Storage \
   --private-key $PRIV_KEY \
-  --rpc-url "http://executor.astria.localdev.me"
+  --rpc-url "http://executor.astria.127.0.0.1.nip.io"
 ```
 
 ### Helpful links

--- a/charts/astrotrek/Chart.yaml
+++ b/charts/astrotrek/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1
+version: 0.0.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/astrotrek/values.yaml
+++ b/charts/astrotrek/values.yaml
@@ -61,8 +61,8 @@ config:
     postgresPassword: indexer-user
     postgresDb: astria
   frontend:
-    rpcApiUrl: http://api.sequencer.localdev.me/v1
-    wsApiUrl: ws://api.sequencer.localdev.me/v1/ws
+    rpcApiUrl: http://api.sequencer.127.0.0.1.nip.io/v1
+    wsApiUrl: ws://api.sequencer.127.0.0.1.nip.io/v1/ws
 
 ingress:
   enabled: true
@@ -75,12 +75,12 @@ ingress:
       nginx.ingress.kubernetes.io/cors-allow-headers: "DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range"
       nginx.ingress.kubernetes.io/cors-expose-headers: "Content-Length,Content-Range"
       nginx.ingress.kubernetes.io/cors-max-age: "86400"
-    host: api.sequencer.localdev.me
+    host: api.sequencer.127.0.0.1.nip.io
     tls: []
   frontend:
     className: "nginx"
     annotations: {}
-    host: astrotrek.sequencer.localdev.me
+    host: astrotrek.sequencer.127.0.0.1.nip.io
     tls: []
 
 ports:

--- a/charts/celestia-local/Chart.yaml
+++ b/charts/celestia-local/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.3
+version: 0.7.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/celestia-local/values.yaml
+++ b/charts/celestia-local/values.yaml
@@ -60,7 +60,7 @@ ports:
 ingress:
   labels: {}
   annotations: {}
-  hostname: localdev.me
+  hostname: 127.0.0.1.nip.io
   className: nginx
   services:
     bridgeRpc:

--- a/charts/evm-faucet/Chart.yaml
+++ b/charts/evm-faucet/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.1.4
+version: 0.1.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/evm-faucet/values.yaml
+++ b/charts/evm-faucet/values.yaml
@@ -33,7 +33,7 @@ config:
 ingress:
   enabled: false
   labels: {}
-  hostname: localdev.me
+  hostname: 127.0.0.1.nip.io
   className: nginx
   services:
     faucet:

--- a/charts/evm-rollup/Chart.yaml
+++ b/charts/evm-rollup/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.3
+version: 2.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/evm-rollup/values.yaml
+++ b/charts/evm-rollup/values.yaml
@@ -312,7 +312,7 @@ alerting:
 ingress:
   enabled: false
   labels: {}
-  hostname: localdev.me
+  hostname: 127.0.0.1.nip.io
   className: nginx
   services:
     rpc:

--- a/charts/evm-stack/Chart.lock
+++ b/charts/evm-stack/Chart.lock
@@ -4,10 +4,10 @@ dependencies:
   version: 0.5.0
 - name: evm-rollup
   repository: file://../evm-rollup
-  version: 2.0.3
+  version: 2.0.4
 - name: flame-rollup
   repository: file://../flame-rollup
-  version: 0.1.2
+  version: 0.1.3
 - name: composer
   repository: file://../composer
   version: 1.0.3
@@ -16,7 +16,7 @@ dependencies:
   version: 0.0.2
 - name: evm-faucet
   repository: file://../evm-faucet
-  version: 0.1.4
+  version: 0.1.5
 - name: evm-bridge-withdrawer
   repository: file://../evm-bridge-withdrawer
   version: 1.0.5
@@ -26,5 +26,5 @@ dependencies:
 - name: blockscout-stack
   repository: https://blockscout.github.io/helm-charts
   version: 1.6.8
-digest: sha256:939b8feced240e9ebfe72bc4b678e1b56afcf75f3d6a4da0e7106992e59f8edc
-generated: "2025-05-02T12:27:43.563027-07:00"
+digest: sha256:c80afe5e4cdff30a0a041292aadee6fb165f966a538dfc3d0704346a19088771
+generated: "2025-05-12T14:19:59.881116-07:00"

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.2
+version: 2.1.3
 
 dependencies:
   - name: celestia-node
@@ -23,11 +23,11 @@ dependencies:
     repository: "file://../celestia-node"
     condition: celestia-node.enabled
   - name: evm-rollup
-    version: 2.0.3
+    version: 2.0.4
     repository: "file://../evm-rollup"
     condition: evm-rollup.enabled
   - name: flame-rollup
-    version: 0.1.2
+    version: 0.1.3
     repository: "file://../flame-rollup"
     condition: flame-rollup.enabled
   - name: composer
@@ -39,7 +39,7 @@ dependencies:
     repository: "file://../auctioneer"
     condition: auctioneer.enabled
   - name: evm-faucet
-    version: 0.1.4
+    version: 0.1.5
     repository: "file://../evm-faucet"
     condition: evm-faucet.enabled
   - name: evm-bridge-withdrawer

--- a/charts/external-ingress/Chart.yaml
+++ b/charts/external-ingress/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/external-ingress/values.yaml
+++ b/charts/external-ingress/values.yaml
@@ -12,7 +12,7 @@ ingress: {}
 #    service: evm-rpc
 #    port: 8545
 #    hosts:
-#      - rpc.flame.localdev.me
+#      - rpc.flame.127.0.0.1.nip.io
 #    labels: {}
 #    annotations: {}
 #    tls: {}
@@ -20,7 +20,7 @@ ingress: {}
 #    service: evm-rpc
 #    port: 8546
 #    hosts:
-#      - ws.flame.localdev.me
+#      - ws.flame.127.0.0.1.nip.io
 #    labels: {}
 #    annotations: {}
 #    tls: {}
@@ -28,7 +28,7 @@ ingress: {}
 #    service: evm-faucet
 #    port: 8080
 #    hosts:
-#      - faucet.flame.localdev.me
+#      - faucet.flame.127.0.0.1.nip.io
 #    labels: { }
 #    annotations: {}
 #    tls: {}

--- a/charts/flame-rollup/Chart.yaml
+++ b/charts/flame-rollup/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.1.2
+version: 0.1.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/flame-rollup/values.yaml
+++ b/charts/flame-rollup/values.yaml
@@ -239,7 +239,7 @@ alerting:
 ingress:
   enabled: false
   labels: {}
-  hostname: localdev.me
+  hostname: 127.0.0.1.nip.io
   className: nginx
   services:
     rpc:

--- a/charts/graph-node/Chart.yaml
+++ b/charts/graph-node/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: graph-node
 description: A Helm chart for Graph Node deployment
-version: 0.2.1
+version: 0.2.2
 appVersion: "0.0.1"
 
 maintainers:

--- a/charts/graph-node/values.yaml
+++ b/charts/graph-node/values.yaml
@@ -30,7 +30,7 @@ ingress:
     {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
-  host: graph-node.localdev.me
+  host: graph-node.127.0.0.1.nip.io
   tls: []
   #  - secretName: graph-node-tls
   #    hosts:

--- a/charts/hermes/Chart.yaml
+++ b/charts/hermes/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.0
+version: 0.7.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hermes/values.yaml
+++ b/charts/hermes/values.yaml
@@ -141,7 +141,7 @@ ports:
 ingress:
   enabled: false
   labels: {}
-  hostname: localdev.me
+  hostname: 127.0.0.1.nip.io
   className: nginx
   services:
     rest:

--- a/charts/hyperlane-agents/Chart.yaml
+++ b/charts/hyperlane-agents/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.1.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hyperlane-agents/values.yaml
+++ b/charts/hyperlane-agents/values.yaml
@@ -37,7 +37,7 @@ config:
         protocol: ethereum
         isTestnet: true
         rpcUrls:
-          - http: 'https://executor.astria.localdev.me'
+          - http: 'https://executor.astria.127.0.0.1.nip.io'
         nativeToken:
           name: RIA
           symbol: RIA

--- a/charts/just/defaults.just
+++ b/charts/just/defaults.just
@@ -16,14 +16,14 @@ defaultHypRelayerPrivateKey   := ""
 defaultHypValidatorPrivateKey := ""
 
 evm_destination_address := "0xaC21B97d35Bf75A7dAb16f35b111a50e78A72F30"
-eth_rpc_url := "http://executor.astria.localdev.me/"
+eth_rpc_url := "http://executor.astria.127.0.0.1.nip.io/"
 
 validatorName             := "single"
 # 1 RIA is 10^9 nRIA
 sequencer_base_amount     := "1000000000"
 # 10 RIA
 sequencer_transfer_amount := "10"
-sequencer_rpc_url         := "http://rpc.sequencer.localdev.me"
+sequencer_rpc_url         := "http://rpc.sequencer.127.0.0.1.nip.io"
 sequencer_bridge_address  := "astria13ahqz4pjqfmynk9ylrqv4fwe4957x2p0h5782u"
 sequencer_bridge_pkey     := "dfa7108e38ab71f89f356c72afc38600d5758f11a8c337164713e4471411d2e0"
 sequencer_chain_id        := "sequencer-test-chain-0"

--- a/charts/just/run/ibc-test.just
+++ b/charts/just/run/ibc-test.just
@@ -160,7 +160,7 @@ without-native tag=defaultTag:
 # Run IBC Test With Refund Timeout
 ###################################
 sequencer_tia_bridge_address := "astria1d7zjjljc0dsmxa545xkpwxym86g8uvvwhtezcr"
-eth_ws_url := "ws://ws-executor.astria.localdev.me/"
+eth_ws_url := "ws://ws-executor.astria.127.0.0.1.nip.io/"
 evm_contract_address := "0xA58639fB5458e65E4fA917FF951C390292C24A15"
 [no-cd]
 [doc("
@@ -337,7 +337,7 @@ sequencer_sudo_address := "astria1rsxyjrcm255ds9euthjx6yc3vrjt9sxrm9cfgm"
 compat_address := "astriacompat1cewd7alwml4fhx3w3lxq3vgf20cqe0qmdzxmvn"
 celestia_dev_account_address := "celestia1m0ksdjl2p5nzhqy3p47fksv52at3ln885xvl96"
 celestia_chain_id := "celestia-local-0"
-celestia_node_url := "http://rpc.app.celestia.localdev.me:80"
+celestia_node_url := "http://rpc.app.celestia.127.0.0.1.nip.io:80"
 sequencer_tia_bridge_priv_key := "6015fbe1c365d3c5ef92dc891db8c5bb26ad454bec2db4762b96e9f8b2430285"
 keyring_backend := "test"
 celestia_destination_address := "0x4a58639fb5458e65e4fa917ff951c390292c24a1"

--- a/charts/just/run/mod.just
+++ b/charts/just/run/mod.just
@@ -20,12 +20,12 @@ _default_run:
 
 # RIA is 10^9, WEI is 10^18, 10^9 * 10^9 = 10^18
 rollup_multiplier := "1000000000"
-eth_ws_url := "ws://ws-executor.astria.localdev.me/"
+eth_ws_url := "ws://ws-executor.astria.127.0.0.1.nip.io/"
 # bridge_tx_bytes is the tx to the withdraw smart contract on the evm.
 # Uses private key for 0xaC21B97d35Bf75A7dAb16f35b111a50e78A72F30 to sign tx.
 # was created via:
 #  `forge script script/AstriaWithdrawer.s.sol:AstriaWithdrawerScript \
-#        --rpc-url "http://executor.astria.localdev.me/" \
+#        --rpc-url "http://executor.astria.127.0.0.1.nip.io/" \
 #        --legacy \
 #        --broadcast \
 #        --sig "withdrawToSequencer()" -vvvv`

--- a/charts/sequencer-faucet/Chart.yaml
+++ b/charts/sequencer-faucet/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.1
+version: 0.9.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sequencer-faucet/values.yaml
+++ b/charts/sequencer-faucet/values.yaml
@@ -72,7 +72,7 @@ ingress:
   path: /
   pathType: Prefix
   hosts:
-    - sequencer-faucet.localdev.me
+    - sequencer-faucet.127.0.0.1.nip.io
   service:
     name: sequencer-faucet-service
     port:

--- a/charts/sequencer/Chart.yaml
+++ b/charts/sequencer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.1
+version: 2.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sequencer/values.yaml
+++ b/charts/sequencer/values.yaml
@@ -404,7 +404,7 @@ storage:
 ingress:
   rpc:
     enabled: false
-    hostname: sequencer.localdev.me
+    hostname: sequencer.127.0.0.1.nip.io
     ingressClassName: nginx
     # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
     # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
@@ -448,7 +448,7 @@ ingress:
     #      - chart-example.local
   grpc:
     enabled: false
-    hostname: sequencer.localdev.me
+    hostname: sequencer.127.0.0.1.nip.io
     ingressClassName: nginx
     # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
     # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress

--- a/dev/values/rollup/dev.yaml
+++ b/dev/values/rollup/dev.yaml
@@ -220,7 +220,7 @@ blockscout-stack:
 
     ingress:
       enabled: true
-      hostname: explorer.astria.localdev.me
+      hostname: explorer.astria.127.0.0.1.nip.io
       paths:
         - path: /api
           pathType: Prefix
@@ -253,4 +253,4 @@ blockscout-stack:
         value: "none"
     ingress:
       enabled: true
-      hostname: explorer.astria.localdev.me
+      hostname: explorer.astria.127.0.0.1.nip.io

--- a/dev/values/rollup/evm-restart-test.yaml
+++ b/dev/values/rollup/evm-restart-test.yaml
@@ -207,7 +207,7 @@ blockscout-stack:
 
     ingress:
       enabled: true
-      hostname: explorer.astria.localdev.me
+      hostname: explorer.astria.127.0.0.1.nip.io
       paths:
         - path: /api
           pathType: Prefix
@@ -240,4 +240,4 @@ blockscout-stack:
         value: "none"
     ingress:
       enabled: true
-      hostname: explorer.astria.localdev.me
+      hostname: explorer.astria.127.0.0.1.nip.io

--- a/dev/values/rollup/flame-dev.yaml
+++ b/dev/values/rollup/flame-dev.yaml
@@ -244,7 +244,7 @@ blockscout-stack:
 
     ingress:
       enabled: true
-      hostname: explorer.astria.localdev.me
+      hostname: explorer.astria.127.0.0.1.nip.io
       paths:
         - path: /api
           pathType: Prefix
@@ -277,4 +277,4 @@ blockscout-stack:
         value: "none"
     ingress:
       enabled: true
-      hostname: explorer.astria.localdev.me
+      hostname: explorer.astria.127.0.0.1.nip.io

--- a/dev/values/validators/node1.yml
+++ b/dev/values/validators/node1.yml
@@ -50,7 +50,7 @@ cometbft:
 ingress:
   rpc:
     enabled: true
-    hostname: sequencer-{{ .Values.moniker }}.localdev.me
+    hostname: sequencer-{{ .Values.moniker }}.127.0.0.1.nip.io
   grpc:
     enabled: true
-    hostname: sequencer-{{ .Values.moniker }}.localdev.me
+    hostname: sequencer-{{ .Values.moniker }}.127.0.0.1.nip.io

--- a/dev/values/validators/node2.yml
+++ b/dev/values/validators/node2.yml
@@ -49,7 +49,7 @@ cometbft:
 ingress:
   rpc:
     enabled: true
-    hostname: sequencer-{{ .Values.moniker }}.localdev.me
+    hostname: sequencer-{{ .Values.moniker }}.127.0.0.1.nip.io
   grpc:
     enabled: true
-    hostname: sequencer-{{ .Values.moniker }}.localdev.me
+    hostname: sequencer-{{ .Values.moniker }}.127.0.0.1.nip.io

--- a/dev/values/validators/node3.yml
+++ b/dev/values/validators/node3.yml
@@ -49,7 +49,7 @@ cometbft:
 ingress:
   rpc:
     enabled: true
-    hostname: sequencer-{{ .Values.moniker }}.localdev.me
+    hostname: sequencer-{{ .Values.moniker }}.127.0.0.1.nip.io
   grpc:
     enabled: true
-    hostname: sequencer-{{ .Values.moniker }}.localdev.me
+    hostname: sequencer-{{ .Values.moniker }}.127.0.0.1.nip.io

--- a/dev/values/validators/node4.yml
+++ b/dev/values/validators/node4.yml
@@ -49,7 +49,7 @@ cometbft:
 ingress:
   rpc:
     enabled: true
-    hostname: sequencer-{{ .Values.moniker }}.localdev.me
+    hostname: sequencer-{{ .Values.moniker }}.127.0.0.1.nip.io
   grpc:
     enabled: true
-    hostname: sequencer-{{ .Values.moniker }}.localdev.me
+    hostname: sequencer-{{ .Values.moniker }}.127.0.0.1.nip.io

--- a/system-tests/helpers/astria_cli.py
+++ b/system-tests/helpers/astria_cli.py
@@ -149,9 +149,9 @@ class Cli:
         Returns the stdout output on success, or throws a `DockerException` otherwise.
         """
         if sequencer_name == "node0":
-            url = "http://rpc.sequencer.localdev.me"
+            url = "http://rpc.sequencer.127.0.0.1.nip.io"
         else:
-            url = f"http://rpc.sequencer-{sequencer_name}.localdev.me"
+            url = f"http://rpc.sequencer-{sequencer_name}.127.0.0.1.nip.io"
         args = list(args)
         args.insert(0, "sequencer")
         if use_sequencer_url:

--- a/system-tests/helpers/evm_controller.py
+++ b/system-tests/helpers/evm_controller.py
@@ -161,7 +161,7 @@ class EvmController:
             "params": list(params),
             "id": 1,
         }
-        response = requests.post(f"http://executor.astria.localdev.me/", json=payload).json()
+        response = requests.post(f"http://executor.astria.127.0.0.1.nip.io/", json=payload).json()
         if not "result" in response:
             raise RuntimeError(f"json-rpc error response for `{method}`: {response['error']}")
         return response["result"]

--- a/system-tests/helpers/sequencer_controller.py
+++ b/system-tests/helpers/sequencer_controller.py
@@ -25,12 +25,12 @@ class SequencerController:
         self.name = node_name
         if node_name == "node0":
             self.namespace = "astria-dev-cluster"
-            self.rpc_url = "http://rpc.sequencer.localdev.me"
-            self.grpc_url = "grpc.sequencer.localdev.me:80"
+            self.rpc_url = "http://rpc.sequencer.127.0.0.1.nip.io"
+            self.grpc_url = "grpc.sequencer.127.0.0.1.nip.io:80"
         else:
             self.namespace = f"astria-validator-{node_name}"
-            self.rpc_url = f"http://rpc.sequencer-{node_name}.localdev.me"
-            self.grpc_url = f"grpc.sequencer-{node_name}.localdev.me:80"
+            self.rpc_url = f"http://rpc.sequencer-{node_name}.127.0.0.1.nip.io"
+            self.grpc_url = f"grpc.sequencer-{node_name}.127.0.0.1.nip.io:80"
         self.last_block_height_before_restart = None
 
     # ===========================================================

--- a/system-tests/sequencer_upgrade_test.py
+++ b/system-tests/sequencer_upgrade_test.py
@@ -270,7 +270,7 @@ print("testing bridge out")
 # Uses private key for 0xaC21B97d35Bf75A7dAb16f35b111a50e78A72F30 to sign tx.
 # was created via:
 #  `forge script script/AstriaWithdrawer.s.sol:AstriaWithdrawerScript \
-#        --rpc-url "http://executor.astria.localdev.me/" \
+#        --rpc-url "http://executor.astria.127.0.0.1.nip.io/" \
 #        --legacy \
 #        --broadcast \
 #        --sig "withdrawToSequencer()" -vvvv`


### PR DESCRIPTION
## Summary
Updates all instances of charts using `localdev.me` to use `127.0.0.1.nip.io`.

## Background
 `localdev.me` seems to no longer work, and `nip.io` is a well established service. This was causing test failures.

## Changes
- replace all instances in repo of `localdev.me` with `127.0.0.1.nip.io`
- updating chart versions as required per lint

## Testing
CI/CD 

