### PR TITLE
chore(sequencer): update handling of addition and removal actions

### DIFF
--- a/crates/astria-core/CHANGELOG.md
+++ b/crates/astria-core/CHANGELOG.md
@@ -58,7 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `CheckedTransaction` from this [#2142](https://github.com/astriaorg/astria/pull/2142).
 - Rename ABCI error code 10 from `TRANSACTION_FAILED` to
   `TRANSACTION_FAILED_EXECUTION` [#2142](https://github.com/astriaorg/astria/pull/2142).
-- Change `CurrencyPairsChange` action to hold a `BTreeSet` rather than a `Vec`
+- Change `CurrencyPairsChange` action to hold an `IndexSet` rather than a `Vec`
   of currency pairs [#2171](https://github.com/astriaorg/astria/pull/2171).
 
 ### Removed

--- a/crates/astria-core/CHANGELOG.md
+++ b/crates/astria-core/CHANGELOG.md
@@ -58,6 +58,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `CheckedTransaction` from this [#2142](https://github.com/astriaorg/astria/pull/2142).
 - Rename ABCI error code 10 from `TRANSACTION_FAILED` to
   `TRANSACTION_FAILED_EXECUTION` [#2142](https://github.com/astriaorg/astria/pull/2142).
+- Change `CurrencyPairsChange` action to hold a `BTreeSet` rather than a `Vec`
+  of currency pairs [#2171](https://github.com/astriaorg/astria/pull/2171).
 
 ### Removed
 

--- a/crates/astria-core/src/protocol/transaction/v1/action/group/tests.rs
+++ b/crates/astria-core/src/protocol/transaction/v1/action/group/tests.rs
@@ -1,6 +1,5 @@
-use std::collections::BTreeSet;
-
 use ibc_types::core::client::Height;
+use indexmap::IndexSet;
 
 use crate::{
     crypto::VerificationKey,
@@ -129,7 +128,7 @@ fn from_list_of_actions_bundleable_sudo() {
             client_id: "07-tendermint-0".parse().unwrap(),
             replacement_client_id: "07-tendermint-1".parse().unwrap(),
         }),
-        Action::CurrencyPairsChange(CurrencyPairsChange::Addition(BTreeSet::new())),
+        Action::CurrencyPairsChange(CurrencyPairsChange::Addition(IndexSet::new())),
         Action::MarketsChange(MarketsChange::Creation(vec![])),
     ];
 

--- a/crates/astria-core/src/protocol/transaction/v1/action/group/tests.rs
+++ b/crates/astria-core/src/protocol/transaction/v1/action/group/tests.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeSet;
+
 use ibc_types::core::client::Height;
 
 use crate::{
@@ -127,7 +129,7 @@ fn from_list_of_actions_bundleable_sudo() {
             client_id: "07-tendermint-0".parse().unwrap(),
             replacement_client_id: "07-tendermint-1".parse().unwrap(),
         }),
-        Action::CurrencyPairsChange(CurrencyPairsChange::Addition(vec![])),
+        Action::CurrencyPairsChange(CurrencyPairsChange::Addition(BTreeSet::new())),
         Action::MarketsChange(MarketsChange::Creation(vec![])),
     ];
 

--- a/crates/astria-core/src/protocol/transaction/v1/action/mod.rs
+++ b/crates/astria-core/src/protocol/transaction/v1/action/mod.rs
@@ -1,5 +1,4 @@
 use std::{
-    collections::BTreeSet,
     fmt::Display,
     str::FromStr,
 };
@@ -12,6 +11,7 @@ use ibc_types::{
     },
     IdentifierError,
 };
+use indexmap::IndexSet;
 use penumbra_ibc::IbcRelay;
 use prost::Name as _;
 
@@ -2580,8 +2580,8 @@ enum RecoverIbcClientErrorKind {
 
 #[derive(Debug, Clone)]
 pub enum CurrencyPairsChange {
-    Addition(BTreeSet<CurrencyPair>),
-    Removal(BTreeSet<CurrencyPair>),
+    Addition(IndexSet<CurrencyPair>),
+    Removal(IndexSet<CurrencyPair>),
 }
 
 impl Protobuf for CurrencyPairsChange {
@@ -2623,22 +2623,30 @@ impl Protobuf for CurrencyPairsChange {
             Some(raw::currency_pairs_change::Value::Addition(raw::CurrencyPairs {
                 pairs,
             })) => {
-                let pairs = pairs
+                let pairs_len = pairs.len();
+                let parsed_pairs: IndexSet<_> = pairs
                     .into_iter()
                     .map(CurrencyPair::try_from_raw)
                     .collect::<Result<_, _>>()
                     .map_err(Self::Error::invalid_currency_pair)?;
-                Ok(Self::Addition(pairs))
+                if pairs_len != parsed_pairs.len() {
+                    return Err(Self::Error::duplicate_currency_pair());
+                }
+                Ok(Self::Addition(parsed_pairs))
             }
             Some(raw::currency_pairs_change::Value::Removal(raw::CurrencyPairs {
                 pairs,
             })) => {
-                let pairs = pairs
+                let pairs_len = pairs.len();
+                let parsed_pairs: IndexSet<_> = pairs
                     .into_iter()
                     .map(CurrencyPair::try_from_raw)
                     .collect::<Result<_, _>>()
                     .map_err(Self::Error::invalid_currency_pair)?;
-                Ok(Self::Removal(pairs))
+                if pairs_len != parsed_pairs.len() {
+                    return Err(Self::Error::duplicate_currency_pair());
+                }
+                Ok(Self::Removal(parsed_pairs))
             }
             None => Err(Self::Error::unset()),
         }
@@ -2669,6 +2677,11 @@ impl CurrencyPairsChangeError {
     fn invalid_currency_pair(err: CurrencyPairError) -> Self {
         Self(CurrencyPairsChangeErrorKind::InvalidCurrencyPair(err))
     }
+
+    #[must_use]
+    fn duplicate_currency_pair() -> Self {
+        Self(CurrencyPairsChangeErrorKind::DuplicateCurrencyPair)
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -2677,6 +2690,8 @@ enum CurrencyPairsChangeErrorKind {
     Unset,
     #[error("a currency pair was invalid")]
     InvalidCurrencyPair(#[from] CurrencyPairError),
+    #[error("duplicate currency pair")]
+    DuplicateCurrencyPair,
 }
 
 /// Takes a list of markets and either creates, removes or updates them depending on its variant.

--- a/crates/astria-core/src/protocol/transaction/v1/action/mod.rs
+++ b/crates/astria-core/src/protocol/transaction/v1/action/mod.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::BTreeSet,
     fmt::Display,
     str::FromStr,
 };
@@ -2579,8 +2580,8 @@ enum RecoverIbcClientErrorKind {
 
 #[derive(Debug, Clone)]
 pub enum CurrencyPairsChange {
-    Addition(Vec<CurrencyPair>),
-    Removal(Vec<CurrencyPair>),
+    Addition(BTreeSet<CurrencyPair>),
+    Removal(BTreeSet<CurrencyPair>),
 }
 
 impl Protobuf for CurrencyPairsChange {

--- a/crates/astria-sequencer/CHANGELOG.md
+++ b/crates/astria-sequencer/CHANGELOG.md
@@ -23,6 +23,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for all action types [#2142](https://github.com/astriaorg/astria/pull/2142).
 - Rename metric `ASTRIA_SEQUENCER_CHECK_TX_REMOVED_TOO_LARGE` to
   `ASTRIA_SEQUENCER_CHECK_TX_FAILED_TX_TOO_LARGE` [#2142](https://github.com/astriaorg/astria/pull/2142)
+- Changed `CurrencyPairsChange::Addition` action to fail if any currency pair to
+  be added is already stored [#2171](https://github.com/astriaorg/astria/pull/2171).
+- Changed `CurrencyPairsChange::Removal` action to fail if any currency pair to
+  be removed is not currently stored [#2171](https://github.com/astriaorg/astria/pull/2171).
+- Changed `FeeAssetChange::Addition` action to fail if the fee asset to be added
+  is already stored [#2171](https://github.com/astriaorg/astria/pull/2171).
+- Changed `FeeAssetChange::Removal` action to fail if the fee asset to be
+  removed is not currently stored [#2171](https://github.com/astriaorg/astria/pull/2171).
+- Changed `IbcRelayerChange::Addition` action to fail if the address to be added
+  is already stored [#2171](https://github.com/astriaorg/astria/pull/2171).
+- Changed `IbcRelayerChange::Removal` action to fail if the address to be
+  removed is not currently stored [#2171](https://github.com/astriaorg/astria/pull/2171).
+- Changed `MarketsChange::Removal` action to fail if any market to be removed is
+  not currently stored [#2171](https://github.com/astriaorg/astria/pull/2171).
 
 ### Removed
 

--- a/crates/astria-sequencer/src/app/tests_breaking_changes.rs
+++ b/crates/astria-sequencer/src/app/tests_breaking_changes.rs
@@ -9,12 +9,9 @@
 //! These are due to the extensive setup needed to test them.
 //! If changes are made to the execution results of these actions, manual testing is required.
 
-use std::{
-    collections::{
-        HashMap,
-        HashSet,
-    },
-    str::FromStr as _,
+use std::collections::{
+    HashMap,
+    HashSet,
 };
 
 use astria_core::{
@@ -231,8 +228,6 @@ async fn app_legacy_execute_transactions_with_every_action_snapshot() {
         .build()
         .await;
 
-    let currency_pair_tia = CurrencyPair::from_str("TIA/USD").unwrap();
-    let currency_pair_eth = CurrencyPair::from_str("ETH/USD").unwrap();
     let tx_bundleable_sudo = fixture
         .checked_tx_builder()
         .with_action(IbcRelayerChange::Addition(bob_address))
@@ -241,12 +236,11 @@ async fn app_legacy_execute_transactions_with_every_action_snapshot() {
         .with_action(FeeAssetChange::Addition("test-0".parse().unwrap()))
         .with_action(FeeAssetChange::Addition("test-1".parse().unwrap()))
         .with_action(FeeAssetChange::Removal("test-0".parse().unwrap()))
-        .with_action(CurrencyPairsChange::Addition(vec![
-            currency_pair_tia.clone(),
-            currency_pair_eth.clone(),
-        ]))
+        .with_action(CurrencyPairsChange::Addition(
+            std::iter::once("TIA/USD".parse::<CurrencyPair>().unwrap()).collect(),
+        ))
         .with_action(CurrencyPairsChange::Removal(
-            vec![currency_pair_eth.clone()],
+            std::iter::once("ETH/USD".parse::<CurrencyPair>().unwrap()).collect(),
         ))
         .with_action(MarketsChange::Creation(vec![Market {
             ticker: dummy_ticker("testAssetOne/testAssetTwo", "create market"),

--- a/crates/astria-sequencer/src/checked_actions/checked_action.rs
+++ b/crates/astria-sequencer/src/checked_actions/checked_action.rs
@@ -865,7 +865,6 @@ mod tests {
 
     #[tokio::test]
     async fn should_report_insufficient_funds() {
-        astria_eyre::install().unwrap();
         let mut fixture = Fixture::default_initialized().await;
         let tx_signer = [20; ADDRESS_LENGTH];
         let action = dummy_rollup_data_submission();

--- a/crates/astria-sequencer/src/checked_actions/currency_pairs_change.rs
+++ b/crates/astria-sequencer/src/checked_actions/currency_pairs_change.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeSet;
-
 use astria_core::{
     oracles::price_feed::{
         oracle::v2::CurrencyPairState,
@@ -24,6 +22,7 @@ use cnidarium::{
     StateRead,
     StateWrite,
 };
+use indexmap::IndexSet;
 use tracing::{
     instrument,
     Level,
@@ -131,7 +130,7 @@ impl AssetTransfer for CheckedCurrencyPairsChange {
 
 async fn execute_currency_pairs_addition<S: StateWrite>(
     mut state: S,
-    currency_pairs: &BTreeSet<CurrencyPair>,
+    currency_pairs: &IndexSet<CurrencyPair>,
 ) -> Result<()> {
     let mut next_currency_pair_id = state
         .get_next_currency_pair_id()
@@ -169,7 +168,7 @@ async fn execute_currency_pairs_addition<S: StateWrite>(
 
 async fn execute_currency_pairs_removal<S: StateWrite>(
     mut state: S,
-    currency_pairs: &BTreeSet<CurrencyPair>,
+    currency_pairs: &IndexSet<CurrencyPair>,
 ) -> Result<()> {
     let mut num_currency_pairs = state
         .get_num_currency_pairs()
@@ -193,8 +192,6 @@ async fn execute_currency_pairs_removal<S: StateWrite>(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeSet;
-
     use astria_core::{
         oracles::price_feed::types::v2::CurrencyPairId,
         protocol::transaction::v1::action::SudoAddressChange,
@@ -215,7 +212,7 @@ mod tests {
         pairs_iter: I,
     ) -> CurrencyPairsChange {
         let count = pairs_iter.clone().into_iter().count();
-        let pairs: BTreeSet<_> = pairs_iter.into_iter().map(|s| s.parse().unwrap()).collect();
+        let pairs: IndexSet<_> = pairs_iter.into_iter().map(|s| s.parse().unwrap()).collect();
         assert_eq!(pairs.len(), count, "cannot use duplicate pairs");
         CurrencyPairsChange::Addition(pairs)
     }
@@ -224,7 +221,7 @@ mod tests {
         pairs_iter: I,
     ) -> CurrencyPairsChange {
         let count = pairs_iter.clone().into_iter().count();
-        let pairs: BTreeSet<_> = pairs_iter.into_iter().map(|s| s.parse().unwrap()).collect();
+        let pairs: IndexSet<_> = pairs_iter.into_iter().map(|s| s.parse().unwrap()).collect();
         assert_eq!(pairs.len(), count, "cannot use duplicate pairs");
         CurrencyPairsChange::Removal(pairs)
     }

--- a/crates/astria-sequencer/src/checked_actions/currency_pairs_change.rs
+++ b/crates/astria-sequencer/src/checked_actions/currency_pairs_change.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeSet;
+
 use astria_core::{
     oracles::price_feed::{
         oracle::v2::CurrencyPairState,
@@ -23,7 +25,6 @@ use cnidarium::{
     StateWrite,
 };
 use tracing::{
-    debug,
     instrument,
     Level,
 };
@@ -73,6 +74,33 @@ impl CheckedCurrencyPairsChange {
             &sudo_address == self.tx_signer.as_bytes(),
             "transaction signer not authorized to change currency pairs",
         );
+
+        match &self.action {
+            CurrencyPairsChange::Addition(currency_pairs) => {
+                for currency_pair in currency_pairs {
+                    let maybe_pair_id = state
+                        .get_currency_pair_id(currency_pair)
+                        .await
+                        .wrap_err("failed to read currency pair id from storage")?;
+                    ensure!(
+                        maybe_pair_id.is_none(),
+                        "failed to add currency pair `{currency_pair}`: already added"
+                    );
+                }
+            }
+            CurrencyPairsChange::Removal(currency_pairs) => {
+                for currency_pair in currency_pairs {
+                    let maybe_pair_id = state
+                        .get_currency_pair_id(currency_pair)
+                        .await
+                        .wrap_err("failed to read currency pair id from storage")?;
+                    ensure!(
+                        maybe_pair_id.is_some(),
+                        "failed to remove currency pair `{currency_pair}`: not currently included"
+                    );
+                }
+            }
+        }
         Ok(())
     }
 
@@ -103,7 +131,7 @@ impl AssetTransfer for CheckedCurrencyPairsChange {
 
 async fn execute_currency_pairs_addition<S: StateWrite>(
     mut state: S,
-    currency_pairs: &[CurrencyPair],
+    currency_pairs: &BTreeSet<CurrencyPair>,
 ) -> Result<()> {
     let mut next_currency_pair_id = state
         .get_next_currency_pair_id()
@@ -115,16 +143,6 @@ async fn execute_currency_pairs_addition<S: StateWrite>(
         .wrap_err("failed to read number of currency pairs from storage")?;
 
     for pair in currency_pairs {
-        if state
-            .get_currency_pair_state(pair)
-            .await
-            .wrap_err("failed to read currency pair state from storage")?
-            .is_some()
-        {
-            debug!(%pair, "currency pair already exists, skipping");
-            continue;
-        }
-
         let currency_pair_state = CurrencyPairState {
             price: None,
             nonce: CurrencyPairNonce::new(0),
@@ -151,7 +169,7 @@ async fn execute_currency_pairs_addition<S: StateWrite>(
 
 async fn execute_currency_pairs_removal<S: StateWrite>(
     mut state: S,
-    currency_pairs: &[CurrencyPair],
+    currency_pairs: &BTreeSet<CurrencyPair>,
 ) -> Result<()> {
     let mut num_currency_pairs = state
         .get_num_currency_pairs()
@@ -159,17 +177,15 @@ async fn execute_currency_pairs_removal<S: StateWrite>(
         .wrap_err("failed to read number of currency pairs from storage")?;
 
     for pair in currency_pairs {
-        if state
+        state
             .remove_currency_pair(pair)
             .await
-            .wrap_err("failed to delete currency pair from storage")?
-        {
-            num_currency_pairs = num_currency_pairs
-                .checked_sub(1)
-                .ok_or_eyre("failed to decrement number of currency pairs")?;
-        }
+            .wrap_err("failed to delete currency pair from storage")?;
     }
 
+    num_currency_pairs = num_currency_pairs
+        .checked_sub(u64::try_from(currency_pairs.len()).expect("will never exceed u64::MAX"))
+        .ok_or_eyre("failed to decrement number of currency pairs")?;
     state
         .put_num_currency_pairs(num_currency_pairs)
         .wrap_err("failed to write number of currency pairs to storage")
@@ -177,6 +193,8 @@ async fn execute_currency_pairs_removal<S: StateWrite>(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
+
     use astria_core::{
         oracles::price_feed::types::v2::CurrencyPairId,
         protocol::transaction::v1::action::SudoAddressChange,
@@ -193,18 +211,22 @@ mod tests {
         },
     };
 
-    fn new_addition<'a, I: IntoIterator<Item = &'a str>>(pairs: I) -> CurrencyPairsChange {
-        CurrencyPairsChange::Addition(pairs.into_iter().map(|s| s.parse().unwrap()).collect())
+    fn new_addition<'a, I: IntoIterator<Item = &'a str> + Clone>(
+        pairs_iter: I,
+    ) -> CurrencyPairsChange {
+        let count = pairs_iter.clone().into_iter().count();
+        let pairs: BTreeSet<_> = pairs_iter.into_iter().map(|s| s.parse().unwrap()).collect();
+        assert_eq!(pairs.len(), count, "cannot use duplicate pairs");
+        CurrencyPairsChange::Addition(pairs)
     }
 
-    fn new_removal<'a, I: IntoIterator<Item = &'a str>>(pairs: I) -> CurrencyPairsChange {
-        CurrencyPairsChange::Removal(pairs.into_iter().map(|s| s.parse().unwrap()).collect())
-    }
-
-    fn pairs(action: CurrencyPairsChange) -> Vec<CurrencyPair> {
-        match action {
-            CurrencyPairsChange::Addition(pairs) | CurrencyPairsChange::Removal(pairs) => pairs,
-        }
+    fn new_removal<'a, I: IntoIterator<Item = &'a str> + Clone>(
+        pairs_iter: I,
+    ) -> CurrencyPairsChange {
+        let count = pairs_iter.clone().into_iter().count();
+        let pairs: BTreeSet<_> = pairs_iter.into_iter().map(|s| s.parse().unwrap()).collect();
+        assert_eq!(pairs.len(), count, "cannot use duplicate pairs");
+        CurrencyPairsChange::Removal(pairs)
     }
 
     #[tokio::test]
@@ -236,12 +258,41 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn should_fail_construction_of_addition_if_pair_already_exists() {
+        // `Fixture::default_initialized` executes the Aspen upgrade, which adds currency pairs
+        // "BTC/USD" and "ETH/USD", so we'll use these for this test.
+        let fixture = Fixture::default_initialized().await;
+
+        let action = new_addition(["BTC/USD"]);
+        let err = fixture
+            .new_checked_action(action, *SUDO_ADDRESS_BYTES)
+            .await
+            .unwrap_err();
+        assert_error_contains(&err, "failed to add currency pair `BTC/USD`: already added");
+    }
+
+    #[tokio::test]
+    async fn should_fail_construction_of_removal_if_pair_doesnt_exist() {
+        let fixture = Fixture::default_initialized().await;
+
+        let action = new_removal(["BTC/ETH"]);
+        let err = fixture
+            .new_checked_action(action, *SUDO_ADDRESS_BYTES)
+            .await
+            .unwrap_err();
+        assert_error_contains(
+            &err,
+            "failed to remove currency pair `BTC/ETH`: not currently included",
+        );
+    }
+
+    #[tokio::test]
     async fn should_fail_execution_if_signer_is_not_sudo_address() {
         let mut fixture = Fixture::default_initialized().await;
 
         // Construct the addition and removal checked actions while the sudo address is still the
         // tx signer so construction succeeds.
-        let addition_action = new_addition(Some("BTC/USD"));
+        let addition_action = new_addition(Some("TIA/USD"));
         let checked_addition_action: CheckedCurrencyPairsChange = fixture
             .new_checked_action(addition_action, *SUDO_ADDRESS_BYTES)
             .await
@@ -293,13 +344,71 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn should_fail_execution_of_addition_if_pair_already_exists() {
+        let mut fixture = Fixture::default_initialized().await;
+
+        // Use duplicate additions.
+        let action = new_addition(["TIA/USD"]);
+        let checked_action_1: CheckedCurrencyPairsChange = fixture
+            .new_checked_action(action.clone(), *SUDO_ADDRESS_BYTES)
+            .await
+            .unwrap()
+            .into();
+        let checked_action_2: CheckedCurrencyPairsChange = fixture
+            .new_checked_action(action, *SUDO_ADDRESS_BYTES)
+            .await
+            .unwrap()
+            .into();
+
+        // First addition should succeed.
+        checked_action_1.execute(fixture.state_mut()).await.unwrap();
+
+        // Second should fail due to pair now existing.
+        let err = checked_action_2
+            .execute(fixture.state_mut())
+            .await
+            .unwrap_err();
+        assert_error_contains(&err, "failed to add currency pair `TIA/USD`: already added");
+    }
+
+    #[tokio::test]
+    async fn should_fail_execution_of_removal_if_pair_doesnt_exist() {
+        let mut fixture = Fixture::default_initialized().await;
+
+        // Use duplicate removals.
+        let action = new_removal(["BTC/USD"]);
+        let checked_action_1: CheckedCurrencyPairsChange = fixture
+            .new_checked_action(action.clone(), *SUDO_ADDRESS_BYTES)
+            .await
+            .unwrap()
+            .into();
+        let checked_action_2: CheckedCurrencyPairsChange = fixture
+            .new_checked_action(action, *SUDO_ADDRESS_BYTES)
+            .await
+            .unwrap()
+            .into();
+
+        // First removal should succeed.
+        checked_action_1.execute(fixture.state_mut()).await.unwrap();
+
+        // Second should fail due to pair now not existing.
+        let err = checked_action_2
+            .execute(fixture.state_mut())
+            .await
+            .unwrap_err();
+        assert_error_contains(
+            &err,
+            "failed to remove currency pair `BTC/USD`: not currently included",
+        );
+    }
+
+    #[tokio::test]
     async fn should_execute_addition() {
         // `Fixture::default_initialized` executes the Aspen upgrade, which adds currency pairs
         // "BTC/USD" and "ETH/USD", so we'll use different ones for this test.
         let mut fixture = Fixture::default_initialized().await;
 
-        // Ensure providing duplicate pairs succeeds.
-        let action = new_addition(["TIA/USD", "TIA/ETH", "TIA/USD"]);
+        let action = new_addition(["TIA/USD", "TIA/ETH"]);
         let checked_action: CheckedCurrencyPairsChange = fixture
             .new_checked_action(action.clone(), *SUDO_ADDRESS_BYTES)
             .await
@@ -308,11 +417,16 @@ mod tests {
 
         checked_action.execute(fixture.state_mut()).await.unwrap();
 
-        let pairs = pairs(action);
+        let mut pairs_iter = match action {
+            CurrencyPairsChange::Addition(pairs) | CurrencyPairsChange::Removal(pairs) => {
+                pairs.into_iter()
+            }
+        };
+        let pair = pairs_iter.next().unwrap();
         assert_eq!(
             fixture
                 .state()
-                .get_currency_pair_state(&pairs[0])
+                .get_currency_pair_state(&pair)
                 .await
                 .unwrap()
                 .unwrap(),
@@ -322,10 +436,11 @@ mod tests {
                 id: CurrencyPairId::new(2),
             }
         );
+        let pair = pairs_iter.next().unwrap();
         assert_eq!(
             fixture
                 .state()
-                .get_currency_pair_state(&pairs[1])
+                .get_currency_pair_state(&pair)
                 .await
                 .unwrap()
                 .unwrap(),
@@ -360,8 +475,7 @@ mod tests {
             .unwrap()
             .is_some());
 
-        // Ensure removing duplicate pairs succeeds, and removing a non-existent pair succeeds.
-        let action = new_removal(["BTC/USD", "TIA/USD", "BTC/USD"]);
+        let action = new_removal(["BTC/USD"]);
         let checked_action: CheckedCurrencyPairsChange = fixture
             .new_checked_action(action.clone(), *SUDO_ADDRESS_BYTES)
             .await
@@ -382,12 +496,6 @@ mod tests {
             .await
             .unwrap()
             .is_some());
-        assert!(fixture
-            .state()
-            .get_currency_pair_state(&"TIA/USD".parse::<CurrencyPair>().unwrap())
-            .await
-            .unwrap()
-            .is_none());
         assert_eq!(
             fixture.state().get_next_currency_pair_id().await.unwrap(),
             CurrencyPairId::new(2)

--- a/crates/astria-sequencer/src/checked_actions/fee_asset_change.rs
+++ b/crates/astria-sequencer/src/checked_actions/fee_asset_change.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use astria_core::{
     primitive::v1::{
         asset::IbcPrefixed,
@@ -15,7 +17,6 @@ use cnidarium::{
     StateWrite,
 };
 use futures::TryStreamExt as _;
-use tokio::pin;
 use tracing::{
     instrument,
     Level,
@@ -66,6 +67,48 @@ impl CheckedFeeAssetChange {
             &sudo_address == self.tx_signer.as_bytes(),
             "transaction signer not authorized to change fee assets"
         );
+
+        // NOTE: To allow `app_legacy_execute_transactions_with_every_action_snapshot` to continue
+        // to pass, we need to make an exception for `test-0` here to allow the test tx to be
+        // constructed. This exception can be removed once the legacy test is removed.
+        #[cfg(test)]
+        {
+            let fee_asset = match &self.action {
+                FeeAssetChange::Addition(asset) | FeeAssetChange::Removal(asset) => asset,
+            };
+            if *fee_asset == "test-0".parse().unwrap() {
+                return Ok(());
+            }
+        }
+        match &self.action {
+            FeeAssetChange::Addition(fee_asset) => {
+                let is_allowed_fee_asset = state
+                    .is_allowed_fee_asset(fee_asset)
+                    .await
+                    .wrap_err("failed to read fee asset from storage")?;
+                ensure!(
+                    !is_allowed_fee_asset,
+                    "failed to add fee asset `{fee_asset}`: already is an allowed fee asset"
+                );
+            }
+            FeeAssetChange::Removal(fee_asset) => {
+                let allowed_fee_assets: HashSet<IbcPrefixed> = state
+                    .allowed_fee_assets()
+                    .try_collect()
+                    .await
+                    .wrap_err("failed to stream fee assets from storage")?;
+                ensure!(
+                    allowed_fee_assets.contains(&fee_asset.to_ibc_prefixed()),
+                    "failed to remove fee asset `{fee_asset}`: is not currently an allowed fee \
+                     asset"
+                );
+                ensure!(
+                    allowed_fee_assets.len() > 1,
+                    "cannot remove last allowed fee asset",
+                );
+            }
+        }
+
         Ok(())
     }
 
@@ -74,24 +117,13 @@ impl CheckedFeeAssetChange {
         self.run_mutable_checks(&state).await?;
 
         match &self.action {
-            FeeAssetChange::Addition(asset) => {
+            FeeAssetChange::Addition(fee_asset) => {
                 state
-                    .put_allowed_fee_asset(asset)
+                    .put_allowed_fee_asset(fee_asset)
                     .wrap_err("failed to write allowed fee asset to storage")?;
             }
-            FeeAssetChange::Removal(asset) => {
-                state.delete_allowed_fee_asset(asset);
-                pin!(
-                    let assets = state.allowed_fee_assets();
-                );
-                ensure!(
-                    assets
-                        .try_next()
-                        .await
-                        .wrap_err("failed to stream fee assets from storage")?
-                        .is_some(),
-                    "cannot remove last allowed fee asset",
-                );
+            FeeAssetChange::Removal(fee_asset) => {
+                state.delete_allowed_fee_asset(fee_asset);
             }
         }
         Ok(())
@@ -119,6 +151,7 @@ mod tests {
             assert_error_contains,
             astria_address,
             denom_1,
+            denom_2,
             nria,
             Fixture,
             SUDO_ADDRESS_BYTES,
@@ -163,19 +196,68 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn should_fail_construction_of_addition_if_fee_asset_already_allowed() {
+        let fixture = Fixture::default_initialized().await;
+
+        let action = FeeAssetChange::Addition(nria().into());
+        let err = fixture
+            .new_checked_action(action, *SUDO_ADDRESS_BYTES)
+            .await
+            .unwrap_err();
+        assert_error_contains(
+            &err,
+            "failed to add fee asset `nria`: already is an allowed fee asset",
+        );
+    }
+
+    #[tokio::test]
+    async fn should_fail_construction_of_removal_if_fee_asset_not_currently_allowed() {
+        let fixture = Fixture::default_initialized().await;
+
+        let action = FeeAssetChange::Removal(denom_1());
+        let err = fixture
+            .new_checked_action(action, *SUDO_ADDRESS_BYTES)
+            .await
+            .unwrap_err();
+        assert_error_contains(
+            &err,
+            "failed to remove fee asset `denom_1`: is not currently an allowed fee asset",
+        );
+    }
+
+    #[tokio::test]
+    async fn should_fail_construction_if_attempting_to_remove_only_fee_asset() {
+        let fixture = Fixture::default_initialized().await;
+
+        let action = FeeAssetChange::Removal(nria().into());
+        let err = fixture
+            .new_checked_action(action, *SUDO_ADDRESS_BYTES)
+            .await
+            .unwrap_err();
+
+        assert_error_contains(&err, "cannot remove last allowed fee asset");
+    }
+
+    #[tokio::test]
     async fn should_fail_execution_if_signer_is_not_sudo_address() {
         let mut fixture = Fixture::default_initialized().await;
+        // Need two fee assets to be stored to allow for creating a checked actions that removes
+        // one.
+        fixture
+            .state_mut()
+            .put_allowed_fee_asset(&denom_1())
+            .unwrap();
 
         // Construct the addition and removal checked actions while the sudo address is still the
         // tx signer so construction succeeds.
-        let addition_action = FeeAssetChange::Addition(denom_1());
+        let addition_action = FeeAssetChange::Addition(denom_2());
         let checked_addition_action: CheckedFeeAssetChange = fixture
             .new_checked_action(addition_action, *SUDO_ADDRESS_BYTES)
             .await
             .unwrap()
             .into();
 
-        let removal_action = FeeAssetChange::Removal(denom_1());
+        let removal_action = FeeAssetChange::Removal(nria().into());
         let checked_removal_action: CheckedFeeAssetChange = fixture
             .new_checked_action(removal_action, *SUDO_ADDRESS_BYTES)
             .await
@@ -220,17 +302,98 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn should_fail_execution_if_attempting_to_remove_only_asset() {
+    async fn should_fail_execution_of_addition_if_fee_asset_already_allowed() {
         let mut fixture = Fixture::default_initialized().await;
 
-        let action = FeeAssetChange::Removal(nria().into());
-        let checked_action: CheckedFeeAssetChange = fixture
+        // Use duplicate additions.
+        let action = FeeAssetChange::Addition(denom_1());
+        let checked_action_1: CheckedFeeAssetChange = fixture
+            .new_checked_action(action.clone(), *SUDO_ADDRESS_BYTES)
+            .await
+            .unwrap()
+            .into();
+        let checked_action_2: CheckedFeeAssetChange = fixture
             .new_checked_action(action, *SUDO_ADDRESS_BYTES)
             .await
             .unwrap()
             .into();
 
-        let err = checked_action
+        // First addition should succeed.
+        checked_action_1.execute(fixture.state_mut()).await.unwrap();
+
+        // Second should fail due to fee asset now being stored.
+        let err = checked_action_2
+            .execute(fixture.state_mut())
+            .await
+            .unwrap_err();
+        assert_error_contains(
+            &err,
+            "failed to add fee asset `denom_1`: already is an allowed fee asset",
+        );
+    }
+
+    #[tokio::test]
+    async fn should_fail_execution_of_removal_if_fee_asset_not_currently_allowed() {
+        let mut fixture = Fixture::default_initialized().await;
+        fixture
+            .state_mut()
+            .put_allowed_fee_asset(&denom_1())
+            .unwrap();
+
+        // Use duplicate removals.
+        let action = FeeAssetChange::Removal(denom_1());
+        let checked_action_1: CheckedFeeAssetChange = fixture
+            .new_checked_action(action.clone(), *SUDO_ADDRESS_BYTES)
+            .await
+            .unwrap()
+            .into();
+        let checked_action_2: CheckedFeeAssetChange = fixture
+            .new_checked_action(action, *SUDO_ADDRESS_BYTES)
+            .await
+            .unwrap()
+            .into();
+
+        // First removal should succeed.
+        checked_action_1.execute(fixture.state_mut()).await.unwrap();
+
+        // Second should fail due to fee asset now not being stored.
+        let err = checked_action_2
+            .execute(fixture.state_mut())
+            .await
+            .unwrap_err();
+        assert_error_contains(
+            &err,
+            "failed to remove fee asset `denom_1`: is not currently an allowed fee asset",
+        );
+    }
+
+    #[tokio::test]
+    async fn should_fail_execution_if_attempting_to_remove_only_asset() {
+        let mut fixture = Fixture::default_initialized().await;
+        // Need two fee assets to be stored to allow for creating checked actions that remove both.
+        fixture
+            .state_mut()
+            .put_allowed_fee_asset(&denom_1())
+            .unwrap();
+
+        let action_1 = FeeAssetChange::Removal(nria().into());
+        let checked_action_1: CheckedFeeAssetChange = fixture
+            .new_checked_action(action_1, *SUDO_ADDRESS_BYTES)
+            .await
+            .unwrap()
+            .into();
+        let action_2 = FeeAssetChange::Removal(denom_1());
+        let checked_action_2: CheckedFeeAssetChange = fixture
+            .new_checked_action(action_2, *SUDO_ADDRESS_BYTES)
+            .await
+            .unwrap()
+            .into();
+
+        // First removal should succeed.
+        checked_action_1.execute(fixture.state_mut()).await.unwrap();
+
+        // Second should fail due to fee asset now being the only one stored.
+        let err = checked_action_2
             .execute(fixture.state_mut())
             .await
             .unwrap_err();

--- a/crates/astria-sequencer/src/mempool/transactions_container.rs
+++ b/crates/astria-sequencer/src/mempool/transactions_container.rs
@@ -991,7 +991,7 @@ mod tests {
                 }
                 Some(Group::BundleableSudo) => {
                     self.checked_tx_builder
-                        .with_action(FeeAssetChange::Addition(denom_0()))
+                        .with_action(FeeAssetChange::Addition(denom_1()))
                         .build()
                         .await
                 }

--- a/crates/astria-sequencer/src/oracles/price_feed/oracle/state_ext.rs
+++ b/crates/astria-sequencer/src/oracles/price_feed/oracle/state_ext.rs
@@ -292,18 +292,16 @@ pub(crate) trait StateWriteExt: StateWrite {
     }
 
     #[instrument(skip_all)]
-    async fn remove_currency_pair(&mut self, currency_pair: &CurrencyPair) -> Result<bool> {
-        let Some(id) = self
+    async fn remove_currency_pair(&mut self, currency_pair: &CurrencyPair) -> Result<()> {
+        let id = self
             .get_currency_pair_id(currency_pair)
             .await
             .wrap_err("failed to get currency pair ID")?
-        else {
-            return Ok(false);
-        };
+            .ok_or_eyre("currency pair ID not found")?;
         self.delete(keys::currency_pair_to_id(currency_pair));
         self.delete(keys::id_to_currency_pair(id));
         self.delete(keys::currency_pair_state(currency_pair));
-        Ok(true)
+        Ok(())
     }
 }
 

--- a/crates/astria-sequencer/src/test_utils/mod.rs
+++ b/crates/astria-sequencer/src/test_utils/mod.rs
@@ -263,7 +263,11 @@ pub(crate) fn dummy_bridge_unlock() -> BridgeUnlock {
 
 /// Returns a `CurrencyPairsChange::Addition` action with a dummy value of "TIA/USD" and "ETH/USD".
 pub(crate) fn dummy_currency_pairs_change() -> CurrencyPairsChange {
-    CurrencyPairsChange::Addition(vec!["TIA/USD".parse().unwrap(), "ETH/USD".parse().unwrap()])
+    CurrencyPairsChange::Addition(
+        ["TIA/USD".parse().unwrap(), "ETH/USD".parse().unwrap()]
+            .into_iter()
+            .collect(),
+    )
 }
 
 /// Returns an `IbcRelay::CreateClient` action with dummy values.


### PR DESCRIPTION
## Summary
This changes how actions involving addition or removal of data are handled.

## Background
In some cases currently, we silently ignore additions where the data already exists, or removals where the data does not exist.  We want to always treat these as error conditions.

## Changes
- Changed `CurrencyPairsChange::Addition` action to fail if any currency pair to be added is already stored.
- Changed `CurrencyPairsChange::Removal` action to fail if any currency pair to be removed is not currently stored.
- Changed `FeeAssetChange::Addition` action to fail if the fee asset to be added is already stored.
- Changed `FeeAssetChange::Removal` action to fail if the fee asset to be removed is not currently stored.
- Changed `IbcRelayerChange::Addition` action to fail if the address to be added is already stored.
- Changed `IbcRelayerChange::Removal` action to fail if the address to be removed is not currently stored.
- Changed `MarketsChange::Removal` action to fail if any market to be removed is not currently stored.

## Testing
Added/updated unit tests for all of the changed behaviour.

## Changelogs
Changelogs updated.

## Related Issues
Closes #2158.
