### PR TITLE
chore(sequencer): improve fee handling

### DIFF
--- a/crates/astria-sequencer/src/app/mod.rs
+++ b/crates/astria-sequencer/src/app/mod.rs
@@ -1547,12 +1547,12 @@ impl App {
         // clear validator updates
         state_tx.clear_block_validator_updates();
 
-        // gather block fees and transfer them to the block proposer
-        let fees = self.state.get_block_fees();
+        // gather block fees and transfer them to the fee recipient
+        let block_fees = self.state.get_block_fees();
 
-        for fee in fees {
+        for (fee_asset, total_amount) in block_fees {
             state_tx
-                .increase_balance(fee_recipient, fee.asset(), fee.amount())
+                .increase_balance(fee_recipient, &fee_asset, total_amount)
                 .await
                 .wrap_err("failed to increase fee recipient balance")?;
         }

--- a/crates/astria-sequencer/src/checked_actions/checked_action.rs
+++ b/crates/astria-sequencer/src/checked_actions/checked_action.rs
@@ -653,7 +653,11 @@ where
         return Ok(());
     };
 
-    state.add_fee_to_block_fees::<_, F>(fee_asset, total_fee, position_in_transaction);
+    state
+        .add_fee_to_block_fees::<_, F>(fee_asset, total_fee, position_in_transaction)
+        .map_err(|source| {
+            CheckedActionFeeError::internal("failed adding fee to block fees", source)
+        })?;
     state
         .decrease_balance(tx_signer, fee_asset, total_fee)
         .await

--- a/crates/astria-sequencer/src/fees/mod.rs
+++ b/crates/astria-sequencer/src/fees/mod.rs
@@ -1,5 +1,3 @@
-use astria_core::primitive::v1::asset;
-
 pub(crate) mod component;
 mod fee_handler;
 pub(crate) mod query;
@@ -14,21 +12,3 @@ pub(crate) use state_ext::{
     StateReadExt,
     StateWriteExt,
 };
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub(crate) struct Fee {
-    action_name: String,
-    asset: asset::Denom,
-    amount: u128,
-    position_in_transaction: u64,
-}
-
-impl Fee {
-    pub(crate) fn asset(&self) -> &asset::Denom {
-        &self.asset
-    }
-
-    pub(crate) fn amount(&self) -> u128 {
-        self.amount
-    }
-}

--- a/crates/astria-sequencer/src/fees/tests.rs
+++ b/crates/astria-sequencer/src/fees/tests.rs
@@ -28,7 +28,6 @@ use prost::Name as _;
 
 use super::{
     fee_handler::base_deposit_fee,
-    Fee,
     FeeHandler,
     StateWriteExt as _,
 };
@@ -55,12 +54,7 @@ fn test_asset() -> asset::Denom {
 }
 
 fn total_block_fees(fixture: &Fixture) -> u128 {
-    fixture
-        .state()
-        .get_block_fees()
-        .iter()
-        .map(Fee::amount)
-        .sum()
+    fixture.state().get_block_fees().values().sum()
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
This simplifies the logic of accruing fee totals while executing a block.

## Background
The existing implementation is slightly complex.

## Changes
- Changed the type held in the cnidarium ephemeral store from `Vec<Fee>` to `HashMap<IbcPrefixed, u128>`.
- Removed the `Fee` type as it's no longer needed.

## Testing
Existing unit tests updated as required.

## Changelogs
No updates required: this is a change to an internal implementation detail of the sequencer.
