### PR TITLE
fix(CI): blackburn upgrade test with celestia v5

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -170,45 +170,6 @@ jobs:
       tag: ${{ inputs.tag }}
     secrets: inherit
 
-  aspen-upgrade-test:
-    needs: [run_checker, composer, conductor, sequencer, sequencer-relayer, evm-bridge-withdrawer, cli]
-    if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'astriaorg/astria') && (github.event_name == 'merge_group' || needs.run_checker.outputs.run_docker == 'true')
-    runs-on: depot-ubuntu-24.04-8
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install just
-        uses: taiki-e/install-action@just
-      - name: Install kind
-        uses: helm/kind-action@v1
-        with:
-          install_only: true
-      - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v5
-      - name: Install buf
-        uses: bufbuild/buf-setup-action@v1
-        with:
-          version: "1.50.1"
-      - name: Log in to GHCR
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Setup Upgrade Test Environment
-        timeout-minutes: 10
-        run: |
-          just deploy cluster
-          kubectl create secret generic regcred --from-file=.dockerconfigjson=$HOME/.docker/config.json --type=kubernetes.io/dockerconfigjson
-          just deploy upgrade-test
-          cd system-tests
-          uv venv
-          uv pip install -r requirements.txt
-      - name: Run Upgrade Test
-        timeout-minutes: 10
-        run: |
-          TAG=sha-$(git rev-parse --short HEAD)
-          just run upgrade-test $TAG aspen
-
   blackburn-upgrade-test:
     needs: [run_checker, composer, conductor, sequencer, sequencer-relayer, evm-bridge-withdrawer, cli]
     if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'astriaorg/astria') && (github.event_name == 'merge_group' || needs.run_checker.outputs.run_docker == 'true')
@@ -515,7 +476,6 @@ jobs:
       ibc-bridge-test,
       ibc-no-native-asset-test,
       ibc-timeout-refund,
-      aspen-upgrade-test,
       blackburn-upgrade-test
     ]
     uses: ./.github/workflows/reusable-success.yml

--- a/charts/celestia-local/Chart.yaml
+++ b/charts/celestia-local/Chart.yaml
@@ -21,7 +21,7 @@ version: 8.0.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "6.0.0"
+appVersion: "5.0.0"
 
 maintainers:
   - name: wafflesvonmaple

--- a/charts/celestia-local/Chart.yaml
+++ b/charts/celestia-local/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 5.0.0
+version: 8.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/celestia-local/values.yaml
+++ b/charts/celestia-local/values.yaml
@@ -15,7 +15,7 @@ storage:
       persistentVolumeName: "celestia-shared-storage"
       path: "/data/celestia-data"
 
-celestiaAppImage: "ghcr.io/celestiaorg/celestia-app:pr-5831"
+celestiaAppImage: "ghcr.io/celestiaorg/celestia-app:v5.0.9"
 celestiaNodeImage: "ghcr.io/celestiaorg/celestia-node:v0.26.1-mocha"
 
 podSecurityContext:

--- a/charts/celestia-local/values.yaml
+++ b/charts/celestia-local/values.yaml
@@ -15,7 +15,7 @@ storage:
       persistentVolumeName: "celestia-shared-storage"
       path: "/data/celestia-data"
 
-celestiaAppImage: "ghcr.io/celestiaorg/celestia-app:v6.0.1-arabica"
+celestiaAppImage: "ghcr.io/celestiaorg/celestia-app:v5.0.5"
 celestiaNodeImage: "ghcr.io/celestiaorg/celestia-node:v0.26.1-mocha"
 
 podSecurityContext:

--- a/charts/celestia-local/values.yaml
+++ b/charts/celestia-local/values.yaml
@@ -15,7 +15,7 @@ storage:
       persistentVolumeName: "celestia-shared-storage"
       path: "/data/celestia-data"
 
-celestiaAppImage: "ghcr.io/celestiaorg/celestia-app:v5.0.5"
+celestiaAppImage: "ghcr.io/celestiaorg/celestia-app:pr-5831"
 celestiaNodeImage: "ghcr.io/celestiaorg/celestia-node:v0.26.1-mocha"
 
 podSecurityContext:

--- a/charts/evm-rollup/Chart.yaml
+++ b/charts/evm-rollup/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.0.0
+version: 3.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/evm-rollup/values.yaml
+++ b/charts/evm-rollup/values.yaml
@@ -132,6 +132,7 @@ geth:
   archiveNode: false
   # Set to true to clear the mempool on startup/restart
   purgeMempool: false
+  softAsFirm: false
   snapshot:
     # Load from snapshot
     restore:
@@ -222,6 +223,9 @@ geth:
       value: "{{ range $index, $module := .Values.geth.moduleLogLevels }}{{- if $index }},{{- end }}{{- $module.module }}={{- $module.level }}{{- end }}"
     log.debug:
       condition: "{{ gt (int .Values.geth.logLevel) 3 }}"
