### PR TITLE
chore: cleanup buildjet reference

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -296,7 +296,7 @@ jobs:
   smoke-test-evm-restart:
     needs: [run_checker, composer, conductor, sequencer, sequencer-relayer, evm-bridge-withdrawer, cli]
     if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'astriaorg/astria') && (github.event_name == 'merge_group' || needs.run_checker.outputs.run_docker == 'true')
-    runs-on: buildjet-8vcpu-ubuntu-2204
+    runs-on: depot-ubuntu-24.04-8
     steps:
       - uses: actions/checkout@v4
       - name: Install just


### PR DESCRIPTION
## Summary
We generally migrated off of buildjet in https://github.com/astriaorg/astria/pull/1047, but this test was added which used buildjet after the fact. Migrate this one run to depot.
