### PR TITLE
feat(charts): add forma mainnet genesis + helper values

### DIFF
--- a/charts/evm-rollup/Chart.yaml
+++ b/charts/evm-rollup/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.1
+version: 2.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/evm-rollup/files/genesis/forma-mainnet.genesis.json
+++ b/charts/evm-rollup/files/genesis/forma-mainnet.genesis.json
@@ -1,0 +1,92 @@
+{
+  "config": {
+    "chainId": 984122,
+    "homesteadBlock": 0,
+    "eip150Block": 0,
+    "eip155Block": 0,
+    "eip158Block": 0,
+    "byzantiumBlock": 0,
+    "constantinopleBlock": 0,
+    "petersburgBlock": 0,
+    "istanbulBlock": 0,
+    "berlinBlock": 0,
+    "londonBlock": 0,
+    "shanghaiTime": 0,
+    "terminalTotalDifficulty": 0,
+    "terminalTotalDifficultyPassed": true,
+    "ethash": {},
+    "astriaRollupName": "forma",
+    "astriaOverrideGenesisExtraData": true,
+    "astriaForks": {
+      "canvas": {
+        "height": 1,
+        "extraDataOverride": "0x659cf6172e50002432e07f91df0ef15206a5251145e089067efecb7d182da372",
+        "feeCollector": "0xcc9Dc6b16775c097559a3817C1D4e64d5975C6D4",
+        "eip1559Params": { "minBaseFee": 18000000000, "elasticityMultiplier": 2, "baseFeeChangeDenominator": 8 },
+        "sequencer": {
+          "chainId": "forma-net-1",
+          "addressPrefix": "astria",
+          "startHeight": 530
+        },
+        "celestia": {
+          "chainId": "celestia",
+          "startHeight": 1504062,
+          "searchHeightMaxLookAhead": 15000
+        },
+        "precompiles": [
+          {
+            "precompileType": "nativeminter",
+            "address": "0x00000000000000000000000000000F043A000001"
+          },
+          {
+            "precompileType": "compress",
+            "address": "0x00000000000000000000000000000F043A000002"
+          },
+          {
+            "precompileType": "jsonutil",
+            "address": "0x00000000000000000000000000000F043A000003"
+          },
+          {
+            "precompileType": "base64",
+            "address": "0x00000000000000000000000000000F043A000004"
+          },
+          {
+            "precompileType": "strings",
+            "address": "0x00000000000000000000000000000F043A000005"
+          },
+          {
+            "precompileType": "integers",
+            "address": "0x00000000000000000000000000000F043A000006"
+          },
+          {
+            "precompileType": "jsonstore",
+            "address": "0x00000000000000000000000000000F043A000007"
+          }
+        ]
+      }
+    },
+    "forma": {
+      "hyperlaneMailbox": "0xcb912D357c3f9aB7bdAD50B7D6Cb668896f17FE3"
+    }
+  },
+  "difficulty": "0",
+  "gasLimit": "0x1c9c380",
+  "alloc": {
+    "0x3D1447C4979bE846dc8e6dc9311a3E5b042446Ee": {
+      "balance": "5000000000000000000"
+    },
+    "0xD49eA2803323a1693efCd9a5EDDaF4c556Da15D3": {
+      "balance": "5000000000000000000"
+    },
+    "0x00000000000000000000000000000f043a000001": {
+      "balance": "0",
+      "storage": {
+        "0x00": "0x0000000000000000000000003D1447C4979bE846dc8e6dc9311a3E5b042446Ee"
+      }
+    },
+    "0x4e59b44847b379578588920cA78FbF26c0B4956C": {
+      "balance": "0",
+      "code": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf3"
+    }
+  }
+}

