### PR TITLE
release: image cuts to support celestia v6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -609,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "astria-conductor"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "astria-build-info",
  "astria-config",
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "astria-sequencer-relayer"
-version = "1.0.1"
+version = "2.0.0"
 dependencies = [
  "assert-json-diff",
  "astria-build-info",

--- a/charts/celestia-local/Chart.yaml
+++ b/charts/celestia-local/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 8.0.0
+version: 9.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "5.0.0"
+appVersion: "6.0.0"
 
 maintainers:
   - name: wafflesvonmaple

--- a/charts/celestia-local/values.yaml
+++ b/charts/celestia-local/values.yaml
@@ -15,8 +15,8 @@ storage:
       persistentVolumeName: "celestia-shared-storage"
       path: "/data/celestia-data"
 
-celestiaAppImage: "ghcr.io/celestiaorg/celestia-app:v5.0.9"
-celestiaNodeImage: "ghcr.io/celestiaorg/celestia-node:v0.26.1-mocha"
+celestiaAppImage: "ghcr.io/celestiaorg/celestia-app:v6.1.0-rc0"
+celestiaNodeImage: "ghcr.io/celestiaorg/celestia-node:v0.27.5-mocha"
 
 podSecurityContext:
   runAsUser: 10001

--- a/charts/celestia-node/Chart.yaml
+++ b/charts/celestia-node/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.25.3"
+appVersion: "0.27.5"
 
 maintainers:
   - name: wafflesvonmaple

--- a/charts/celestia-node/values.yaml
+++ b/charts/celestia-node/values.yaml
@@ -20,7 +20,7 @@ config:
 
 images:
   pullPolicy: IfNotPresent
-  node: ghcr.io/celestiaorg/celestia-node:v0.25.3
+  node: ghcr.io/celestiaorg/celestia-node:v0.27.5
 
 ports:
   celestia:

--- a/charts/composer/Chart.yaml
+++ b/charts/composer/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.5
+version: 2.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.0.1"
+appVersion: "2.0.0"
 
 maintainers:
   - name: wafflesvonmaple

--- a/charts/composer/templates/configmap.yaml
+++ b/charts/composer/templates/configmap.yaml
@@ -30,7 +30,6 @@ data:
   OTEL_EXPORTER_OTLP_TRACE_HEADERS: "{{ tpl .Values.otel.traceHeaders . }}"
   OTEL_SERVICE_NAME: "{{ tpl .Values.otel.serviceName . }}"
   {{- if not .Values.global.dev }}
-  ASTRIA_COMPOSER_PRETTY_PRINT: "{{ .Values.global.useTTY }}"
   {{- else }}
   {{- end }}
 ---

--- a/charts/composer/values.yaml
+++ b/charts/composer/values.yaml
@@ -9,7 +9,7 @@ images:
   composer:
     repo: ghcr.io/astriaorg/composer
     pullPolicy: IfNotPresent
-    tag: 1.0.1
+    tag: 2.0.0
     devTag: latest
 
 config:

--- a/charts/evm-stack/Chart.lock
+++ b/charts/evm-stack/Chart.lock
@@ -10,7 +10,7 @@ dependencies:
   version: 0.1.3
 - name: composer
   repository: file://../composer
-  version: 1.0.5
+  version: 2.0.0
 - name: auctioneer
   repository: file://../auctioneer
   version: 0.0.2
@@ -26,5 +26,5 @@ dependencies:
 - name: blockscout-stack
   repository: https://blockscout.github.io/helm-charts
   version: 1.6.8
-digest: sha256:2c9b9b63d5d6fcbaa860475e850a0b180ffd0cc8f2fd9034618676e0242634f3
-generated: "2025-09-24T20:56:43.085682+03:00"
+digest: sha256:2fc7f07770d691679ca7b2af03dbe4d4b1cc7a856b39538864e250a85f567b2f
+generated: "2025-10-02T10:20:04.84082-07:00"

--- a/charts/evm-stack/Chart.lock
+++ b/charts/evm-stack/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: celestia-node
   repository: file://../celestia-node
-  version: 0.6.0
+  version: 0.7.0
 - name: evm-rollup
   repository: file://../evm-rollup
   version: 3.0.1
@@ -26,5 +26,5 @@ dependencies:
 - name: blockscout-stack
   repository: https://blockscout.github.io/helm-charts
   version: 1.6.8
-digest: sha256:2fc7f07770d691679ca7b2af03dbe4d4b1cc7a856b39538864e250a85f567b2f
-generated: "2025-10-02T10:20:04.84082-07:00"
+digest: sha256:fa5f1169b017cf05b467b11bf9a1f41e68cea64fc1bbd0ffa4c1379a169b42f8
+generated: "2025-10-03T13:02:10.883499-07:00"

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.0.0
+version: 4.0.1
 
 dependencies:
   - name: celestia-node

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -31,7 +31,7 @@ dependencies:
     repository: "file://../flame-rollup"
     condition: flame-rollup.enabled
   - name: composer
-    version: 1.0.5
+    version: 2.0.0
     repository: "file://../composer"
     condition: composer.enabled
   - name: auctioneer

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -19,7 +19,7 @@ version: 4.0.1
 
 dependencies:
   - name: celestia-node
-    version: 0.6.0
+    version: 0.7.0
     repository: "file://../celestia-node"
     condition: celestia-node.enabled
   - name: evm-rollup

--- a/charts/sequencer-relayer/Chart.yaml
+++ b/charts/sequencer-relayer/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.7
+version: 2.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 1.0.1
+appVersion: 2.0.0
 
 maintainers:
   - name: wafflesvonmaple

--- a/charts/sequencer-relayer/templates/configmaps.yaml
+++ b/charts/sequencer-relayer/templates/configmaps.yaml
@@ -11,6 +11,7 @@ data:
   ASTRIA_SEQUENCER_RELAYER_SEQUENCER_GRPC_ENDPOINT: "{{ .Values.config.relayer.sequencerGrpc }}"
   ASTRIA_SEQUENCER_RELAYER_CELESTIA_APP_GRPC_ENDPOINT: "{{ .Values.config.relayer.celestiaAppGrpc }}"
   ASTRIA_SEQUENCER_RELAYER_CELESTIA_APP_KEY_FILE: "/celestia-key/{{ .Values.config.celestiaAppPrivateKey.secret.filename }}"
+  ASTRIA_SEQUENCER_RELAYER_CELESTIA_DEFAULT_MIN_GAS_PRICE: "{{ .Values.config.relayer.celestiaDefaultMinGasPrice }}"
   ASTRIA_SEQUENCER_RELAYER_API_ADDR: "0.0.0.0:{{ .Values.ports.healthAPI }}"
   ASTRIA_SEQUENCER_RELAYER_NO_METRICS: "{{ not .Values.config.relayer.metrics.enabled }}"
   ASTRIA_SEQUENCER_RELAYER_METRICS_HTTP_LISTENER_ADDR: "0.0.0.0:{{ .Values.ports.metrics }}"
@@ -28,9 +29,7 @@ data:
   ASTRIA_SEQUENCER_RELAYER_SEQUENCER_CHAIN_ID: "{{ include "sequencer-relayer.sequencerChainId" . }}"
   ASTRIA_SEQUENCER_RELAYER_CELESTIA_CHAIN_ID: "{{ include "sequencer-relayer.celestiaChainId" . }}"
   {{- if not .Values.global.dev }}
-  ASTRIA_SEQUENCER_RELAYER_PRETTY_PRINT: "{{ .Values.global.useTTY }}"
   {{- else }}
-  ASTRIA_SEQUENCER_RELAYER_CELESTIA_DEFAULT_MIN_GAS_PRICE: "{{ .Values.config.relayer.celestiaDefaultMinGasPrice }}"
   {{- end }}
 ---
 apiVersion: v1

--- a/charts/sequencer/Chart.lock
+++ b/charts/sequencer/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: sequencer-relayer
   repository: file://../sequencer-relayer
-  version: 1.0.7
-digest: sha256:4c47bcdb39e650d23a245ba32a342d659437233e4921c56cc0902872e38298b2
-generated: "2025-09-29T11:36:20.568656238+01:00"
+  version: 2.0.0
+digest: sha256:87d575d89b073999f9e138f8f29e3bdb387511bf389172c4a7dcae44f46700ab
+generated: "2025-10-02T10:20:16.711148-07:00"

--- a/charts/sequencer/Chart.yaml
+++ b/charts/sequencer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.0.0-rc.4
+version: 4.0.0-rc.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,7 +25,7 @@ appVersion: 4.0.0-rc.1
 
 dependencies:
   - name: sequencer-relayer
-    version: "1.0.7"
+    version: "2.0.0"
     repository: "file://../sequencer-relayer"
     condition: sequencer-relayer.enabled
 

--- a/charts/sequencer/files/upgrades/dawn-1.upgrades.json
+++ b/charts/sequencer/files/upgrades/dawn-1.upgrades.json
@@ -17,14 +17,5 @@
     },
     "validatorUpdateActionChange": {},
     "ibcAcknowledgementFailureChange": {}
