### PR TITLE
fix(conductor): don't use last block validator set

### DIFF
--- a/crates/astria-conductor/src/celestia/block_verifier.rs
+++ b/crates/astria-conductor/src/celestia/block_verifier.rs
@@ -314,7 +314,7 @@ mod tests {
         };
 
         (
-            validators::Response::new(height.checked_sub(1).unwrap().into(), vec![validator], 1),
+            validators::Response::new(height.into(), vec![validator], 1),
             address,
             commit,
         )
@@ -480,7 +480,7 @@ mod tests {
         // curl http://localhost:26657/validators
         // curl http://localhost:26657/commit?height=79
         let validator_set_str = r#"{
-            "block_height":"78",
+            "block_height":"79",
             "validators":[
                 {
                     "address":"D223B03AE01B4A0296053E01A41AE1E2F9CDEBC9",
@@ -529,7 +529,7 @@ mod tests {
             Engine as _,
         };
         let validator_set = validators::Response::new(
-            78u32.into(),
+            79u32.into(),
             vec![Validator {
                 name: None,
                 address: "D223B03AE01B4A0296053E01A41AE1E2F9CDEBC9"

--- a/crates/astria-conductor/src/celestia/block_verifier.rs
+++ b/crates/astria-conductor/src/celestia/block_verifier.rs
@@ -88,8 +88,7 @@ pub(super) fn ensure_commit_has_quorum(
     validator_set: &tendermint_rpc::endpoint::validators::Response,
     chain_id: &tendermint::chain::Id,
 ) -> Result<(), QuorumError> {
-    // Validator set at Block N-1 is used for block N
-    let expected_height = validator_set.block_height.increment();
+    let expected_height = validator_set.block_height;
     let actual_height = commit.height;
     if expected_height != actual_height {
         return Err(QuorumError::CommitHeightMismatch {

--- a/crates/astria-conductor/src/celestia/verify.rs
+++ b/crates/astria-conductor/src/celestia/verify.rs
@@ -229,7 +229,7 @@ impl VerificationMeta {
         )
         .map_err(|source| VerificationMetaError::NoQuorum {
             height_of_commit: height,
-            height_of_validator_set: prev_height,
+            height_of_validator_set: height,
             source,
         })?;
 
@@ -359,7 +359,7 @@ async fn fetch_validators_with_retry(
         let client = client.clone();
         async move {
             client
-                .validators(prev_height, tendermint_rpc::Paging::Default)
+                .validators(height, tendermint_rpc::Paging::Default)
                 .await
         }
     })

--- a/crates/astria-conductor/src/celestia/verify.rs
+++ b/crates/astria-conductor/src/celestia/verify.rs
@@ -176,9 +176,7 @@ enum VerificationMetaError {
         height: SequencerHeight,
         source: tendermint_rpc::Error,
     },
-    #[error(
-        "failed fetching Sequencer validators at height `{height}`"
-    )]
+    #[error("failed fetching Sequencer validators at height `{height}`")]
     FetchValidators {
         height: SequencerHeight,
         source: tendermint_rpc::Error,
@@ -402,12 +400,8 @@ fn should_retry(error: &tendermint_rpc::Error) -> bool {
 }
 
 enum VerificationRequest {
-    Commit {
-        height: SequencerHeight,
-    },
-    Validators {
-        height: SequencerHeight,
-    },
+    Commit { height: SequencerHeight },
+    Validators { height: SequencerHeight },
 }
 
 #[derive(Debug)]

--- a/crates/astria-conductor/tests/blackbox/firm_only.rs
+++ b/crates/astria-conductor/tests/blackbox/firm_only.rs
@@ -88,7 +88,7 @@ async fn simple() {
         height: 3u32,
     );
 
-    mount_sequencer_validator_set!(test_conductor, height: 2u32);
+    mount_sequencer_validator_set!(test_conductor, height: 3u32);
 
     let execute_block = mount_execute_block!(
         test_conductor,
@@ -171,14 +171,14 @@ async fn submits_two_heights_in_succession() {
         height: 3u32,
     );
 
-    mount_sequencer_validator_set!(test_conductor, height: 2u32);
+    mount_sequencer_validator_set!(test_conductor, height: 3u32);
 
     mount_sequencer_commit!(
         test_conductor,
         height: 4u32,
     );
 
-    mount_sequencer_validator_set!(test_conductor, height: 3u32);
+    mount_sequencer_validator_set!(test_conductor, height: 4u32);
 
     let execute_block_number_2 = mount_execute_block!(
         test_conductor,
@@ -289,7 +289,7 @@ async fn skips_already_executed_heights() {
         height: 7u32,
     );
 
-    mount_sequencer_validator_set!(test_conductor, height: 6u32);
+    mount_sequencer_validator_set!(test_conductor, height: 7u32);
 
     let execute_block = mount_execute_block!(
         test_conductor,
@@ -372,7 +372,7 @@ async fn fetch_from_later_celestia_height() {
         height: 3u32,
     );
 
-    mount_sequencer_validator_set!(test_conductor, height: 2u32);
+    mount_sequencer_validator_set!(test_conductor, height: 3u32);
 
     let execute_block = mount_execute_block!(
         test_conductor,
@@ -579,8 +579,8 @@ async fn restarts_after_reaching_stop_block_height() {
         test_conductor,
         height: 4u32,
     );
-    mount_sequencer_validator_set!(test_conductor, height: 2u32);
     mount_sequencer_validator_set!(test_conductor, height: 3u32);
+    mount_sequencer_validator_set!(test_conductor, height: 4u32);
 
     let execute_block_1 = mount_execute_block!(
         test_conductor,

--- a/crates/astria-conductor/tests/blackbox/soft_and_firm.rs
+++ b/crates/astria-conductor/tests/blackbox/soft_and_firm.rs
@@ -124,7 +124,7 @@ async fn executes_soft_first_then_updates_firm() {
         height: 3u32,
     );
 
-    mount_sequencer_validator_set!(test_conductor, height: 2u32);
+    mount_sequencer_validator_set!(test_conductor, height: 3u32);
 
     let update_commitment_state_firm = mount_update_commitment_state!(
         test_conductor,
@@ -219,7 +219,7 @@ async fn executes_firm_then_soft_at_next_height() {
         height: 3u32,
     );
 
-    mount_sequencer_validator_set!(test_conductor, height: 2u32);
+    mount_sequencer_validator_set!(test_conductor, height: 3u32);
 
     let execute_block = mount_execute_block!(
         test_conductor,
@@ -387,7 +387,7 @@ async fn missing_block_is_fetched_for_updating_firm_commitment() {
         height: 3u32,
     );
 
-    mount_sequencer_validator_set!(test_conductor, height: 2u32);
+    mount_sequencer_validator_set!(test_conductor, height: 3u32);
 
     let update_commitment_state_firm = mount_update_commitment_state!(
         test_conductor,
@@ -509,7 +509,7 @@ async fn restarts_on_permission_denied() {
         height: 3u32,
     );
 
-    mount_sequencer_validator_set!(test_conductor, height: 2u32);
+    mount_sequencer_validator_set!(test_conductor, height: 3u32);
 
     mount_abci_info!(
         test_conductor,
@@ -673,8 +673,8 @@ async fn restarts_after_reaching_soft_stop_height_first() {
         test_conductor,
         height: 4u32,
     );
-    mount_sequencer_validator_set!(test_conductor, height: 2u32);
     mount_sequencer_validator_set!(test_conductor, height: 3u32);
+    mount_sequencer_validator_set!(test_conductor, height: 4u32);
 
     let execute_block_1 = mount_execute_block!(
         test_conductor,
@@ -897,8 +897,8 @@ async fn restarts_after_reaching_firm_stop_height_first() {
         test_conductor,
         height: 4u32,
     );
-    mount_sequencer_validator_set!(test_conductor, height: 2u32);
     mount_sequencer_validator_set!(test_conductor, height: 3u32);
+    mount_sequencer_validator_set!(test_conductor, height: 4u32);
 
     let execute_block_1 = mount_execute_block!(
         test_conductor,


### PR DESCRIPTION
## Summary
Updates Conductor to use the validator set at same height as a given commit.

## Background
We were previously using the previous commit, which worked when validator didn't change quickly enough to affect quorum, and allowed the use the proposer priorities to determine the correct validating node. We no longer use this priority, and quick changes to the validator set have caused the quorum to be unreachable from previously blocks proposer set.

## Changes
- Use commit height instead of previous height for validator set.

## Testing
CI/CD updates + manual testing. 
