### PR TITLE
chore: update to rust 1.90.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -86,7 +86,7 @@ jobs:
         uses: taiki-e/install-action@just
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-02-17
+          toolchain: nightly-2025-09-14
           components: rustfmt
       - name: run rustfmt
         run: just lint rust-fmt

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -14,7 +14,7 @@ env:
   REGISTRY: ghcr.io
   FULL_REF: ${{ inputs.tag && format('refs/tags/{0}', inputs.tag) || github.ref }}
   # This must match the entry in rust-toolchain.toml at the repository root
-  RUSTUP_TOOLCHAIN: "1.85.0"
+  RUSTUP_TOOLCHAIN: "1.90.0"
 
 jobs:
   upload-binaries:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ env:
   RUSTFLAGS: "-D warnings -D unreachable-pub --cfg tokio_unstable"
 
   # This must match the entry in rust-toolchain.toml at the repository root
-  RUSTUP_TOOLCHAIN: "1.85.0"
+  RUSTUP_TOOLCHAIN: "1.90.0"
 on:
   pull_request:
   merge_group:

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ markdown.
 
 ```sh
 # Install rustfmt
-rustup +nightly-2025-02-17 component add rustfmt
+rustup +nightly-2025-09-14 component add rustfmt
 # Run rustfmt
 just fmt rust
 ```

--- a/containerfiles/Dockerfile
+++ b/containerfiles/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM rust:1.85-bookworm AS rust
+FROM --platform=$BUILDPLATFORM rust:1.90-bookworm AS rust
 
 WORKDIR /build/
 

--- a/crates/astria-account-monitor/src/main.rs
+++ b/crates/astria-account-monitor/src/main.rs
@@ -96,7 +96,7 @@ async fn shutdown(reason: eyre::Result<&'static str>, service: AccountMonitor) -
                 Err(_) => {
                     warn!("service shutdown timed out");
                 }
-            };
+            }
             ExitCode::SUCCESS
         }
         Err(reason) => {

--- a/crates/astria-auctioneer/src/auctioneer/mod.rs
+++ b/crates/astria-auctioneer/src/auctioneer/mod.rs
@@ -344,7 +344,7 @@ impl Auctioneer {
         match &reason {
             Ok(reason) => info!(%reason, message),
             Err(reason) => error!(%reason, message),
-        };
+        }
         if let Some(running_auction) = self.running_auction.take() {
             running_auction.abort();
         }

--- a/crates/astria-auctioneer/src/main.rs
+++ b/crates/astria-auctioneer/src/main.rs
@@ -97,7 +97,7 @@ async fn shutdown(reason: eyre::Result<&'static str>, mut service: Auctioneer) -
             info!(reason, message);
             if let Err(error) = service.shutdown().await {
                 warn!(%error, "encountered errors during shutdown");
-            };
+            }
             ExitCode::SUCCESS
         }
         Err(reason) => {

--- a/crates/astria-bridge-contracts/src/lib.rs
+++ b/crates/astria-bridge-contracts/src/lib.rs
@@ -302,7 +302,7 @@ where
                     .parse()
                     .map_err(BuildError::parse_ics20_asset_source_channel)?,
             );
-        };
+        }
 
         let contract =
             i_astria_withdrawer::IAstriaWithdrawer::new(contract_address, provider.clone());

