### PR TITLE
release(sequencer): Sequencer 4.0.0-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "astria-sequencer"
-version = "3.0.0"
+version = "4.0.0-rc.1"
 dependencies = [
  "assert-json-diff",
  "astria-build-info",

--- a/crates/astria-sequencer/CHANGELOG.md
+++ b/crates/astria-sequencer/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.0-rc.1] - 2025-07-28
+
 ### Added
 
 - Add cache of recent execution results to mempool [#2163](https://github.com/astriaorg/astria/pull/2163).
@@ -683,7 +685,8 @@ address [#721](https://github.com/astriaorg/astria/pull/721).
 
 - Initial release.
 
-[unreleased]: https://github.com/astriaorg/astria/compare/sequencer-v3.0.0...HEAD
+[unreleased]: https://github.com/astriaorg/astria/compare/sequencer-v4.0.0-rc.1...HEAD
+[v4.0.0-rc.1]: https://github.com/astriaorg/astria/compare/sequencer-v3.0.0...sequencer-v4.0.0-rc.1
 [3.0.0]: https://github.com/astriaorg/astria/compare/sequencer-v2.0.1...sequencer-v3.0.0
 [3.0.0-rc.2]: https://github.com/astriaorg/astria/compare/sequencer-v3.0.0-rc.1...sequencer-v3.0.0-rc.2
 [3.0.0-rc.1]: https://github.com/astriaorg/astria/compare/sequencer-v2.0.1...sequencer-v3.0.0-rc.1

--- a/crates/astria-sequencer/Cargo.toml
+++ b/crates/astria-sequencer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astria-sequencer"
-version = "3.0.0"
+version = "4.0.0-rc.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 rust-version = "1.83.0"


### PR DESCRIPTION
## Summary
Cuts release of new sequencer binary in prep for Blackbrun upgrade.