--- a/charts/evm-rollup/templates/_helpers.tpl
+++ b/charts/evm-rollup/templates/_helpers.tpl
@@ -19,6 +19,7 @@ files/genesis/{{ include "rollup.type" . }}.genesis.json
 {{- if eq $rollupType "flame-mainnet" -}}253368190
 {{- else if eq $rollupType "flame-testnet" -}}16604737732183
 {{- else if eq $rollupType "flame-devnet" -}}912559
+{{- else if eq $rollupType "forma-mainnet" -}}984122
 {{- else if eq $rollupType "forma-testnet" -}}984123
 {{- else -}}{{ tpl .Values.genesis.chainId . }}
 {{- end -}}
@@ -38,6 +39,7 @@ files/genesis/{{ include "rollup.type" . }}.genesis.json
 {{- else if eq $rollupType "flame-mainnet" -}}1.1.0
 {{- else if eq $rollupType "flame-testnet" -}}1.1.0
 {{- else if eq $rollupType "flame-devnet" -}}2.0.0-beta.1
+{{- else if eq $rollupType "forma-mainnet" -}}2.0.0-beta.1-forma-dev.2
 {{- else if eq $rollupType "forma-testnet" -}}2.0.0-beta.1-forma-dev.2
 {{- end -}}
 {{- end }}
@@ -48,6 +50,7 @@ files/genesis/{{ include "rollup.type" . }}.genesis.json
 {{- else if eq $rollupType "flame-mainnet" -}}1.1.0
 {{- else if eq $rollupType "flame-testnet" -}}1.1.0
 {{- else if eq $rollupType "flame-devnet" -}}2.0.0-rc.1
+{{- else if eq $rollupType "forma-mainnet" -}}sha-08fe3e6
 {{- else if eq $rollupType "forma-testnet" -}}sha-08fe3e6
 {{- end -}}
 {{- end }}
@@ -57,8 +60,9 @@ files/genesis/{{ include "rollup.type" . }}.genesis.json
 {{- $rollupName := (include "rollup.name" . ) -}}
 {{- if eq $rollupName "flame" -}}flame-mainnet
 {{- else if eq $rollupName "flame-dawn-1" -}}flame-testnet
-{{- else if eq $rollupName "flame-dusk-11"}}flame-devnet
-{{- else if eq $rollupName "forma-sketchpad"}}forma-testnet
+{{- else if eq $rollupName "flame-dusk-11" -}}flame-devnet
+{{- else if eq $rollupName "forma" -}}forma-mainnet
+{{- else if eq $rollupName "forma-sketchpad" -}}forma-testnet
 {{- else -}}custom
 {{- end -}}
 {{- end }}

--- a/charts/evm-stack/Chart.lock
+++ b/charts/evm-stack/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.5.1
 - name: evm-rollup
   repository: file://../evm-rollup
-  version: 2.1.1
+  version: 2.1.2
 - name: flame-rollup
   repository: file://../flame-rollup
   version: 0.1.3
@@ -26,5 +26,5 @@ dependencies:
 - name: blockscout-stack
   repository: https://blockscout.github.io/helm-charts
   version: 1.6.8
-digest: sha256:4716e599456a1bb082f4e53e9f911043bb134e0b90b7cb8be3ac4aa578607dd3
-generated: "2025-05-12T20:58:12.143644-04:00"
+digest: sha256:a4d08b1c595a9f4928ff87fbf2e162910979e2bf899036c9df080a84b658b4af
+generated: "2025-05-13T09:27:14.647469-04:00"

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -23,7 +23,7 @@ dependencies:
     repository: "file://../celestia-node"
     condition: celestia-node.enabled
   - name: evm-rollup
-    version: 2.1.1
+    version: 2.1.2
     repository: "file://../evm-rollup"
     condition: evm-rollup.enabled
   - name: flame-rollup


### PR DESCRIPTION
## Summary
Add Forma mainnet genesis + image values to the evm-rollup chart

## Background
Changes to deploy new evm-cluster node for Forma mainnet using exec api v2 to prep for mainnet migration to astria mainnet.

## Changelogs
No updates required.