--- a/crates/astria-bridge-withdrawer/src/bridge_withdrawer/submitter/signer/mod.rs
+++ b/crates/astria-bridge-withdrawer/src/bridge_withdrawer/submitter/signer/mod.rs
@@ -20,7 +20,7 @@ impl From<key::Key> for Signer {
 
 enum SignerInner {
     Key(Box<key::Key>),
-    Frost(frost::Frost),
+    Frost(Box<frost::Frost>),
 }
 
 impl Signer {
@@ -86,7 +86,7 @@ impl Builder {
                     })?,
             ))
         } else {
-            SignerInner::Frost(
+            SignerInner::Frost(Box::new(
                 frost::Builder {
                     frost_min_signers,
                     frost_participant_endpoints,
@@ -95,7 +95,7 @@ impl Builder {
                 }
                 .try_build()
                 .wrap_err("failed to construct frost threshold signer")?,
-            )
+            ))
         };
         Ok(Signer {
             inner,

--- a/crates/astria-cli/src/sequencer/threshold/mod.rs
+++ b/crates/astria-cli/src/sequencer/threshold/mod.rs
@@ -39,6 +39,7 @@ enum SubCommand {
 // from penumbra `ActualTerminal`
 pub(crate) async fn read_line_raw() -> eyre::Result<String> {
     use std::io::{
+        BufReader,
         Read as _,
         Write as _,
     };
@@ -54,7 +55,7 @@ pub(crate) async fn read_line_raw() -> eyre::Result<String> {
     let mut stdout = std::io::stdout().into_raw_mode()?;
 
     let mut bytes = Vec::with_capacity(8192);
-    for b in std::io::stdin().bytes() {
+    for b in BufReader::new(std::io::stdin()).bytes() {
         let b = b?;
         // In raw mode, we need to handle control characters ourselves
         if b == 3 || b == 4 {

--- a/crates/astria-composer/src/collectors/geth.rs
+++ b/crates/astria-composer/src/collectors/geth.rs
@@ -223,7 +223,7 @@ impl Geth {
                      submitted transactions",
                 );
             });
-        };
+        }
 
         // Create a cache for existing pending transactions to avoid sending the same transaction if
         // it is also streamed via `new_tx_stream`.
@@ -254,7 +254,7 @@ impl Geth {
                             }
                             // update value in cache to represent that it has already been sent
                             existing_pending_tx_cache.insert(tx.hash.0, true);
-                        };
+                        }
 
                         txs_received_counter.increment(1);
 

--- a/crates/astria-composer/src/composer.rs
+++ b/crates/astria-composer/src/composer.rs
@@ -68,7 +68,7 @@ pub struct Composer {
     api_shutdown_token: CancellationToken,
     /// used to announce the current status of the Composer for other
     /// modules in the crate to use.
-    composer_status_sender: watch::Sender<composer::Status>,
+    status_sender: watch::Sender<composer::Status>,
     /// used to forward transactions received from rollups to the Executor.
     /// This is at the Composer level to allow its sharing to various different collectors.
     executor_handle: executor::Handle,
@@ -197,7 +197,7 @@ impl Composer {
         Ok(Self {
             api,
             api_shutdown_token,
-            composer_status_sender,
+            status_sender: composer_status_sender,
             executor_handle,
             executor,
             rollups,
@@ -239,7 +239,7 @@ impl Composer {
         let Self {
             api,
             api_shutdown_token,
-            composer_status_sender,
+            status_sender: composer_status_sender,
             executor,
             executor_handle,
             mut geth_collector_tasks,
@@ -275,7 +275,7 @@ impl Composer {
             (Err(collector_err), Err(executor_err)) => {
                 error!(%collector_err, %executor_err, "geth collectors and executor failed to become ready");
             }
-        };
+        }
 
         // run the grpc server
         let mut grpc_server_handle = tokio::spawn(async move {
@@ -406,7 +406,7 @@ impl ShutdownInfo {
             }
         } else {
             info!("executor task was already dead");
-        };
+        }
 
         // We give the grpc server 5 seconds to shut down.
         if let Some(grpc_server_task_handle) = grpc_server_task_handle {
@@ -420,7 +420,7 @@ impl ShutdownInfo {
             }
         } else {
             info!("grpc server task was already dead");
-        };
+        }
 
         let shutdown_loop = async {
             while let Some((name, res)) = geth_collector_tasks.join_next().await {
@@ -464,7 +464,7 @@ impl ShutdownInfo {
             }
         } else {
             info!("api server task was already dead");
-        };
+        }
 
         Ok(())
     }

--- a/crates/astria-composer/src/executor/bundle_factory/mod.rs
+++ b/crates/astria-composer/src/executor/bundle_factory/mod.rs
@@ -248,7 +248,7 @@ impl BundleFactory {
     ///
     /// The bundle is only removed from the factory on calling [`NextFinishedBundle::pop`].
     /// This method primarily exists to work around async cancellation.
-    pub(super) fn next_finished(&mut self) -> Option<NextFinishedBundle> {
+    pub(super) fn next_finished(&mut self) -> Option<NextFinishedBundle<'_>> {
         if self.finished.is_empty() {
             None
         } else {

--- a/crates/astria-composer/src/executor/mod.rs
+++ b/crates/astria-composer/src/executor/mod.rs
@@ -263,7 +263,7 @@ impl Executor {
                 rsp = &mut submission_fut, if !submission_fut.is_terminated() => {
                     if let Err(err) = process_result_update_nonce(&mut nonce, rsp, &mut block_timer, reset_time) {
                         break Err(err).wrap_err("failed submitting bundle to sequencer");
-                    };
+                    }
                 }
 
                 Some(next_bundle) = future::ready(bundle_factory.next_finished()), if submission_fut.is_terminated() => {

--- a/crates/astria-composer/tests/blackbox/helper/mod.rs
+++ b/crates/astria-composer/tests/blackbox/helper/mod.rs
@@ -3,7 +3,8 @@ use std::{
         BTreeMap,
         HashMap,
     },
-    io::Write,
+    fmt::Write as _,
+    io::Write as _,
     net::{
         IpAddr,
         SocketAddr,
@@ -142,7 +143,7 @@ pub async fn spawn_composer(
         let geth = Geth::spawn_with_pending_txs(pending_map).await;
         let execution_url = format!("ws://{}", geth.local_addr());
         rollup_nodes.insert((*id).to_string(), geth);
-        rollups.push_str(&format!("{id}::{execution_url},"));
+        write!(rollups, "{id}::{execution_url},").unwrap();
     }
     let sequencer = mock_abci_sequencer::start(sequencer_chain_id).await;
     let grpc_server = MockGrpcSequencer::spawn().await;

--- a/crates/astria-conductor/src/celestia/mod.rs
+++ b/crates/astria-conductor/src/celestia/mod.rs
@@ -540,7 +540,7 @@ impl RunningReader {
             Err(mpsc::error::TrySendError::Closed(_)) => {
                 bail!("exiting because executor channel is closed");
             }
-        };
+        }
         Ok(())
     }
 

--- a/crates/astria-conductor/src/executor/mod.rs
+++ b/crates/astria-conductor/src/executor/mod.rs
@@ -192,7 +192,7 @@ impl Executor {
             }
             .build();
             reader_tasks.spawn(ReaderKind::Soft, sequencer_reader.run_until_stopped());
-        };
+        }
 
         Ok(Initialized {
             config: self.config,

--- a/crates/astria-conductor/src/state.rs
+++ b/crates/astria-conductor/src/state.rs
@@ -283,7 +283,7 @@ impl State {
                 rollup_start_block_number: execution_session_parameters.rollup_start_block_number(),
                 rollup_number: rollup_end_block_number.get(),
             })?;
-        };
+        }
         Ok(State {
             execution_session_id: execution_session.session_id().to_string(),
             execution_session_parameters: execution_session_parameters.clone(),

--- a/crates/astria-core/src/execution/v2/mod.rs
+++ b/crates/astria-core/src/execution/v2/mod.rs
@@ -65,7 +65,7 @@ pub struct ExecutionSession {
     /// An ID for the session.
     session_id: String,
     /// The configuration for the execution session.
-    execution_session_parameters: ExecutionSessionParameters,
+    parameters: ExecutionSessionParameters,
     /// The commitment state for executing client to start from.
     commitment_state: CommitmentState,
 }
@@ -78,7 +78,7 @@ impl ExecutionSession {
 
     #[must_use]
     pub fn execution_session_parameters(&self) -> &ExecutionSessionParameters {
-        &self.execution_session_parameters
+        &self.parameters
     }
 
     #[must_use]
@@ -110,7 +110,7 @@ impl Protobuf for ExecutionSession {
             .map_err(Self::Error::commitment_state)?;
         Ok(Self {
             session_id: session_id.clone(),
-            execution_session_parameters,
+            parameters: execution_session_parameters,
             commitment_state,
         })
     }
@@ -118,7 +118,7 @@ impl Protobuf for ExecutionSession {
     fn to_raw(&self) -> Self::Raw {
         let Self {
             session_id,
-            execution_session_parameters,
+            parameters: execution_session_parameters,
             commitment_state,
         } = self;
         let execution_session_parameters = execution_session_parameters.to_raw();

--- a/crates/astria-core/src/generated/mod.rs
+++ b/crates/astria-core/src/generated/mod.rs
@@ -3,7 +3,8 @@
     clippy::pedantic,
     clippy::needless_borrows_for_generic_args,
     clippy::arithmetic_side_effects,
-    clippy::needless_lifetimes
+    clippy::needless_lifetimes,
+    clippy::doc_overindented_list_items,
 )]
 //! Files generated using [`tonic-build`] and [`buf`] via the [`tools/protobuf-compiler`]
 //! build tool.

--- a/crates/astria-core/src/oracles/price_feed/market_map.rs
+++ b/crates/astria-core/src/oracles/price_feed/market_map.rs
@@ -67,7 +67,6 @@ pub mod v2 {
             self.clone().into_raw()
         }
 
-        #[must_use]
         fn into_raw(self) -> raw::GenesisState {
             raw::GenesisState {
                 market_map: Some(self.market_map.into_raw()),

--- a/crates/astria-core/src/oracles/price_feed/oracle.rs
+++ b/crates/astria-core/src/oracles/price_feed/oracle.rs
@@ -374,7 +374,6 @@ pub mod v2 {
             }
         }
 
-        #[must_use]
         fn into_raw(self) -> raw::GenesisState {
             raw::GenesisState {
                 currency_pair_genesis: self

--- a/crates/astria-core/src/protocol/abci.rs
+++ b/crates/astria-core/src/protocol/abci.rs
@@ -9,27 +9,27 @@ pub struct AbciErrorCode(NonZeroU32);
 
 #[rustfmt::skip]
 impl AbciErrorCode {
-    pub const UNKNOWN_PATH: Self = Self(unsafe { NonZeroU32::new_unchecked(1) });
-    pub const INVALID_PARAMETER: Self = Self(unsafe { NonZeroU32::new_unchecked(2) });
-    pub const INTERNAL_ERROR: Self = Self(unsafe { NonZeroU32::new_unchecked(3) });
-    pub const INVALID_NONCE: Self = Self(unsafe { NonZeroU32::new_unchecked(4) });
-    pub const TRANSACTION_TOO_LARGE: Self = Self(unsafe { NonZeroU32::new_unchecked(5) });
-    pub const INSUFFICIENT_FUNDS: Self = Self(unsafe { NonZeroU32::new_unchecked(6) });
-    pub const INVALID_CHAIN_ID: Self = Self(unsafe { NonZeroU32::new_unchecked(7) });
-    pub const VALUE_NOT_FOUND: Self = Self(unsafe { NonZeroU32::new_unchecked(8) });
-    pub const TRANSACTION_EXPIRED: Self = Self(unsafe { NonZeroU32::new_unchecked(9) });
-    pub const TRANSACTION_FAILED_EXECUTION: Self = Self(unsafe { NonZeroU32::new_unchecked(10) });
-    pub const TRANSACTION_INSERTION_FAILED: Self = Self(unsafe { NonZeroU32::new_unchecked(11) });
-    pub const LOWER_NONCE_INVALIDATED: Self = Self(unsafe { NonZeroU32::new_unchecked(12) });
-    pub const BAD_REQUEST: Self = Self(unsafe { NonZeroU32::new_unchecked(13) });
-    pub const ALREADY_PRESENT: Self = Self(unsafe { NonZeroU32::new_unchecked(14) });
-    pub const NONCE_TAKEN: Self = Self(unsafe { NonZeroU32::new_unchecked(15) });
-    pub const ACCOUNT_SIZE_LIMIT: Self = Self(unsafe { NonZeroU32::new_unchecked(16) });
-    pub const PARKED_FULL: Self = Self(unsafe { NonZeroU32::new_unchecked(17) });
-    pub const TRANSACTION_INCLUDED_IN_BLOCK: Self = Self(unsafe { NonZeroU32::new_unchecked(18) });
-    pub const TRANSACTION_FAILED_CHECK_TX: Self = Self(unsafe { NonZeroU32::new_unchecked(19) });
-    pub const INVALID_TRANSACTION_BYTES: Self = Self(unsafe { NonZeroU32::new_unchecked(20) });
-    pub const INVALID_TRANSACTION: Self = Self(unsafe { NonZeroU32::new_unchecked(21) });
+    pub const UNKNOWN_PATH: Self = Self(NonZeroU32::new(1).unwrap());
+    pub const INVALID_PARAMETER: Self = Self(NonZeroU32::new(2).unwrap());
+    pub const INTERNAL_ERROR: Self = Self(NonZeroU32::new(3).unwrap());
+    pub const INVALID_NONCE: Self = Self(NonZeroU32::new(4).unwrap());
+    pub const TRANSACTION_TOO_LARGE: Self = Self(NonZeroU32::new(5).unwrap());
+    pub const INSUFFICIENT_FUNDS: Self = Self(NonZeroU32::new(6).unwrap());
+    pub const INVALID_CHAIN_ID: Self = Self(NonZeroU32::new(7).unwrap());
+    pub const VALUE_NOT_FOUND: Self = Self(NonZeroU32::new(8).unwrap());
+    pub const TRANSACTION_EXPIRED: Self = Self(NonZeroU32::new(9).unwrap());
+    pub const TRANSACTION_FAILED_EXECUTION: Self = Self(NonZeroU32::new(10).unwrap());
+    pub const TRANSACTION_INSERTION_FAILED: Self = Self(NonZeroU32::new(11).unwrap());
+    pub const LOWER_NONCE_INVALIDATED: Self = Self(NonZeroU32::new(12).unwrap());
+    pub const BAD_REQUEST: Self = Self(NonZeroU32::new(13).unwrap());
+    pub const ALREADY_PRESENT: Self = Self(NonZeroU32::new(14).unwrap());
+    pub const NONCE_TAKEN: Self = Self(NonZeroU32::new(15).unwrap());
+    pub const ACCOUNT_SIZE_LIMIT: Self = Self(NonZeroU32::new(16).unwrap());
+    pub const PARKED_FULL: Self = Self(NonZeroU32::new(17).unwrap());
+    pub const TRANSACTION_INCLUDED_IN_BLOCK: Self = Self(NonZeroU32::new(18).unwrap());
+    pub const TRANSACTION_FAILED_CHECK_TX: Self = Self(NonZeroU32::new(19).unwrap());
+    pub const INVALID_TRANSACTION_BYTES: Self = Self(NonZeroU32::new(20).unwrap());
+    pub const INVALID_TRANSACTION: Self = Self(NonZeroU32::new(21).unwrap());
     // NOTE: When adding a new code, ensure it is added to `ALL_CODES` in the `tests` module below.
 }
 

--- a/crates/astria-core/src/protocol/genesis/v1.rs
+++ b/crates/astria-core/src/protocol/genesis/v1.rs
@@ -958,7 +958,7 @@ mod tests {
                 other => panic!(
                     "expected: `GenesisAppStateErrorKind::AddressDoesNotMatchBase\ngot: {other:?}`"
                 ),
-            };
+            }
         }
         assert_bad_prefix(
             raw::GenesisAppState {

--- a/crates/astria-core/src/protocol/transaction/v1/action/group/tests.rs
+++ b/crates/astria-core/src/protocol/transaction/v1/action/group/tests.rs
@@ -262,7 +262,7 @@ fn from_list_of_actions_mixed() {
 fn from_list_of_actions_empty() {
     let error_kind = Actions::try_from_list_of_actions(vec![]).unwrap_err().0;
     assert!(
-        matches!(error_kind, ErrorKind::Empty { .. }),
+        matches!(error_kind, ErrorKind::Empty),
         "expected ErrorKind::Empty, got {error_kind:?}"
     );
 }

--- a/crates/astria-core/src/protocol/transaction/v1/action/mod.rs
+++ b/crates/astria-core/src/protocol/transaction/v1/action/mod.rs
@@ -79,7 +79,6 @@ impl Protobuf for Action {
     type Error = Error;
     type Raw = raw::Action;
 
-    #[must_use]
     fn to_raw(&self) -> Self::Raw {
         use raw::action::Value;
         let kind = match self {
@@ -535,7 +534,6 @@ impl Protobuf for RollupDataSubmission {
     type Error = RollupDataSubmissionError;
     type Raw = raw::RollupDataSubmission;
 
-    #[must_use]
     fn to_raw(&self) -> raw::RollupDataSubmission {
         let Self {
             rollup_id,
@@ -590,7 +588,6 @@ impl Protobuf for Transfer {
     type Error = TransferError;
     type Raw = raw::Transfer;
 
-    #[must_use]
     fn to_raw(&self) -> raw::Transfer {
         let Self {
             to,
@@ -831,7 +828,6 @@ impl Protobuf for ValidatorUpdate {
         Self::try_from_raw(raw.clone())
     }
 
-    #[must_use]
     fn to_raw(&self) -> Self::Raw {
         use crate::generated::astria_vendored::tendermint::crypto::{
             public_key,
@@ -893,7 +889,6 @@ impl Protobuf for SudoAddressChange {
         }
     }
 
-    #[must_use]
     fn to_raw(&self) -> raw::SudoAddressChange {
         let Self {
             new_address,
@@ -963,7 +958,6 @@ impl Protobuf for IbcSudoChange {
         }
     }
 
-    #[must_use]
     fn to_raw(&self) -> raw::IbcSudoChange {
         raw::IbcSudoChange {
             new_address: Some(self.new_address.to_raw()),
@@ -1112,7 +1106,6 @@ impl Protobuf for Ics20Withdrawal {
     type Error = Ics20WithdrawalError;
     type Raw = raw::Ics20Withdrawal;
 
-    #[must_use]
     fn to_raw(&self) -> raw::Ics20Withdrawal {
         raw::Ics20Withdrawal {
             amount: Some(self.amount.into()),
@@ -1129,7 +1122,6 @@ impl Protobuf for Ics20Withdrawal {
         }
     }
 
-    #[must_use]
     fn into_raw(self) -> raw::Ics20Withdrawal {
         raw::Ics20Withdrawal {
             amount: Some(self.amount.into()),
@@ -1358,7 +1350,6 @@ impl Protobuf for IbcRelayerChange {
     type Error = IbcRelayerChangeError;
     type Raw = raw::IbcRelayerChange;
 
-    #[must_use]
     fn to_raw(&self) -> raw::IbcRelayerChange {
         match self {
             IbcRelayerChange::Addition(address) => raw::IbcRelayerChange {
@@ -1432,7 +1423,6 @@ impl Protobuf for FeeAssetChange {
     type Error = FeeAssetChangeError;
     type Raw = raw::FeeAssetChange;
 
-    #[must_use]
     fn to_raw(&self) -> raw::FeeAssetChange {
         match self {
             FeeAssetChange::Addition(asset) => raw::FeeAssetChange {
@@ -1513,7 +1503,6 @@ impl Protobuf for InitBridgeAccount {
     type Error = InitBridgeAccountError;
     type Raw = raw::InitBridgeAccount;
 
-    #[must_use]
     fn into_raw(self) -> raw::InitBridgeAccount {
         raw::InitBridgeAccount {
             rollup_id: Some(self.rollup_id.to_raw()),
@@ -1524,7 +1513,6 @@ impl Protobuf for InitBridgeAccount {
         }
     }
 
-    #[must_use]
     fn to_raw(&self) -> raw::InitBridgeAccount {
         raw::InitBridgeAccount {
             rollup_id: Some(self.rollup_id.to_raw()),
@@ -1658,7 +1646,6 @@ impl Protobuf for BridgeLock {
     type Error = BridgeLockError;
     type Raw = raw::BridgeLock;
 
-    #[must_use]
     fn into_raw(self) -> raw::BridgeLock {
         raw::BridgeLock {
             to: Some(self.to.to_raw()),
@@ -1669,7 +1656,6 @@ impl Protobuf for BridgeLock {
         }
     }
 
-    #[must_use]
     fn to_raw(&self) -> raw::BridgeLock {
         raw::BridgeLock {
             to: Some(self.to.to_raw()),
@@ -1791,7 +1777,6 @@ impl Protobuf for BridgeUnlock {
     type Error = BridgeUnlockError;
     type Raw = raw::BridgeUnlock;
 
-    #[must_use]
     fn into_raw(self) -> raw::BridgeUnlock {
         raw::BridgeUnlock {
             to: Some(self.to.into_raw()),
@@ -1804,7 +1789,6 @@ impl Protobuf for BridgeUnlock {
         }
     }
 
-    #[must_use]
     fn to_raw(&self) -> raw::BridgeUnlock {
         raw::BridgeUnlock {
             to: Some(self.to.to_raw()),
@@ -1926,7 +1910,6 @@ impl Protobuf for BridgeSudoChange {
     type Error = BridgeSudoChangeError;
     type Raw = raw::BridgeSudoChange;
 
-    #[must_use]
     fn into_raw(self) -> raw::BridgeSudoChange {
         raw::BridgeSudoChange {
             bridge_address: Some(self.bridge_address.to_raw()),
@@ -1936,7 +1919,6 @@ impl Protobuf for BridgeSudoChange {
         }
     }
 
-    #[must_use]
     fn to_raw(&self) -> raw::BridgeSudoChange {
         raw::BridgeSudoChange {
             bridge_address: Some(self.bridge_address.to_raw()),
@@ -2063,7 +2045,6 @@ impl Protobuf for BridgeTransfer {
     type Error = BridgeTransferError;
     type Raw = raw::BridgeTransfer;
 
-    #[must_use]
     fn into_raw(self) -> raw::BridgeTransfer {
         raw::BridgeTransfer {
             to: Some(self.to.into_raw()),
@@ -2076,7 +2057,6 @@ impl Protobuf for BridgeTransfer {
         }
     }
 
-    #[must_use]
     fn to_raw(&self) -> raw::BridgeTransfer {
         raw::BridgeTransfer {
             to: Some(self.to.to_raw()),
@@ -2251,7 +2231,6 @@ impl Protobuf for FeeChange {
     type Error = FeeChangeError;
     type Raw = raw::FeeChange;
 
-    #[must_use]
     fn to_raw(&self) -> raw::FeeChange {
         raw::FeeChange {
             fee_components: Some(match &self {
@@ -2520,7 +2499,6 @@ impl Protobuf for RecoverIbcClient {
     type Error = RecoverIbcClientError;
     type Raw = raw::RecoverIbcClient;
 
-    #[must_use]
     fn into_raw(self) -> raw::RecoverIbcClient {
         raw::RecoverIbcClient {
             client_id: self.client_id.to_string(),
@@ -2528,7 +2506,6 @@ impl Protobuf for RecoverIbcClient {
         }
     }
 
-    #[must_use]
     fn to_raw(&self) -> raw::RecoverIbcClient {
         raw::RecoverIbcClient {
             client_id: self.client_id.clone().to_string(),
@@ -2588,7 +2565,6 @@ impl Protobuf for CurrencyPairsChange {
     type Error = CurrencyPairsChangeError;
     type Raw = raw::CurrencyPairsChange;
 
-    #[must_use]
     fn into_raw(self) -> Self::Raw {
         let raw = match self {
             CurrencyPairsChange::Addition(pairs) => {
@@ -2607,7 +2583,6 @@ impl Protobuf for CurrencyPairsChange {
         }
     }
 
-    #[must_use]
     fn to_raw(&self) -> Self::Raw {
         self.clone().into_raw()
     }

--- a/crates/astria-core/src/sequencerblock/v1/block/mod.rs
+++ b/crates/astria-core/src/sequencerblock/v1/block/mod.rs
@@ -989,7 +989,7 @@ impl SequencerBlock {
             let id = id.into();
             if let Some(rollup_transactions) = self.rollup_transactions.shift_remove(&id) {
                 filtered_rollup_transactions.insert(id, rollup_transactions);
-            };
+            }
         }
 
         FilteredSequencerBlock {
@@ -1017,7 +1017,7 @@ impl SequencerBlock {
             let id = id.into();
             if let Some(rollup_transactions) = self.rollup_transactions.get(&id).cloned() {
                 filtered_rollup_transactions.insert(id, rollup_transactions);
-            };
+            }
         }
 
         FilteredSequencerBlock {
@@ -1091,7 +1091,7 @@ impl SequencerBlock {
             .verify(&Sha256::digest(header.rollup_transactions_root), data_hash)
         {
             return Err(SequencerBlockError::invalid_rollup_transactions_root());
-        };
+        }
 
         if !are_rollup_txs_included(&rollup_transactions, &rollup_transactions_proof, data_hash) {
             return Err(SequencerBlockError::rollup_transactions_not_in_sequencer_block());
@@ -2300,7 +2300,7 @@ impl ExtendedCommitInfoWithProof {
 #[derive(Debug, Clone, PartialEq)]
 pub struct Price {
     currency_pair: CurrencyPair,
-    price: crate::oracles::price_feed::types::v2::Price,
+    value: crate::oracles::price_feed::types::v2::Price,
     decimals: u8,
 }
 
@@ -2313,7 +2313,7 @@ impl Price {
     ) -> Self {
         Self {
             currency_pair,
-            price,
+            value: price,
             decimals,
         }
     }
@@ -2325,7 +2325,7 @@ impl Price {
 
     #[must_use]
     pub fn price(&self) -> crate::oracles::price_feed::types::v2::Price {
-        self.price
+        self.value
     }
 
     #[must_use]
@@ -2337,7 +2337,7 @@ impl Price {
     pub fn into_raw(self) -> raw::Price {
         let Self {
             currency_pair,
-            price,
+            value: price,
             decimals,
         } = self;
         raw::Price {
@@ -2372,7 +2372,7 @@ impl Price {
             .map_err(|_| PriceError::decimals_too_large())?;
         Ok(Self {
             currency_pair,
-            price,
+            value: price,
             decimals,
         })
     }

--- a/crates/astria-core/src/sequencerblock/v1/celestia.rs
+++ b/crates/astria-core/src/sequencerblock/v1/celestia.rs
@@ -598,7 +598,7 @@ impl SubmittedMetadata {
 
     /// Returns the rollup IDs.
     #[must_use]
-    pub fn rollup_ids(&self) -> RollupIdIter {
+    pub fn rollup_ids(&self) -> RollupIdIter<'_> {
         RollupIdIter(self.rollup_ids.iter())
     }
 

--- a/crates/astria-grpc-mock-test/src/lib.rs
+++ b/crates/astria-grpc-mock-test/src/lib.rs
@@ -8,8 +8,7 @@
 #[expect(
     clippy::allow_attributes,
     clippy::allow_attributes_without_reason,
-    clippy::needless_lifetimes,
-    reason = "cannot prevent generated files from having allow attributes or specific lifetimes"
+    reason = "cannot prevent generated files from having allow attributes"
 )]
 pub mod health {
     include!("generated/grpc.health.v1.rs");

--- a/crates/astria-grpc-mock/src/mock_set.rs
+++ b/crates/astria-grpc-mock/src/mock_set.rs
@@ -69,7 +69,7 @@ impl MockSet {
                 continue;
             }
             match mock.match_and_respond::<U>(rpc, &erased) {
-                (MockResult::NoMatch, _) => continue,
+                (MockResult::NoMatch, _) => (),
                 (MockResult::BadResponse(status), _) => {
                     mock_response.replace(Err(status));
                     break;

--- a/crates/astria-grpc-mock/src/response.rs
+++ b/crates/astria-grpc-mock/src/response.rs
@@ -383,5 +383,9 @@ impl ResponseTemplate {
 ///
 /// This trait can also be implemented to use custom response logic.
 pub trait Respond: Send + Sync {
+    #[expect(
+        clippy::result_large_err,
+        reason = "mock response only, mem consumption not an issue"
+    )]
     fn respond(&self, req: &tonic::Request<AnyMessage>) -> ResponseResult;
 }

--- a/crates/astria-merkle/benches/benchmark.rs
+++ b/crates/astria-merkle/benches/benchmark.rs
@@ -160,7 +160,9 @@ fn verify_leaf_ct_merkle(bencher: Bencher, leaf_count: usize, input_sizes: Input
         .with_inputs(|| {
             let raw_leaves = raw_leaves(leaf_count, input_sizes);
             let mut tree = CtMerkleTree::<Sha256, Vec<u8>>::new();
-            raw_leaves.iter().for_each(|value| tree.push(value.clone()));
+            for value in &raw_leaves {
+                tree.push(value.clone());
+            }
             let root = tree.root();
             let leaves_and_proofs =
                 raw_leaves

--- a/crates/astria-merkle/src/audit.rs
+++ b/crates/astria-merkle/src/audit.rs
@@ -507,7 +507,7 @@ impl Proof {
     ///     .perform());
     /// ```
     #[must_use = "an audit must be performed to be useful"]
-    pub fn audit(&self) -> Audit {
+    pub fn audit(&self) -> Audit<'_> {
         Audit::new(self)
     }
 

--- a/crates/astria-sequencer-relayer/src/relayer/celestia_client/tests.rs
+++ b/crates/astria-sequencer-relayer/src/relayer/celestia_client/tests.rs
@@ -68,7 +68,7 @@ fn new_msg_pay_for_blobs_should_fail_for_large_blob() {
         clippy::manual_assert,
         reason = "`assert!(matches!(..))` provides poor feedback on failure"
     )]
-    if !matches!(error, TrySubmitError::BlobTooLarge { byte_count } if byte_count == u32::MAX as usize + 1)
+    if !matches!(*error, TrySubmitError::BlobTooLarge { byte_count } if byte_count == u32::MAX as usize + 1)
     {
         panic!("expected `Error::BlobTooLarge` with byte_count == u32::MAX + 1, got {error:?}");
     }
@@ -102,7 +102,7 @@ fn account_from_bad_response_should_fail() {
         clippy::manual_assert,
         reason = "`assert!(matches!(..))` provides poor feedback on failure"
     )]
-    if !matches!(error, TrySubmitError::FailedToGetAccountInfo(_)) {
+    if !matches!(*error, TrySubmitError::FailedToGetAccountInfo(_)) {
         panic!("expected `Error::FailedToGetAccountInfo`, got {error:?}");
     }
 
@@ -115,7 +115,7 @@ fn account_from_bad_response_should_fail() {
         clippy::manual_assert,
         reason = "`assert!(matches!(..))` provides poor feedback on failure"
     )]
-    if !matches!(error, TrySubmitError::EmptyAccountInfo) {
+    if !matches!(*error, TrySubmitError::EmptyAccountInfo) {
         panic!("expected `Error::EmptyAccountInfo`, got {error:?}");
     }
 
@@ -130,7 +130,7 @@ fn account_from_bad_response_should_fail() {
         account: Some(bad_url_account),
     }));
     let error = account_from_response(response).unwrap_err();
-    match error {
+    match *error {
         TrySubmitError::AccountInfoTypeMismatch {
             expected,
             received,
@@ -154,7 +154,7 @@ fn account_from_bad_response_should_fail() {
         clippy::manual_assert,
         reason = "`assert!(matches!(..))` provides poor feedback on failure"
     )]
-    if !matches!(error, TrySubmitError::DecodeAccountInfo(_)) {
+    if !matches!(*error, TrySubmitError::DecodeAccountInfo(_)) {
         panic!("expected `Error::DecodeAccountInfo`, got {error:?}");
     }
 }
@@ -201,7 +201,7 @@ fn min_gas_price_from_bad_response_should_fail() {
         clippy::manual_assert,
         reason = "`assert!(matches!(..))` provides poor feedback on failure"
     )]
-    if !matches!(error, TrySubmitError::FailedToGetMinGasPrice(_)) {
+    if !matches!(*error, TrySubmitError::FailedToGetMinGasPrice(_)) {
         panic!("expected `Error::FailedToGetMinGasPrice`, got {error:?}");
     }
 
@@ -212,7 +212,7 @@ fn min_gas_price_from_bad_response_should_fail() {
         minimum_gas_price: bad_suffix.to_string(),
     }));
     let error = min_gas_price_from_response(response, TEST_DEFAULT_MIN_GAS_PRICE).unwrap_err();
-    match error {
+    match *error {
         TrySubmitError::MinGasPriceBadSuffix {
             min_gas_price,
             expected_suffix,
@@ -230,7 +230,7 @@ fn min_gas_price_from_bad_response_should_fail() {
         minimum_gas_price: format!("{bad_value}utia"),
     }));
     let error = min_gas_price_from_response(response, TEST_DEFAULT_MIN_GAS_PRICE).unwrap_err();
-    match error {
+    match *error {
         TrySubmitError::FailedToParseMinGasPrice {
             min_gas_price, ..
         } => {
@@ -318,7 +318,7 @@ fn tx_hash_from_bad_response_should_fail() {
         clippy::manual_assert,
         reason = "`assert!(matches!(..))` provides poor feedback on failure"
     )]
-    if !matches!(error, TrySubmitError::FailedToBroadcastTx(_)) {
+    if !matches!(*error, TrySubmitError::FailedToBroadcastTx(_)) {
         panic!("expected `Error::FailedToBroadcastTx`, got {error:?}");
     }
 
@@ -331,7 +331,7 @@ fn tx_hash_from_bad_response_should_fail() {
         clippy::manual_assert,
         reason = "`assert!(matches!(..))` provides poor feedback on failure"
     )]
-    if !matches!(error, TrySubmitError::EmptyBroadcastTxResponse) {
+    if !matches!(*error, TrySubmitError::EmptyBroadcastTxResponse) {
         panic!("expected `Error::EmptyBroadcastTxResponse`, got {error:?}");
     }
 
@@ -351,7 +351,7 @@ fn tx_hash_from_bad_response_should_fail() {
         tx_response: Some(tx_response),
     }));
     let error = lowercase_hex_encoded_tx_hash_from_response(response).unwrap_err();
-    match error {
+    match *error {
         TrySubmitError::BroadcastTxResponseErrorCode {
             tx_hash: received_tx_hash,
             code: received_code,
@@ -388,7 +388,7 @@ fn block_height_from_bad_response_should_fail() {
         clippy::manual_assert,
         reason = "`assert!(matches!(..))` provides poor feedback on failure"
     )]
-    if !matches!(error, TrySubmitError::FailedToGetTx(_)) {
+    if !matches!(*error, TrySubmitError::FailedToGetTx(_)) {
         panic!("expected `Error::FailedToGetTx`, got {error:?}");
     }
 
@@ -402,7 +402,7 @@ fn block_height_from_bad_response_should_fail() {
         clippy::manual_assert,
         reason = "`assert!(matches!(..))` provides poor feedback on failure"
     )]
-    if !matches!(error, TrySubmitError::EmptyGetTxResponse) {
+    if !matches!(*error, TrySubmitError::EmptyGetTxResponse) {
         panic!("expected `Error::EmptyGetTxResponse`, got {error:?}");
     }
 
@@ -422,7 +422,7 @@ fn block_height_from_bad_response_should_fail() {
         tx_response: Some(tx_response),
     }));
     let error = block_height_from_response(response).unwrap_err();
-    match error {
+    match *error {
         TrySubmitError::GetTxResponseErrorCode {
             tx_hash: received_tx_hash,
             code: received_code,
@@ -448,7 +448,7 @@ fn block_height_from_response_with_negative_height_should_fail() {
     });
 
     let error = block_height_from_response(Ok(response)).unwrap_err();
-    match error {
+    match *error {
         TrySubmitError::GetTxResponseNegativeBlockHeight(received_height) => {
             assert_eq!(height, received_height);
         }

--- a/crates/astria-sequencer-relayer/tests/blackbox/helpers/mock_sequencer_server.rs
+++ b/crates/astria-sequencer-relayer/tests/blackbox/helpers/mock_sequencer_server.rs
@@ -107,6 +107,10 @@ impl MockSequencerServer {
     }
 }
 
+#[expect(
+    clippy::large_enum_variant,
+    reason = "test util, mem consumption not an issue"
+)]
 pub enum SequencerBlockToMount {
     GoodAtHeight(u32),
     BadAtHeight(u32),

--- a/crates/astria-sequencer-utils/src/genesis_example.rs
+++ b/crates/astria-sequencer-utils/src/genesis_example.rs
@@ -157,7 +157,7 @@ impl Args {
                     opt.write(true).truncate(true);
                 } else {
                     opt.write(true).create_new(true);
-                };
+                }
                 opt.open(p)
                     .map(|f| Box::new(f) as Box<dyn Write>)
                     .wrap_err("failed opening provided file for writing")

--- a/crates/astria-sequencer/src/app/mod.rs
+++ b/crates/astria-sequencer/src/app/mod.rs
@@ -1017,7 +1017,7 @@ impl App {
     /// Returns the encoded upgrade change hashes if an upgrade was executed.
     ///
     /// This *must* be called any time before a block's txs are executed, whether it's
-    /// during the proposal phase, or finalize_block phase.
+    /// during the proposal phase, or `finalize_block` phase.
     #[instrument(name = "App::pre_execute_transactions", skip_all, err(level = Level::WARN))]
     async fn pre_execute_transactions(&mut self, block_data: BlockData) -> Result<Vec<ChangeHash>> {
         let mut delta_delta = StateDelta::new(self.state.clone());
@@ -1118,7 +1118,7 @@ impl App {
     /// `SequencerBlock`.
     ///
     /// this must be called after a block's transactions are executed.
-    /// FIXME: don't return sequencer block but grab the block from state delta https://github.com/astriaorg/astria/issues/1436
+    /// FIXME: don't return sequencer block but grab the block from state delta <https://github.com/astriaorg/astria/issues/1436>
     #[instrument(name = "App::post_execute_transactions", skip_all, err(level = Level::WARN))]
     async fn post_execute_transactions(
         &mut self,
@@ -1163,8 +1163,10 @@ impl App {
         let injected_tx_count = expanded_block_data.injected_transaction_count();
         let mut finalize_block_tx_results: Vec<ExecTxResult> =
             Vec::with_capacity(expanded_block_data.user_submitted_transactions.len());
-        finalize_block_tx_results
-            .extend(std::iter::repeat(ExecTxResult::default()).take(injected_tx_count));
+        finalize_block_tx_results.extend(std::iter::repeat_n(
+            ExecTxResult::default(),
+            injected_tx_count,
+        ));
         finalize_block_tx_results.extend(
             executed_txs
                 .iter()
@@ -1399,8 +1401,10 @@ impl App {
         // transaction, not the injected ones.
         let mut finalize_block_tx_results: Vec<ExecTxResult> =
             Vec::with_capacity(tx_results.len().saturating_add(injected_tx_count));
-        finalize_block_tx_results
-            .extend(std::iter::repeat(ExecTxResult::default()).take(injected_tx_count));
+        finalize_block_tx_results.extend(std::iter::repeat_n(
+            ExecTxResult::default(),
+            injected_tx_count,
+        ));
         finalize_block_tx_results.extend(tx_results.iter().map(|(_, tx_result)| tx_result.clone()));
 
         // prepare the `WriteBatch` for a later commit.

--- a/crates/astria-sequencer/src/app/tests_app/mod.rs
+++ b/crates/astria-sequencer/src/app/tests_app/mod.rs
@@ -529,7 +529,7 @@ async fn app_execution_results_match_proposal_vs_after_proposal() {
         proposer_address: [0u8; 20].to_vec().try_into().unwrap(),
         txs: transactions_with_extended_commit_info_and_commitments(
             height,
-            &[tx.clone()],
+            std::slice::from_ref(&tx),
             Some(deposits),
         ),
         decided_last_commit: CommitInfo {
@@ -1275,7 +1275,7 @@ async fn app_proposal_fingerprint_triggers_update() {
     let block_hash = Hash::Sha256(raw_hash);
     let txs_with_commitments = transactions_with_extended_commit_info_and_commitments(
         height,
-        &[tx.clone()],
+        std::slice::from_ref(&tx),
         Some(deposits.clone()),
     );
 

--- a/crates/astria-sequencer/src/bridge/query.rs
+++ b/crates/astria-sequencer/src/bridge/query.rs
@@ -174,7 +174,7 @@ pub(crate) async fn bridge_account_info_request(
 
     let address = match preprocess_request(&params) {
         Ok(tup) => tup,
-        Err(err_rsp) => return err_rsp,
+        Err(err_rsp) => return *err_rsp,
     };
 
     let snapshot = storage.latest_snapshot();
@@ -223,7 +223,7 @@ pub(crate) async fn bridge_account_last_tx_hash_request(
 
     let address = match preprocess_request(&params) {
         Ok(tup) => tup,
-        Err(err_rsp) => return err_rsp,
+        Err(err_rsp) => return *err_rsp,
     };
 
     // use latest snapshot, as this is a query for latest tx
@@ -271,16 +271,16 @@ pub(crate) async fn bridge_account_last_tx_hash_request(
     }
 }
 
-fn preprocess_request(params: &[(String, String)]) -> Result<Address, response::Query> {
+fn preprocess_request(params: &[(String, String)]) -> Result<Address, Box<response::Query>> {
     let Some(address) = params
         .iter()
         .find_map(|(k, v)| (k == "address").then_some(v))
     else {
-        return Err(error_query_response(
+        return Err(Box::new(error_query_response(
             None,
             AbciErrorCode::INVALID_PARAMETER,
             "path did not contain address parameter",
-        ));
+        )));
     };
     let address = address
         .parse()

--- a/crates/astria-sequencer/src/checked_actions/checked_action.rs
+++ b/crates/astria-sequencer/src/checked_actions/checked_action.rs
@@ -917,6 +917,6 @@ mod tests {
                 assert_eq!(amount, expected_fees.1);
             }
             _ => panic!("should be fee error, got {error:?}"),
-        };
+        }
     }
 }

--- a/crates/astria-sequencer/src/checked_actions/markets_change.rs
+++ b/crates/astria-sequencer/src/checked_actions/markets_change.rs
@@ -141,7 +141,7 @@ impl CheckedMarketsChange {
                     })? = market.clone();
                 }
             }
-        };
+        }
 
         state
             .put_market_map(market_map)

--- a/crates/astria-sequencer/src/checked_transaction/mod.rs
+++ b/crates/astria-sequencer/src/checked_transaction/mod.rs
@@ -123,7 +123,7 @@ impl CheckedTransaction {
                 current_nonce,
                 tx_nonce,
             });
-        };
+        }
 
         let tx_id = TransactionId::new(sha2::Sha256::digest(&tx_bytes).into());
         let tx_chain_id = tx.chain_id().to_string();
@@ -273,7 +273,7 @@ impl CheckedTransaction {
                 expected: current_nonce,
                 tx_nonce,
             });
-        };
+        }
 
         if state
             .get_bridge_account_rollup_id(self)

--- a/crates/astria-sequencer/src/grpc/mod.rs
+++ b/crates/astria-sequencer/src/grpc/mod.rs
@@ -243,7 +243,7 @@ async fn perform_shutdown(mut background_tasks: BackgroundTasks) {
             "background tasks did not finish during shutdown window and will be aborted",
         );
         background_tasks.abort_all();
-    };
+    }
 
     info!("reached shutdown target");
 }

--- a/crates/astria-sequencer/src/grpc/sequencer.rs
+++ b/crates/astria-sequencer/src/grpc/sequencer.rs
@@ -98,7 +98,7 @@ impl SequencerService for SequencerServer {
         Ok(Response::new(block.into_raw()))
     }
 
-    /// Given a block height and set of rollup ids, returns a SequencerBlock which
+    /// Given a block height and set of rollup ids, returns a `SequencerBlock` which
     /// is filtered to contain only the transactions that are relevant to the given rollup.
     #[instrument(skip_all)]
     async fn get_filtered_sequencer_block(

--- a/crates/astria-sequencer/src/mempool/mod.rs
+++ b/crates/astria-sequencer/src/mempool/mod.rs
@@ -130,7 +130,7 @@ impl RemovalCache {
     fn add(&mut self, tx_id: TransactionId, reason: RemovalReason) {
         if self.cache.contains_key(&tx_id) {
             return;
-        };
+        }
 
         if self.remove_queue.len() == usize::from(self.max_size) {
             // This should not happen if `REMOVAL_CACHE_SIZE` is >= CometBFT's configured mempool

--- a/crates/astria-sequencer/src/mempool/recent_execution_results.rs
+++ b/crates/astria-sequencer/src/mempool/recent_execution_results.rs
@@ -118,7 +118,7 @@ impl RecentExecutionResults {
                 );
             } else {
                 self.timestamped_ids.push_back((tx_id, now));
-            };
+            }
         }
     }
 
@@ -135,7 +135,7 @@ impl RecentExecutionResults {
                     "transaction ID {tx_id} not found in recent execution results cache, not \
                      removing it"
                 );
-            };
+            }
         }
     }
 }

--- a/crates/astria-sequencer/src/mempool/transactions_container.rs
+++ b/crates/astria-sequencer/src/mempool/transactions_container.rs
@@ -608,7 +608,6 @@ pub(super) trait TransactionsContainer<T: TransactionsForAccount> {
                     address = %telemetry::display::base64(address_bytes),
                     "failed to calculate new transaction cost when cleaning accounts: {error:#}"
                 );
-                continue;
             }
         }
     }
@@ -792,7 +791,7 @@ impl PendingTransactions {
     ) -> HashMap<IbcPrefixed, u128> {
         if let Some(account) = self.txs.get(address_bytes) {
             account.subtract_contained_costs(&mut current_balances);
-        };
+        }
         current_balances
     }
 

--- a/crates/astria-sequencer/src/service/consensus.rs
+++ b/crates/astria-sequencer/src/service/consensus.rs
@@ -379,7 +379,7 @@ mod tests {
             .await
             .unwrap();
 
-        let process_proposal = new_process_proposal_request(&[tx.clone()]);
+        let process_proposal = new_process_proposal_request(std::slice::from_ref(&tx));
         let expected_txs: Vec<Bytes> = process_proposal.txs.clone();
 
         assert_eq!(

--- a/crates/astria-sequencer/src/service/mempool/mod.rs
+++ b/crates/astria-sequencer/src/service/mempool/mod.rs
@@ -157,7 +157,7 @@ async fn handle_check_tx_request<S: StateRead>(
                 metrics.increment_check_tx_removed_failed_execution();
             }
             _ => {}
-        };
+        }
         mempool.remove_from_removal_cache(&tx_id).await;
         reason.into()
     } else {

--- a/crates/astria-telemetry/src/display.rs
+++ b/crates/astria-telemetry/src/display.rs
@@ -126,7 +126,7 @@ where
         fn io_error(_: fmt::Error) -> io::Error {
             // Error value does not matter because Display impl just maps it
             // back to fmt::Error.
-            io::Error::new(io::ErrorKind::Other, "fmt error")
+            io::Error::other("fmt error")
         }
 
         let mut wr = WriterFormatter {

--- a/crates/astria-telemetry/src/metrics/builders.rs
+++ b/crates/astria-telemetry/src/metrics/builders.rs
@@ -211,7 +211,7 @@ impl RegisteringBuilder {
         &mut self,
         name: &'static str,
         description: &'static str,
-    ) -> Result<CounterFactory, Error> {
+    ) -> Result<CounterFactory<'_>, Error> {
         if !self.counters.insert(name.to_string()) {
             return Err(Error::MetricAlreadyRegistered {
                 metric_type: CounterFactory::metric_type(),
@@ -233,7 +233,7 @@ impl RegisteringBuilder {
         &mut self,
         name: &'static str,
         description: &'static str,
-    ) -> Result<GaugeFactory, Error> {
+    ) -> Result<GaugeFactory<'_>, Error> {
         if !self.gauges.insert(name.to_string()) {
             return Err(Error::MetricAlreadyRegistered {
                 metric_type: GaugeFactory::metric_type(),
@@ -255,7 +255,7 @@ impl RegisteringBuilder {
         &mut self,
         name: &'static str,
         description: &'static str,
-    ) -> Result<HistogramFactory, Error> {
+    ) -> Result<HistogramFactory<'_>, Error> {
         if !self.histograms.insert(name.to_string()) {
             return Err(Error::MetricAlreadyRegistered {
                 metric_type: HistogramFactory::metric_type(),

--- a/crates/astria-test-utils/src/mock/geth.rs
+++ b/crates/astria-test-utils/src/mock/geth.rs
@@ -159,6 +159,10 @@ mod __rpc_traits {
 }
 
 #[derive(Clone, Debug)]
+#[expect(
+    clippy::large_enum_variant,
+    reason = "test util, mem consumption not an issue"
+)]
 pub enum SubscriptionCommand {
     Abort,
     Send(Transaction),
@@ -303,6 +307,10 @@ impl Geth {
     /// # Errors
     ///
     /// Returns the same error as tokio's [`Sender::send`].
+    #[expect(
+        clippy::result_large_err,
+        reason = "test util, mem consumption not an issue"
+    )]
     pub fn cancel_subscriptions(&self) -> Result<usize, SendError<SubscriptionCommand>> {
         self.command.send(SubscriptionCommand::Abort)
     }
@@ -316,6 +324,10 @@ impl Geth {
     /// # Errors
     ///
     /// Returns the same error as tokio's [`Sender::send`].
+    #[expect(
+        clippy::result_large_err,
+        reason = "test util, mem consumption not an issue"
+    )]
     pub fn push_tx(&self, tx: Transaction) -> Result<usize, SendError<SubscriptionCommand>> {
         self.command.send(tx.into())
     }

--- a/justfile
+++ b/justfile
@@ -165,7 +165,7 @@ _fmt-all:
 
 [no-exit-message]
 _fmt-rust:
-  cargo +nightly-2025-02-17 fmt --all
+  cargo +nightly-2025-09-14 fmt --all
 
 [no-exit-message]
 _lint-rust:
@@ -175,7 +175,7 @@ _lint-rust:
 
 [no-exit-message]
 _lint-rust-fmt:
-  cargo +nightly-2025-02-17 fmt --all -- --check
+  cargo +nightly-2025-09-14 fmt --all -- --check
 
 [no-exit-message]
 _lint-rust-clippy:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.85.0"
+channel = "1.90.0"
 components = ["cargo", "clippy", "rust-std", "rustc"]

--- a/tools/protobuf-compiler/src/main.rs
+++ b/tools/protobuf-compiler/src/main.rs
@@ -48,7 +48,7 @@ fn main() {
         Err(e) => {
             panic!(
                 "failed creating file descriptor set from protobuf: failed to invoke buf (path: \
-                 {buf:?}): {e:?}"
+                 {}): {e:?}", buf.display()
             );
         }
         Ok(output) => output,


### PR DESCRIPTION
## Summary
Updates pinned rust version to 1.90.0.

## Background
We want the latest version of Rust; potentially we'll see some benefits from [better cache management](https://blog.rust-lang.org/2025/06/26/Rust-1.88.0/#cargo-automatic-cache-cleaning) implemented in 1.88.0.

## Changes
- Updated stable version to 1.90.0 and nightly (for formatting only) to `nightly-2025-09-14`.
- Fixed new compiler and clippy warnings.

## Testing
No new tests added.

## Changelogs
No updates required.
