### PR TITLE
fix(charts, celestia-node): update celestia-node configs to match latest update

### DIFF
--- a/charts/celestia-node/Chart.yaml
+++ b/charts/celestia-node/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.0
+version: 0.7.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/celestia-node/files/config.toml
+++ b/charts/celestia-node/files/config.toml
@@ -15,7 +15,8 @@
 [State]
   DefaultKeyName = "my_celes_key"
   DefaultBackendName = "test"
-
+  EstimatorAddress = ""	
+  EnableEstimatorTLS = false
 [P2P]
   ListenAddresses = ["/ip4/0.0.0.0/udp/2121/quic-v1", "/ip6/::/udp/2121/quic-v1", "/ip4/0.0.0.0/tcp/2121", "/ip6/::/tcp/2121"]
   AnnounceAddresses = []
@@ -45,15 +46,12 @@
   UseShareExchange = true
   [Share.EDSStoreParams]
     RecentBlocksCacheSize = 10
-  [Share.ShrExEDSParams]
-    ServerReadTimeout = "5s"
-    ServerWriteTimeout = "1m0s"
-    HandleRequestTimeout = "1m0s"
-    ConcurrencyLimit = 10
-    BufferSize = 32768
-  [Share.ShrExNDParams]
-    ServerReadTimeout = "5s"
-    ServerWriteTimeout = "1m0s"
+  [Share.ShrexClient]	
+    ReadTimeout = "2m0s"	
+    WriteTimeout = "5s"	
+  [Share.ShrexServer]	
+    ReadTimeout = "5s"	
+    WriteTimeout = "1m0s"
     HandleRequestTimeout = "1m0s"
     ConcurrencyLimit = 10
   [Share.PeerManagerParams]
@@ -70,28 +68,28 @@
     AdvertiseInterval = "22h0m0s"
 
 [Header]
-  TrustedHash = {{ .Values.config.trustedHash | quote }}
   TrustedPeers = []
   [Header.Store]
     StoreCacheSize = 4096
     IndexCacheSize = 16384
     WriteBatchSize = 2048
   [Header.Syncer]
-    TrustingPeriod = "168h0m0s"
+    SyncFromHash = {{ .Values.config.trustedHash | quote }}
+    SyncFromHeight = {{ toString .Values.config.startHeight | replace "\"" "" }}
+    PruningWindow = "337h0m0s"
   [Header.Server]
     WriteDeadline = "8s"
     ReadDeadline = "1m0s"
-    RangeRequestTimeout = "10s"
+    RequestTimeout = "10s"
 {{- if ne .Values.config.type "bridge" }}
   [Header.Client]
     MaxHeadersPerRangeRequest = 64
-    RangeRequestTimeout = "8s"
+    RequestTimeout = "8s"
 {{- end }}
 
 [DASer]
   SamplingRange = 100
   BackgroundStoreInterval = "10m0s"
-  SampleFrom = {{ toString .Values.config.startHeight | replace "\"" "" }}
 {{- if eq .Values.config.type "light" }}
   ConcurrencyLimit = 16
   SampleTimeout = "4m0s"
@@ -100,6 +98,3 @@
   ConcurrencyLimit = 6
   SampleTimeout = "3m0s"  
 {{- end }}
-
-[Pruner]
-  EnableService = {{ .Values.config.enablePruner }}

--- a/charts/evm-stack/Chart.lock
+++ b/charts/evm-stack/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: celestia-node
   repository: file://../celestia-node
-  version: 0.7.0
+  version: 0.7.1
 - name: evm-rollup
   repository: file://../evm-rollup
   version: 4.0.0
@@ -26,5 +26,5 @@ dependencies:
 - name: blockscout-stack
   repository: https://blockscout.github.io/helm-charts
   version: 1.6.8
-digest: sha256:f0119764f06b5469c2cfd4f4fb07b840e56da5f5e5799617a233f30ad5cd84a5
-generated: "2025-10-06T11:26:52.342817-07:00"
+digest: sha256:8cf03d8aab9184afeadec2837a920b81ad7be35366bba5f76d828bbaac69f199
+generated: "2025-10-08T19:16:01.538372+03:00"

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 5.0.0
+version: 5.0.1
 
 dependencies:
   - name: celestia-node

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -19,7 +19,7 @@ version: 5.0.0
 
 dependencies:
   - name: celestia-node
-    version: 0.7.0
+    version: 0.7.1
     repository: "file://../celestia-node"
     condition: celestia-node.enabled
   - name: evm-rollup


### PR DESCRIPTION
## Summary
Updates celestia-node config.toml helm template
## Background
The current node configs are outdated, causing node to crush when running with newest version.
## Changes
- `config.toml `values

## Testing
By running `helm template test ./charts/celestia-node` and comparing with a working node configs.
