### PR TITLE
fix(ci): use oidc for depot setup step

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -46,6 +46,8 @@ jobs:
           ref: ${{ inputs.tag }}
           submodules: 'true'
       - uses: depot/setup-action@v1
+        with:
+          oidc: true
       - name: Login to Docker Hub
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'astriaorg/astria'
         uses: docker/login-action@v2


### PR DESCRIPTION
## Summary
Fixes an issue w/ missing api token when using depot builds

## Background
Changes were made due to failing docker builds

## Changes
- oidc set to true in setup step

## Testing
Manually
