### PR TITLE
release(charts): blackburn upgrade

### DIFF
--- a/charts/sequencer/Chart.yaml
+++ b/charts/sequencer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.0.0-rc.1
+version: 4.0.0-rc.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sequencer/files/upgrades/dawn-1.upgrades.json
+++ b/charts/sequencer/files/upgrades/dawn-1.upgrades.json
@@ -17,5 +17,13 @@
     },
     "validatorUpdateActionChange": {},
     "ibcAcknowledgementFailureChange": {}
+  },
+  "blackburn": {
+    "baseInfo": {
+      "activationHeight": "10560000",
+      "appVersion": "4"
+    },
+    "ics20TransferActionChange": {},
+    "allowIbcRelayToFail": {}
   }
 }

--- a/charts/sequencer/files/upgrades/mainnet.upgrades.json
+++ b/charts/sequencer/files/upgrades/mainnet.upgrades.json
@@ -17,5 +17,13 @@
     },
     "validatorUpdateActionChange": {},
     "ibcAcknowledgementFailureChange": {}
+  },
+  "blackburn": {
+    "baseInfo": {
+      "activationHeight": "10600000",
+      "appVersion": "4"
+    },
+    "ics20TransferActionChange": {},
+    "allowIbcRelayToFail": {}
   }
 }


### PR DESCRIPTION
## Summary
Updates chart release to include mainnet and dawn-1 blackburn upgrade files.

## Background
Estimated release times:
```
❯ cargo run -- estimate-activation-point -u https://rpc.sequencer.dawn-1.astria.org -t 10560000 -v
current height on `dawn-1`: 10519438
estimated instant on `dawn-1` for block 10560000: 2025-08-01T16:17:59.631550947Z

❯ cargo run -- estimate-activation-point -u https://rpc.astria.org -t 10600000 -v              
current height on `astria`: 10389959
estimated instant on `astria` for block 10600000: 2025-08-06T20:33:38.811249501Z
```

## Changes
- Set upgrade in charts for blackburn testnet and mainnet.
- Release new chart version with files.

## Changelogs
No updates required.