-  },
-  "blackburn": {
-    "baseInfo": {
-      "activationHeight": "10560000",
-      "appVersion": "4"
-    },
-    "ics20TransferActionChange": {},
-    "allowIbcRelayToFail": {},
-    "disableableBridgeAccountDeposits": {}
   }
 }

--- a/charts/sequencer/files/upgrades/mainnet.upgrades.json
+++ b/charts/sequencer/files/upgrades/mainnet.upgrades.json
@@ -17,14 +17,5 @@
     },
     "validatorUpdateActionChange": {},
     "ibcAcknowledgementFailureChange": {}
-  },
-  "blackburn": {
-    "baseInfo": {
-      "activationHeight": "10600000",
-      "appVersion": "4"
-    },
-    "ics20TransferActionChange": {},
-    "allowIbcRelayToFail": {},
-    "disableableBridgeAccountDeposits": {}
   }
 }

--- a/crates/astria-conductor/CHANGELOG.md
+++ b/crates/astria-conductor/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0]
+
 ### Changed
 
 - Update `celestia-rpc`, `celestia-types` and `jsonrpsee` dependencies [#2253](https://github.com/astriaorg/astria/pull/2253).
@@ -407,7 +409,8 @@ address [#721](https://github.com/astriaorg/astria/pull/721).
 
 - Initial release.
 
-[unreleased]: https://github.com/astriaorg/astria/compare/conductor-v2.0.0...HEAD
+[unreleased]: https://github.com/astriaorg/astria/compare/conductor-v3.0.0...HEAD
+[3.0.0]: https://github.com/astriaorg/astria/compare/conductor-v2.0.0...v3.0.0
 [2.0.0]: https://github.com/astriaorg/astria/compare/conductor-v1.1.0...v2.0.0
 [2.0.0-rc.2]: https://github.com/astriaorg/astria/compare/conductor-v2.0.0-rc.1...conductor-v2.0.0-rc.2
 [2.0.0-rc.1]: https://github.com/astriaorg/astria/compare/conductor-v1.1.0...conductor-v2.0.0-rc.1

--- a/crates/astria-conductor/Cargo.toml
+++ b/crates/astria-conductor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astria-conductor"
-version = "2.0.0"
+version = "3.0.0"
 edition = "2021"
 rust-version = "1.83.0"
 license = "MIT OR Apache-2.0"

--- a/crates/astria-sequencer-relayer/CHANGELOG.md
+++ b/crates/astria-sequencer-relayer/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0]
+
 ### Changed
 
 - Update `celestia-types` dependency [#2253](https://github.com/astriaorg/astria/pull/2253).
@@ -278,7 +280,8 @@ address [#721](https://github.com/astriaorg/astria/pull/721).
 
 - Initial release.
 
-[unreleased]: https://github.com/astriaorg/astria/compare/sequencer-relayer-v1.0.1...HEAD
+[unreleased]: https://github.com/astriaorg/astria/compare/sequencer-relayer-v2.0.0...HEAD
+[2.0.0]: https://github.com/astriaorg/astria/compare/sequencer-relayer-v1.0.1...sequencer-relayer-v2.0.0
 [1.0.1]: https://github.com/astriaorg/astria/compare/sequencer-relayer-v1.0.0...sequencer-relayer-v1.0.1
 [1.0.0]: https://github.com/astriaorg/astria/compare/sequencer-relayer-v1.0.0-rc.2...sequencer-relayer-v1.0.0
 [1.0.0-rc.2]: https://github.com/astriaorg/astria/compare/sequencer-relayer-v1.0.0-rc.1...sequencer-relayer-v1.0.0-rc.2

--- a/crates/astria-sequencer-relayer/Cargo.toml
+++ b/crates/astria-sequencer-relayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astria-sequencer-relayer"
-version = "1.0.1"
+version = "2.0.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 rust-version = "1.83.0"


### PR DESCRIPTION
## Summary
Celestia v6 includes breaking changes to celestia apis. This has rolled out to mocha, these chart updates support rolling out to our networks with these new changes.

Additionally rolled back the dawn and mainnet blackburn upgrade information as these have not been activated yet.

## Changelogs
Changelogs updated.
