### PR TITLE
chore(sequencer): include error backtrace in CheckTx response

### DIFF
--- a/crates/astria-sequencer/src/service/mempool/mod.rs
+++ b/crates/astria-sequencer/src/service/mempool/mod.rs
@@ -357,8 +357,7 @@ impl From<RemovalReason> for response::CheckTx {
 
 impl From<CheckedTransactionInitialCheckError> for response::CheckTx {
     fn from(error: CheckedTransactionInitialCheckError) -> Self {
-        let log = format!("transaction failed initial checks: {error}");
-        let code = match error {
+        let code = match &error {
             CheckedTransactionInitialCheckError::TooLarge {
                 ..
             } => AbciErrorCode::TRANSACTION_TOO_LARGE,
@@ -379,6 +378,9 @@ impl From<CheckedTransactionInitialCheckError> for response::CheckTx {
                 ..
             } => AbciErrorCode::INTERNAL_ERROR,
         };
+        let log = Report::new(error)
+            .wrap_err("transaction failed initial checks")
+            .to_string();
         error_response(code, log)
     }
 }


### PR DESCRIPTION
## Summary
Improved the `log` field of `CheckTx` response.

## Background
The log included in a `CheckTx` response when a `CheckedTransactionInitialCheckError` occurred doesn't have the full error backtrace.  It is more useful to the user to see the full backtrace.

## Changes
- Convert a `CheckedTransactionInitialCheckError` to an eyre `Report` before converting to a string for the `log` field.

## Testing
N/A

## Changelogs
No updates required.