### PR TITLE
fix(charts): remove "-mocha" as the celestiaNode.image helper handles it

### DIFF
--- a/charts/celestia-node/Chart.yaml
+++ b/charts/celestia-node/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.1
+version: 0.5.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/celestia-node/values.yaml
+++ b/charts/celestia-node/values.yaml
@@ -20,7 +20,7 @@ config:
 
 images:
   pullPolicy: IfNotPresent
-  node: ghcr.io/celestiaorg/celestia-node:v0.22.2-mocha
+  node: ghcr.io/celestiaorg/celestia-node:v0.22.2
 
 ports:
   celestia:

--- a/charts/evm-stack/Chart.lock
+++ b/charts/evm-stack/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: celestia-node
   repository: file://../celestia-node
-  version: 0.5.1
+  version: 0.5.2
 - name: evm-rollup
   repository: file://../evm-rollup
   version: 2.1.1
@@ -26,5 +26,5 @@ dependencies:
 - name: blockscout-stack
   repository: https://blockscout.github.io/helm-charts
   version: 1.6.8
-digest: sha256:4716e599456a1bb082f4e53e9f911043bb134e0b90b7cb8be3ac4aa578607dd3
-generated: "2025-05-12T20:58:12.143644-04:00"
+digest: sha256:885e1e66f2e68e25a057b6c0944868cc6a5c373a10b776015c77b623dca0f198
+generated: "2025-05-13T12:47:53.651113-04:00"

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -19,7 +19,7 @@ version: 2.1.4
 
 dependencies:
   - name: celestia-node
-    version: 0.5.1
+    version: 0.5.2
     repository: "file://../celestia-node"
     condition: celestia-node.enabled
   - name: evm-rollup


### PR DESCRIPTION
## Summary
Remove `-mocha` from celestia image tag, as the `celestiaNode.image` helper now handles it.

## Background
Previous merge of forma testnet chart updates failed to account for the `celestiaNode.image` helper

## Changelogs
No updates required.
