### PR TITLE
fix(charts): bump fork height by 1

### DIFF
--- a/charts/evm-rollup/Chart.yaml
+++ b/charts/evm-rollup/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.0.1
+version: 4.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/evm-rollup/files/genesis/flame-testnet.genesis.json
+++ b/charts/evm-rollup/files/genesis/flame-testnet.genesis.json
@@ -101,7 +101,7 @@
         }
       },
       "celestia_update": {
-        "height": 12994834,
+        "height": 12994835,
         "celestia":  {
           "chainId": "mocha-4",
           "startHeight": 8299669,

--- a/charts/evm-rollup/files/genesis/forma-testnet.genesis.json
+++ b/charts/evm-rollup/files/genesis/forma-testnet.genesis.json
@@ -23,7 +23,11 @@
         "height": 1,
         "extraDataOverride": "0xdb8f666f726d612d736b6574636870616483027100831a6cd8825460",
         "feeCollector": "0xBd2949362b3087E7BCc442A19CeC9F921385f846",
-        "eip1559Params": { "minBaseFee": 45000000000, "elasticityMultiplier": 2, "baseFeeChangeDenominator": 8 },
+        "eip1559Params": {
+          "minBaseFee": 45000000000,
+          "elasticityMultiplier": 2,
+          "baseFeeChangeDenominator": 8
+        },
         "sequencer": {
           "chainId": "astria-dusk-5",
           "addressPrefix": "astria",
@@ -68,7 +72,11 @@
       "canvasReduceFees": {
         "height": 809300,
         "extraDataOverride": "0xdb8f666f726d612d736b6574636870616483027100831a6cd8825460",
-        "eip1559Params": { "minBaseFee": 18000000000, "elasticityMultiplier": 2, "baseFeeChangeDenominator": 8 }
+        "eip1559Params": {
+          "minBaseFee": 18000000000,
+          "elasticityMultiplier": 2,
+          "baseFeeChangeDenominator": 8
+        }
       },
       "palette": {
         "height": 13763210,
@@ -80,8 +88,8 @@
         }
       },
       "celestia_update": {
-        "height": 19282943,
-        "celestia":  {
+        "height": 19282944,
+        "celestia": {
           "chainId": "mocha-4",
           "startHeight": 8299669,
           "searchHeightMaxLookAhead": 129600

--- a/charts/evm-stack/Chart.lock
+++ b/charts/evm-stack/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.7.1
 - name: evm-rollup
   repository: file://../evm-rollup
-  version: 4.0.1
+  version: 4.0.2
 - name: flame-rollup
   repository: file://../flame-rollup
   version: 0.1.3
@@ -26,5 +26,5 @@ dependencies:
 - name: blockscout-stack
   repository: https://blockscout.github.io/helm-charts
   version: 1.6.8
-digest: sha256:ae2659c2aaeea1a991b7f0cb5d1abc74ab14ce38f151b183bd194f1d7b13f681
-generated: "2025-10-08T21:31:23.657881+03:00"
+digest: sha256:2ad7fc8251e201d58436a6cfdb3a9c29dc66b9488d49ae1f5306ce325d056e25
+generated: "2025-10-08T23:59:25.650023+03:00"

--- a/charts/evm-stack/Chart.yaml
+++ b/charts/evm-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 5.0.2
+version: 5.0.3
 
 dependencies:
   - name: celestia-node
@@ -23,7 +23,7 @@ dependencies:
     repository: "file://../celestia-node"
     condition: celestia-node.enabled
   - name: evm-rollup
-    version: 4.0.1
+    version: 4.0.2
     repository: "file://../evm-rollup"
     condition: evm-rollup.enabled
   - name: flame-rollup


### PR DESCRIPTION
## Summary
bump celestia_update fork height by one in order to allow for `soft_as_firm` mode to start executing blocks

