### PR TITLE
chore(charts, celestia): bump celestia apps version

### DIFF
--- a/charts/celestia-local/Chart.yaml
+++ b/charts/celestia-local/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.4
+version: 0.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.3.1"
+appVersion: "4.0.1"
 
 maintainers:
   - name: wafflesvonmaple

--- a/charts/celestia-local/files/scripts/init-celestia-appd.sh
+++ b/charts/celestia-local/files/scripts/init-celestia-appd.sh
@@ -17,12 +17,12 @@ echo "$validator_mnemonic" | celestia-appd keys add \
   --recover
 
 validator_key=$(celestia-appd keys show "$validator_key_name" -a --keyring-backend="$keyring_backend" --home "$home_dir")
-celestia-appd add-genesis-account \
+celestia-appd genesis add-genesis-account \
   "$validator_key" \
   --home "$home_dir" \
   "$coins"
 
-celestia-appd gentx \
+celestia-appd genesis gentx \
   "$validator_key_name" \
   "$validator_stake" \
   --keyring-backend="$keyring_backend" \
@@ -37,7 +37,7 @@ echo "$ibc_account_mnemonic" | celestia-appd keys add \
   --keyring-backend="$keyring_backend" \
   --recover
 ibc_account_key=$(celestia-appd keys show "$ibc_account_key_name" -a --keyring-backend="$keyring_backend" --home "$home_dir")
-celestia-appd add-genesis-account \
+celestia-appd genesis add-genesis-account \
   "$ibc_account_key" \
   --home "$home_dir" \
   "$coins"
@@ -49,12 +49,12 @@ echo "$dev_account_mnemonic" | celestia-appd keys add \
   --keyring-backend="$keyring_backend" \
   --recover
 dev_account_key=$(celestia-appd keys show "$dev_account_key_name" -a --keyring-backend="$keyring_backend" --home "$home_dir")
-celestia-appd add-genesis-account \
+celestia-appd genesis add-genesis-account \
   "$dev_account_key" \
   --home "$home_dir" \
   "$coins"
 
-celestia-appd collect-gentxs --home "$home_dir"
+celestia-appd genesis collect-gentxs --home "$home_dir"
 
 # Enable transaction indexing
 sed -i'.bak' 's#"null"#"kv"#g' "${home_dir}"/config/config.toml

--- a/charts/celestia-local/files/scripts/start-celestia-appd.sh
+++ b/charts/celestia-local/files/scripts/start-celestia-appd.sh
@@ -3,27 +3,9 @@
 set -o errexit -o nounset
 
 # Start the celestia-app
-{
-  # Wait for block 1
-  sleep 15
-
-  VALIDATOR_ADDRESS=$(celestia-appd keys show $validator_key_name --home $home_dir --bech val --address)
-  echo "Registering an EVM address for validator..."
-  celestia-appd tx qgb register \
-    $VALIDATOR_ADDRESS \
-    $evm_address \
-    --from $validator_key_name \
-    --home $home_dir \
-    --fees 30000utia \
-    --broadcast-mode block \
-    --yes \
-    &> /dev/null # Hide output to reduce terminal noise
-
-  echo "Registered EVM address."
-} &
-
 exec celestia-appd start --home "${home_dir}" \
   --grpc.address "0.0.0.0:$celestia_app_grpc_port" \
+  --rpc.grpc_laddr "tcp://0.0.0.0:$celestia_app_broadcast_grpc_port" \
   --rpc.laddr "tcp://0.0.0.0:$celestia_app_host_port" \
   --api.enable \
   --api.enabled-unsafe-cors \

--- a/charts/celestia-local/templates/configmap.yaml
+++ b/charts/celestia-local/templates/configmap.yaml
@@ -17,6 +17,7 @@ data:
   bridge_rpc_port: "{{ .Values.ports.bridgeRPC }}"
   celestia_app_host_port: "{{ .Values.ports.celestiaAppHostPort }}"
   celestia_app_grpc_port: "{{ .Values.ports.celestiaAppGrpcPort }}"
+  celestia_app_broadcast_grpc_port: "{{ .Values.ports.celestiaAppBroadcastTxGrpcPort }}"
   ibc_account_mnemonic: "{{ .Values.ibcAccountMnemonic }}"
   ibc_account_key_name: "{{ .Values.ibcAccountKeyName }}"
   dev_account_mnemonic: "{{ .Values.devAccountMnemonic }}"

--- a/charts/celestia-local/templates/service.yaml
+++ b/charts/celestia-local/templates/service.yaml
@@ -32,3 +32,6 @@ spec:
     - name: app-rest
       port: {{ .Values.ports.celestiaAppRestPort }}
       targetPort: app-rest
+    - name: grpc-laddr-svc
+      port: {{ .Values.ports.celestiaAppBroadcastTxGrpcPort }}
+      targetPort: grpc-laddr-svc

