### PR TITLE
Fix Typos in Documentation for Conductor and Sequencer App Specs

### DIFF
--- a/specs/conductor.md
+++ b/specs/conductor.md
@@ -11,7 +11,7 @@ against a rollup (currently geth). It does this by:
    [`astria.execution.v2` API](./execution-api.md).
 
 Executed rollup data that is read directly from Sequencer is referred to
-*soft*-committed, while rollup data read from the data availability provder
+*soft*-committed, while rollup data read from the data availability provider
 is referred to a *firm*-committed.
 
 Conductor is intended to be a side-car to a rollup node.

--- a/specs/sequencer-app.md
+++ b/specs/sequencer-app.md
@@ -117,7 +117,7 @@ is another chain. It consists of the following:
 
 ### Bridge Actions
 
-These actions deal with transfering funds to/from a bridge account to be used on
+These actions deal with transferring funds to/from a bridge account to be used on
 a rollup.
 
 * `InitBridgeAccount`: initializes a bridge account for the given rollup on the


### PR DESCRIPTION


Description:  
This pull request corrects minor typographical errors in the documentation files specs/conductor.md and specs/sequencer-app.md. Specifically, it fixes the spelling of "provider" and "transferring" to improve clarity and maintain consistency throughout the documentation. No functional code changes are included.
