### PR TITLE
Add TLS config for composer when sequencer endpoint is tls

### DIFF
--- a/crates/astria-composer/CHANGELOG.md
+++ b/crates/astria-composer/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fetch and submit transactions already in the rollup transaction pool before submitting
     those coming from `eth_subscribe` [#2086](https://github.com/astriaorg/astria/pull/2086).
 
+### Fixed
+
+- Fix TLS errors when connecting to remote seqeuncer networks.
+
 ## [1.0.1] - 2025-03-06
 
 ### Changed

--- a/crates/astria-composer/Cargo.toml
+++ b/crates/astria-composer/Cargo.toml
@@ -50,7 +50,7 @@ tokio = { workspace = true, features = [
 tokio-util = { workspace = true, features = ["rt"] }
 tracing = { workspace = true, features = ["attributes"] }
 tryhard = { workspace = true }
-tonic = { workspace = true }
+tonic = { workspace = true, features = ["tls", "tls-native-roots"] }
 tokio-stream = { workspace = true, features = ["net"] }
 
 [dependencies.sequencer-client]

--- a/crates/astria-composer/src/executor/builder.rs
+++ b/crates/astria-composer/src/executor/builder.rs
@@ -17,6 +17,12 @@ use astria_eyre::eyre::{
 };
 use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
+use tonic::transport::{
+    Channel,
+    ClientTlsConfig,
+    Endpoint,
+    Uri,
+};
 
 use crate::{
     executor,
@@ -104,11 +110,12 @@ fn read_signing_key_from_file<P: AsRef<Path>>(path: P) -> eyre::Result<SigningKe
 
 fn connect_sequencer_grpc(
     grpc_endpoint: &str,
-) -> eyre::Result<SequencerServiceClient<tonic::transport::Channel>> {
-    let uri: tonic::transport::Uri = grpc_endpoint
+) -> eyre::Result<SequencerServiceClient<Channel>> {
+    let uri: Uri = grpc_endpoint
         .parse()
         .wrap_err("failed to parse endpoint as URI")?;
-    Ok(SequencerServiceClient::new(
-        tonic::transport::Endpoint::from(uri).connect_lazy(),
-    ))
+    let endpoint = Endpoint::from(uri.clone())
+        .tls_config(ClientTlsConfig::new().with_enabled_roots())
+        .wrap_err("failed to configure TLS for sequencer client")?;
+    Ok(SequencerServiceClient::new(endpoint.connect_lazy()))
 }


### PR DESCRIPTION
## Summary
Add explicit TLS config for composer's sequencer connection

## Background
Tonic [removed implicit TLS configs](https://github.com/hyperium/tonic/pull/1731) in v0.12.0 which now causes TLS errors when conductor tries to connect to a remote sequencer network over TLS.

## Changelogs
Changelogs updated.

## Related Issues
Similar to fix done for conductor in [PR #2140](https://github.com/astriaorg/astria/pull/2140)