--- a/charts/celestia-local/values.yaml
+++ b/charts/celestia-local/values.yaml
@@ -15,8 +15,8 @@ storage:
       persistentVolumeName: "celestia-shared-storage"
       path: "/data/celestia-data"
 
-celestiaAppImage: "ghcr.io/celestiaorg/celestia-app:v3.8.1"
-celestiaNodeImage: "ghcr.io/celestiaorg/celestia-node:v0.22.1"
+celestiaAppImage: "ghcr.io/celestiaorg/celestia-app:v4.0.1-mocha"
+celestiaNodeImage: "ghcr.io/celestiaorg/celestia-node:v0.23.0-mocha"
 
 podSecurityContext:
   runAsUser: 10001
@@ -53,6 +53,7 @@ fast: false
 ports:
   celestiaAppHostPort: 26657
   celestiaAppGrpcPort: 9090
+  celestiaAppBroadcastTxGrpcPort: 9091
   celestiaAppRestPort: 1317
   bridgeRPC: 26658
   bridgeHTTP: 26659

--- a/charts/celestia-local/values.yaml
+++ b/charts/celestia-local/values.yaml
@@ -15,7 +15,7 @@ storage:
       persistentVolumeName: "celestia-shared-storage"
       path: "/data/celestia-data"
 
-celestiaAppImage: "ghcr.io/celestiaorg/celestia-app:v4.0.1-mocha"
+celestiaAppImage: "ghcr.io/celestiaorg/celestia-app:e558b89"
 celestiaNodeImage: "ghcr.io/celestiaorg/celestia-node:v0.23.0-mocha"
 
 podSecurityContext:

--- a/charts/celestia-local/values.yaml
+++ b/charts/celestia-local/values.yaml
@@ -15,7 +15,7 @@ storage:
       persistentVolumeName: "celestia-shared-storage"
       path: "/data/celestia-data"
 
-celestiaAppImage: "ghcr.io/celestiaorg/celestia-app:e558b89"
+celestiaAppImage: "ghcr.io/celestiaorg/celestia-app:v4.0.1-mocha"
 celestiaNodeImage: "ghcr.io/celestiaorg/celestia-node:v0.23.0-mocha"
 
 podSecurityContext:

--- a/charts/celestia-node/Chart.yaml
+++ b/charts/celestia-node/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.2
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.22.2"
+appVersion: "0.23.0"
 
 maintainers:
   - name: wafflesvonmaple

--- a/charts/celestia-node/values.yaml
+++ b/charts/celestia-node/values.yaml
@@ -20,7 +20,7 @@ config:
 
 images:
   pullPolicy: IfNotPresent
-  node: ghcr.io/celestiaorg/celestia-node:v0.22.2
+  node: ghcr.io/celestiaorg/celestia-node:v0.23.0-mocha
 
 ports:
   celestia:

--- a/charts/evm-stack/Chart.lock
+++ b/charts/evm-stack/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: celestia-node
   repository: file://../celestia-node
-  version: 0.5.2
+  version: 0.6.0
 - name: evm-rollup
   repository: file://../evm-rollup
   version: 2.1.1
@@ -26,5 +26,5 @@ dependencies:
 - name: blockscout-stack
   repository: https://blockscout.github.io/helm-charts
   version: 1.6.8
-digest: sha256:885e1e66f2e68e25a057b6c0944868cc6a5c373a10b776015c77b623dca0f198
-generated: "2025-05-13T12:47:53.651113-04:00"
+digest: sha256:f48661d700d4665b817073d763617cc10abeef17fd68fcbfe999140c6d8e33d9
+generated: "2025-05-21T17:54:56.726043+03:00"

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -15,11 +15,11 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.5
+version: 2.1.6
 
 dependencies:
   - name: celestia-node
-    version: 0.5.2
+    version: 0.6.0
     repository: "file://../celestia-node"
     condition: celestia-node.enabled
   - name: evm-rollup

--- a/charts/just/defaults.just
+++ b/charts/just/defaults.just
@@ -28,4 +28,7 @@ sequencer_bridge_address  := "astria13ahqz4pjqfmynk9ylrqv4fwe4957x2p0h5782u"
 sequencer_bridge_pkey     := "dfa7108e38ab71f89f356c72afc38600d5758f11a8c337164713e4471411d2e0"
 sequencer_chain_id        := "sequencer-test-chain-0"
 
+defaultCelestiaHome := "/home/celestia"
+defaultCelestiaDenom := "utia"
+
 cli_image := "ghcr.io/astriaorg/astria-cli"

--- a/charts/just/run/ibc-test.just
+++ b/charts/just/run/ibc-test.just
@@ -383,8 +383,8 @@ Usage:
 ")]
 get-celestia-height namespace=defaultNamespace home=defaultCelestiaHome:
   #!/usr/bin/env bash
