### PR TITLE
fix(sequencer): avoid including unexecuted rollup data

### DIFF
--- a/crates/astria-sequencer/CHANGELOG.md
+++ b/crates/astria-sequencer/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix issue where proposer includes unexecuted rollup data bytes [#2190](https://github.com/astriaorg/astria/pull/2190).
+
 ## [3.0.0-rc.2]
 
 ### Added


### PR DESCRIPTION
## Summary
This is a bugfix for `App::prepare_proposal`.

## Background
In `prepare_proposal`, while iterating the txs to be executed, we append the rollup data bytes to the collection of these _before_ checking and executing the tx.

This is an issue if the given tx fails the size checks or fails execution.  The end result is that the proposer later returns an error in finalize_block as the rest of the validators have a different (correct) view of the sequencer block and its included Merkle roots.

## Changes
- Changed the type stored by the `App` under `EXECUTION_RESULTS_KEY` in the ephemeral store from `(rollup_data_bytes, tx_results, tx_ids)` to a `Vec<ExecutedTransaction>` where the `ExecutedTransaction` holds the checked tx and the corresponding execution result.  This avoids the possibility of a mismatch between the number (or order) of the three discrete collections currently cached.

## Testing
There are no current unit or integration tests which would catch this.  This probably suits a new form of integration test more akin to the app upgrade tests, or even a new system-test.

In the meantime, I tested locally by sending a few rollup data submission txs which were too large to all be included in a single block to a 5 node network.

## Changelogs
Changelogs updated.
