### PR TITLE
fix: correct typo in variable name TRANSFERED_BALANCE → TRANSFERRED_BALANCE

### DIFF
--- a/charts/just/run/mod.just
+++ b/charts/just/run/mod.just
@@ -81,8 +81,8 @@ smoke-test tag=defaultTag:
 
   echo "Testing Bridge Out..."
   just evm send-raw-transaction {{bridge_tx_bytes}}
-  TRANSFERED_BALANCE=$(echo "1 * {{sequencer_base_amount}} * {{rollup_multiplier}}" | bc)
-  EXPECTED_BALANCE=$(echo "$EXPECTED_BALANCE - $TRANSFERED_BALANCE" | bc)
+  TRANSFERRED_BALANCE=$(echo "1 * {{sequencer_base_amount}} * {{rollup_multiplier}}" | bc)
+  EXPECTED_BALANCE=$(echo "$EXPECTED_BALANCE - $TRANSFERRED_BALANCE" | bc)
   CHECKS=0
   while (( $CHECKS < $MAX_CHECKS )); do
     CHECKS=$((CHECKS+1))


### PR DESCRIPTION
## Summary
Brief summary of the changes made, ie "what?"

## Background
Brief background on why these changes were made, ie "why?"

## Changes

TRANSFERED_BALANCE → TRANSFERRED_BALANCE

## Testing
How are these changes tested?

## Changelogs
No updates required