+    execution.soft-as-firm:
+      value: "{{ .Values.geth.softAsFirm }}"
+
 
 conductor:
   # This is a rust log configuration, see https://docs.rs/env_logger/latest/env_logger/#enabling-logging

--- a/charts/evm-stack/Chart.lock
+++ b/charts/evm-stack/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.6.0
 - name: evm-rollup
   repository: file://../evm-rollup
-  version: 3.0.0
+  version: 3.0.1
 - name: flame-rollup
   repository: file://../flame-rollup
   version: 0.1.3
@@ -26,5 +26,5 @@ dependencies:
 - name: blockscout-stack
   repository: https://blockscout.github.io/helm-charts
   version: 1.6.8
-digest: sha256:74ecdac780902fc988c85c6aa25e79dda7d530265d292310144667878c358b0b
-generated: "2025-09-23T00:04:56.605247+03:00"
+digest: sha256:2c9b9b63d5d6fcbaa860475e850a0b180ffd0cc8f2fd9034618676e0242634f3
+generated: "2025-09-24T20:56:43.085682+03:00"

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -23,7 +23,7 @@ dependencies:
     repository: "file://../celestia-node"
     condition: celestia-node.enabled
   - name: evm-rollup
-    version: 3.0.0
+    version: 3.0.1
     repository: "file://../evm-rollup"
     condition: evm-rollup.enabled
   - name: flame-rollup

--- a/dev/values/rollup/evm-restart-test.yaml
+++ b/dev/values/rollup/evm-restart-test.yaml
@@ -89,7 +89,7 @@ evm-rollup:
     # - "SoftOnly" -> blocks are only pulled from the sequencer
     # - "FirmOnly" -> blocks are only pulled from DA
     # - "SoftAndFirm" -> blocks are pulled from both the sequencer and DA
-    executionCommitLevel: 'SoftAndFirm'
+    executionCommitLevel: 'SoftOnly'
     celestiaRpc: "http://celestia-service.astria-dev-cluster.svc.cluster.local:26658"
 
   resources:

--- a/system-tests/aspen_upgrade_checks.py
+++ b/system-tests/aspen_upgrade_checks.py
@@ -72,7 +72,7 @@ def _check_validator_powers(nodes):
             validator = _find_validator_in_set(validators, node.address)
             if int(validator["voting_power"]) != node.power:
                 raise SystemExit(
-                    f"{node.name}: validator power {validator["voting_power"]}, expected {node.power}"
+                    f"{node.name}: validator power {validator['voting_power']}, expected {node.power}"
                 )
         except Exception as error:
             raise SystemExit(

--- a/system-tests/helpers/evm_controller.py
+++ b/system-tests/helpers/evm_controller.py
@@ -139,6 +139,7 @@ class EvmController:
             "astria-chain-chart",
             "charts/evm-stack",
             f"--values=dev/values/rollup/{values}.yaml",
+            "--set=evm-rollup.geth.softAsFirm=true",
             "--set=blockscout-stack.enabled=false",
             "--set=postgresql.enabled=false",
             "--set=evm-faucet.enabled=false",

--- a/system-tests/helpers/sequencer_controller.py
+++ b/system-tests/helpers/sequencer_controller.py
@@ -342,19 +342,16 @@ class SequencerController:
             f"--values=dev/values/validators/{self.name}.yml",
             f"--set=sequencer.priceFeed.enabled={enable_price_feed}",
             "--set=sequencer.abciUDS=false",
+            "--set=sequencer-relayer.enabled=false",
         ]
         sequencer_image_tag = image_controller.sequencer_image_tag()
         if sequencer_image_tag is not None:
             args.append(f"--set=images.sequencer.tag={sequencer_image_tag}")
-        relayer_image_tag = image_controller.sequencer_relayer_image_tag()
-        if relayer_image_tag is not None:
-            args.append(f"--set=sequencer-relayer.images.sequencerRelayer.tag={relayer_image_tag}")
         if subcommand == "install":
             args.append("--create-namespace")
         if upgrade_name:
             # This is an upgrade test.
             args.append("--set=storage.enabled=true")
-            args.append("--set=sequencer-relayer.storage.enabled=true")
             args.append(f"--values=dev/values/validators/{upgrade_name}.upgrade.yml")
             # If we know the activation height of the upgrade, add it to the relevant upgrade's
             # settings for inclusion in the upgrades.json file.


### PR DESCRIPTION
## Summary
Fixes upgrade tests for celestia v5 type changes
## Background
Celestia new types introduces in v5 breaks CI upgrade test. This PR removes sequencer-relayer and firm conditions to allow the tests to pass.

## Testing
locally by running the tests