-  height=$(kubectl exec -n {{namespace}} pods/celestia-local-0 celestia-app --home {{home}} -- /bin/bash -c \
-  'celestia-appd query block' | jq '.block.header.height')
+  height=$(kubectl exec -n {{namespace}} pods/celestia-local-0 celestia-app -- /bin/bash -c \
+  'celestia-appd query block --home {{home}}' | tail -n +2 | jq '.header.height')
   # remove quotes
   height=${height//\"/}
   echo $height

--- a/charts/just/run/ibc-test.just
+++ b/charts/just/run/ibc-test.just
@@ -365,10 +365,10 @@ Usage:
       ADDRESS= celestia_dev_account_address (see 'ibc-test.just')
       NAMESPACE= 'astria-dev-cluster'
 ")]
-get-celestia-balance address=celestia_dev_account_address namespace=defaultNamespace:
+get-celestia-balance address=celestia_dev_account_address namespace=defaultNamespace home=defaultCelestiaHome denom=defaultCelestiaDenom:
   #!/usr/bin/env bash
   balance=$(kubectl exec -n {{namespace}} pods/celestia-local-0 celestia-app -- /bin/bash -c \
-  'celestia-appd query bank balance --home /home/celestia --output json {{address}} utia' | jq '.balance.amount')
+  'celestia-appd query bank balance --home {{home}} --output json {{address}} {{denom}}' | jq '.balance.amount')
   # remove quotes
   balance=${balance//\"/}
   echo $balance
@@ -381,9 +381,9 @@ Obtains the current height of the local Celestia network.
 Usage:
   just run ibc-test get-celestia-height <NAMESPACE> (default: 'astria-dev-cluster')
 ")]
-get-celestia-height namespace=defaultNamespace:
+get-celestia-height namespace=defaultNamespace home=defaultCelestiaHome:
   #!/usr/bin/env bash
-  height=$(kubectl exec -n {{namespace}} pods/celestia-local-0 celestia-app -- /bin/bash -c \
+  height=$(kubectl exec -n {{namespace}} pods/celestia-local-0 celestia-app --home {{home}} -- /bin/bash -c \
   'celestia-appd query block' | jq '.block.header.height')
   # remove quotes
   height=${height//\"/}

--- a/charts/just/run/ibc-test.just
+++ b/charts/just/run/ibc-test.just
@@ -166,7 +166,7 @@ evm_contract_address := "0xA58639fB5458e65E4fA917FF951C390292C24A15"
 [doc("
 Test IBC transfers between the Rollup and Celestia with a refund timeout.
 Usage:
-  just run ibc-test refund-timeout <TAG> (default: '')
+  just run ibc-test timeout-refund <TAG> (default: '')
 ")]
 timeout-refund tag=defaultTag:
   #!/usr/bin/env bash
@@ -384,7 +384,7 @@ Usage:
 get-celestia-height namespace=defaultNamespace home=defaultCelestiaHome:
   #!/usr/bin/env bash
   height=$(kubectl exec -n {{namespace}} pods/celestia-local-0 celestia-app -- /bin/bash -c \
-  'celestia-appd query block --home {{home}}' | tail -n +2 | jq '.header.height')
+  'celestia-appd query block --home {{home}} -o json' | tail -n +2 | jq '.header.height')
   # remove quotes
   height=${height//\"/}
   echo $height

--- a/charts/just/run/ibc-test.just
+++ b/charts/just/run/ibc-test.just
@@ -368,7 +368,7 @@ Usage:
 get-celestia-balance address=celestia_dev_account_address namespace=defaultNamespace:
   #!/usr/bin/env bash
   balance=$(kubectl exec -n {{namespace}} pods/celestia-local-0 celestia-app -- /bin/bash -c \
-  'celestia-appd query bank balances --denom utia --output json {{address}}' | jq '.amount')
+  'celestia-appd query bank balance --home /home/celestia --output json {{address}} utia' | jq '.balance.amount')
   # remove quotes
   balance=${balance//\"/}
   echo $balance

--- a/dev/values/hermes/local.yaml
+++ b/dev/values/hermes/local.yaml
@@ -36,7 +36,7 @@ chains:
 
   celestia-local-0:
     type: CosmosSdk
-    compatMode: "0.34"
+    compatMode: "0.38"
     rpcAddr: http://celestia-app-service.astria-dev-cluster.svc.cluster.local:26657
     grpcAddr: http://celestia-app-service.astria-dev-cluster.svc.cluster.local:9090
     rpcTimeout: 15s


### PR DESCRIPTION
## Summary
bumps default celestia binary versions to `celestia-app:v4.0.0-mocha` and `celestia-node:v0.23.0-mocha`, preparing for v4 upgrade.
## Background
celestia testnet is in the process of upgrading to v4, we should keep our charts up to date.

## Changes
- bump image version
- fix script for breaking `celestia-appd` genesis commands
- expose a broadcastTx only [grpc port](https://github.com/celestiaorg/celestia-app/blob/main/docs/release-notes/release-notes.md)

## Testing
locally by deploying celestia and sequencer networks, running `just deploy::astria-local`.

## Changelogs
No updates required.
