### PR TITLE
chart: update evm chart for cel v6

### DIFF
--- a/charts/evm-rollup/Chart.yaml
+++ b/charts/evm-rollup/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.0.1
+version: 4.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/evm-rollup/templates/_helpers.tpl
+++ b/charts/evm-rollup/templates/_helpers.tpl
@@ -47,11 +47,11 @@ files/genesis/{{ include "rollup.type" . }}.genesis.json
 {{- define "rollup.tags.conductor" -}}
 {{- $rollupType := (include "rollup.type" . ) -}}
 {{- if or (eq $rollupType "custom") .Values.global.dev -}}{{ .Values.images.conductor.tag }}
-{{- else if eq $rollupType "flame-mainnet" -}}2.0.0
-{{- else if eq $rollupType "flame-testnet" -}}2.0.0
+{{- else if eq $rollupType "flame-mainnet" -}}3.0.0
+{{- else if eq $rollupType "flame-testnet" -}}3.0.0
 {{- else if eq $rollupType "flame-devnet" -}}2.0.0
-{{- else if eq $rollupType "forma-mainnet" -}}2.0.0
-{{- else if eq $rollupType "forma-testnet" -}}2.0.0
+{{- else if eq $rollupType "forma-mainnet" -}}3.0.0
+{{- else if eq $rollupType "forma-testnet" -}}3.0.0
 {{- end -}}
 {{- end }}
 

--- a/charts/evm-stack/Chart.lock
+++ b/charts/evm-stack/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.7.0
 - name: evm-rollup
   repository: file://../evm-rollup
-  version: 3.0.1
+  version: 4.0.0
 - name: flame-rollup
   repository: file://../flame-rollup
   version: 0.1.3
@@ -26,5 +26,5 @@ dependencies:
 - name: blockscout-stack
   repository: https://blockscout.github.io/helm-charts
   version: 1.6.8
-digest: sha256:fa5f1169b017cf05b467b11bf9a1f41e68cea64fc1bbd0ffa4c1379a169b42f8
-generated: "2025-10-03T13:02:10.883499-07:00"
+digest: sha256:f0119764f06b5469c2cfd4f4fb07b840e56da5f5e5799617a233f30ad5cd84a5
+generated: "2025-10-06T11:26:52.342817-07:00"

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.0.1
+version: 5.0.0
 
 dependencies:
   - name: celestia-node
@@ -23,7 +23,7 @@ dependencies:
     repository: "file://../celestia-node"
     condition: celestia-node.enabled
   - name: evm-rollup
-    version: 3.0.1
+    version: 4.0.0
     repository: "file://../evm-rollup"
     condition: evm-rollup.enabled
   - name: flame-rollup


### PR DESCRIPTION
## Summary
Updates the evm chart to use latest conductor needed for using v6 celestia.

